### PR TITLE
fix(#6852): zig's import IMPORTS anchored on a path only `importTopSegment` can spell — arm 12, the LAST, and the ledger reaches EMPTY

### DIFF
--- a/internal/extractor/carrier_caller_set_6861_test.go
+++ b/internal/extractor/carrier_caller_set_6861_test.go
@@ -208,6 +208,7 @@ func TestCarrierCallerSetIsGradedFromSource_6861(t *testing.T) {
 		{"internal/extractors/cobol/extractor.go", []string{prependFileCarrier}},
 		{"internal/extractors/crystal/extractor.go", []string{prependFileCarrier}},
 		{"internal/extractors/dart/dart.go", []string{prependFileCarrier}},
+		{"internal/extractors/zig/zig.go", []string{prependFileCarrier}},
 	}
 
 	nonTest := 0

--- a/internal/extractor/file_carrier.go
+++ b/internal/extractor/file_carrier.go
@@ -111,6 +111,29 @@ import "github.com/cajasmota/grafel/internal/types"
 //     over "every Name this package emits" is the claim most likely to be
 //     wrong, because one builder concatenating a prefix onto a literal-derived
 //     operand defeats it — clojure's `.clj-kondo` correction, one package over.
+//     zig (#6852) is the LAST arm, and it answers that lesson with the strongest
+//     form the series found. Its one candidate name site, importTopSegment,
+//     trims exactly ONE trailing extension, so a ROOT main.zig importing
+//     "main.zig.zig" names an import stub exactly the path and clause 3
+//     declines — driven, not argued. What settles the NESTED question is not a
+//     character-class closure at all: the arm brute-forces the whole input
+//     space and establishes that importTopSegment's result is always a
+//     SUBSTRING of its input. That is the anti-concatenation property itself,
+//     asserted over the function rather than over a paragraph, so the edit that
+//     defeated cobol's closure — concatenating a prefix onto a literal-derived
+//     operand — fails a test here instead of quietly invalidating prose. The
+//     nested cell that remains (a path ending in '/') is DRIVEN too, and
+//     reported as alive-but-not-production-reachable by naming the input.
+//     Pinned by TestZig_ImportStubNamedLikeThePath_6852 and, for the
+//     enumeration, TestZig_ImportTopSegmentIsAlwaysASubstring_6852.
+//
+// WITH THE ZIG ARM, #6852'S LEDGER REACHED EMPTY over #6847's corpus:
+// knownMissingCarrier6847 has no entries left. That is a statement about a
+// CORPUS, not about the registered language set — reasonml and rescript are
+// confirmed offenders that corpus never reaches, and the population stays
+// unbounded above until every registered language is driven. Read
+// len(knownMissingCarrier6847) and the coverage sets beside it, never this
+// sentence, for the current state.
 //
 // Clause 3 is checked for EVERY record, before the loop may short-circuit on
 // clause 2 being satisfied — deliberately, and the order is load-bearing.

--- a/internal/extractors/file_anchored_carrier_runtime_6847_test.go
+++ b/internal/extractors/file_anchored_carrier_runtime_6847_test.go
@@ -126,12 +126,17 @@
 //
 // THE LEDGER IS AN EXACT SET, NOT A FLOOR, IN BOTH DIRECTIONS. A language not
 // in knownMissingCarrier6847 fails this test; so does fixing one that IS in it
-// without removing its entry. NOTE THAT THE SET SHRINKS AS LANGUAGES ARE
-// FIXED — it opened at twelve and #6852 removes one per landed arm (bicep is
-// the first), so any count written here goes stale by design. Read
-// len(knownMissingCarrier6847), not a number in prose. A guard that only checked "no NEW offender" would be blind to the
-// permissive direction — a walk that silently stopped detecting anything would
-// stay green under a floor and goes red here.
+// without removing its entry. THE SET SHRANK AS LANGUAGES WERE FIXED — it
+// opened at twelve, #6852 removed one per landed arm (bicep first, zig last),
+// and it is now EMPTY over this corpus. Read len(knownMissingCarrier6847), not
+// a number in prose.
+//
+// AN EMPTY LEDGER CHANGES WHAT THIS FILE PROVES, and the change is written up
+// at the declaration below rather than left implicit: the "still reproduces"
+// direction now iterates nothing, so the permissive failure it used to catch —
+// a walk that silently stopped detecting anything — is caught by
+// TestFileAnchoredCarrier_EveryAnchoringFileCarries_6847 instead, which
+// accounts for a non-empty population in the positive direction.
 package extractors_test
 
 import (
@@ -163,9 +168,22 @@ import (
 // for the conditional-carrier shape #6815 and #6518 settled on) and delete the
 // line. To ADD one: do not. A new offender is the defect this file exists to
 // catch; adding a line to keep it green is the failure mode #6834 names.
-var knownMissingCarrier6847 = map[string]string{
-	"zig": "zig.go:272 `FromID: filePath` on IMPORTS; no carrier emitted",
-}
+// THE SET IS NOW EMPTY, AND THAT CHANGES WHICH ASSERTION IS LOAD-BEARING.
+// While it had entries, the second loop of TestFileAnchoredCarrier_NoNewOffender_6847
+// ("every known offender still reproduces") doubled as this file's strongest
+// anti-vacuity check: a walk that silently stopped detecting anything went RED
+// there. Empty, that loop iterates nothing and can no longer fail, so "zero
+// offenders" became a conclusion a broken walk reaches just as easily as a
+// fixed tree does — the #6908 shape, an anti-vacuity guard relaxed by the very
+// change it exists to catch.
+//
+// The replacement is TestFileAnchoredCarrier_EveryAnchoringFileCarries_6847
+// below, which states the SAME invariant in the positive direction over a
+// population that is not empty and cannot become empty without failing:
+// every one of the anchoringLanguages6847 files must be MATCHED to a carrier,
+// per language and per file count. Deleting the detection step from the walk
+// now fails there instead of passing here.
+var knownMissingCarrier6847 = map[string]string{}
 
 // exercisedLanguages6847 is the exact set of registered languages the corpus
 // actually drives. It is pinned so that a corpus file being deleted, renamed
@@ -268,6 +286,8 @@ type carrierScanResult struct {
 	candidates       int
 	exercised        map[string]int
 	anchoring        map[string]int
+	carried          map[string]int
+	detected         map[string]int
 	noExtractorLangs map[string]int
 	offenders        []carrierFinding
 }
@@ -335,6 +355,8 @@ func scanCorpusForMissingCarriers() (carrierScanResult, error) {
 		candidates:       len(files),
 		exercised:        map[string]int{},
 		anchoring:        map[string]int{},
+		carried:          map[string]int{},
+		detected:         map[string]int{},
 		noExtractorLangs: map[string]int{},
 	}
 	cls := classifier.New(nil)
@@ -383,6 +405,46 @@ func scanCorpusForMissingCarriers() (carrierScanResult, error) {
 		}
 		if anchored {
 			res.anchoring[cr.Language]++
+			// PER-FILE POSITIVE CONTROL FOR THE MATCHER, run through the walk's
+			// own call rather than beside it. Take the carrier away and the file
+			// becomes a genuine offender; if the matcher does NOT report it, the
+			// matcher is not detecting anything and the empty offender list
+			// below is a no-op that reads like a guard. This is the check that
+			// replaces what an entry in knownMissingCarrier6847 used to provide:
+			// with the ledger empty, nothing else here fails when the detection
+			// step is neutered.
+			//
+			// THE CARRIER IS UN-NAMED, NOT DELETED, and the distinction is not
+			// cosmetic — deleting it was measured and was WRONG. For java,
+			// python, typescript, javascript and graphql the record that carries
+			// the path is the same record that OWNS the path-anchored edges, so
+			// removing it removes the anchor too and the matcher correctly
+			// reports nothing. Blanking the two name fields leaves the anchor in
+			// place and isolates exactly the property under test.
+			stripped := make([]types.EntityRecord, len(recs))
+			copy(stripped, recs)
+			for i := range stripped {
+				if stripped[i].Name == vrel || stripped[i].QualifiedName == vrel {
+					stripped[i].Name = ""
+					stripped[i].QualifiedName = ""
+				}
+			}
+			if len(pathAnchoredKindsMissingCarrier(vrel, stripped)) > 0 {
+				res.detected[cr.Language]++
+			}
+			// The POSITIVE half of the invariant, derived DIRECTLY from the
+			// records and NOT from the offender list below. Deriving it from
+			// `kinds` was measured and was wrong: a walk that stopped calling
+			// the matcher would then count every anchoring file as carried and
+			// report no offenders, so a real regression would produce a green
+			// run twice over. Read straight from the records, that same walk
+			// mutant leaves this count intact and the regression still fails.
+			for i := range recs {
+				if recs[i].Name == vrel || recs[i].QualifiedName == vrel {
+					res.carried[cr.Language]++
+					break
+				}
+			}
 		}
 		if kinds := pathAnchoredKindsMissingCarrier(vrel, recs); len(kinds) > 0 {
 			res.offenders = append(res.offenders, carrierFinding{lang: cr.Language, path: vrel, kinds: kinds})
@@ -422,13 +484,76 @@ func TestFileAnchoredCarrier_NoNewOffender_6847(t *testing.T) {
 	}
 }
 
+// TestFileAnchoredCarrier_EveryAnchoringFileCarries_6847 is the invariant said
+// in the POSITIVE direction, and it exists because knownMissingCarrier6847 is
+// now empty.
+//
+// "No offender" is a claim about an empty set, and an empty set is what a walk
+// that reads nothing, extracts nothing, or no longer applies the matcher also
+// produces. While the ledger had entries, the "still reproduces" loop above
+// caught that; empty, it iterates nothing. This test asks instead for a
+// NON-EMPTY population to be positively accounted for: for every language whose
+// corpus files anchor on their own path, the number of files MATCHED to a
+// carrier must equal the number that anchor — per language, per file, not as a
+// floor.
+//
+// It fails on all three of the shapes the empty ledger stopped catching:
+// deleting the matcher call, an extractor losing its carrier, and a walk that
+// silently stops extracting. It is deliberately NOT derived from
+// res.offenders — the count it reads is incremented in the same branch as the
+// offender list, so the two cannot disagree about what was measured.
+func TestFileAnchoredCarrier_EveryAnchoringFileCarries_6847(t *testing.T) {
+	res := carrierScan(t)
+
+	if diff := diffStringSets(anchoringLanguages6847, sortedStringKeys(res.carried)); diff != "" {
+		t.Errorf("the set of languages whose anchored corpus files ALL carry changed:\n%s\n"+
+			"A language that leaves this set has anchored files with no carrier — the #6815 "+
+			"defect class, now reported here as well as in the offender test, because an "+
+			"empty knownMissingCarrier6847 can no longer report it by disappearing.", diff)
+	}
+	total := 0
+	for _, lang := range anchoringLanguages6847 {
+		total += res.carried[lang]
+		if res.carried[lang] != res.anchoring[lang] {
+			t.Errorf("language %q: %d corpus files anchor on their own path but only %d carry — "+
+				"the %d-file difference is the dangling-FROM-end defect (#6815/#6847), one "+
+				"file at a time", lang, res.anchoring[lang], res.carried[lang],
+				res.anchoring[lang]-res.carried[lang])
+		}
+	}
+	// A floor on the accounted population, so this test cannot pass by having
+	// measured an empty corpus: sets that are equal because both are empty
+	// would satisfy every comparison above.
+	const minCarriedFiles6847 = 100
+	if total < minCarriedFiles6847 {
+		t.Errorf("only %d corpus files were positively accounted for, want at least %d — "+
+			"below that this test is comparing near-empty sets and the assertion is vacuous",
+			total, minCarriedFiles6847)
+	}
+
+	// THE MATCHER'S OWN POSITIVE CONTROL, measured inside the walk. Every
+	// anchoring file must become a REPORTED offender once its carrier is
+	// stripped. Without this, a pathAnchoredKindsMissingCarrier that returned
+	// nil unconditionally — or a walk that stopped calling it — would produce
+	// an empty offender list, an intact carried count, and a clean run.
+	for _, lang := range anchoringLanguages6847 {
+		if res.detected[lang] != res.anchoring[lang] {
+			t.Errorf("language %q: %d anchoring corpus files, but stripping the carrier made "+
+				"only %d of them REPORT as offenders — the detection step is not detecting, so "+
+				"an empty offender list is not evidence of anything", lang,
+				res.anchoring[lang], res.detected[lang])
+		}
+	}
+}
+
 // TestFileAnchoredCarrier_CorpusCoverage_6847 pins what the walk read. Without
 // it, deleting every corpus file for a language would leave
-// TestFileAnchoredCarrier_NoNewOffender_6847 green for the wrong reason —
-// except for the pinned offenders still in knownMissingCarrier6847, whose
-// disappearance already fails it.
-// The nine remaining #6834 shapes are not so protected, which is why the two
-// exact sets below are asserted rather than a file count alone.
+// TestFileAnchoredCarrier_NoNewOffender_6847 green for the wrong reason. That
+// used to be softened by the pinned offenders in knownMissingCarrier6847, whose
+// disappearance failed the offender test directly — but that set is empty now,
+// so nothing about a shrinking corpus is caught there any more.
+// The nine remaining #6834 shapes are not otherwise protected, which is why the
+// two exact sets below are asserted rather than a file count alone.
 func TestFileAnchoredCarrier_CorpusCoverage_6847(t *testing.T) {
 	res := carrierScan(t)
 

--- a/internal/extractors/zig/file_carrier_6852_test.go
+++ b/internal/extractors/zig/file_carrier_6852_test.go
@@ -1,0 +1,578 @@
+// Package zig_test — file_carrier_6852_test.go
+//
+// Issue #6852, arm 12 (zig) — the LAST arm of the series #6847 measured.
+//
+// THE DEFECT. buildImportEntities stamps `FromID: filePath` on the IMPORTS edge
+// of every `@import("...")` stub. internal/resolve/refs.go has no path→entity
+// index, so a path-valued FromID resolves if and only if some emitted record
+// carries that exact string as its Name (zig sets no QualifiedName on any
+// record, so the byQualifiedName tier — a DIFFERENT consumer, and one that has
+// nothing to do with FileCarrierFor's clause 3 — cannot apply here at all).
+// Nothing zig emits is named after the file as a rule, so before this arm the
+// raw path reached the graph as the edge's FROM end.
+//
+// THE FIX is extractor.PrependFileCarrier, the CONDITIONAL carrier #6518 and
+// #6815 settled on. Unconditional FileEntity would mint one bare orphan node
+// per .zig file across a whole repo, which no recall-shaped assertion can see.
+//
+// ZIG HAS EXACTLY ONE FromID SITE AND EXACTLY FOUR Name SITES, and neither
+// count is left as prose: TestZig_SourceSiteCountsAreWhatThisFileAssumes_6852
+// reads them out of zig.go on every run, so a fifth Name site or a second
+// path-anchored edge fails a test rather than ageing a comment (#6861's shape).
+//
+// THE CLOSURE THIS FILE RESTS ON, and why it survives concatenation. Three of
+// the four Name sites assign a `(\w+)` capture VERBATIM — `\w` is
+// [0-9A-Za-z_], so those Names hold neither '.' nor '/'. The fourth is
+// importTopSegment, and it is not argued about at all: import_top_segment_-
+// 6852_test.go BRUTE-FORCES all 5461 targets over {a _ . /} up to length 6 and
+// establishes two properties — the result is always a SUBSTRING of the input
+// (which is the anti-concatenation property itself, stated over the function
+// rather than over a paragraph), and a '/'-bearing result always ENDS in '/'.
+// So an import stub can be named after a ROOT path, which is DRIVEN below, and
+// after a path ending in '/', which is also DRIVEN below rather than argued
+// unreachable — four arms of #6852 shipped an unreachability claim a driven
+// cell later disproved.
+package zig_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	_ "github.com/cajasmota/grafel/internal/extractors/zig"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// runZig6852 drives the REGISTERED production extractor over src at path.
+func runZig6852(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("zig")
+	if !ok {
+		t.Fatal("zig extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "zig",
+	})
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	return recs
+}
+
+// zigCarriers6852 returns every record that IS the file carrier for path.
+// Subtype "file" is what separates it from zig's other SCOPE.Component records:
+// the struct records carry "struct" and the import stubs carry "import".
+func zigCarriers6852(recs []types.EntityRecord, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Subtype == "file" && r.Name == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// zigNamedExactly6852 returns every record whose Name is path. Name only, and
+// deliberately so: zig sets QualifiedName nowhere (pinned by
+// TestZig_SourceSiteCountsAreWhatThisFileAssumes_6852), so adding the
+// QualifiedName disjunct here would be a check that can never fire for this
+// package and would read as coverage it does not have.
+func zigNamedExactly6852(recs []types.EntityRecord, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Name == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// zigPathAnchored6852 returns every relationship in recs whose FromID is
+// exactly path — the shape whose FROM end has nothing to resolve onto.
+func zigPathAnchored6852(recs []types.EntityRecord, path string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.FromID == path {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+// resolveZig6852 extracts src at path, stamps ids the way graph assembly does,
+// runs the production resolver pipeline, and returns the records plus the
+// id→record index. The assertion that follows is on the EMITTED ARTEFACT after
+// resolution — the edge's FROM end — not on a counter the code keeps about
+// itself.
+func resolveZig6852(t *testing.T, src, path string) ([]types.EntityRecord, map[string]*types.EntityRecord) {
+	t.Helper()
+	recs := runZig6852(t, src, path)
+	if len(recs) == 0 {
+		t.Fatalf("extract %s: no records", path)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6852", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+	byID := make(map[string]*types.EntityRecord, len(recs))
+	for i := range recs {
+		byID[recs[i].ID] = &recs[i]
+	}
+	return recs, byID
+}
+
+// assertZigImportsResolve6852 fails for every IMPORTS edge whose FROM end names
+// no record, and fails OUTRIGHT when the fixture produced no IMPORTS at all — a
+// resolution assertion over an empty set is a no-op that reads like a guard.
+func assertZigImportsResolve6852(t *testing.T, recs []types.EntityRecord, byID map[string]*types.EntityRecord) {
+	t.Helper()
+	seen := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			seen++
+			if _, ok := byID[r.FromID]; !ok {
+				t.Errorf("IMPORTS owned by %q: FROM end %q resolves to no record "+
+					"(refs.go has no path→entity index; a path-valued FromID resolves "+
+					"iff some record carries that exact string as its Name — emit a file "+
+					"carrier, internal/extractor/file_carrier.go)", recs[i].Name, r.FromID)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("fixture produced no IMPORTS edges — this measurement is vacuous")
+	}
+}
+
+// carrierSrcZig6852 exercises EVERY pass of extractZig: the pub-fn pass, the
+// private-fn pass (with a call, so CALLS edges exist), the struct pass (with a
+// method, so a CONTAINS edge exists), and the import pass with two distinct
+// targets — a stdlib token and a relative path, the two shapes importTopSegment
+// treats differently. A carrier wired into any one of those passes would still
+// be seen by the tests below.
+const carrierSrcZig6852 = `const std = @import("std");
+const util = @import("./util/helper.zig");
+
+pub fn main() void {
+    helper();
+}
+
+fn helper() void {
+    std.debug.print("x", .{});
+}
+
+const Handler = struct {
+    pub fn handle(self: *Handler) void {}
+};
+`
+
+// TestZig_ImportsFromEndResolves_6852 is the fix's behavioural test. It drives
+// the cells in which the edge DANGLES — root and nested depth, both of which
+// reach clause 2 and neither of which reaches clause 3. The cells where the
+// source itself spells the path are driven by
+// TestZig_ImportStubNamedLikeThePath_6852 below.
+func TestZig_ImportsFromEndResolves_6852(t *testing.T) {
+	for _, path := range []string{"main.zig", "src/app/main.zig"} {
+		t.Run(path, func(t *testing.T) {
+			recs, byID := resolveZig6852(t, carrierSrcZig6852, path)
+
+			// The PRE-resolution records are what carry the shape this arm
+			// exists for: after ReferencesEmbedded rewrites the FROM end, no
+			// FromID is the raw path any more, so the premise has to be taken
+			// from a second, unresolved extraction of the same input.
+			pre := runZig6852(t, carrierSrcZig6852, path)
+			if got := len(zigPathAnchored6852(pre, path)); got != 2 {
+				t.Fatalf("fixture emits %d path-anchored relationships at %s, want 2 "+
+					"(one per @import target) — the cell under test is not being reached",
+					got, path)
+			}
+
+			carriers := zigCarriers6852(recs, path)
+			if len(carriers) != 1 {
+				t.Fatalf("want exactly 1 file carrier named %q, got %d", path, len(carriers))
+			}
+			if recs[0].Name != path || recs[0].Subtype != "file" {
+				t.Errorf("carrier is not at index 0: recs[0] = {Name:%q Subtype:%q}. "+
+					"#577's convention is that the file entity is the first record, and "+
+					"python/re_exports.go and python/prune_import_placeholders.go rely on it.",
+					recs[0].Name, recs[0].Subtype)
+			}
+			assertZigImportsResolve6852(t, recs, byID)
+		})
+	}
+}
+
+// TestZig_NoCarrierWithoutAnImport_6852 is the OVER-FIRING control for
+// FileCarrierFor's clause 2, and it is the assertion an UNCONDITIONAL carrier
+// fails. Recall-shaped tests only ever ask whether the carrier EXISTS, so
+// nothing else in this package can see the difference between conditional and
+// unconditional — one bare orphan node per .zig file is invisible to every
+// other check here (#6518, #6815).
+//
+// The fixture varies exactly ONE axis against carrierSrcZig6852: it has no
+// `@import` directive. Every other pass — pub fn, private fn with a call,
+// struct with a method — is held constant, so a failure here cannot be read as
+// "the file was too empty to extract anything".
+func TestZig_NoCarrierWithoutAnImport_6852(t *testing.T) {
+	const src = `pub fn main() void {
+    helper();
+}
+
+fn helper() void {
+    other();
+}
+
+const Handler = struct {
+    pub fn handle(self: *Handler) void {}
+};
+`
+	const path = "src/app/main.zig"
+	recs := runZig6852(t, src, path)
+
+	if len(recs) == 0 {
+		t.Fatal("no records — the fixture extracts nothing, so the absence of a carrier " +
+			"below would prove nothing about clause 2")
+	}
+	if got := len(zigPathAnchored6852(recs, path)); got != 0 {
+		t.Fatalf("fixture unexpectedly emits %d path-anchored relationships — the premise "+
+			"of this over-firing control is that NOTHING anchors on the path", got)
+	}
+	if got := zigCarriers6852(recs, path); len(got) != 0 {
+		t.Errorf("a file with no path-anchored edge got %d carrier(s) — the carrier is "+
+			"CONDITIONAL, and an unconditional one mints a bare orphan node per source "+
+			"file across an entire repo (#6518, #6815)", len(got))
+	}
+	if got := len(zigNamedExactly6852(recs, path)); got != 0 {
+		t.Errorf("%d record(s) named after the path in a file that anchors nothing", got)
+	}
+}
+
+// TestZig_EmptyFileGetsNoCarrier_6852 drives Extract's FIRST return path — the
+// `len(file.Content) == 0` guard, which returns before extractZig is called at
+// all, so the carrier call placed inside extractZig is never reached.
+func TestZig_EmptyFileGetsNoCarrier_6852(t *testing.T) {
+	const path = "src/empty.zig"
+	if got := runZig6852(t, "", path); len(got) != 0 {
+		t.Errorf("an empty .zig file produced %d record(s), want 0", len(got))
+	}
+}
+
+// TestZig_EmptyPathGetsNoCarrier_6852 drives FileCarrierFor CLAUSE 1, which
+// rejects on its own and rejects a record set that DOES anchor: an empty FromID
+// trivially equals an empty path, so clause 2 is satisfied and only clause 1
+// stands between that input and a blank carrier node.
+//
+// The fixture is carrierSrcZig6852 unchanged — the path is the only axis that
+// varies against TestZig_ImportsFromEndResolves_6852.
+func TestZig_EmptyPathGetsNoCarrier_6852(t *testing.T) {
+	recs := runZig6852(t, carrierSrcZig6852, "")
+	if len(recs) == 0 {
+		t.Fatal("no records at an empty path — the absence of a carrier would prove nothing")
+	}
+	anchored := zigPathAnchored6852(recs, "")
+	if len(anchored) == 0 {
+		t.Fatal("no relationship has an empty FromID at an empty path — clause 2 is NOT " +
+			"satisfied here, so this fixture does not isolate clause 1")
+	}
+	for _, r := range recs {
+		if r.Subtype == "file" {
+			t.Errorf("an empty path produced a file carrier %+v — a nameless carrier "+
+				"resolves nothing and adds a blank node", r)
+		}
+	}
+}
+
+// TestZig_OneCarrierPerFileNotPerImport_6852 is the multiplicity control. The
+// anchor lives on EVERY import stub, so a carrier minted inside
+// buildImportEntities' loop — or a FileCarrierFor that kept scanning after the
+// first anchor — would produce one node per import, all under a single
+// graph.EntityID.
+//
+// Varies exactly one axis against carrierSrcZig6852: the number of DISTINCT
+// import targets (five, not two). The passes, the path and the depth are held
+// constant.
+func TestZig_OneCarrierPerFileNotPerImport_6852(t *testing.T) {
+	const src = `const std = @import("std");
+const a = @import("./a.zig");
+const b = @import("./b.zig");
+const c = @import("../lib/c.zig");
+const d = @import("builtin");
+
+pub fn main() void {
+    helper();
+}
+`
+	const path = "src/app/main.zig"
+	recs := runZig6852(t, src, path)
+
+	if got := len(zigPathAnchored6852(recs, path)); got != 5 {
+		t.Fatalf("fixture emits %d path-anchored relationships, want 5 — the multiplicity "+
+			"this test exists to measure is not present", got)
+	}
+	if got := zigCarriers6852(recs, path); len(got) != 1 {
+		t.Errorf("want exactly 1 carrier for 5 anchored imports, got %d — every one of them "+
+			"would land under the same graph.EntityID", len(got))
+	}
+	if got := len(zigNamedExactly6852(recs, path)); got != 1 {
+		t.Errorf("%d records named after the path, want 1", got)
+	}
+}
+
+// TestZig_ImportStubNamedLikeThePath_6852 drives FileCarrierFor CLAUSE 3 — the
+// clause that declines a carrier when some record is ALREADY named the path.
+//
+// THIS IS A DRIVEN CELL, NOT A CLOSURE. graph.EntityID does not hash Subtype,
+// so a carrier minted beside a record of the same Kind and Name lands a SECOND
+// node under one id (the #6369/#6480 hazard) and makes the rewrite target
+// ambiguous. zig reaches that state through importTopSegment: it trims exactly
+// ONE trailing extension, so in a ROOT file main.zig the target
+// `@import("main.zig.zig")` names the import stub exactly `main.zig`.
+//
+// The nested subtest is the CONTRAST that stops the root subtest passing on a
+// carrier that is never emitted at all: same source, same import target, one
+// axis changed (the path's depth), and there the carrier IS due.
+//
+// The third subtest is the case four earlier arms would have written a closure
+// about. Nothing in zig's Name sites forbids a nested clause-3 hit outright;
+// what the enumeration in import_top_segment_6852_test.go establishes is that
+// such a Name must END in '/'. So the cell is DRIVEN with a path that ends in
+// '/' — clause 3 fires there too, at depth. It is not production-reachable (no
+// file on disk has a path ending in '/'), and that is stated as a property of
+// the INPUT rather than as a property of the code.
+func TestZig_ImportStubNamedLikeThePath_6852(t *testing.T) {
+	cases := []struct {
+		name string
+		// varies names the ONE axis that changes against the root case.
+		varies      string
+		path        string
+		src         string
+		wantCarrier bool
+	}{{
+		name:        "root_path_spelled_by_a_double_extension_target",
+		varies:      "nothing — this is the base case",
+		path:        "main.zig",
+		src:         "const self = @import(\"main.zig.zig\");\n\npub fn main() void {}\n",
+		wantCarrier: false,
+	}, {
+		name:        "nested_path_the_same_target_cannot_spell",
+		varies:      "the path's DEPTH; the source and the import target are byte-identical",
+		path:        "src/main.zig",
+		src:         "const self = @import(\"main.zig.zig\");\n\npub fn main() void {}\n",
+		wantCarrier: true,
+	}, {
+		name:        "path_ending_in_a_slash",
+		varies:      "the path ends in '/', the one nested shape importTopSegment can return",
+		path:        "src/",
+		src:         "const self = @import(\"src/\");\n\npub fn main() void {}\n",
+		wantCarrier: false,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			recs := runZig6852(t, tc.src, tc.path)
+
+			if got := len(zigPathAnchored6852(recs, tc.path)); got != 1 {
+				t.Fatalf("fixture emits %d path-anchored relationships, want 1 — clause 2 "+
+					"is not satisfied, so clause 3 is never consulted and this cell measures "+
+					"nothing", got)
+			}
+			named := zigNamedExactly6852(recs, tc.path)
+			if len(named) != 1 {
+				t.Fatalf("want exactly 1 record named %q, got %d — two nodes under one "+
+					"graph.EntityID is the #6369/#6480 hazard clause 3 exists to prevent",
+					tc.path, len(named))
+			}
+			carriers := zigCarriers6852(recs, tc.path)
+			if tc.wantCarrier {
+				if len(carriers) != 1 {
+					t.Fatalf("want a carrier at %q, got %d — the contrast case is what stops "+
+						"the clause-3 cases passing on a carrier that is never emitted at all",
+						tc.path, len(carriers))
+				}
+				return
+			}
+			if len(carriers) != 0 {
+				t.Fatalf("clause 3 did not decline at %q: got %d carrier(s) beside the "+
+					"import stub already named after the path", tc.path, len(carriers))
+			}
+			if named[0].Subtype != "import" {
+				t.Fatalf("the one record named %q is %+v — clause 3 should have declined in "+
+					"favour of the IMPORT STUB importTopSegment already named after the path. "+
+					"If this record is the carrier, the premise of this cell has broken: the "+
+					"offender importTopSegment can spell no longer exists.", tc.path, named[0])
+			}
+		})
+	}
+}
+
+// TestZig_WordCaptureNameSitesCannotSpellAPath_6852 OBSERVES the half of the
+// closure the enumeration does not cover: the three Name sites that are
+// verbatim `(\w+)` regex captures (pub fn, private fn, struct).
+//
+// Observed by driving rather than argued from the regex source, because an
+// argument from a pattern is exactly what clojure's character-set closure was
+// when `.clj-kondo/hooks/foo.clj` disproved it (#6897). The fixture is
+// adversarial on purpose: every declaration is spelled with the path's own
+// bytes around it, so if any of these three sites carried its surrounding text
+// into Name it would show up here.
+func TestZig_WordCaptureNameSitesCannotSpellAPath_6852(t *testing.T) {
+	const path = "src/app/main.zig"
+	const src = `const std = @import("std");
+
+pub fn src_app_main_zig() void {}
+
+fn main_zig() void {}
+
+const src = struct {
+    pub fn app(self: *src) void {}
+};
+
+const main_zig_t = struct {};
+`
+	recs := runZig6852(t, src, path)
+
+	checked := 0
+	for _, r := range recs {
+		if r.Subtype != "function" && r.Subtype != "struct" {
+			continue
+		}
+		checked++
+		if strings.ContainsAny(r.Name, "./") {
+			t.Errorf("a %s record is named %q — a `(\\w+)` capture has stopped being one, "+
+				"and the closure this arm rests on (three of four Name sites hold neither "+
+				"'.' nor '/') no longer holds", r.Subtype, r.Name)
+		}
+	}
+	if checked < 5 {
+		t.Fatalf("only %d function/struct records were checked, want at least 5 — the "+
+			"fixture stopped reaching the sites this test grades", checked)
+	}
+	if got := len(zigNamedExactly6852(recs, path)); got != 1 {
+		t.Fatalf("want exactly 1 record named %q (the carrier), got %d", path, got)
+	}
+	if got := zigCarriers6852(recs, path); len(got) != 1 {
+		t.Fatalf("the one record named after the path is not the carrier: %d carrier(s)", len(got))
+	}
+}
+
+// TestZig_CarrierShape_6852 pins what the carrier IS, and grades the "zig"
+// token passed to PrependFileCarrier.
+//
+// HOW THE TOKEN IS GRADED HERE, stated because the mechanism is not the same as
+// for every caller. extractZig sets Language: "zig" EXPLICITLY on all four of
+// its record shapes, so Extract's TagEntitiesLanguage is a no-op for every zig
+// record — it only fills a record whose Language is EMPTY, and stamps
+// Properties["language"] when it does. The carrier is therefore the ONE record
+// in a zig extraction that TagEntitiesLanguage could ever touch, and the
+// carrier call sits INSIDE extractZig, i.e. before that tagging runs. So an
+// empty token would be filled to "zig" on the Language field and would be
+// indistinguishable there — but it would arrive carrying
+// Properties["language"], which no other zig record has. Both halves are
+// asserted below: the token on Language, and the ABSENCE of
+// Properties["language"] that is the premise for reading Language as evidence
+// at all.
+func TestZig_CarrierShape_6852(t *testing.T) {
+	const path = "src/app/main.zig"
+	recs := runZig6852(t, carrierSrcZig6852, path)
+
+	carriers := zigCarriers6852(recs, path)
+	if len(carriers) != 1 {
+		t.Fatalf("want exactly 1 carrier, got %d", len(carriers))
+	}
+	c := carriers[0]
+	if c.Kind != "SCOPE.Component" || c.Subtype != "file" {
+		t.Errorf("carrier Kind/Subtype = %q/%q, want SCOPE.Component/file", c.Kind, c.Subtype)
+	}
+	if c.Name != path || c.SourceFile != path {
+		t.Errorf("carrier Name/SourceFile = %q/%q, want both %q", c.Name, c.SourceFile, path)
+	}
+	if c.Language != "zig" {
+		t.Errorf("carrier Language = %q, want %q — the token is stamped explicitly so the "+
+			"carrier cannot become the one record in an extraction that disagrees with the "+
+			"classifier token every other record carries (proto's #6356 trap)", c.Language, "zig")
+	}
+	if _, ok := c.Properties["language"]; ok {
+		t.Errorf("carrier carries Properties[\"language\"] — that is TagEntitiesLanguage's " +
+			"provenance stamp, and its presence means the carrier reached Extract's tagging " +
+			"call with an EMPTY Language. The Language assertion above is then evidence of " +
+			"the tagger's fill, not of the token this extractor passed.")
+	}
+	if len(c.Relationships) != 0 {
+		t.Errorf("carrier owns %d relationship(s), want 0 — zig's path-anchored records "+
+			"carry the IMPORTS edges themselves, so re-homing them onto the carrier would "+
+			"DOUBLE every import edge", len(c.Relationships))
+	}
+	// The carrier must not displace what the other passes emit.
+	for _, want := range []string{"main", "helper", "Handler", "std", "helper"} {
+		found := false
+		for _, r := range recs {
+			if r.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("record %q disappeared once the carrier was added", want)
+		}
+	}
+}
+
+// TestZig_SourceSiteCountsAreWhatThisFileAssumes_6852 reads zig.go and pins the
+// two counts every closure in this file depends on: ONE `FromID:` site and FOUR
+// `Name:` sites, plus ZERO `QualifiedName` sites.
+//
+// This exists because #6861 recorded the same lesson three times over: a count
+// stated in prose is a measurement that ages silently. A fifth Name site, or a
+// second path-anchored relationship, changes what this arm has graded — and
+// fails here rather than leaving a paragraph quietly wrong.
+func TestZig_SourceSiteCountsAreWhatThisFileAssumes_6852(t *testing.T) {
+	root, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatalf("repo root: %v", err)
+	}
+	const rel = "internal/extractors/zig/zig.go"
+	body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	src := string(body)
+	if len(src) < 8000 {
+		t.Fatalf("read only %d bytes of %s — the file is far larger, so the counts below "+
+			"would be measured over a PREFIX", len(src), rel)
+	}
+	for _, tc := range []struct {
+		tok  string
+		want int
+		why  string
+	}{
+		{"FromID:", 1, "buildImportEntities' IMPORTS edge is the only path-anchored " +
+			"relationship this arm fixed; a second site is a second offender"},
+		{"Name:", 4, "pub fn / private fn / struct / import stub — three `(\\w+)` captures " +
+			"and importTopSegment. A fifth site is a Name shape no closure here covers"},
+		{"QualifiedName:", 0, "zig sets no QualifiedName, which is why the resolution " +
+			"question for this package is a Name question only"},
+	} {
+		if got := strings.Count(src, tc.tok); got != tc.want {
+			t.Errorf("%s contains %d occurrences of %q, want %d — %s", rel, got, tc.tok, tc.want, tc.why)
+		}
+	}
+	if !strings.Contains(src, "extractor.PrependFileCarrier(") {
+		t.Errorf("%s no longer calls extractor.PrependFileCarrier — the fix this whole file "+
+			"grades has been removed", rel)
+	}
+}

--- a/internal/extractors/zig/import_top_segment_6852_test.go
+++ b/internal/extractors/zig/import_top_segment_6852_test.go
@@ -1,0 +1,161 @@
+// Package zig — import_top_segment_6852_test.go
+//
+// Issue #6852, arm 12 (zig), the LAST arm. This file is an INTERNAL test
+// (package zig, not zig_test) for one reason: it enumerates the input space of
+// importTopSegment, which is unexported and is the only Name site in this
+// package that can produce a byte outside [0-9A-Za-z_].
+//
+// WHY AN ENUMERATION AND NOT AN ARGUMENT. Four arms of #6852 shipped a closure
+// of the form "no Name this package emits can equal the file path", and four
+// were disproved in review — astro by a prop key spelled as the path, clojure
+// by `.clj-kondo/hooks/foo.clj`, cobol twice, the second time by a builder that
+// concatenated a mandatory "<OP> " prefix onto a literal-derived operand. The
+// two closures that SURVIVED review were the ones that could not be defeated by
+// concatenation: crystal's LENGTH invariant and dart's brute force over 299,592
+// URIs. This file takes dart's route, and takes it one step further: the
+// property enumerated below is not "the output has no '/'" but "the output is a
+// SUBSTRING of the input". That is the anti-concatenation property itself. A
+// future edit that concatenated anything onto importTopSegment's result —
+// exactly the edit that killed cobol's first closure — fails this test on the
+// first input that reaches the new code, rather than silently invalidating a
+// paragraph of prose somewhere else.
+package zig
+
+import (
+	"strings"
+	"testing"
+)
+
+// enumAlphabet6852 is the alphabet the brute force runs over. Every byte in it
+// is load-bearing for importTopSegment's four behaviours:
+//
+//	'/'  the separator LastIndexByte('/') slices on, and the byte a nested
+//	     file path must contain;
+//	'.'  the separator the extension strip slices on;
+//	'a'  a plain [0-9A-Za-z_] byte, so a segment can be non-empty;
+//	'_'  a second such byte, so a two-character segment can be distinguished
+//	     from a repeated one when a slice boundary is off by one.
+//
+// The leading "./" and "../" strips are combinations of '.' and '/', so they
+// are reached by the alphabet rather than needing members of their own.
+var enumAlphabet6852 = []byte{'a', '_', '.', '/'}
+
+// enumMaxLen6852 is the longest input enumerated. Six is not arbitrary: the
+// longest single behaviour importTopSegment has is "../" (3 bytes) followed by
+// a segment with an extension ("a.a", 3 bytes), so six is the shortest length
+// at which every branch can be reached SIMULTANEOUSLY, and the enumeration runs
+// every shorter combination as well.
+const enumMaxLen6852 = 6
+
+// forEachImportTarget6852 calls fn for every string over enumAlphabet6852 of
+// length 0..enumMaxLen6852 inclusive, and returns how many it produced. The
+// count is returned rather than asserted inside so the caller can pin it: a
+// generator that silently stopped early would leave every property below
+// trivially true, which is the vacuity shape #6834 names.
+func forEachImportTarget6852(fn func(string)) int {
+	n := 0
+	buf := make([]byte, 0, enumMaxLen6852)
+	var rec func(depth int)
+	rec = func(depth int) {
+		fn(string(buf))
+		n++
+		if depth == enumMaxLen6852 {
+			return
+		}
+		for _, c := range enumAlphabet6852 {
+			buf = append(buf, c)
+			rec(depth + 1)
+			buf = buf[:len(buf)-1]
+		}
+	}
+	rec(0)
+	return n
+}
+
+// wantEnumCount6852 is the exact size of the enumerated space:
+// sum(4^k) for k in 0..6 = (4^7-1)/3 = 5461. Pinned so that a generator bug —
+// a wrong recursion bound, an alphabet trimmed to one byte — fails here instead
+// of quietly shrinking every property in this file to a handful of cases.
+const wantEnumCount6852 = 5461
+
+// TestZig_ImportTopSegmentIsAlwaysASubstring_6852 is the anti-concatenation
+// property, enumerated rather than argued.
+//
+// importTopSegment is the ONLY Name site in this package whose output is not a
+// verbatim `(\w+)` regex capture, so it is the only site that could ever spell
+// a byte a file path needs. What this test establishes is that the function
+// only ever SLICES its input: leading "./" / "../" removal, a slice after the
+// last '/', a slice before the last '.', and two `return mod` fall-backs. Every
+// one of those is a substring, and the enumeration says so for all 5461 inputs.
+//
+// THE CONSEQUENCE, which is what file_carrier_6852_test.go rests on: an output
+// containing '/' must have come from a '/'-containing INPUT, and the second
+// property below pins where in that input the '/' can be.
+func TestZig_ImportTopSegmentIsAlwaysASubstring_6852(t *testing.T) {
+	bad := 0
+	n := forEachImportTarget6852(func(mod string) {
+		got := importTopSegment(mod)
+		if !strings.Contains(mod, got) {
+			bad++
+			if bad <= 5 {
+				t.Errorf("importTopSegment(%q) = %q, which is NOT a substring of the input — "+
+					"the function has stopped being slice-only. A builder that concatenates onto "+
+					"this result can spell anything, including a file path at any depth, which is "+
+					"the exact defeat cobol's first closure took (#6899).", mod, got)
+			}
+		}
+	})
+	if n != wantEnumCount6852 {
+		t.Fatalf("enumerated %d inputs, want %d — the generator, not the property, is what "+
+			"changed; every assertion in this file is only as wide as this number", n, wantEnumCount6852)
+	}
+	if bad > 0 {
+		t.Errorf("%d of %d enumerated inputs produced a non-substring result", bad, n)
+	}
+}
+
+// TestZig_ImportTopSegmentSlashImpliesTrailingSlash_6852 is the property that
+// makes zig's clause-3 depth split a fact about importTopSegment rather than an
+// artefact of a closure, which is what cobol's "root depth only" turned out to
+// be (#6899).
+//
+// A nested file path contains a '/' that is not its last byte. This test
+// enumerates the whole space and finds that whenever importTopSegment returns a
+// '/'-bearing string, that string ENDS with '/' — the two `return mod`
+// fall-backs are reached only when the basename slice came out empty, which
+// means the input ended with '/'. So no import target can name an import stub
+// after a nested path, and the only clause-3 route left at nested depth needs a
+// path that ends in '/'. That input is DRIVEN, not asserted away, by
+// TestZig_ImportStubNamedLikeThePath_6852/path_ending_in_a_slash.
+func TestZig_ImportTopSegmentSlashImpliesTrailingSlash_6852(t *testing.T) {
+	bad := 0
+	withSlash := 0
+	n := forEachImportTarget6852(func(mod string) {
+		got := importTopSegment(mod)
+		if !strings.Contains(got, "/") {
+			return
+		}
+		withSlash++
+		if !strings.HasSuffix(got, "/") {
+			bad++
+			if bad <= 5 {
+				t.Errorf("importTopSegment(%q) = %q — contains '/' without ending in one, so an "+
+					"import stub CAN be named after a nested path and zig's clause-3 depth split "+
+					"is wrong", mod, got)
+			}
+		}
+	})
+	if n != wantEnumCount6852 {
+		t.Fatalf("enumerated %d inputs, want %d", n, wantEnumCount6852)
+	}
+	// POSITIVE CONTROL for this property, not a decoration: if no enumerated
+	// output contained a '/' at all, the loop body above would never run and
+	// the test would pass while measuring nothing.
+	if withSlash == 0 {
+		t.Fatal("no enumerated input produced a '/'-bearing result — the property above is " +
+			"vacuous, and a slash-free result set means the alphabet or the generator changed")
+	}
+	if bad > 0 {
+		t.Errorf("%d of %d slash-bearing results did not end in '/'", bad, withSlash)
+	}
+}

--- a/internal/extractors/zig/zig.go
+++ b/internal/extractors/zig/zig.go
@@ -226,7 +226,76 @@ func extractZig(src, filePath string) []types.EntityRecord {
 		entities = append(importEntities, entities...)
 	}
 
-	return entities
+	// ── #6852 — file carrier for the path-anchored IMPORTS above ─────────
+	//
+	// buildImportEntities stamps the source path as the FROM end of every
+	// import stub's IMPORTS edge, and internal/resolve/refs.go has no
+	// path→entity index: such an edge resolves iff some emitted node carries
+	// that exact string as its name. Zig emits no qualified names at all, so
+	// the byQualifiedName tier — a different consumer, and one FileCarrierFor's
+	// clause 3 never reads — cannot stand in either. Nothing here is named
+	// after the file as a rule, so without this the raw path reached the graph
+	// as the edge's FROM end: #6847's measurement, #6815's fix shape.
+	//
+	// CONDITIONAL, via extractor.PrependFileCarrier. An unconditional carrier
+	// mints one bare orphan node per .zig file across a whole repo, which no
+	// recall-shaped assertion can see (#6518, #6815). The over-firing direction
+	// is graded by TestZig_NoCarrierWithoutAnImport_6852.
+	//
+	// THE ONE SITE THAT CAN SPELL THE PATH is importTopSegment (named, not
+	// line-cited — same-file line cites go stale the next time someone edits a
+	// comment above them). It trims exactly ONE trailing extension, so in a
+	// ROOT file main.zig the target `@import("main.zig.zig")` names the import
+	// stub exactly `main.zig`, clause 3 declines, and the second node that
+	// would otherwise land under the same graph.EntityID (which does not hash
+	// Subtype — the #6369/#6480 hazard) is never minted. That is a DRIVEN cell,
+	// not a closure: TestZig_ImportStubNamedLikeThePath_6852 runs it, with a
+	// nested subtest as the contrast that stops it passing on a carrier that is
+	// never emitted at all.
+	//
+	// AT NESTED DEPTH the same route needs a path ending in '/', and that is
+	// settled by ENUMERATION rather than by argument, because four arms of
+	// #6852 shipped a closure a driven cell later disproved.
+	// import_top_segment_6852_test.go brute-forces all 5461 targets over
+	// {a _ . /} up to length 6 and finds that importTopSegment's result is
+	// always a SUBSTRING of its input — the anti-concatenation property itself,
+	// which is what defeated cobol's closure (#6899) — and that a '/'-bearing
+	// result always ENDS in '/'. The remaining cell is DRIVEN too (a path
+	// spelled "src/"); it is alive but not production-reachable, because no
+	// file on disk has a path ending in '/'. The other three name sites are
+	// verbatim `(\w+)` captures with no builder concatenating onto them, and
+	// `\w` is [0-9A-Za-z_], so none can hold the '.' every .zig path carries —
+	// OBSERVED by TestZig_WordCaptureNameSitesCannotSpellAPath_6852.
+	//
+	// PLACEMENT: last, and the two reasons are scored PART BY PART with the
+	// ENTAILED one named (the cobol lesson, #6899).
+	//
+	//  1. INDEPENDENT AND LOAD-BEARING — CLAUSE 2 REACHABILITY. The ONLY
+	//     path-anchored relationship zig emits is built in the import pass
+	//     immediately above. A carrier call placed anywhere before it sees no
+	//     anchored edge, clause 2 rejects, and NO carrier is minted at all —
+	//     the defect survives silently. Graded by
+	//     TestZig_ImportsFromEndResolves_6852, which goes red on any such move.
+	//  2. ENTAILED — CLAUSE 3 VISIBILITY. FileCarrierFor can only decline for a
+	//     record it is handed, so in general the call must run after the pass
+	//     that emits the path-named record. For zig that reason buys nothing
+	//     independently and is named rather than dressed up as a second one:
+	//     the only record that can be named after the path is an import stub,
+	//     built in the SAME pass as the anchor, so any position satisfying
+	//     reason 1 satisfies this one too.
+	//
+	//     Zig stores no index into `entities` anywhere — the struct pass hangs
+	//     its CONTAINS edges on structural refs, not on slice positions — so
+	//     dart's index-shift hazard (#6907) has no analogue here, and the
+	//     positions after the import pass are behaviourally equivalent.
+	//
+	// The "zig" token is stamped explicitly rather than left to Extract's
+	// TagEntitiesLanguage, which runs AFTER this. Every other record here sets
+	// its language explicitly, so that tagger is a no-op for them and the
+	// carrier is the one record it could fill: an empty token would be filled
+	// on the language field and caught instead by the provenance stamp the
+	// tagger leaves behind. TestZig_CarrierShape_6852 asserts both halves.
+	return extractor.PrependFileCarrier(filePath, "zig", entities)
 }
 
 // collectImports returns the textual targets of every @import("...") call.


### PR DESCRIPTION
Arm 12 of 12. Zig has **exactly one** `FromID` site — `buildImportEntities` → `FromID: filePath` on IMPORTS — now fixed with a conditional `extractor.PrependFileCarrier`. `knownMissingCarrier6847` goes from `{zig}` to **`{}`**.

**The site table, all four Name producers, proven not asserted.** `zig.go` has 4 `Name:` sites and 1 `FromID:` site, and those counts are now READ OUT OF THE SOURCE on every run by `TestZig_SourceSiteCountsAreWhatThisFileAssumes_6852` (which also pins `QualifiedName:` at 0 — zig sets none, so the resolution question here is a Name question only). Three sites are verbatim `(\w+)` captures, OBSERVED by driving an adversarial fixture. The fourth is `importTopSegment`.

**The closure survives concatenation because the enumeration IS the anti-concatenation property.** `import_top_segment_6852_test.go` brute-forces all **5461** targets over `{a _ . /}` up to length 6 and establishes that `importTopSegment`'s result is always a **SUBSTRING of its input**. Cobol's closure died to a builder concatenating a prefix onto a literal-derived operand; that exact edit fails this test on its first input rather than silently invalidating prose. The second enumerated property — a '/'-bearing result always **ends** in '/' — is what makes the depth split a fact about the function.

**Both clause-3 cells are DRIVEN, neither is argued away.** Root: `importTopSegment` trims exactly ONE extension, so `main.zig` importing `"main.zig.zig"` names the import stub exactly the path; clause 3 declines and the second node under one `graph.EntityID` (which does not hash Subtype — #6369/#6480) is never minted. Nested: the only shape the enumeration leaves open is a path ending in '/', so that cell is driven too (path `src/`) and reported as **alive but not production-reachable — the input is a path ending in '/'**, which no file on disk has. A nested contrast subtest stops both passing on a carrier that is never emitted at all.

**Placement enumerated, not argued — 6 positions.** P1 top of `extractZig` (M3 **DEAD**), P2 between the fn passes (M4 **DEAD**), P3 before the import pass (M5 **DEAD**) — all three mint nothing, because zig's ONLY path-anchored edge is built in the import pass, so clause 2 rejects and the defect survives silently. P4 end of `extractZig` (shipped). P5 in `Extract` before tagging (M6 **ALIVE**) and P6 after tagging (M7 **ALIVE**) are **equivalent, not merely ungraded**: the carrier owns zero relationships and carries a non-empty explicit Language, so neither tagging call can touch it and the output is byte-identical. Tail-append instead of index 0 is M10, **DEAD**. The compound is scored part by part with the **entailed** conjunct named: clause-2 reachability is the independent reason; clause-3 visibility is **entailed**, because the only record that can be named after the path is an import stub built in the same pass as the anchor. Zig stores no index into `entities`, so dart's index-shift hazard has no analogue here — stated rather than inherited.

**Mutants — 13 author mutants, every edit gated on an exact match count before scoring, `go vet` before each, restored by `cp` from shasum-verified backups.**

| # | mutant | verdict |
|---|---|---|
| M1 | drop the `PrependFileCarrier` call | DEAD |
| M2 | unconditional `FileEntity` instead | DEAD (over-firing control + empty-path) |
| M3 | placement P1 | DEAD |
| M4 | placement P2 | DEAD |
| M5 | placement P3 | DEAD |
| M6 | placement P5 (Extract, pre-tagging) | ALIVE — **equivalent** (identical output) |
| M7 | placement P6 (Extract, post-tagging) | ALIVE — **equivalent** (identical output) |
| M8 | empty lang token | DEAD via the `Properties["language"]` provenance stamp |
| M9 | wrong token `"ziglang"` | DEAD on `Language` |
| M10 | append at tail, not index 0 | DEAD (#577's index-0 convention) |
| M11 | **premise mutant** — `importTopSegment` strips ALL extensions | DEAD: the clause-3 offender ceases to exist and the root cell says so |
| T1 | travelling: clause 3 `&& len(rels) > 0` | ALIVE in zig, **DEAD in `./internal/extractor/`** |
| T2 | travelling: clause 3 `&& len(rels) == 0` | **DEAD on zig's own cells**, ALIVE in `./internal/extractor/` |

**The travelling mutant, with the honest split.** T1 is *indistinguishable inside this package* and the reason is checkable: zig's only path-named record is an import stub, and `buildImportEntities` gives every stub exactly one IMPORTS edge, so a path-named record with zero relationships is a shape zig cannot emit. Graded elsewhere, gap disclosed — dart's verdict, same mechanism. T2 is the interesting one: it is **ALIVE on the generic #6815 fixtures** (whose path-named records own no edges) and **DEAD on zig's cells**. Zig is where the `== 0` variant is graded at all. Series tally: DEAD on astro · ALIVE on clojure · ALIVE on cobol until a new cell · graded on crystal by disjoint cells · graded-elsewhere on dart · **T1 graded-elsewhere / T2 graded HERE on zig**.

**The emptied guard was restated, because emptying it opened a hole.** With entries, `TestFileAnchoredCarrier_NoNewOffender_6847`'s "every known offender still reproduces" loop was this file's strongest anti-vacuity check; empty, it iterates nothing and can no longer fail. Measured, not assumed:

- **V1** — `pathAnchoredKindsMissingCarrier` returns nil unconditionally: with the ledger empty this used to be a clean green run. Now **DEAD**, via a new per-file positive control run *through the walk's own call*: for every anchoring corpus file, blanking the carrier's name fields must make the matcher REPORT.
- **V2** — the walk stops recording offenders: **ALIVE**, and correctly so — the offender list is now the diagnostic, not the assertion. Its safety is proved rather than asserted by **V4**.
- **V3** — zig loses its carrier again, guard unmutated: **DEAD**, three assertions firing.
- **V4** — zig loses its carrier **AND** V2 is applied: still **DEAD** ("3 corpus files anchor on their own path but only 0 carry"). That is the proof the emptied guard remains a meaningful assertion.

`TestFileAnchoredCarrier_EveryAnchoringFileCarries_6847` states the invariant in the positive direction over a **non-empty** population — per language and per file count, with a floor of 100 accounted files — and its `carried` count is derived **directly from the records, not from the offender list**. Deriving it from the matcher was tried first and was wrong: a walk that stopped calling the matcher would then count every anchoring file as carried, and a real regression would read green twice over. The positive control also **un-names** the carrier rather than deleting it — deleting was measured and was wrong, because for java, python, typescript, javascript and graphql the path-named record is the same record that OWNS the anchored edges.

**Prose, since nothing downstream corrects the last arm.** `file_carrier.go`'s clause-3 paragraph gains zig's route and the enumeration lesson, plus an explicit note that "the ledger is empty" is a statement about **#6847's CORPUS**, not about the registered language set — reasonml and rescript remain confirmed offenders that corpus never reaches, and the population is still unbounded above. Same-file references name functions, not line numbers.

**Fixture axes.** `TestZig_ImportStubNamedLikeThePath_6852` varies exactly one axis per case — the path's **depth** (root / nested / trailing-slash) — holding the source bytes and the import target **byte-identical** across the first two. `TestZig_NoCarrierWithoutAnImport_6852` varies only the **presence of an `@import`**, holding every other pass (pub fn, private fn with a call, struct with a method) constant. `TestZig_OneCarrierPerFileNotPerImport_6852` varies only the **number of distinct import targets** (5 vs 2), holding path, depth and passes constant.

Verification: `./internal/extractors/zig/`, `./internal/extractors/`, `./internal/extractor/`, `./internal/resolve/`, `./cmd/grafel/` all green at `-count=1`; the whole-graph digest is unmoved (`custom_extractor_spans_6118_test.go` has no zig member — grepped, 0 occurrences); ratchet `scripts/quality/run.sh --ratchet` exit 0, 31 gated fixtures held baseline, 22 at 100% must-have recall, premise confirmed (no zig fixture exists under `internal/quality/golden/`). NOT run: the full repo suite, `-race`, and any Windows/Linux leg — CI has those.

Closes #6852. Refs #6847, #6815, #6861.
