### PR TITLE
feat(#6918): `group add --track-worktrees` — worktree tracking without the watcher-unit install, for containers with no service manager

### DIFF
--- a/internal/cli/group.go
+++ b/internal/cli/group.go
@@ -37,6 +37,7 @@ func newGroupAddCmd() *cobra.Command {
 		reposCSV  string
 		groupDocs string
 		watchers  bool
+		trackWT   bool
 		gitHooks  bool
 		rules     bool
 		mcp       bool
@@ -73,22 +74,25 @@ new group immediately via the 'group' MCP parameter.
 
 Examples:
   grafel group add new-backend --repo core=/abs/path/to/repo --index
-  grafel group add legacy --repo /abs/api --repo /abs/web --no-watchers --json`,
+  grafel group add legacy --repo /abs/api --repo /abs/web --no-watchers --json
+  # container / no service manager: worktree tracking, no OS watcher units
+  grafel group add app --repo /abs/app --track-worktrees --json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gaFlags := groupAddFlags{
-				repoArgs:  repoArgs,
-				reposCSV:  reposCSV,
-				groupDocs: groupDocs,
-				watchers:  watchers,
-				gitHooks:  gitHooks,
-				rules:     rules,
-				mcp:       mcp,
-				runInst:   runInst,
-				doIndex:   doIndex,
-				jsonOut:   jsonOut,
-				tools:     toolsCSV,
-				projGuide: projGuide,
+				repoArgs:       repoArgs,
+				reposCSV:       reposCSV,
+				groupDocs:      groupDocs,
+				watchers:       watchers,
+				trackWorktrees: trackWT,
+				gitHooks:       gitHooks,
+				rules:          rules,
+				mcp:            mcp,
+				runInst:        runInst,
+				doIndex:        doIndex,
+				jsonOut:        jsonOut,
+				tools:          toolsCSV,
+				projGuide:      projGuide,
 			}
 			return runGroupAddImpl(cmd, args[0], gaFlags, "")
 		},
@@ -102,6 +106,8 @@ Examples:
 		"optional path to shared group docs")
 	cmd.Flags().BoolVar(&watchers, "watchers", false,
 		"install OS watcher units for each repo")
+	cmd.Flags().BoolVar(&trackWT, "track-worktrees", false,
+		"enable per-worktree tracking (features.track_worktrees): the daemon discovers this group's linked git worktrees and registers them as ephemeral children. Independent of --watchers — it installs NO OS watcher units and shells out to no service manager, so it is usable in containers and on hosts with no systemd/launchd")
 	cmd.Flags().BoolVar(&gitHooks, "git-hooks", true,
 		"install git hooks (post-merge/checkout reindex)")
 	cmd.Flags().BoolVar(&rules, "rules", true,
@@ -122,19 +128,30 @@ Examples:
 }
 
 type groupAddFlags struct {
-	repoArgs  []string
-	reposCSV  string
-	groupDocs string
-	watchers  bool
-	gitHooks  bool
-	rules     bool
-	mcp       bool
-	runInst   bool
-	doIndex   bool
-	jsonOut   bool
-	tools     string // --tools CSV → GroupConfig.Tools (#5701)
-	projGuide bool
+	repoArgs       []string
+	reposCSV       string
+	groupDocs      string
+	watchers       bool
+	gitHooks       bool
+	rules          bool
+	mcp            bool
+	runInst        bool
+	doIndex        bool
+	jsonOut        bool
+	trackWorktrees bool   // --track-worktrees → Features.TrackWorktrees (#6918)
+	tools          string // --tools CSV → GroupConfig.Tools (#5701)
+	projGuide      bool
 }
+
+// applyGroupConfigFn indirects applyGroupConfig at the `group add` call site.
+//
+// It is a test seam and nothing else: `group add`'s job is to turn flags into a
+// GroupConfig plus a groupApplyOptions, and the second half of that — which
+// side effects the install transaction is authorised to perform — is otherwise
+// unobservable without performing them. install.Apply gates its watcher branch
+// on `!SkipWatchers && Features.Watchers`, so an option wired wrongly can look
+// identical on disk to one wired correctly (#6918).
+var applyGroupConfigFn = applyGroupConfig
 
 type groupAddRepo struct {
 	Slug string `json:"slug"`
@@ -180,6 +197,14 @@ func runGroupAddImpl(cmd *cobra.Command, group string, f groupAddFlags, socketPa
 
 	cfg := &registry.GroupConfig{Name: group, GroupDocs: f.groupDocs}
 	cfg.Features.Watchers = f.watchers
+	// #6918: an INDEPENDENT capability from Watchers, deliberately not folded
+	// into SkipWatchers below. The daemon opts a group into worktree discovery
+	// when TrackWorktrees || Watchers, so before this flag existed the only CLI
+	// route to worktree tracking was --watchers — which also runs the OS
+	// watcher-unit install, inapplicable inside a container whose PID 1 is
+	// docker-init and which has no systemctl. Setting this flag must leave the
+	// install transaction's watcher branch exactly as --watchers alone decides.
+	cfg.Features.TrackWorktrees = f.trackWorktrees
 	cfg.Features.GitHooks = f.gitHooks
 	// Per-tool selection (#5701): an explicit --tools value wins and is validated
 	// before any registration. When omitted, cfg.Tools is left empty so
@@ -205,7 +230,7 @@ func runGroupAddImpl(cmd *cobra.Command, group string, f groupAddFlags, socketPa
 	if f.jsonOut {
 		applyOut = io.Discard
 	}
-	res, err := applyGroupConfig(applyOut, cfg, groupApplyOptions{
+	res, err := applyGroupConfigFn(applyOut, cfg, groupApplyOptions{
 		RunInstall:      f.runInst,
 		SkipHooks:       !f.gitHooks,
 		SkipWatchers:    !f.watchers,

--- a/internal/cli/group_track_worktrees_6918_test.go
+++ b/internal/cli/group_track_worktrees_6918_test.go
@@ -1,0 +1,247 @@
+package cli
+
+// group_track_worktrees_6918_test.go — `--track-worktrees` enables per-worktree
+// tracking WITHOUT the OS watcher-unit install transaction.
+//
+// The consumer this exists for runs grafel in minimal Docker containers: PID 1
+// is `docker-init`, there is no systemd and no `systemctl` on PATH. The
+// in-process fsnotify path behind `features.track_worktrees` works fine there;
+// the watcher-unit install does not. Before #6918 the only CLI route to
+// `track_worktrees` was `--watchers` (the daemon opts a group in when
+// `TrackWorktrees || Watchers`, cmd/grafel/daemon.go), which drags the whole
+// unit-install transaction along with it.
+//
+// ── Why this asserts SkipWatchers and not just the unit file ────────────────
+//
+// install.Apply gates its watcher branch on `!opts.SkipWatchers &&
+// opts.Config.Features.Watchers` (internal/install/install.go:303) — BOTH.
+// So the regression this file exists to prevent, wiring --track-worktrees into
+// SkipWatchers (`SkipWatchers: !(f.watchers || f.trackWorktrees)`), writes no
+// unit file either, because Features.Watchers is still false. A test that only
+// looked at the emitted artefact would score that mutant ALIVE while it sat one
+// unrelated edit away from re-introducing the container problem. The option
+// handed to the transaction is therefore asserted directly, through the
+// applyGroupConfigFn seam, AND the artefact is asserted alongside it.
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// captureGroupApplyOptions swaps the applyGroupConfigFn seam for one that
+// records the options `group add` derives from its flags and then delegates to
+// the real implementation, so the install transaction still runs for real.
+func captureGroupApplyOptions(t *testing.T, got *groupApplyOptions) {
+	t.Helper()
+	prev := applyGroupConfigFn
+	applyGroupConfigFn = func(out io.Writer, cfg *registry.GroupConfig, ga groupApplyOptions) (*install.Result, error) {
+		*got = ga
+		return prev(out, cfg, ga)
+	}
+	t.Cleanup(func() { applyGroupConfigFn = prev })
+}
+
+// TestGroupAdd_TrackWorktreesIsIndependentOfWatchers is the four-cell table
+// over the two flags. The `--track-worktrees` row is the load-bearing one.
+func TestGroupAdd_TrackWorktreesIsIndependentOfWatchers(t *testing.T) {
+	cases := []struct {
+		name string
+		// inputs
+		watchers       bool
+		trackWorktrees bool
+		// expected persisted features
+		wantWatchers       bool
+		wantTrackWorktrees bool
+		// expected install-transaction option
+		wantSkipWatchers bool
+		// expected artefact: a watcher unit file on disk
+		wantUnitFile bool
+	}{
+		{
+			name:               "track-worktrees alone installs no watcher units",
+			trackWorktrees:     true,
+			wantTrackWorktrees: true,
+			wantWatchers:       false,
+			wantSkipWatchers:   true,
+			wantUnitFile:       false,
+		},
+		{
+			name:               "watchers alone is unchanged",
+			watchers:           true,
+			wantWatchers:       true,
+			wantTrackWorktrees: false,
+			wantSkipWatchers:   false,
+			wantUnitFile:       true,
+		},
+		{
+			name:               "both compose",
+			watchers:           true,
+			trackWorktrees:     true,
+			wantWatchers:       true,
+			wantTrackWorktrees: true,
+			wantSkipWatchers:   false,
+			wantUnitFile:       true,
+		},
+		{
+			name:               "neither",
+			wantWatchers:       false,
+			wantTrackWorktrees: false,
+			wantSkipWatchers:   true,
+			wantUnitFile:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The --watchers rows reach install.Apply's loader activation, a
+			// MUTATING service-manager verb. Those are stubbed so no test can
+			// drive the developer's real launchd/systemd (see
+			// internal/install/watchers/test_isolation_guard.go); the unit-file
+			// write they assert on stays entirely real.
+			//
+			// The rows WITHOUT --watchers are deliberately left unstubbed. The
+			// claim being made is "--track-worktrees shells out to no service
+			// manager", and the guard is what enforces it: any mutating verb
+			// reaching a real exec under `go test` PANICS. Stubbing those rows
+			// would replace that proof with a no-op and leave the claim
+			// untested.
+			if tc.watchers {
+				defer watchers.StubServiceCallsForTest()()
+			}
+
+			home := withSandboxHome(t)
+			repo := filepath.Join(home, "repos", "alpha")
+			makeRepo(t, repo)
+
+			var opts groupApplyOptions
+			captureGroupApplyOptions(t, &opts)
+
+			cmd := &cobra.Command{}
+			out := &bytes.Buffer{}
+			cmd.SetOut(out)
+			err := runGroupAddImpl(cmd, "demo", groupAddFlags{
+				repoArgs:       []string{repo},
+				watchers:       tc.watchers,
+				trackWorktrees: tc.trackWorktrees,
+				gitHooks:       false,
+				rules:          false,
+				mcp:            false,
+				runInst:        true,
+				doIndex:        false,
+				jsonOut:        true,
+			}, "")
+			if err != nil {
+				t.Fatalf("group add: %v\n%s", err, out.String())
+			}
+
+			// The persisted group config, read back from disk rather than from
+			// the in-memory struct the command happened to build.
+			path, err := registry.ConfigPathFor("demo")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := registry.LoadGroupConfig(path)
+			if err != nil {
+				t.Fatalf("LoadGroupConfig: %v", err)
+			}
+			if cfg.Features.TrackWorktrees != tc.wantTrackWorktrees {
+				t.Errorf("features.track_worktrees = %v, want %v",
+					cfg.Features.TrackWorktrees, tc.wantTrackWorktrees)
+			}
+			if cfg.Features.Watchers != tc.wantWatchers {
+				t.Errorf("features.watchers = %v, want %v",
+					cfg.Features.Watchers, tc.wantWatchers)
+			}
+
+			// The install transaction's watcher branch, as handed to it.
+			if opts.SkipWatchers != tc.wantSkipWatchers {
+				t.Errorf("install options SkipWatchers = %v, want %v "+
+					"(--track-worktrees must never move this)",
+					opts.SkipWatchers, tc.wantSkipWatchers)
+			}
+
+			// And the artefact that option decides.
+			unit := unitPathForRepo(t, "demo", repo)
+			_, statErr := os.Stat(unit)
+			gotUnitFile := statErr == nil
+			if gotUnitFile != tc.wantUnitFile {
+				t.Errorf("watcher unit file present = %v (%s), want %v",
+					gotUnitFile, unit, tc.wantUnitFile)
+			}
+		})
+	}
+}
+
+// TestGroupAddCmd_TrackWorktreesFlagDefaultsOff pins the flag's registration
+// and its default. The default is load-bearing: track_worktrees is documented
+// "opt-in to preserve existing behaviour" (internal/registry/registry.go), and
+// a default of true would turn every `group add` into a worktree-polling group.
+func TestGroupAddCmd_TrackWorktreesFlagDefaultsOff(t *testing.T) {
+	f := newGroupAddCmd().Flags().Lookup("track-worktrees")
+	if f == nil {
+		t.Fatal("group add has no --track-worktrees flag")
+	}
+	if f.Value.Type() != "bool" {
+		t.Errorf("--track-worktrees is %s, want bool", f.Value.Type())
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--track-worktrees defaults to %q, want \"false\"", f.DefValue)
+	}
+	// It must not be quietly aliased onto --watchers.
+	if w := newGroupAddCmd().Flags().Lookup("watchers"); w == nil || w.DefValue != "false" {
+		t.Errorf("--watchers default changed: %+v", w)
+	}
+}
+
+// TestGroupAddCmd_TrackWorktreesFlagIsBoundToTheField pins the wiring from the
+// parsed cobra flag through to the persisted feature — the RunE closure, which
+// the table test above bypasses by constructing groupAddFlags directly.
+func TestGroupAddCmd_TrackWorktreesFlagIsBoundToTheField(t *testing.T) {
+	// Not stubbed, on purpose: see the table test above. Under `go test` the
+	// watchers package refuses (panics on) any mutating service-manager call
+	// that reaches a real exec, so this run passing is positive evidence that
+	// --track-worktrees alone reached none.
+	home := withSandboxHome(t)
+	repo := filepath.Join(home, "repos", "alpha")
+	makeRepo(t, repo)
+
+	var opts groupApplyOptions
+	captureGroupApplyOptions(t, &opts)
+
+	cmd := newGroupAddCmd()
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"demo", "--repo", repo, "--track-worktrees",
+		"--git-hooks=false", "--rules=false", "--mcp=false", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v\n%s", err, out.String())
+	}
+
+	path, err := registry.ConfigPathFor("demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := registry.LoadGroupConfig(path)
+	if err != nil {
+		t.Fatalf("LoadGroupConfig: %v", err)
+	}
+	if !cfg.Features.TrackWorktrees {
+		t.Error("--track-worktrees did not set features.track_worktrees")
+	}
+	if cfg.Features.Watchers {
+		t.Error("--track-worktrees set features.watchers")
+	}
+	if !opts.SkipWatchers {
+		t.Error("--track-worktrees cleared SkipWatchers on the install transaction")
+	}
+}


### PR DESCRIPTION
Closes #6918.

## What

`grafel group add --track-worktrees` (bool, default false) sets
`features.track_worktrees` **without** the OS watcher-unit install transaction.

The daemon opts a group into worktree discovery when `TrackWorktrees || Watchers`
(`cmd/grafel/daemon.go:1152`, a retroactive per-call read), so before this the only CLI route to
per-worktree tracking was `--watchers` — which also writes a unit file and activates it through
launchd/systemd/schtasks. Inside a minimal Docker container (PID 1 = `docker-init`, no systemd, no
`systemctl` on PATH) the in-process fsnotify path works fine and the unit install does not, so the
consumer had to request a capability they cannot use in order to get the one they can.

The flag composes with `--watchers` rather than replacing it. `internal/registry/registry.go:184`
and `internal/cli/status.go:197` already model and report the field; only the wiring was missing.

## The load-bearing property

**`--track-worktrees` must never move `SkipWatchers`.** That is the whole point, and it is also the
one thing an obvious test would miss.

`install.Apply` gates its watcher branch on `!opts.SkipWatchers && opts.Config.Features.Watchers` —
**both** (`internal/install/install.go:303`). So the regression this PR exists to prevent, folding the
new flag into the option (`SkipWatchers: !(f.watchers || f.trackWorktrees)`), writes **no unit file
either**, because `Features.Watchers` is still false. A test asserting only the emitted artefact
would score that mutant ALIVE while it sat one unrelated edit away from re-introducing the container
problem.

So the option is asserted directly, through a one-line seam (`applyGroupConfigFn`) at the `group add`
call site, **and** the artefact is asserted alongside it.

## The four-cell table

`TestGroupAdd_TrackWorktreesIsIndependentOfWatchers` — each row reads the persisted config back off
disk (not the in-memory struct the command happened to build), the captured install option, and the
unit file:

| flags | `track_worktrees` | `watchers` | `SkipWatchers` | unit file |
|---|---|---|---|---|
| `--track-worktrees` | true | false | **true** | none |
| `--watchers` | false | true | false | written |
| both | true | true | false | written |
| neither | false | false | true | none |

Rows 2 and 4 were green before the implementation landed — they pin today's behaviour as unchanged.

Plus `TestGroupAddCmd_TrackWorktreesFlagDefaultsOff` (registration, bool, default false — the default
is load-bearing, `track_worktrees` is documented "opt-in to preserve existing behaviour") and
`TestGroupAddCmd_TrackWorktreesFlagIsBoundToTheField`, which drives the real cobra command so the
`RunE` closure binding is covered too, not only a hand-built `groupAddFlags`.

## Service-manager isolation, as evidence rather than as a stub

The `--watchers` rows reach `loader.Load`, a mutating verb, and are stubbed via
`watchers.StubServiceCallsForTest()` (`internal/install/watchers/test_isolation_guard.go` exists
because a test once drove a real `launchctl bootout` against the developer's machine).

The rows **without** `--watchers` are left deliberately unstubbed. The claim being made is
"`--track-worktrees` shells out to no service manager", and the guard is what enforces it: any
mutating verb reaching a real exec under `go test` panics. Stubbing those rows would replace that
proof with a no-op.

Verified the guard is a live control, not a dormant one — forcing the watcher branch on for the
track-worktrees-only row (SkipWatchers mutant + `Watchers = watchers || trackWorktrees`) panics:

```
panic: watchers: test attempted a REAL service-manager call that is not a known read-only probe:
launchctl [enable gui/501/com.grafel.watcher.demo.alpha-450a9830]
```

## Mutants

Scored at the call site (`internal/cli/group.go`), `-count=1`, `go vet` before each score, each edit's
post-application match count asserted as a hard gate (a silently unapplied edit reads ALIVE and
argues the opposite), restored by `cp` from a shasum-verified backup.

| # | mutant | applied | verdict |
|---|---|---|---|
| M1 | `SkipWatchers: !(f.watchers \|\| f.trackWorktrees)` — the regression this PR prevents | 1 | **DEAD** |
| M2 | flag default `false` → `true` | 1 | **DEAD** |
| M3 | drop `cfg.Features.TrackWorktrees = f.trackWorktrees` | 1 | **DEAD** |
| M4 | `cfg.Features.TrackWorktrees = f.watchers` | 1 | **DEAD** |
| M5 | `cfg.Features.Watchers = f.watchers \|\| f.trackWorktrees` | 1 | **DEAD** |
| M6 | drop the `RunE` binding (`trackWorktrees: false`) | 1 | **DEAD** |

No survivors, so no three-way verdicts to record. All-DEAD proves pinning rather than truth on its
own, which is why the positive control above is included: it demonstrates the isolation assertion is
capable of failing.

## Follow-up worth filing separately — NOT fixed here

`group add --watchers` on a systemctl-less host **degrades gracefully rather than erroring**:
`internal/install/install.go:370` turns a `loader.Load` failure into a `WatcherWarnings` entry, which
is deliberate (#5338 — a flaky service manager must not fail a whole wizard run). That is correct and
untouched.

But `internal/install/watchers/loader_linux.go` has **no `LookPath` guard and no unsupported-platform
branch**, so a container install still writes a systemd unit file to disk that nothing will ever load,
alongside the warning. Worth its own issue; out of scope here.

## Verified

- `go test -count=1 ./internal/cli/` — green (53s), full package, not a `-run` subset.
- `go vet ./internal/cli/` — clean.
- `gofmt -l internal/cli internal/registry` — clean.

**Not run, and why:** `./internal/registry/` — the package is read-only in this change, no file in it
was touched. `./cmd/grafel/`'s graph-digest test — this is a CLI-flag change touching no extractor and
no entity kind, so the digest is not implicated. The rest of the repo suite was skipped by instruction
(concurrent Go-compiling agents on a memory-constrained machine); CI covers it.
