### PR TITLE
fix(#6776): arm B9 — bare `Endpoint` is a produced kind that is nobody's synonym, so it enters the enum as its own member and #6744's ledger is retired, not ratcheted to zero

### DIFF
--- a/internal/entkinds/enum_member_corresponds_6818_test.go
+++ b/internal/entkinds/enum_member_corresponds_6818_test.go
@@ -435,6 +435,19 @@ func TestEnumOnlyEntityKinds6818_AllowListDoesNotRot(t *testing.T) {
 // an entry the enum also carries, "non-deferred enum member" stops being a
 // synonym for "enum member" and the sweep needs the exclusion it currently does
 // without.
+//
+// # THE ANTI-VACUITY FATAL ON AN EMPTY LEDGER IS GONE, AND WAS NOT SIMPLY DROPPED
+//
+// This test used to t.Fatal when ruleDeclaredKindsDeferred was empty, on the
+// premise that an empty ledger cannot be told apart from a scan that stopped
+// looking. #6776 arm B9 retired the ledger — the last row, `Endpoint`, is now
+// an enum member — so that premise had to be either honoured (leaving the arm
+// unable to finish) or REPLACED. It is replaced, by a stronger statement of the
+// same thing: rule_ledger_retired_6776_test.go asserts, against a live scan
+// with a floor under it, that ZERO of the 532 rule-YAML sites names a kind
+// outside the enum. Emptiness is now a measured fact with its own guard, so
+// this test asserts it rather than refusing it — a ledger that comes BACK is
+// then the anomaly, and the row loop below still grades it.
 func TestEnumEntityKinds6818_NoDeferredLedgerOverlapsTheEnum(t *testing.T) {
 	inEnum := map[string]bool{}
 	for _, k := range enumEntityKindStrings() {
@@ -443,8 +456,11 @@ func TestEnumEntityKinds6818_NoDeferredLedgerOverlapsTheEnum(t *testing.T) {
 	if len(inEnum) == 0 {
 		t.Fatal("types.AllEntityKinds() is empty; the disjointness below would hold vacuously")
 	}
-	if len(ruleDeclaredKindsDeferred) == 0 {
-		t.Fatal("ruleDeclaredKindsDeferred is empty; the disjointness below would hold vacuously")
+	if len(ruleDeclaredKindsDeferred) != 0 {
+		t.Logf("ruleDeclaredKindsDeferred has %d row(s); #6776 arm B9 retired it, so the loop "+
+			"below is grading a ledger that came back — check "+
+			"TestRuleDeclaredLedger6776_IsRetiredBecauseThePopulationIsEmpty first",
+			len(ruleDeclaredKindsDeferred))
 	}
 	for k := range ruleDeclaredKindsDeferred {
 		if inEnum[k] {

--- a/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
+++ b/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
@@ -13,13 +13,23 @@ package entkinds_test
 // validation, so a rule file can mint any string it likes.
 //
 // The live scan of the rule tree finds 532 declaration sites and 27 distinct
-// values. Exactly TWO of them are valid entity kinds — `Module` (valid only
+// values. Exactly TWO of them were valid entity kinds — `Module` (valid only
 // because types.EntityKindModule is itself un-prefixed) and `SCOPE.IngressHost`
-// (added by this change). The other 25 were ledgered below; #6776 arms B5-B8
-// declared twenty-four of them in types.AllEntityKinds() with their un-prefixed
-// spellings unchanged (thirteen at B5, four at B6, four at B7, three at B8).
+// (added by this change). The other 25 were ledgered below; #6776 arms B5-B9
+// declared ALL of them in types.AllEntityKinds() with their un-prefixed
+// spellings unchanged (thirteen at B5, four at B6, four at B7, three at B8, one
+// at B9).
 //
-// DO NOT RESTATE THE REMAINDER AS A NUMBER HERE — it went stale three arms
+// # THE LEDGER IS RETIRED, and this is the one number safe to state here
+//
+// Not "ratcheted to zero": the POPULATION is empty, and that is measured rather
+// than inferred from an empty map. rule_ledger_retired_6776_test.go scans the
+// rule tree and asserts, over a floor that catches a collapsed scan, that not
+// one of the 532 sites names a kind AllEntityKinds() rejects. Every guard in
+// this file that treated an empty ledger as evidence of a broken scan was
+// correct to, while the ledger was the only evidence; it is not any more.
+//
+// DO NOT RESTATE A REMAINDER AS A NUMBER HERE — it went stale three arms
 // running before this sentence replaced it. ruleDeclaredKindsDeferred below is
 // the population, and it is pinned by exact set equality in both directions
 // plus ruleDeclaredKindsDeferredMax, so reading it is always current and
@@ -78,6 +88,13 @@ package entkinds_test
 // migration is triaged — anything new that is not on the ledger fails,
 // immediately, naming the file and line.
 //
+// That stance was about the ORDER of the work, not about never finishing it,
+// and #6776 kept it: the population was published, ranked and migrated arm by
+// arm over B5-B9, each arm naming its sites, and only then did the ledger go
+// empty. With the ratchet at 0 the sweep is now strictly stricter than it was
+// — any rule-declared kind outside the enum fails, with no ledger row
+// available to absorb it.
+//
 // # The ratchet, and why it is spelled this way
 //
 // ruleDeclaredKindsDeferredMax pins the ledger's EXACT size, so an author who
@@ -117,9 +134,18 @@ import (
 // Every entry was produced by the live scan, not transcribed from the issue —
 // the issue named three sites and the scan found 532, of which 25 distinct
 // values are invalid. This list must only ever SHRINK, and that is ENFORCED.
-var ruleDeclaredKindsDeferred = map[string]string{
-	"Endpoint": "rule_namespace", // 3 sites; javascript_typescript/frameworks/electron.yaml:41
-}
+// RETIRED, and EMPTY is the finished state rather than a hole. #6776 arm B9
+// declared the last entry (`Endpoint`, the Electron IPC kind) in
+// internal/types/kinds.go, and the population this ledger stood in for is now
+// measured directly by rule_ledger_retired_6776_test.go: 532 rule-YAML sites,
+// zero naming a kind AllEntityKinds() rejects. That measurement is what makes
+// the emptiness readable as "nothing left to defer" rather than "the scan
+// stopped looking", which is the only reading an empty map could otherwise
+// carry.
+//
+// The map is kept, not deleted, so the next drift lands on a mechanism instead
+// of inventing one — and so the ratchet below can hold it at zero.
+var ruleDeclaredKindsDeferred = map[string]string{}
 
 // ruleDeclaredKindsDeferredMax is the RATCHET on ruleDeclaredKindsDeferred: the
 // EXACT number of entries the ledger is allowed to hold.
@@ -135,23 +161,23 @@ var ruleDeclaredKindsDeferred = map[string]string{
 //   - SHRINKS (a kind was declared or removed, which is the point) → this fires
 //     and requires the constant to come down with it, so the bar is never left
 //     slack for a later append to slip under.
-const ruleDeclaredKindsDeferredMax = 1
+const ruleDeclaredKindsDeferredMax = 0
 
 // ruleDeclaredFamily explains each family tag. A ledger entry without a stated
 // reason is not a decision, it is a silence.
+// EMPTY because the ledger is. The one family it held, `rule_namespace`,
+// explained the un-prefixed rule-YAML spelling as an accident rather than a
+// second namespace; #6776 acted on that reading across arms B4-B9 and there is
+// now no deferred kind for it to explain. It is deliberately not left standing
+// with no rows: TestYAMLHalfObservesDeclaredKinds requires live YAML traffic
+// for every family here, so an unused family is either a red suite or, once
+// that check goes unreachable, a documented slot inviting a row with no
+// decision behind it. TestRuleDeclaredLedger6776_EveryFamilyIsUsedByARow is the
+// standing check on that direction.
 var ruleDeclaredFamily = map[string]struct {
 	Origin string
 	Why    string
-}{
-	"rule_namespace": {
-		Origin: entkinds.OriginRuleYAML,
-		Why: "an un-prefixed name declared by internal/engine/rules/**/*.yaml. " +
-			"internal/engine/detector.go:411 writes SourcePattern.EntityType straight into " +
-			"types.EntityRecord.Kind with no validation, so the string reaches the graph exactly " +
-			"as spelled. The un-prefixed spelling is an accident, not a namespace — see the file " +
-			"header. Fixing it is a ~530-site migration filed separately.",
-	},
-}
+}{}
 
 func repoRoot(t *testing.T) string {
 	t.Helper()
@@ -523,6 +549,15 @@ func TestYAMLHalfObservesDeclaredKinds(t *testing.T) {
 	// Positive, per-mechanism traffic for the ledger itself: the YAML half must
 	// carry ledgered sites, or the exact-set comparison above is measuring an
 	// empty set against an empty set.
+	//
+	// UNREACHABLE TODAY, and deliberately kept: ruleDeclaredFamily is empty
+	// since #6776 arm B9 retired the ledger, so this loop drives nothing. It is
+	// the check that fires again the moment a family is reintroduced with no
+	// live YAML site behind it. What it can no longer do — object to a family
+	// with no ledger ROW — is carried by
+	// TestRuleDeclaredLedger6776_EveryFamilyIsUsedByARow, and the sentinels
+	// above still hold the YAML half of the scan to real, located traffic
+	// without depending on the ledger at all.
 	perFamily := map[string]int{}
 	for _, s := range yamlSites(res) {
 		if fam, ok := ruleDeclaredKindsDeferred[s.Kind]; ok {

--- a/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
+++ b/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
@@ -815,6 +815,24 @@ func TestBoundPathsMirrorEngineSchema(t *testing.T) {
 // TestLedgerIsDescribedByItsOwnScan keeps this file honest about how it was
 // built: every ledger entry names a real, currently-scanned site with a
 // location, so the failure text a future author sees can point at one.
+//
+// FULLY VACUOUS TODAY, disclosed rather than left to be tripped over. #6776 arm
+// B9 emptied ruleDeclaredKindsDeferred, so this loop drives nothing and this
+// test is a green over zero entries. It is the FOURTH guard the retirement
+// relaxed, alongside enum_member_corresponds_6818_test.go's empty-ledger fatal,
+// the perFamily traffic loop above, and internal/graph/fbwriter's ledger
+// transcription.
+//
+// It is kept, and NOT given a floor, because the only floor available —
+// "the ledger is non-empty" — is the assertion arm B9 deliberately falsified.
+// What it actually observed, "a kind this file names resolves to a located
+// site", is not lost: it moved to
+// TestRuleDeclaredLedger6776_IsRetiredBecauseThePopulationIsEmpty, which pins
+// EntityKindEndpointBare's three electron.yaml sites LINE-EXACTLY. That is the
+// same property, made about the one kind that still needs it — the member
+// admitted on the strength of those sites — instead of about a ledger row that
+// no longer exists. This test remains as the drift guard that fires again the
+// moment a row comes back.
 func TestLedgerIsDescribedByItsOwnScan(t *testing.T) {
 	res := scanRepo(t)
 	for kind := range ruleDeclaredKindsDeferred {

--- a/internal/entkinds/rule_ledger_retired_6776_test.go
+++ b/internal/entkinds/rule_ledger_retired_6776_test.go
@@ -1,0 +1,122 @@
+package entkinds_test
+
+// rule_ledger_retired_6776_test.go — #6776 arm B9 retires #6744's ledger.
+//
+// # Why a RETIREMENT needs its own guard, and is not "the ratchet reached zero"
+//
+// Every anti-vacuity guard in this area is built on the same premise: an empty
+// ledger is indistinguishable from a scan that stopped looking. That premise is
+// correct while the ledger is the only evidence, and it is the reason
+// TestEnumEntityKinds6818_NoDeferredLedgerOverlapsTheEnum used to t.Fatal on an
+// empty map.
+//
+// The population, not the ledger, is what actually reached zero: the rule-YAML
+// half of the scan declares 532 sites and NOT ONE of them names a kind
+// types.AllEntityKinds() rejects. That is a positive, measured statement, and
+// it is strictly stronger than any ledger row — it is what the ledger was a
+// stand-in for. So this file asserts the population directly, and the empty
+// ledger becomes a consequence rather than an assumption.
+//
+// Varies: nothing — this is a population floor plus an emptiness pin.
+// Holds constant: the live scan of the shipped rule tree.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/entkinds"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// minRuleYAMLSites is a slack FLOOR under the rule-YAML half, not a count.
+// Measured on this branch with entkinds.ScanRuleYAML: 732 YAML files, 532
+// sites, 0 unresolved. The floor catches a scan that COLLAPSES — which is the
+// only way "zero invalid kinds" could become a lie — and deliberately does not
+// track the churn of the rule tree.
+const minRuleYAMLSites = 300
+
+// TestRuleDeclaredLedger6776_IsRetiredBecauseThePopulationIsEmpty
+//
+// This is the assertion that replaces the ledger. Read it as: the thing the
+// ledger recorded no longer exists, and here is the measurement, not the
+// absence of a measurement.
+func TestRuleDeclaredLedger6776_IsRetiredBecauseThePopulationIsEmpty(t *testing.T) {
+	res, err := entkinds.ScanRuleYAML(repoRoot(t))
+	if err != nil {
+		t.Fatalf("ScanRuleYAML: %v", err)
+	}
+
+	// FLOOR FIRST. "No invalid kind was found" is the same sentence for a live
+	// scan and for a scan that read nothing, and #6534 is this repo's standing
+	// example of the second one shipping as the first.
+	if len(res.Sites) < minRuleYAMLSites {
+		t.Fatalf("the rule-YAML scan produced only %d site(s) from %d file(s) (floor: %d). "+
+			"An emptied scan reports every rule file clean; the zero below would then mean "+
+			"'nothing was read', not 'nothing is invalid'.",
+			len(res.Sites), res.YAMLFilesParsed, minRuleYAMLSites)
+	}
+	if res.Unresolved() != 0 {
+		t.Errorf("%d rule-YAML site(s) are unresolved; a site whose kind could not be read is "+
+			"outside the sweep below and must not be counted as clean", res.Unresolved())
+	}
+
+	invalid := map[string][]string{}
+	for _, s := range res.Sites {
+		if types.IsValidEntityKind(s.Kind) {
+			continue
+		}
+		invalid[s.Kind] = append(invalid[s.Kind], fmt.Sprintf("%s:%d", s.File, s.Line))
+	}
+	if len(invalid) > 0 {
+		var lines []string
+		for k, where := range invalid {
+			lines = append(lines, fmt.Sprintf("%s (%d site(s)): %s", k, len(where), strings.Join(where, ", ")))
+		}
+		sort.Strings(lines)
+		t.Errorf("the rule-YAML half declares %d entity kind(s) types.AllEntityKinds() rejects:\n  %s\n\n"+
+			"#6744's ledger was RETIRED by #6776 arm B9 on the strength of this set being empty. "+
+			"Do not reinstate it to hold a new entry: declare the kind in internal/types/kinds.go, "+
+			"which is what every arm B5-B9 did.",
+			len(invalid), strings.Join(lines, "\n  "))
+	}
+
+	// And the ledger itself must be gone, in BOTH of its halves — a retired
+	// ledger that keeps a family tag is a ledger with room for a row.
+	if len(ruleDeclaredKindsDeferred) != 0 || ruleDeclaredKindsDeferredMax != 0 {
+		t.Errorf("ruleDeclaredKindsDeferred has %d entry/entries and the ratchet reads %d, but the "+
+			"population above is empty. The ledger is retired: a row here now names a kind the "+
+			"live scan does not produce, which TestNoUndeclaredRuleEntityKinds reports as stale.",
+			len(ruleDeclaredKindsDeferred), ruleDeclaredKindsDeferredMax)
+	}
+	if len(ruleDeclaredFamily) != 0 {
+		t.Errorf("ruleDeclaredFamily still explains %d family/families for an empty ledger. "+
+			"TestYAMLHalfObservesDeclaredKinds requires live YAML traffic for every family it "+
+			"holds, so a family with no rows is either a broken guard or an invitation to add one.",
+			len(ruleDeclaredFamily))
+	}
+}
+
+// TestRuleDeclaredLedger6776_EveryFamilyIsUsedByARow is the reverse coupling
+// the perFamily traffic check in TestYAMLHalfObservesDeclaredKinds used to
+// provide and cannot any more.
+//
+// With the ledger empty, that check's loop body is unreachable, so a future
+// author could reintroduce ruleDeclaredFamily["something"] with no ledger row
+// and nothing would object. This says the two maps move together in the
+// direction the ledger's own family check does not cover: an entry needs a
+// family (checked there), and a family needs an entry (checked here).
+func TestRuleDeclaredLedger6776_EveryFamilyIsUsedByARow(t *testing.T) {
+	used := map[string]bool{}
+	for _, fam := range ruleDeclaredKindsDeferred {
+		used[fam] = true
+	}
+	for fam := range ruleDeclaredFamily {
+		if !used[fam] {
+			t.Errorf("ruleDeclaredFamily explains family %q, which no ledger row uses. Delete it, "+
+				"or add the row it exists for — an unused family is a documented slot with no "+
+				"decision behind it.", fam)
+		}
+	}
+}

--- a/internal/entkinds/rule_ledger_retired_6776_test.go
+++ b/internal/entkinds/rule_ledger_retired_6776_test.go
@@ -17,7 +17,21 @@ package entkinds_test
 // stand-in for. So this file asserts the population directly, and the empty
 // ledger becomes a consequence rather than an assumption.
 //
-// Varies: nothing — this is a population floor plus an emptiness pin.
+// # WHAT THIS IS STRONGER AND WEAKER THAN, stated in both directions
+//
+// STRONGER than any ledger row in the direction the ledger was built for: a
+// kind outside the enum, anywhere in the rule tree, fails here with a
+// line-exact diagnosis and no row available to absorb it.
+//
+// WEAKER, on its own, in the direction the ledger held INCIDENTALLY: a row
+// named a kind, so the sweep noticed when that kind's sites disappeared. An
+// "is the set empty" question cannot notice that a MEMBER's producers vanished.
+// That is why this file also pins EntityKindEndpointBare's three sites
+// line-exactly below — the retirement would otherwise have dropped the only
+// coupling between the member and the three producers that justify it.
+//
+// Varies: nothing — this is a population floor, an emptiness pin, and a
+// site-level anchor for the member arm B9 admitted.
 // Holds constant: the live scan of the shipped rule tree.
 
 import (
@@ -60,6 +74,54 @@ func TestRuleDeclaredLedger6776_IsRetiredBecauseThePopulationIsEmpty(t *testing.
 	if res.Unresolved() != 0 {
 		t.Errorf("%d rule-YAML site(s) are unresolved; a site whose kind could not be read is "+
 			"outside the sweep below and must not be counted as clean", res.Unresolved())
+	}
+
+	// THE PREDICATE'S OWN POSITIVE CONTROL. Of the five ways a
+	// scan-and-assert-absence guard goes no-op, the floor above covers "failed
+	// to read" and the sweep below covers "read the wrong files / the wrong
+	// content / failed to detect / failed to act". The fifth is the DETECTOR
+	// itself going permissive, and it was ungraded here: making
+	// IsValidEntityKind return true for any non-empty string left this package
+	// GREEN while internal/types and internal/graph/fbwriter went red — a hole
+	// in this fixture, not in the suite, and the same discipline this arm
+	// already applies to IsHTTPEndpointKind in
+	// TestEndpointBare6776_MembershipIsNotHTTPMembership.
+	const notAKind = "SCOPE.ZZNotAKindAnyProducerWrites"
+	if types.IsValidEntityKind(notAKind) {
+		t.Fatalf("fixture is inert: IsValidEntityKind(%q) is true, so it accepts everything and "+
+			"the empty set below is a statement about a constant, not about the rule tree", notAKind)
+	}
+
+	// THE SITES THAT JUSTIFY THE MEMBER. This is the direction the retirement
+	// dropped and the ledger used to hold incidentally: with the row gone,
+	// nothing observed that EntityKindEndpointBare still HAS producers.
+	// Measured — re-spelling electron.yaml's three `entity_type: Endpoint` rows
+	// to `SCOPE.Endpoint` (the silent rename #6820 rejected) left all six
+	// packages green on this branch, and failed three tests on the parent.
+	//
+	// It is asserted LINE-EXACT rather than as a count, because the count alone
+	// would accept the three sites moving to a file that has nothing to do with
+	// Electron IPC, which is the concept the member is named for.
+	wantEndpointSites := []string{
+		"internal/engine/rules/javascript_typescript/frameworks/electron.yaml:41",
+		"internal/engine/rules/javascript_typescript/frameworks/electron.yaml:46",
+		"internal/engine/rules/javascript_typescript/frameworks/electron.yaml:52",
+	}
+	var gotEndpointSites []string
+	for _, s := range res.Sites {
+		if s.Kind == string(types.EntityKindEndpointBare) {
+			gotEndpointSites = append(gotEndpointSites, fmt.Sprintf("%s:%d", s.File, s.Line))
+		}
+	}
+	sort.Strings(gotEndpointSites)
+	if strings.Join(gotEndpointSites, ",") != strings.Join(wantEndpointSites, ",") {
+		t.Errorf("rule-YAML sites for %q:\n  got  %v\n  want %v\n\n"+
+			"#6776 arm B9 admitted this kind to types.AllEntityKinds() on the strength of exactly "+
+			"those three producers (ipcMain / ipcRenderer / contextBridge). If they are gone or "+
+			"re-spelled, the member is enum-only and that is a KindVocabularyVersion decision plus "+
+			"an enumOnlyEntityKinds row — not something to pass in silence. A re-spelling to "+
+			"SCOPE.Endpoint in particular is the rename #6820 considered and rejected.",
+			types.EntityKindEndpointBare, gotEndpointSites, wantEndpointSites)
 	}
 
 	invalid := map[string][]string{}

--- a/internal/graph/fbwriter/non_enum_entity_kinds_6776_test.go
+++ b/internal/graph/fbwriter/non_enum_entity_kinds_6776_test.go
@@ -36,37 +36,39 @@ import (
 //   - the entity half reaches graph-stats.json, under its own Scanned flag;
 //   - EntitySummary is textually separable from Summary;
 //   - nothing is dropped;
-//   - every kind on #6744's ledger is countable by this path.
+//   - the metric is countable for kinds a real producer writes.
 //
-// # THE NON-ENUM CONTROLS, and why these two
+// # THE NON-ENUM CONTROLS, and why they all come from ONE ledger now
 //
 // Every fixture below needs at least one kind that IsValidEntityKind rejects,
 // and each such fixture hard-fails "fixture is inert" the moment its control
 // becomes valid. That has fired once per migration arm: the controls were
 // Controller/Schema/Route/Config in turn, then Endpoint/Plugin/Template after
-// arm B7, and are now:
+// arm B7, then Endpoint/File after arm B8.
 //
-//	Endpoint  the ONE entry left on #6744's ledger after arm B8. It is not
-//	          leftover work — bare `Endpoint` is declared only by
-//	          javascript_typescript/frameworks/electron.yaml (Electron IPC)
-//	          while SCOPE.Endpoint is the HTTP concept, so it is the one pair
-//	          on that ledger that is NOT a synonym, and #6820 owns the ruling.
-//	          Its durability is therefore a real question, not an assumption.
-//	File      internal/engine/commit_coupling_edges.go:117, `const KindFile =
-//	          "File"`. NOT rule-declared, so it is not on #6776's migration
-//	          path at all; it is on internal/types' goUnprefixedKindsDeferred,
-//	          whose own comment says it is "an internal commit-coupling
-//	          artefact rather than a first-class kind; it is ledgered here, not
-//	          promoted". internal/types' arm-B4 negative test has carried it as
-//	          a permanent non-enum row for the same reason.
+// #6776 arm B9 declared `Endpoint` and RETIRED #6744's rule-YAML ledger — there
+// is no rule-declared kind outside the enum any more, so the source those
+// earlier controls were drawn from is empty and cannot be drawn from again. The
+// controls are now drawn ENTIRELY from internal/types' goUnprefixedKindsDeferred,
+// the Go half, which survives precisely because nothing proposes to move it:
 //
-// THE ADVICE THE INERT GUARDS BELOW GIVE IS PARTLY STALE, ON PURPOSE. They say
-// to re-pick from internal/entkinds' ledger. After arm B8 that ledger holds one
-// entry, and it is `Endpoint` — already in use here, and itself a migration
-// candidate the moment #6820 is ruled on. A replacement must come from the
-// kinds that are outside the enum because NOTHING PROPOSES TO MOVE THEM, which
-// is what `File` is; the guards' message is kept because naming the stale kind
-// is the useful half, and this paragraph is the correction to the other half.
+//	ChannelEvent  internal/engine/websocket_edges.go
+//	File          internal/engine/commit_coupling_edges.go, `KindFile = "File"`
+//	Stream        internal/engine/sse_edges.go
+//	Subscription  internal/engine/graphql_subscriptions.go
+//
+// Each is a kind a real Go producer writes, not an invented string, which is
+// what makes "countable at the write path" a statement about production. That
+// ledger's own doc records the stance for `File` and it generalises to the
+// four: "an internal commit-coupling artefact rather than a first-class kind;
+// it is ledgered here, not promoted". They are pinned OUTSIDE the enum by
+// internal/types' own exact-set ledger guard, so a promotion cannot happen
+// silently on either side.
+//
+// THE ADVICE THE INERT GUARDS BELOW GIVE WAS STALE AND IS NOW CORRECTED IN THE
+// MESSAGES THEMSELVES. They used to say "re-pick from internal/entkinds'
+// ledger", which was already partly wrong at arm B8 and is now advice to read
+// an empty map. They name internal/types' goUnprefixedKindsDeferred instead.
 
 // entFixture builds an entity with the given id and kind.
 func entFixture(id, kind string) graph.Entity {
@@ -98,7 +100,7 @@ func TestStreamingWriterTalliesOnlyEntityKindsAbsentFromTheEnum(t *testing.T) {
 	// Both are kinds a real producer writes, not invented strings — see THE
 	// NON-ENUM CONTROLS in the file header for what each one is and why it is
 	// expected to stay outside.
-	for _, invalid := range []string{"Endpoint", "File"} {
+	for _, invalid := range []string{"ChannelEvent", "File"} {
 		if types.IsValidEntityKind(invalid) {
 			t.Fatalf("fixture is inert: %q is expected to be ABSENT FROM THE ENUM but IsValidEntityKind accepts it", invalid)
 		}
@@ -109,8 +111,8 @@ func TestStreamingWriterTalliesOnlyEntityKindsAbsentFromTheEnum(t *testing.T) {
 			entFixture("a", string(types.EntityKindFunction)),
 			entFixture("b", string(types.EntityKindFunction)),
 			entFixture("c", string(types.EntityKindModule)),
-			entFixture("d", "Endpoint"),
-			entFixture("e", "Endpoint"),
+			entFixture("d", "ChannelEvent"),
+			entFixture("e", "ChannelEvent"),
 			entFixture("f", "File"),
 		},
 	}
@@ -126,7 +128,7 @@ func TestStreamingWriterTalliesOnlyEntityKindsAbsentFromTheEnum(t *testing.T) {
 		t.Errorf("Entities = %d, want 3 (6 entities written, 3 with a kind absent from the enum)", rep.Entities)
 	}
 	if rep.EntityDistinctKinds != 2 {
-		t.Errorf("EntityDistinctKinds = %d, want 2 (Endpoint, File)", rep.EntityDistinctKinds)
+		t.Errorf("EntityDistinctKinds = %d, want 2 (ChannelEvent, File)", rep.EntityDistinctKinds)
 	}
 	if rep.EntityKindsClean() {
 		t.Error("EntityKindsClean() = true, but 3 entities with non-enum kinds were written")
@@ -136,8 +138,8 @@ func TestStreamingWriterTalliesOnlyEntityKindsAbsentFromTheEnum(t *testing.T) {
 	for _, k := range rep.EntityKinds {
 		got[k.Kind] = k.Entities
 	}
-	if got["Endpoint"] != 2 {
-		t.Errorf("Endpoint entities = %d, want 2 (report: %+v)", got["Endpoint"], rep.EntityKinds)
+	if got["ChannelEvent"] != 2 {
+		t.Errorf("ChannelEvent entities = %d, want 2 (report: %+v)", got["ChannelEvent"], rep.EntityKinds)
 	}
 	if got["File"] != 1 {
 		t.Errorf("File entities = %d, want 1 (report: %+v)", got["File"], rep.EntityKinds)
@@ -151,7 +153,7 @@ func TestStreamingWriterTalliesOnlyEntityKindsAbsentFromTheEnum(t *testing.T) {
 	// The names, not just the total: a bare count says something is wrong,
 	// the names say what, and what is the input to the migration ranking.
 	sum := rep.EntitySummary()
-	for _, want := range []string{"Endpoint", "File"} {
+	for _, want := range []string{"ChannelEvent", "File"} {
 		if !strings.Contains(sum, want) {
 			t.Errorf("EntitySummary() = %q, missing non-enum kind name %q", sum, want)
 		}
@@ -209,7 +211,7 @@ func TestEntityKindReportIsEmptyButSCANNEDForAnAllEnumGraph(t *testing.T) {
 	}
 	// And a nil tally must survive being handed an entity kind, since that is
 	// exactly what graphFitsSingleBuilder does on every probed entity.
-	noTally.observeEntity("Endpoint")
+	noTally.observeEntity("ChannelEvent")
 	if noTally.report().Scanned {
 		t.Error("a nil tally reports Scanned=true after observing an entity")
 	}
@@ -262,10 +264,11 @@ func TestEntityKindReportCapsTheListButNotTheCounts(t *testing.T) {
 func TestWriteGraphGenReportWiresTheFlatEntityProducerPath(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAFEL_STREAM_SEGMENTS", "0")
-	const nonEnum = "Endpoint"
+	const nonEnum = "Stream"
 	if types.IsValidEntityKind(nonEnum) {
 		t.Fatalf("fixture is inert: %q is a valid entity kind, so the flat path has nothing "+
-			"non-enum to report; pick one still on internal/entkinds' ledger", nonEnum)
+			"non-enum to report; re-pick from internal/types' goUnprefixedKindsDeferred (see THE "+
+			"NON-ENUM CONTROLS in this file's header — internal/entkinds' ledger is retired)", nonEnum)
 	}
 	doc := &graph.Document{
 		Entities: []graph.Entity{
@@ -348,10 +351,11 @@ func TestWriteGraphGenReportWiresTheSegmentedEntityProducerPath(t *testing.T) {
 // avoid. These two slots have been re-picked once per migration arm as their
 // occupants became valid: "Schema"/"Route" were swapped for
 // "Operation"/"Endpoint" (arm B6, then arm B7), "Operation" for "Template"
-// (arm B7), and "Template" for "File" (arm B8). Each swap keeps the document
-// covering the non-enum side, which is the side that can be dropped. Only one
-// of the two is still a #6744 ledger entry; see THE NON-ENUM CONTROLS in the
-// file header for why the other deliberately is not.
+// (arm B7), "Template" for "File" (arm B8), and "Endpoint" for "Subscription"
+// (arm B9). Each swap keeps the document covering the non-enum side, which is
+// the side that can be dropped. NEITHER slot is a #6744 ledger entry any more
+// — that ledger is retired — and both now come from internal/types'
+// goUnprefixedKindsDeferred; see THE NON-ENUM CONTROLS in the file header.
 func TestEntityKindsAreCountedNotDropped(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAFEL_STREAM_SEGMENTS", "0")
@@ -361,7 +365,7 @@ func TestEntityKindsAreCountedNotDropped(t *testing.T) {
 	// to ignore it. Measured at arm B7, when this slot held "Template": before
 	// the guard existed, swapping it for the valid "Model" left the test green.
 	enumKind := string(types.EntityKindFunction)
-	nonEnumKinds := []string{"Endpoint", "File"}
+	nonEnumKinds := []string{"Subscription", "File"}
 	if !types.IsValidEntityKind(enumKind) {
 		t.Fatalf("fixture is inert: %q must be IN the enum", enumKind)
 	}
@@ -372,7 +376,8 @@ func TestEntityKindsAreCountedNotDropped(t *testing.T) {
 	for _, k := range nonEnumKinds {
 		if types.IsValidEntityKind(k) {
 			t.Fatalf("fixture is inert: %q has been migrated into the enum, so this document no "+
-				"longer covers the droppable side; re-pick from internal/entkinds' ledger", k)
+				"longer covers the droppable side; re-pick from internal/types' "+
+				"goUnprefixedKindsDeferred (internal/entkinds' ledger is retired)", k)
 		}
 	}
 	doc := &graph.Document{
@@ -413,7 +418,7 @@ func TestApplyToSidecarCarriesTheEntityHalf(t *testing.T) {
 		Entities:            17,
 		EntityDistinctKinds: NonEnumKindListCap + 4,
 		EntityKinds: []NonEnumEntityKind{
-			{Kind: "Endpoint", Entities: 11},
+			{Kind: "ChannelEvent", Entities: 11},
 			{Kind: "File", Entities: 6},
 		},
 	}
@@ -432,8 +437,8 @@ func TestApplyToSidecarCarriesTheEntityHalf(t *testing.T) {
 		t.Errorf("EntityDistinctKindsNotInEnum = %d, want %d — it must be the uncapped count, not len(EntityKinds)=%d",
 			side.EntityDistinctKindsNotInEnum, NonEnumKindListCap+4, len(rep.EntityKinds))
 	}
-	if side.EntityKindsNotInEnum["Endpoint"] != 11 || side.EntityKindsNotInEnum["File"] != 6 {
-		t.Errorf("EntityKindsNotInEnum = %v, want Endpoint:11 File:6", side.EntityKindsNotInEnum)
+	if side.EntityKindsNotInEnum["ChannelEvent"] != 11 || side.EntityKindsNotInEnum["File"] != 6 {
+		t.Errorf("EntityKindsNotInEnum = %v, want ChannelEvent:11 File:6", side.EntityKindsNotInEnum)
 	}
 
 	// An unscanned report must leave the flag false, so a consumer can tell
@@ -460,7 +465,7 @@ func TestApplyToSidecarCarriesTheEntityHalf(t *testing.T) {
 // merged.
 func TestEntitySummaryIsSeparableFromTheRelationshipSummary(t *testing.T) {
 	doc := &graph.Document{
-		Entities:      []graph.Entity{entFixture("a", "Endpoint")},
+		Entities:      []graph.Entity{entFixture("a", "ChannelEvent")},
 		Relationships: []graph.Relationship{relFixture("OWNS", "a", "b")},
 	}
 	_, rep, err := marshalWithReport(doc)
@@ -471,8 +476,8 @@ func TestEntitySummaryIsSeparableFromTheRelationshipSummary(t *testing.T) {
 	if relSum == "" || entSum == "" {
 		t.Fatalf("fixture is inert: Summary()=%q EntitySummary()=%q — both must be non-empty here", relSum, entSum)
 	}
-	if strings.Contains(relSum, "Endpoint") {
-		t.Errorf("Summary() = %q — the relationship line names the entity kind Endpoint", relSum)
+	if strings.Contains(relSum, "ChannelEvent") {
+		t.Errorf("Summary() = %q — the relationship line names the entity kind ChannelEvent", relSum)
 	}
 	if strings.Contains(entSum, "OWNS") {
 		t.Errorf("EntitySummary() = %q — the entity line names the relationship kind OWNS", entSum)
@@ -485,56 +490,70 @@ func TestEntitySummaryIsSeparableFromTheRelationshipSummary(t *testing.T) {
 	}
 }
 
-// ruleDeclaredKinds6776 is #6744's ledger, transcribed. It is NOT the source of
-// truth — internal/entkinds' guard is, and it fails if the population moves —
-// but it is the list #6776 proposes to migrate, and the point of arm A is that
-// every one of these must be COUNTABLE at the write path before anyone ranks
-// the migration by declaration-site count.
-var ruleDeclaredKinds6776 = []string{
-	"Endpoint",
+// nonEnumProducerKinds6776 is the population this file's "every" claim is now
+// made about: the UN-PREFIXED entity kinds a Go producer writes that
+// types.AllEntityKinds() does not carry — internal/types'
+// goUnprefixedKindsDeferred, minus the one row that is not a producer kind.
+//
+// # WHY THIS REPLACES THE #6744 LEDGER TRANSCRIPTION, RATHER THAN THE TEST BEING DELETED
+//
+// This used to be `ruleDeclaredKinds6776`, a transcription of #6744's rule-YAML
+// ledger, and its floor said: "If #6744's ledger really has reached zero, delete
+// this test and say so — do not leave it standing as a no-op." #6776 arm B9 took
+// that ledger to zero. Deleting outright would have thrown away the PROPERTY as
+// well as the population, and the property is what the arm-A measurement rests
+// on: a kind invisible to the write path reports a zero that means "not
+// measurable" rather than "not produced", and a migration ranking must never
+// confuse those two answers. The rule-YAML population is empty; the property is
+// not, because the Go half of the same accident is still outside the enum. So
+// the population is re-aimed and the mechanism — a floor, an exact pin, and a
+// per-kind assertion — is kept intact.
+//
+// `relationship` is deliberately EXCLUDED: its own ledger comment calls it a
+// fallback that is unreachable, so driving it here would assert countability
+// for a string no graph carries. That exclusion is why this list is pinned at
+// four against a ledger of five rather than mirroring it.
+var nonEnumProducerKinds6776 = []string{
+	"ChannelEvent",
+	"File",
+	"Stream",
+	"Subscription",
 }
 
-// TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath
+// TestEveryNonEnumProducerKindIsCountedByTheWritePath
 //
-// Varies: the entity kind, across ALL ledger entries — the name of this test
-// says "every", so the body drives every one of them, individually, and
-// asserts a per-kind count rather than a total that one lucky kind could
+// Varies: the entity kind, across EVERY kind in the population — the name of
+// this test says "every", so the body drives every one of them, individually,
+// and asserts a per-kind count rather than a total that one lucky kind could
 // satisfy.
-//
-// The ledger is down to ONE entry after arm B8 (`Endpoint`, held back by
-// #6820), so "every" and "the only one" currently coincide. TWO separate
-// checks keep that honest, and they are not redundant: an EXACT pin, so a
-// ledger that grows or shrinks fails here and this comment cannot go stale
-// unobserved; and an absolute NON-EMPTY floor, because the pin alone is
-// satisfiable by emptying the list and re-pinning to zero, which leaves the
-// loop unreachable and this test reporting success over nothing.
 // Holds constant: one entity per kind, the flat writer, and an empty
 // relationship vector.
 //
-// This is the pin under the measurement #6776 asked for: if any ledger kind
-// were silently invisible to the write path, the runtime table would report a
-// zero for it that means "not measurable" rather than "not produced", and
-// those are the two answers a migration ranking must never confuse.
-func TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath(t *testing.T) {
+// TWO separate checks keep the population honest, and they are not redundant:
+// an EXACT pin, so a list that grows or shrinks fails here and the comment
+// above cannot go stale unobserved; and an absolute NON-EMPTY floor, because
+// the pin alone is satisfiable by emptying the list and re-pinning to zero,
+// which leaves the loop unreachable and this test reporting success over
+// nothing — measured, ALIVE, before that floor existed.
+func TestEveryNonEnumProducerKindIsCountedByTheWritePath(t *testing.T) {
 	// The FLOOR first, and it is a separate assertion from the pin below on
-	// purpose. The pin is a literal that an author re-pins when the ledger
-	// moves, so emptying the list and re-pinning to 0 keeps it satisfied while
-	// the loop below becomes unreachable and this test becomes a vacuous green
-	// — measured, ALIVE, before this floor existed. An absolute zero-check
-	// cannot be satisfied that way.
-	if len(ruleDeclaredKinds6776) == 0 {
-		t.Fatal("ledger transcription is EMPTY, so the loop below drives nothing and this test " +
-			"reports success having observed no kind at all. If #6744's ledger really has reached " +
-			"zero, delete this test and say so — do not leave it standing as a no-op.")
+	// purpose; see the doc comment for why the pin alone does not cover it.
+	if len(nonEnumProducerKinds6776) == 0 {
+		t.Fatal("the population is EMPTY, so the loop below drives nothing and this test " +
+			"reports success having observed no kind at all. If internal/types' " +
+			"goUnprefixedKindsDeferred really has reached zero, delete this test and say so — " +
+			"do not leave it standing as a no-op.")
 	}
-	if len(ruleDeclaredKinds6776) != 1 {
-		t.Fatalf("ledger transcription has %d entries, want 1 (see internal/entkinds)", len(ruleDeclaredKinds6776))
+	if len(nonEnumProducerKinds6776) != 4 {
+		t.Fatalf("population has %d entries, want 4 (see internal/types' goUnprefixedKindsDeferred, "+
+			"five rows minus the unreachable `relationship` fallback)", len(nonEnumProducerKinds6776))
 	}
-	for _, kind := range ruleDeclaredKinds6776 {
+	for _, kind := range nonEnumProducerKinds6776 {
 		t.Run(kind, func(t *testing.T) {
 			if types.IsValidEntityKind(kind) {
-				t.Fatalf("%q is now a valid entity kind — it has been migrated, so drop it from "+
-					"ruleDeclaredKinds6776 and from internal/entkinds' ledger in the same change", kind)
+				t.Fatalf("%q is now a valid entity kind — it has been promoted, so drop it from "+
+					"nonEnumProducerKinds6776 and from internal/types' goUnprefixedKindsDeferred "+
+					"in the same change", kind)
 			}
 			doc := &graph.Document{Entities: []graph.Entity{
 				entFixture("x", kind),
@@ -587,7 +606,7 @@ func TestSCOPEPrefixedKindsOutsideTheEnumAreStillCounted(t *testing.T) {
 	// zero assertions while reporting SKIP, and its un-prefixed control was
 	// never reached — measured, by putting the VALID kind "Model" in that
 	// control slot and watching the package stay green (#6831).
-	const realPrefixed, inventedPrefixed, unprefixed = "SCOPE.Process", "SCOPE.ZZNotAKind", "Endpoint"
+	const realPrefixed, inventedPrefixed, unprefixed = "SCOPE.Process", "SCOPE.ZZNotAKind", "File"
 	var prefixed []string
 	for _, k := range []string{realPrefixed, inventedPrefixed} {
 		if !types.IsValidEntityKind(k) {
@@ -605,7 +624,8 @@ func TestSCOPEPrefixedKindsOutsideTheEnumAreStillCounted(t *testing.T) {
 	}
 	if types.IsValidEntityKind(unprefixed) {
 		t.Fatalf("fixture is inert: the un-prefixed control %q is expected to be ABSENT FROM THE "+
-			"ENUM but IsValidEntityKind accepts it; re-pick from internal/entkinds' ledger", unprefixed)
+			"ENUM but IsValidEntityKind accepts it; re-pick from internal/types' "+
+			"goUnprefixedKindsDeferred (internal/entkinds' ledger is retired)", unprefixed)
 	}
 	if strings.HasPrefix(unprefixed, "SCOPE.") {
 		t.Fatal("fixture is inert: the control kind must NOT carry the SCOPE. prefix")

--- a/internal/types/all_entity_kinds_roster_6830_test.go
+++ b/internal/types/all_entity_kinds_roster_6830_test.go
@@ -17,7 +17,7 @@ package types_test
 //     invisible to it.
 //
 // MEASURED at the time this guard was added: 93 EntityKind constants declared,
-// 93 elements in AllEntityKinds(), every element an *ast.Ident, zero duplicate
+// 93 elements in AllEntityKinds() (94/94 since #6776 arm B9), every element an *ast.Ident, zero duplicate
 // values, zero conversion literals, zero constants sharing a value, and no
 // EntityKind constant declared outside kinds.go. So this ships as a RATCHET,
 // not a repair — the roster is correct today and nothing observed that it was.

--- a/internal/types/endpoint_bare_kind_6776_test.go
+++ b/internal/types/endpoint_bare_kind_6776_test.go
@@ -1,0 +1,108 @@
+package types_test
+
+// endpoint_bare_kind_6776_test.go — #6776 arm B9, the last arm of the B series.
+//
+// Bare `Endpoint` enters types.AllEntityKinds() as a DISTINCT KIND, not as a
+// synonym of SCOPE.Endpoint. That distinction is the whole content of this
+// arm, so it is asserted rather than described:
+//
+//   - It is a produced kind. internal/engine/rules/javascript_typescript/
+//     frameworks/electron.yaml:41,46,52 declare it (ipcMain / ipcRenderer /
+//     contextBridge) and internal/engine/detector.go writes the declared
+//     string verbatim into EntityRecord.Kind, so it reaches the graph exactly
+//     as spelled. #6776 exists to make produced kinds valid; this is the last
+//     produced kind that was not.
+//   - It is NOT the HTTP concept. #6820 was decided (2026-09-06) by fixing the
+//     ten consumer sites that keyed on the bare spelling, with no rename and no
+//     stored-graph migration: the HTTP panes key on SCOPE.Endpoint, and bare
+//     `Endpoint` keeps its spelling as the Electron IPC kind. Membership in the
+//     entity-kind vocabulary must therefore NOT drag it into the HTTP
+//     vocabulary.
+//
+// Varies: the SPELLING (bare vs SCOPE.-prefixed) and the VOCABULARY the
+// spelling is tested against (entity kinds vs HTTP endpoint kinds).
+// Holds constant: both validators, and the fact that both spellings name a
+// really-produced kind — so nothing but the spelling/vocabulary pair can move
+// an answer.
+//
+// The rejecting half is the direction that can go wrong silently, and it is
+// deliberately duplicated from http_endpoint_kind_forbidden_6894_test.go
+// rather than left to it. That file grades IsHTTPEndpointKind's rejections in
+// general; this one grades the SPECIFIC hazard this arm introduces — that
+// making a kind valid is mistaken for making it an HTTP kind — and names the
+// arm in its failure text, so the reader is sent to the right decision.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// TestEndpointBare6776_IsADistinctValidEntityKind
+func TestEndpointBare6776_IsADistinctValidEntityKind(t *testing.T) {
+	const bare, prefixed = "Endpoint", "SCOPE.Endpoint"
+
+	if got := string(types.EntityKindEndpointBare); got != bare {
+		t.Fatalf("EntityKindEndpointBare = %q, want %q", got, bare)
+	}
+	if got := string(types.EntityKindEndpoint); got != prefixed {
+		t.Fatalf("EntityKindEndpoint = %q, want %q — the pair this arm keeps apart", got, prefixed)
+	}
+	if bare == prefixed {
+		t.Fatal("fixture is inert: the two spellings must differ, or 'distinct member' means nothing")
+	}
+
+	if !types.IsValidEntityKind(bare) {
+		t.Errorf("IsValidEntityKind(%q) = false. electron.yaml:41,46,52 declare it and "+
+			"detector.go writes it verbatim into EntityRecord.Kind, so it reaches the graph as a "+
+			"kind the vocabulary rejects — the exact condition #6776 exists to end.", bare)
+	}
+	if !types.IsValidEntityKind(prefixed) {
+		t.Errorf("IsValidEntityKind(%q) = false; the prefixed HTTP kind must stay valid, or the "+
+			"'two distinct members' claim below is half-vacuous", prefixed)
+	}
+
+	// BOTH must be present as separate roster elements. A "fix" that dropped
+	// one spelling in favour of the other would satisfy IsValidEntityKind for
+	// the survivor and silently orphan every stored graph carrying the other —
+	// the rename #6820 and #6776 both rejected.
+	var sawBare, sawPrefixed int
+	for _, k := range types.AllEntityKinds() {
+		switch string(k) {
+		case bare:
+			sawBare++
+		case prefixed:
+			sawPrefixed++
+		}
+	}
+	if sawBare != 1 || sawPrefixed != 1 {
+		t.Errorf("AllEntityKinds() holds %q %d time(s) and %q %d time(s); want exactly one each — "+
+			"they are two members naming two concepts (Electron IPC channel, HTTP entrypoint), "+
+			"not one member with two spellings", bare, sawBare, prefixed, sawPrefixed)
+	}
+}
+
+// TestEndpointBare6776_MembershipIsNotHTTPMembership is the forbidden
+// direction, which is the invisible one: a test showing bare `Endpoint` is now
+// a valid entity kind cannot see that it also became an HTTP endpoint kind, and
+// that would silently undo #6893's repoint of the ten dashboard/OpenAPI
+// consumer sites.
+func TestEndpointBare6776_MembershipIsNotHTTPMembership(t *testing.T) {
+	const bare = "Endpoint"
+	if !types.IsValidEntityKind(bare) {
+		t.Fatalf("fixture is inert: %q is not a valid entity kind, so this test is not observing "+
+			"the hazard this arm introduces", bare)
+	}
+	// Positive control: the helper must accept something, or the rejection
+	// below is satisfied by a function that returns false for everything.
+	if !types.IsHTTPEndpointKind(string(types.EntityKindHTTPEndpointDefinition)) {
+		t.Fatalf("fixture is inert: IsHTTPEndpointKind rejects %q, so its rejections say nothing",
+			types.EntityKindHTTPEndpointDefinition)
+	}
+	if types.IsHTTPEndpointKind(bare) {
+		t.Errorf("IsHTTPEndpointKind(%q) = true. #6776 arm B9 makes this kind a valid ENTITY "+
+			"kind; it is an Electron IPC channel and never had a URL. #6820's ruling put the "+
+			"HTTP panes on SCOPE.Endpoint precisely so this string stops being read as HTTP — "+
+			"admitting it here re-exports IPC channels into the OpenAPI document.", bare)
+	}
+}

--- a/internal/types/http_endpoint_kind_forbidden_6894_test.go
+++ b/internal/types/http_endpoint_kind_forbidden_6894_test.go
@@ -43,9 +43,13 @@ func TestIsHTTPEndpointKind_ForbiddenRows(t *testing.T) {
 	}
 
 	for _, reject := range []string{
-		// The Electron IPC spelling. It deliberately has no constant — #6776
-		// arm B8 left it off the enum on purpose (#6820).
-		"Endpoint",
+		// The Electron IPC spelling. #6776 arm B9 made it a valid ENTITY kind
+		// (EntityKindEndpointBare) once #6820 was decided, and that is exactly
+		// why this row matters MORE than it did: "it is in the vocabulary now"
+		// is the argument that would fold it into the switch above, and doing
+		// so re-exports IPC channels into the OpenAPI document (#6893). Entity
+		// membership and HTTP membership are different questions.
+		string(EntityKindEndpointBare),
 		string(EntityKindEndpoint),
 		string(EntityKindRouteBare),
 		string(EntityKindRoute),

--- a/internal/types/kind_vocabulary_bump_guard_6779_test.go
+++ b/internal/types/kind_vocabulary_bump_guard_6779_test.go
@@ -102,6 +102,10 @@ var pinnedEntityKindVocabulary = []string{
 	"Controller",
 	"Decorator",
 	"Dependency",
+	// #6776 arm B9 — bare `Endpoint`, the Electron IPC channel kind. ADDED,
+	// not renamed or retired, so KindVocabularyVersion does not move: the bump
+	// rule is about spellings that DISAPPEAR and strand stored graphs.
+	"Endpoint",
 	"Fixture",
 	"Implementation",
 	"Interface",

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -698,17 +698,69 @@ const (
 	// either way: IsValidEntityKind is membership in a string set that never
 	// reads SourceFile. The same point was settled for `Config` in arm B7.
 	//
-	// WHY `Endpoint` IS NOT HERE. It is the one pair on this ledger that is
-	// NOT a synonym. The bare spelling is declared only by
+	// WHY `Endpoint` WAS NOT HERE, and where it went. It is the one pair on
+	// this ledger that is NOT a synonym. The bare spelling is declared only by
 	// javascript_typescript/frameworks/electron.yaml — Electron IPC channels —
-	// while SCOPE.Endpoint names the HTTP concept. Migrating it as a synonym
-	// would put two different concepts under one enum member, which is the one
-	// thing the B5-B8 selection rule has never done. That is #6820 and it
-	// needs an owner ruling, so `Endpoint` stays on internal/entkinds' ledger
-	// and ruleDeclaredKindsDeferredMax lands at 1, not 0.
+	// while SCOPE.Endpoint names the HTTP concept. Arm B8 would have had to
+	// migrate it under the same "same concept, different spelling" heading as
+	// its three, and that heading is false for it, so it was held back at
+	// ruleDeclaredKindsDeferredMax = 1 pending #6820. Arm B9 declares it below
+	// on a DIFFERENT footing, and takes that ledger to zero.
 	EntityKindConstraintBare EntityKind = "Constraint"
 	EntityKindPluginBare     EntityKind = "Plugin"
 	EntityKindTemplateBare   EntityKind = "Template"
+
+	// #6776 arm B9 — the LAST kind on internal/entkinds' rule-YAML ledger, and
+	// the end of the B series. The ledger is retired rather than ratcheted to
+	// zero; internal/entkinds/rule_ledger_retired_6776_test.go carries the
+	// measurement that replaces it (532 rule-YAML sites, zero of them naming a
+	// kind AllEntityKinds() rejects).
+	//
+	// THIS ROW IS NOT A `Bare` SPELLING OF ANYTHING, and that is the one way it
+	// differs from every row in the B6/B7/B8 blocks above. Those all read "the
+	// SPELLING, not a second concept". This one IS a second concept:
+	//
+	//   Endpoint — three sites, all in
+	//              javascript_typescript/frameworks/electron.yaml:41,46,52
+	//              (`ipcMain.handle` / `ipcRenderer.invoke` /
+	//              `contextBridge.exposeInMainWorld`). It is an ELECTRON IPC
+	//              CHANNEL. SCOPE.Endpoint (EntityKindEndpoint above) is the
+	//              HTTP entrypoint. They share seven letters and nothing else:
+	//              an IPC channel never had a URL.
+	//
+	// The `Bare` suffix is kept only because the identifier `EntityKindEndpoint`
+	// is taken; it names the spelling, and the concept note is the paragraph
+	// above rather than the suffix.
+	//
+	// WHY MEMBERSHIP IS STILL THE RIGHT ANSWER FOR A DIFFERENT CONCEPT.
+	// #6776's ruling is that enum membership tracks what producers EMIT, not
+	// what a vocabulary designer would have minted. detector.go writes the
+	// declared string verbatim into EntityRecord.Kind, so these three sites put
+	// `Endpoint` in every Electron graph whether or not this list carries it;
+	// the only question membership answers is whether IsValidEntityKind then
+	// rejects an entity grafel itself produced. A distinct concept is a reason
+	// for a distinct MEMBER — which is what this is — not a reason to keep a
+	// produced kind outside the vocabulary.
+	//
+	// WHY IT IS SAFE NOW AND WAS NOT AT ARM B8. #6820 was decided on
+	// 2026-09-06: fix the ten consumer sites, no rename, no stored-graph
+	// migration. `9706a5cde` repointed the HTTP and OpenAPI panes at
+	// SCOPE.Endpoint (and `fa05d3e2c` did the `Route` twin), so no consumer
+	// reads the bare spelling as HTTP any more. The hazard arm B8 named — a
+	// misleading vocabulary name, with IPC channels reachable through
+	// HTTP-shaped consumers — is closed at the consumers rather than by
+	// withholding membership.
+	//
+	// MEMBERSHIP IS NOT HTTP MEMBERSHIP. IsHTTPEndpointKind must keep
+	// REJECTING this string; http_endpoint_kind_forbidden_6894_test.go pins
+	// that, and endpoint_bare_kind_6776_test.go pins it again in this arm's own
+	// name, because "it is a valid kind now" is exactly the reasoning that
+	// would fold it into the HTTP switch and re-export IPC channels into the
+	// OpenAPI document.
+	//
+	// Spelling unchanged — nothing is renamed or retired — so
+	// KindVocabularyVersion does not move.
+	EntityKindEndpointBare EntityKind = "Endpoint"
 )
 
 // AllEntityKinds returns every EntityKind that grafel extractors are
@@ -858,10 +910,13 @@ func AllEntityKinds() []EntityKind {
 		EntityKindServiceBare,
 		// #6776 arm B8: three of the four kinds left on the ledger — see the
 		// const block for the concept note behind each pair, and for why
-		// Endpoint is deliberately not among them (#6820).
+		// Endpoint was not among them (#6820).
 		EntityKindConstraintBare,
 		EntityKindPluginBare,
 		EntityKindTemplateBare,
+		// #6776 arm B9: the last one, and NOT a spelling pair — the Electron
+		// IPC channel kind, distinct from SCOPE.Endpoint. See the const block.
+		EntityKindEndpointBare,
 	}
 }
 

--- a/internal/types/prefixed_producer_enum_membership_6776_test.go
+++ b/internal/types/prefixed_producer_enum_membership_6776_test.go
@@ -162,17 +162,21 @@ func TestEntityKindEnum6776_B4_PromotedKindsAreValid(t *testing.T) {
 //
 // Varies: the shape of the non-member. Holds constant: the validator.
 //
-//	Endpoint               the ONE un-prefixed rule-declared kind left on
-//	                       internal/entkinds' ledger after arm B8. It is not
-//	                       leftover work: bare `Endpoint` is Electron IPC
-//	                       (electron.yaml) while SCOPE.Endpoint is the HTTP
-//	                       concept, so it is the one pair on that ledger that
-//	                       is not a synonym, and #6820 owns the ruling.
 //	File                   the commit-coupling synthetic, deliberately NOT
 //	                       promoted (894 entities of an internal artefact) —
-//	                       and, since arm B8, also the second kind
-//	                       internal/graph/fbwriter's arm-A fixture asserts is
+//	                       and, since arm B8, also one of the kinds
+//	                       internal/graph/fbwriter's arm-A fixtures assert is
 //	                       still invalid
+//
+// THE RULE-DECLARED AXIS IS GONE FROM THIS TABLE, and its absence is a fact
+// about the tree rather than a gap. It held `Endpoint`, the last row on
+// internal/entkinds' ledger; #6776 arm B9 declared it, and there is now NO
+// rule-declared kind outside the enum for this table to name — that is asserted
+// directly, over a live scan, by internal/entkinds'
+// TestRuleDeclaredLedger6776_IsRetiredBecauseThePopulationIsEmpty. Re-adding a
+// row here would mean inventing a string no producer writes, which is what the
+// SCOPE.Workflows row already covers.
+//
 //	ChannelEvent           a Go producer's UN-prefixed kind: B4 promoted the
 //	                       prefixed ledger only, not goUnprefixedKindsDeferred
 //	Workflow               the prefix-stripped spelling of a promoted kind — a
@@ -182,11 +186,10 @@ func TestEntityKindEnum6776_B4_PromotedKindsAreValid(t *testing.T) {
 //	SCOPE.ExternalAPI      retired by #6451; re-admitting it would undo that
 func TestEntityKindEnum6776_B4_KindsOutsideTheEnumStayOutside(t *testing.T) {
 	for axis, kind := range map[string]string{
-		"rule-declared, the one pair #6820 holds back (fbwriter's arm-A fixture depends on it)": "Endpoint",
-		"the commit-coupling synthetic, deliberately not promoted (fbwriter's second control)":  "File",
-		"a Go producer's un-prefixed kind, on the other B3 ledger":                              "ChannelEvent",
-		"the prefix-stripped spelling of a kind B4 DID promote":                                 "Workflow",
-		"a near-miss spelling that no producer writes":                                          "SCOPE.Workflows",
+		"the commit-coupling synthetic, deliberately not promoted (an fbwriter control)": "File",
+		"a Go producer's un-prefixed kind, on the other B3 ledger":                       "ChannelEvent",
+		"the prefix-stripped spelling of a kind B4 DID promote":                          "Workflow",
+		"a near-miss spelling that no producer writes":                                   "SCOPE.Workflows",
 		"retired by #6451": "SCOPE.ExternalAPI",
 	} {
 		if types.IsValidEntityKind(kind) {

--- a/internal/types/producer_entity_kinds_6776_test.go
+++ b/internal/types/producer_entity_kinds_6776_test.go
@@ -997,12 +997,12 @@ func TestEntityKindDeclarations6776_MatchAllEntityKindsExactly(t *testing.T) {
 			len(notNamedConstants), strings.Join(notNamedConstants, "\n    "))
 	}
 
-	if len(declared) != 93 {
-		t.Errorf("EntityKind-typed constants = %d, want 93; re-pin this number and the "+
+	if len(declared) != 94 {
+		t.Errorf("EntityKind-typed constants = %d, want 94; re-pin this number and the "+
 			"comment in AllEntityKinds beside EntityKindEventType", len(declared))
 	}
-	if namedEntityKind != 92 {
-		t.Errorf("constants NAMED EntityKind* = %d, want 92 (the one EntityKind-typed "+
+	if namedEntityKind != 93 {
+		t.Errorf("constants NAMED EntityKind* = %d, want 93 (the one EntityKind-typed "+
 			"constant not so named is HTTPEndpointKindLegacy)", namedEntityKind)
 	}
 	for name := range declared {


### PR DESCRIPTION
## What this does

`Endpoint` — the last entry on #6744's rule-YAML ledger — enters `types.AllEntityKinds()` as `EntityKindEndpointBare`, and that ledger is **retired**, not ratcheted to zero. This closes #6776's B series: `ruleDeclaredKindsDeferredMax` goes **1 → 0**, and every kind `internal/engine/rules/**/*.yaml` declares is now a kind `IsValidEntityKind` accepts.

Refs #6776. Refs #6820.

## The disposition, and why it is not a synonym migration

Every pair migrated in arms B5–B8 was a *same-concept, different-spelling* pair, and each `Bare` constant's doc says so. **This one is not**, and the change does not pretend otherwise.

Bare `Endpoint` is an **Electron IPC channel** — three sites, all in `internal/engine/rules/javascript_typescript/frameworks/electron.yaml:41,46,52` (`ipcMain.handle` / `ipcRenderer.invoke` / `contextBridge.exposeInMainWorld`). `SCOPE.Endpoint` is the HTTP entrypoint. They share seven letters and nothing else; an IPC channel never had a URL.

So the argument for membership is **not** "it is the same thing as SCOPE.Endpoint". It is #6776's own ruling, which is about producers rather than about vocabulary design:

- `internal/engine/detector.go` writes `SourcePattern.EntityType` **verbatim** into `EntityRecord.Kind`. Those three sites put the string `Endpoint` into every Electron graph whether or not the enum carries it.
- The only question membership answers is whether `IsValidEntityKind` then rejects an entity grafel itself produced. #6776 exists to make that answer "no".
- A distinct concept is a reason for a **distinct member** — which is what this is, alongside `SCOPE.Endpoint`, both spellings kept — not a reason to keep a produced kind outside the vocabulary. No rename, no stored-graph migration, consistent with the standing ruling on both issues.

**The naming debt this incurs, stated rather than denied.** With both spellings in the enum meaning *different* concepts, the `SCOPE.` prefix becomes semantically **load-bearing** for this one pair — which contradicts the framing arms B4–B8 ran on, and which the retired ledger family note still states: the un-prefixed spelling is *"an accident, not a namespace"*. Every earlier arm could say that honestly because both spellings meant the same thing; this one cannot. It is a documented naming debt rather than a namespace admitted by the back door, because the honest alternative for a distinct concept is a distinct **name** (`IPCChannel`) — and the owner priced that and **declined** it in #6820 on 2026-09-06: *"No rename, no stored-graph migration… enum membership is the target, not re-spelling kinds."* With the rename off the table the only two options are *member* or *permanently-invalid produced kind*, and the second is what #6776 exists to end. Recorded here so the older "prefix is an accident" comments do not mislead the next reader; a follow-up issue tracks it.

**Why it is safe now and was not at arm B8.** #6820 was decided on 2026-09-06 and shipped (`9706a5cde`, plus `fa05d3e2c` for the `Route` twin): the ten consumer sites were repointed at `SCOPE.Endpoint`, so no consumer reads the bare spelling as HTTP. The hazard B8 named — a misleading vocabulary name with IPC channels reachable through HTTP-shaped consumers — is closed at the consumers. B8's own words were that reaching zero "was never a goal" and one honestly-justified entry is a legitimate end state; the justification is what expired, not the arm's judgement.

**`internal/types/http_endpoint_kind_forbidden_6894_test.go` is untouched in its assertions.** Only its comment beside the `Endpoint` row changed, and it changed to say the row matters *more* now: "it is in the vocabulary" is precisely the argument that would fold the kind into `IsHTTPEndpointKind` and re-export IPC channels into the OpenAPI document. That row is now written as `string(EntityKindEndpointBare)` so the constant and the prohibition are visibly the same string.

## Retiring the ledger, rather than ratcheting it to zero

Three guards treat an empty ledger as evidence of a broken scan, and they were right to while the ledger was the only evidence. The retirement replaces that premise with a **stronger, positive one** instead of deleting it.

New: `internal/entkinds/rule_ledger_retired_6776_test.go`.

- `TestRuleDeclaredLedger6776_IsRetiredBecauseThePopulationIsEmpty` — scans the rule tree with `ScanRuleYAML` and asserts **zero** of its sites names a kind outside the enum, over a **floor** (`minRuleYAMLSites = 300`) that catches a collapsed scan, plus `Unresolved() == 0`. It carries a **positive control on the predicate itself** (`IsValidEntityKind` must still reject an invented kind), and it pins `EntityKindEndpointBare`'s three `electron.yaml` sites **line-exactly**. Then it asserts the ledger, the ratchet and the family map are all empty. Emptiness stops being an assumption and becomes a measurement with its own guard.

**What that measurement is stronger and weaker than — corrected.** An earlier revision of this body said "strictly stronger than any ledger row". **"Strictly" was wrong**, and review mutant R11 is what showed it:

- **Stronger** in the direction the ledger was built for: any kind outside the enum, anywhere in the rule tree, fails here with a line-exact diagnosis and no row available to absorb it.
- **Weaker**, on its own, in the direction the ledger held *incidentally*: a row named a kind, so the sweep noticed when that kind's sites disappeared. "Is this set empty" cannot notice that a **member's producers vanished**. Re-spelling electron.yaml's three `entity_type: Endpoint` rows to `SCOPE.Endpoint` — the silent rename #6820 rejected — left all six packages **green** on the first revision of this branch, and fails **three** tests on the parent `37f39ca57`.

The site pin is the repair, and it restores the coupling deliberately rather than incidentally: it is asserted as an exact `file:line` set, not a count, because a count alone would accept the three sites moving to a file that has nothing to do with Electron IPC — the concept the member is named for.
- `TestRuleDeclaredLedger6776_EveryFamilyIsUsedByARow` — the reverse coupling that `TestYAMLHalfObservesDeclaredKinds`'s `perFamily` loop can no longer provide (its body is now unreachable). An entry needs a family (checked there); a family needs an entry (checked here).
- `enum_member_corresponds_6818_test.go:447`'s `t.Fatal` on an empty ledger becomes a `t.Logf`, with the replacement named in the comment. Its row loop still grades a ledger that comes back — proven by mutant M4.
- The `perFamily` loop is **kept, not deleted**, with its unreachability stated: it fires again the moment a family is reintroduced with no live YAML site behind it (proven by mutant M8).
- **A FOURTH guard went vacuous, and it is named here rather than left to be tripped over:** `TestLedgerIsDescribedByItsOwnScan` (`rule_declared_kinds_sweep_guard_6744_test.go`) loops over the now-empty ledger, so it is a green over zero entries. It is **kept without a floor**, because the only floor available — "the ledger is non-empty" — is exactly the assertion this arm falsifies. What it actually observed, *"a kind this file names resolves to a located site"*, is not lost: it moved into the new test's line-exact `electron.yaml` pin, made about the one kind that still needs it (the member admitted on the strength of those sites) instead of about a ledger row that no longer exists. The test now carries that paragraph in its own doc comment. It remains as the drift guard that fires again the moment a row comes back.

That is **four** guards the retirement relaxed, not three. The whole risk of this arm is anti-vacuity guards being relaxed by the change they exist to catch, so the list is exhaustive on purpose: `:447`'s empty-ledger fatal, the `perFamily` traffic loop, fbwriter's ledger transcription, and `TestLedgerIsDescribedByItsOwnScan`.

## Evidence — `ScanRuleYAML`, never grep

Re-derived from disk on this branch, not from the brief:

```
yaml files=732  sites=532  unresolved=0
INVALID KINDS: 1
  Endpoint: 3
     internal/engine/rules/javascript_typescript/frameworks/electron.yaml:41
     internal/engine/rules/javascript_typescript/frameworks/electron.yaml:46
     internal/engine/rules/javascript_typescript/frameworks/electron.yaml:52
```

(The brief said 714 YAML files; the live scan says **732**. Sites and the invalid set match.) `ScanGo` reports **0** Go sites for `Endpoint` — see the Go ratchet below.

## Counters, each re-derived from disk

| counter | before | after | why |
|---|---|---|---|
| `ruleDeclaredKindsDeferredMax` | 1 | **0** | retired; the row is now an enum member |
| `ruleDeclaredKindsDeferred` | 1 row | **0 rows** | ditto |
| `ruleDeclaredFamily` | 1 family | **0** | a family with no row is a slot inviting a decision-free row |
| EntityKind constants pin | 93 | **94** | one constant added |
| constants named `EntityKind*` | 92 | **93** | ditto |
| `pinnedEntityKindVocabulary` | — | `+"Endpoint"` | added, not renamed or retired |
| `KindVocabularyVersion` | 1 | **1** | its guard bumps only when `len(removed) > 0`; this removes nothing |
| `goUnprefixedKindsDeferredMax` | 5 | **5** | `Endpoint` is not on the Go ledger — **graded by mutant M7**, not assumed |
| `enumOnlyEntityKindsMax` | 1 | **1** | `Endpoint` has three rule-YAML sites, so it is corroborated; no allow-list row |

`assertLedgerExact` derives its population from the site scanners and is coupled to `IsValidEntityKind` by construction — M7 is exactly that coupling firing.

## The four (actually five) re-picked fbwriter controls

B8's guard messages said to re-pick from `internal/entkinds`' ledger. **That advice expires with this change** — the ledger is now empty and cannot be drawn from. Every replacement comes from `internal/types`' `goUnprefixedKindsDeferred`, the Go half of the same accident, which survives precisely because it is *not* rule-declared and nothing proposes to move it. The guard messages have been rewritten to say so.

| fixture | slot | new control | provenance |
|---|---|---|---|
| `TestStreamingWriterTalliesOnlyEntityKindsAbsentFromTheEnum` (:101) | 2 controls | `ChannelEvent` + `File` | `engine/websocket_edges.go`, `engine/commit_coupling_edges.go` |
| `TestWriteGraphGenReportWiresTheFlatEntityProducerPath` (:265) | **sole** | `Stream` | `engine/sse_edges.go` |
| `TestEntityKindsAreCountedNotDropped` (:364) | 2 controls | `Subscription` + `File` | `engine/graphql_subscriptions.go` |
| `TestEntitySummaryIsSeparableFromTheRelationshipSummary` (:463) | **sole** | `ChannelEvent` | as above |
| `TestSCOPEPrefixedKindsOutsideTheEnumAreStillCounted` (:590) | **sole** un-prefixed | `File` | as above |

**That is FIVE fixtures, not four.** B8's estimate named four (two the header enumerated plus `:267` and `:607`). `TestEntitySummaryIsSeparableFromTheRelationshipSummary` is a fifth: it carries no explicit validity guard, but its `fixture is inert` check on a non-empty `EntitySummary()` fires the moment its control goes valid — confirmed by mutant M6b, which is exactly the failure mode. Also updated for coherence, though neither is validity-gated: the nil-tally `observeEntity` call (:212) and the `ApplyToSidecar` report literals (:416/:435).

`ruleDeclaredKinds6776` — the ledger transcription — and `TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath` are replaced rather than deleted. Its own floor said "if the ledger really has reached zero, delete this test and say so". Deleting outright would have thrown away the **property** along with the population, and the property is what arm A's measurement rests on: a kind invisible to the write path reports a zero meaning "not measurable" rather than "not produced". So the population is re-aimed at `nonEnumProducerKinds6776` (the four producer rows of `goUnprefixedKindsDeferred`; `relationship` is excluded because its own ledger comment calls it unreachable) and the mechanism — floor, exact pin, per-kind assertion — is kept intact as `TestEveryNonEnumProducerKindIsCountedByTheWritePath`.

## Fixture axes — varied vs held constant

- **`endpoint_bare_kind_6776_test.go`** — *varies*: the spelling (bare vs `SCOPE.`-prefixed) and the vocabulary it is tested against (entity kinds vs HTTP endpoint kinds). *Holds constant*: both validators, and that both spellings name a really-produced kind. Positive control on `IsHTTPEndpointKind` so its rejections are not satisfied by a function that returns false for everything.
- **`rule_ledger_retired_6776_test.go`** — *varies*: nothing; it is a population floor plus an emptiness pin. *Holds constant*: the live scan of the shipped rule tree.
- **Re-picked fbwriter fixtures** — each keeps its original varied axis (kind membership / producer path / prefix) and holds its neighbour constant; the swap changes only the identity of the non-enum control, never what the fixture varies. The two-slot fixtures keep their existing "the two slots must differ" guard.

## Mutant table

Every edit's match count was asserted **after** application (an edit that silently fails to apply reads as ALIVE and argues the opposite). All scored at the call site with `-count=1`, restored by `cp` from shasum-verified backups.

| # | mutant | verdict | killed by |
|---|---|---|---|
| M1 | drop `EntityKindEndpointBare` from the `AllEntityKinds()` roster (keep the const) | **DEAD** | 6 tests / 2 pkgs: roster-exactly-once, declarations-match, both new `EndpointBare` tests, `TestNoUndeclaredRuleEntityKinds`, the new retired-ledger test |
| M2 | `EntityKindEndpointBare = "SCOPE.Endpoint"` (migrate it *as a synonym* — the thing this arm must not do) | **DEAD** | vocabulary pin, roster duplicate-value guard, both `EndpointBare` tests, both entkinds population tests |
| M3 | add `case string(EntityKindEndpointBare)` to `IsHTTPEndpointKind` | **DEAD** | `TestIsHTTPEndpointKind_ForbiddenRows`, the new `MembershipIsNotHTTPMembership`, and **four #6820 dashboard tests** (`TestPathsPanes_ExcludeElectronIPCChannels`, `TestSearchPaths_…`, `TestPathDetail_…`, `TestGroupTopFrameworks_…`) |
| M4 | reinstate the ledger row + ratchet + family, keeping the enum change (undo only the retirement) | **DEAD** | `TestEnumEntityKinds6818_NoDeferredLedgerOverlapsTheEnum` (its row loop still grades), `TestNoUndeclaredRuleEntityKinds` (stale-entry half), the new retired-ledger test |
| M5 | *positive control*: point the new test's scan at `t.TempDir()` | **FLOOR FIRES** with the right diagnosis — "produced only 0 site(s) from 0 file(s) (floor: 300)". It does **not** pass on "zero invalid kinds", which is the failure this floor exists to prevent |
| M6 | swap all four validity-gated re-picked controls to the valid `Model` | **DEAD** | all 5 fixtures' `fixture is inert` guards, each naming the stale control |
| M6b | swap `:463`'s control to `Model` (the fixture with no explicit validity guard) | **DEAD** | its `fixture is inert: Summary()=… EntitySummary()=""` check — this is what makes it the fifth fixture |
| M7 | put `Endpoint` on `goUnprefixedKindsDeferred` with the pin raised to 6 | **DEAD** | `TestProducerEntityKinds6776_UnprefixedLedgerIsExact`: *"ledgered kind \"Endpoint\" is no longer declared by any Go producer"* — this is the grading of the "the Go ratchet does not move" claim |
| M8 | add a family to `ruleDeclaredFamily` with no ledger row | **DEAD** | `TestYAMLHalfObservesDeclaredKinds` (the loop kept for exactly this), the retired-ledger test, and the new `EveryFamilyIsUsedByARow` |

### Review round — R10 / R11, and one correction to the review's own reasoning

| # | mutant | verdict |
|---|---|---|
| R11 | re-spell electron.yaml's three `entity_type: Endpoint` rows to `SCOPE.Endpoint` (match count asserted = 3) | was **SURVIVOR**, now **DEAD** — the new line-exact site pin: `got [] want [electron.yaml:41 :46 :52]` |
| R10 | `IsValidEntityKind` returns true for any non-empty string | was **partial** (`internal/entkinds` green), now **DEAD** in `internal/entkinds` too: *"fixture is inert: IsValidEntityKind(\"SCOPE.ZZNotAKindAnyProducerWrites\") is true, so it accepts everything"* |
| R10b | *control on the repair*: apply the R10 mutant with the site pin present but the predicate control removed | **`internal/entkinds` GREEN, exit 0** |

**R10b is a correction to the review.** The review states the site block *"also closes a second gap… one fix for two findings"*. **It does not.** A site-level positive fact is satisfied whether the validator is honest or constant-true — the sites exist either way — so with the pin in place and the one-line control removed, the always-true validator sails through this package. The two findings needed two edits, and the reviewer's own cheaper alternative (the explicit `fixture is inert` line) is the load-bearing half of the R10 fix, not the fallback. Both are in.

No survivors, so there is no equivalent/unreachable verdict to defend.

Two observations worth recording rather than leaving to be rediscovered:

- Under **M1**, `./internal/graph/fbwriter` stays **green**. That is the re-pick working as intended: after this change no fbwriter fixture depends on `Endpoint`'s enum status in either direction.
- **M6b** is the one B8's cost estimate missed, and it is the cheap direction to get wrong: a fixture whose inertness is detected through an empty summary rather than a named `IsValidEntityKind` call.

## Verification

Run, all `-count=1`, all green:

- `go test -count=1` on `./internal/entkinds/`, `./internal/types/`, `./internal/graph/fbwriter/`, `./internal/engine/`, `./internal/dashboard/`, **`./cmd/grafel/`**.
- `./cmd/grafel/` is the mandatory leg for any kind change (`custom_extractor_spans_6118_test.go` digest-pins the whole graph and nothing in the package tree points at it). **The digest did not move**, and that is the expected result rather than a lucky one: the digest hashes `Kind|Name|QualifiedName|Subtype|SourceFile|StartLine|EndLine`, and enum membership changes no entity's `Kind` string — `detector.go` was already writing `Endpoint` verbatim. No constant was bumped.
- **`scripts/quality/run.sh --ratchet`** — `quality ratchet OK — 31 gated fixtures held their baseline (22 at 100% must-have recall)`, exit 0.
- `gofmt -l internal/` clean; `go vet` clean on all touched packages.
- Review round: `go test -count=1` re-run on `./internal/entkinds/`, `./internal/types/`, `./internal/graph/fbwriter/` and `./cmd/grafel/` after the fix.

## What I did NOT run

- **No full corpus index**, so **no `entity_entities_kind_not_in_enum` figure is quoted.** B6 and B7 quoted one; B8 did not, and neither does this. The expected drop is the Electron IPC population, and #6893 measured that at **0 across the corpus** (no indexed group contains `ipcMain`/`ipcRenderer`/`contextBridge`) — but that is a corpus-relative zero and an *inference* about this arm, not a measurement of it. It should be measured before anyone repeats it as a number.
- No full-repo `go test ./...`. Package selection is not suite selection, and the set above is chosen, not derived from the diff: `./cmd/grafel/` and `./internal/dashboard/` are in it precisely because no diff-derived set would reach them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
