### PR TITLE
fix(#6921): an fsnotify queue overflow dropped events forever and only logged — detect it, rescan every subscribed repo, and surface the staleness

### DIFF
--- a/internal/cli/status_daemon_detail.go
+++ b/internal/cli/status_daemon_detail.go
@@ -39,6 +39,21 @@ func printDaemonDetail(w io.Writer, st proto.StatusReply) {
 		fmt.Fprintf(w, "  watcher: %d repo(s) NOT WATCHED — file-descriptor budget full (%d/%d used); edits there will not re-index\n",
 			st.WatcherUnwatched, st.WatcherFDUsed, st.WatcherFDLimit)
 	}
+	// #6921: an fsnotify queue overflow dropped file events that are never
+	// redelivered. Printed on its own line and NOT gated on the watcher line
+	// above, for the same reason the descriptor line is not: the condition is
+	// about events that did NOT arrive, so the counters that gate that line say
+	// nothing about whether this one applies. A rescan has already re-covered
+	// the dropped window; the line exists so a user who saw a stale answer can
+	// tell an overflow from a healthy watcher, which is otherwise impossible.
+	if st.WatcherOverflows > 0 {
+		fmt.Fprintf(w, "  watcher: %d fsnotify queue overflow(s) — file events were DROPPED and never redelivered; %d full rescan(s) triggered to recover",
+			st.WatcherOverflows, st.WatcherOverflowRescans)
+		if st.WatcherLastOverflow != "" {
+			fmt.Fprintf(w, " (last: %s)", st.WatcherLastOverflow)
+		}
+		fmt.Fprintln(w)
+	}
 	if st.QueueLen > 0 || len(st.IndexInFlight) > 0 ||
 		len(st.PendingAlgo) > 0 || len(st.PendingLinks) > 0 {
 		fmt.Fprintf(w, "  scheduler: queue=%d in_flight=%d pending_algo=%d pending_links=%d\n",

--- a/internal/cli/status_overflow_6921_test.go
+++ b/internal/cli/status_overflow_6921_test.go
@@ -1,0 +1,61 @@
+package cli
+
+// status_overflow_6921_test.go — #6921, the print gate for fsnotify queue
+// overflows.
+//
+// The failure being reported is silent staleness: an overflow drops an unknown
+// set of file events, fsnotify never redelivers them, and the watcher keeps
+// reporting healthy. `grafel status` is where a user looks when the graph does
+// not match the tree, so a number that reaches StatusReply and is never printed
+// is the same defect #6014 was — right on the wire, absent from the screen.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+// TestPrintDaemonDetail_OverflowLinePrintsWithNoWatcherActivity is the
+// regression AND the gate assertion. WatcherRepos/WatcherEvents are zero here
+// on purpose: the overflow line must not be nested inside the `watcher:`
+// activity block, because that block is gated on counters describing events
+// that DID arrive, and an overflow is about events that did not.
+func TestPrintDaemonDetail_OverflowLinePrintsWithNoWatcherActivity(t *testing.T) {
+	var buf bytes.Buffer
+	printDaemonDetail(&buf, proto.StatusReply{
+		WatcherRepos:           0,
+		WatcherEvents:          0,
+		WatcherOverflows:       3,
+		WatcherOverflowRescans: 1,
+		WatcherLastOverflow:    "2026-09-06T12:00:00Z",
+	})
+	out := buf.String()
+
+	for _, want := range []string{
+		"3 fsnotify queue overflow(s)",
+		"DROPPED",
+		"1 full rescan(s)",
+		"2026-09-06T12:00:00Z",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("`grafel status` output is missing %q — an overflow the user cannot see is "+
+				"the actual defect in #6921.\ngot:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintDaemonDetail_NoOverflowLineWhenNoneHappened: the line is a warning,
+// so it must be silent in the overwhelmingly common case. A line that always
+// prints trains the reader to ignore it.
+func TestPrintDaemonDetail_NoOverflowLineWhenNoneHappened(t *testing.T) {
+	var buf bytes.Buffer
+	printDaemonDetail(&buf, proto.StatusReply{
+		WatcherRepos:  2,
+		WatcherEvents: 400,
+	})
+	if out := buf.String(); strings.Contains(out, "overflow") {
+		t.Errorf("overflow line printed for a watcher that never overflowed:\n%s", out)
+	}
+}

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -88,15 +88,28 @@ type StatusReply struct {
 	// file-descriptor budget was full, and WatcherFDUsed/WatcherFDLimit are
 	// the ledger behind that decision (#6180). A non-zero WatcherUnwatched
 	// means edits in those repos are not being picked up at all.
-	WatcherUnwatched int                `json:"watcher_unwatched,omitempty"`
-	WatcherFDUsed    int                `json:"watcher_fd_used,omitempty"`
-	WatcherFDLimit   int                `json:"watcher_fd_limit,omitempty"`
-	QueueLen         int                `json:"queue_len,omitempty"`
-	IndexInFlight    []string           `json:"index_in_flight,omitempty"`
-	PendingAlgo      []string           `json:"pending_algo,omitempty"`
-	PendingLinks     []string           `json:"pending_links,omitempty"`
-	IndexedRepos     []IndexedRepoState `json:"indexed_repos,omitempty"`
-	RecentLog        []SchedLogEntry    `json:"recent_log,omitempty"`
+	WatcherUnwatched int `json:"watcher_unwatched,omitempty"`
+	WatcherFDUsed    int `json:"watcher_fd_used,omitempty"`
+	WatcherFDLimit   int `json:"watcher_fd_limit,omitempty"`
+
+	// WatcherOverflows counts fsnotify queue overflows (#6921): the backend
+	// dropped an unknown set of file events, and because fsnotify is
+	// edge-triggered nothing redelivers them. WatcherOverflowRescans is how
+	// many full reindexes of every subscribed repo those overflows triggered —
+	// the recovery — and WatcherLastOverflow (RFC3339) is when the most recent
+	// one arrived, so the user can correlate it with what they were doing.
+	//
+	// A non-zero count is the only way this failure is visible at all: the
+	// watcher keeps running and keeps reporting healthy through an overflow.
+	WatcherOverflows       uint64             `json:"watcher_overflows,omitempty"`
+	WatcherOverflowRescans uint64             `json:"watcher_overflow_rescans,omitempty"`
+	WatcherLastOverflow    string             `json:"watcher_last_overflow,omitempty"`
+	QueueLen               int                `json:"queue_len,omitempty"`
+	IndexInFlight          []string           `json:"index_in_flight,omitempty"`
+	PendingAlgo            []string           `json:"pending_algo,omitempty"`
+	PendingLinks           []string           `json:"pending_links,omitempty"`
+	IndexedRepos           []IndexedRepoState `json:"indexed_repos,omitempty"`
+	RecentLog              []SchedLogEntry    `json:"recent_log,omitempty"`
 
 	// GroupAlgoRunning names the groups whose ANNOTATION (group-algo) pass is
 	// executing right now, and GroupAlgoInFlight counts them. The pass produces

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -396,17 +396,7 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 	reply.DaemonMode = s.daemonMode
 
 	if s.watcher != nil {
-		repos, dirs, events, dropped, unwatched := s.watcher.Stats()
-		reply.WatcherRepos = repos
-		reply.WatcherDirs = dirs
-		reply.WatcherEvents = events
-		reply.WatcherDropped = dropped
-		// #6180: surface repos that are NOT watched for want of file
-		// descriptors, plus the ledger, so `grafel status` says so out loud.
-		reply.WatcherUnwatched = unwatched
-		fdUsed, fdLimit, _, _ := s.watcher.FDBudgetStats()
-		reply.WatcherFDUsed = fdUsed
-		reply.WatcherFDLimit = fdLimit
+		fillWatcherStatus(reply, s.watcher)
 	}
 	// PH2a (#2096): report pause/resume slot counts.
 	if s.watcherMgrStats != nil {

--- a/internal/daemon/service_watcher_status.go
+++ b/internal/daemon/service_watcher_status.go
@@ -1,0 +1,59 @@
+package daemon
+
+// service_watcher_status.go — the watcher half of Service.Status' reply.
+//
+// Extracted from Status (#6921) so the mapping can be driven by a stand-in
+// watcher. Status itself needs a live *watch.Watcher to have counters worth
+// reading, and the one condition that matters most here — a queue overflow —
+// cannot be provoked from outside package watch on any platform, and cannot be
+// provoked at all on macOS, where the kqueue backend never raises it.
+//
+// The extraction moves the mapping out of Status but NOT the decision to call
+// it: Status still owns the `s.watcher != nil` gate, and a test that builds a
+// Service around a real Watcher pins that gate independently — otherwise this
+// would be the classic extraction that pins a helper and leaves the call site
+// free to skip it.
+
+import (
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+// watcherStatusSource is the read-only subset of *watch.Watcher that
+// Service.Status reports. Narrow by construction: everything here is a counter
+// snapshot, so a stand-in is a struct of fields rather than a simulation.
+type watcherStatusSource interface {
+	// Stats returns (repos, dirs, totalEvents, dropped, unwatched).
+	Stats() (int, int, uint64, uint64, int)
+	// FDBudgetStats returns (used, limit, unwatched, unwatchedRepos) (#6180).
+	FDBudgetStats() (int, int, int, []string)
+	// OverflowStats returns (overflows, rescans, coalesced, last) (#6921).
+	OverflowStats() (uint64, uint64, uint64, time.Time)
+}
+
+// fillWatcherStatus copies the watcher's counters into the status reply.
+func fillWatcherStatus(reply *proto.StatusReply, w watcherStatusSource) {
+	repos, dirs, events, dropped, unwatched := w.Stats()
+	reply.WatcherRepos = repos
+	reply.WatcherDirs = dirs
+	reply.WatcherEvents = events
+	reply.WatcherDropped = dropped
+	// #6180: surface repos that are NOT watched for want of file
+	// descriptors, plus the ledger, so `grafel status` says so out loud.
+	reply.WatcherUnwatched = unwatched
+	fdUsed, fdLimit, _, _ := w.FDBudgetStats()
+	reply.WatcherFDUsed = fdUsed
+	reply.WatcherFDLimit = fdLimit
+	// #6921: an fsnotify queue overflow drops an unknown set of file events,
+	// and fsnotify is edge-triggered, so nothing redelivers them. The watcher
+	// recovers with a full rescan of every subscribed repo — but the user must
+	// be able to SEE that it happened, because a watcher that overflowed and a
+	// watcher that is healthy look identical from outside.
+	overflows, overflowRescans, _, lastOverflow := w.OverflowStats()
+	reply.WatcherOverflows = overflows
+	reply.WatcherOverflowRescans = overflowRescans
+	if !lastOverflow.IsZero() {
+		reply.WatcherLastOverflow = lastOverflow.UTC().Format(time.RFC3339)
+	}
+}

--- a/internal/daemon/service_watcher_status_6921_test.go
+++ b/internal/daemon/service_watcher_status_6921_test.go
@@ -1,0 +1,91 @@
+package daemon
+
+// service_watcher_status_6921_test.go — #6921, the status-reply fill.
+//
+// Two levels, deliberately:
+//
+//	fillWatcherStatus  — the mapping, driven by a stand-in whose counters can be
+//	                     set to anything. A queue overflow cannot be provoked
+//	                     from this package (handleOverflow is unexported) and
+//	                     cannot be provoked AT ALL on macOS, where fsnotify's
+//	                     kqueue backend never raises ErrEventOverflow.
+//	Service.Status     — the CALL, driven by a real *watch.Watcher. Extracting
+//	                     the mapping would otherwise leave Status free to stop
+//	                     calling it, with every mapping assertion still green.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/watch"
+)
+
+// stubWatcherStatus is a watcherStatusSource with fixed counters.
+type stubWatcherStatus struct {
+	overflows, rescans, coalesced uint64
+	last                          time.Time
+}
+
+func (stubWatcherStatus) Stats() (int, int, uint64, uint64, int)   { return 2, 9, 400, 3, 1 }
+func (stubWatcherStatus) FDBudgetStats() (int, int, int, []string) { return 10, 20, 1, nil }
+func (s stubWatcherStatus) OverflowStats() (uint64, uint64, uint64, time.Time) {
+	return s.overflows, s.rescans, s.coalesced, s.last
+}
+
+func TestFillWatcherStatusReportsQueueOverflows6921(t *testing.T) {
+	last := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	var reply proto.StatusReply
+	fillWatcherStatus(&reply, stubWatcherStatus{overflows: 4, rescans: 2, coalesced: 2, last: last})
+
+	if reply.WatcherOverflows != 4 || reply.WatcherOverflowRescans != 2 {
+		t.Errorf("overflow counters = (%d, %d), want (4, 2) — without them `grafel status` cannot "+
+			"distinguish a watcher that dropped a window of events from a healthy one",
+			reply.WatcherOverflows, reply.WatcherOverflowRescans)
+	}
+	if reply.WatcherLastOverflow != "2026-09-06T12:00:00Z" {
+		t.Errorf("WatcherLastOverflow = %q, want RFC3339 2026-09-06T12:00:00Z", reply.WatcherLastOverflow)
+	}
+	// The pre-existing fields must survive the extraction untouched.
+	if reply.WatcherRepos != 2 || reply.WatcherDirs != 9 || reply.WatcherEvents != 400 ||
+		reply.WatcherDropped != 3 || reply.WatcherUnwatched != 1 ||
+		reply.WatcherFDUsed != 10 || reply.WatcherFDLimit != 20 {
+		t.Errorf("a pre-existing watcher field was dropped by the extraction: %+v", reply)
+	}
+}
+
+// TestFillWatcherStatusOmitsOverflowTimeWhenNoneHappened: a watcher that never
+// overflowed must not publish a zero-value timestamp, which renders as an
+// overflow in year 1.
+func TestFillWatcherStatusOmitsOverflowTimeWhenNoneHappened6921(t *testing.T) {
+	var reply proto.StatusReply
+	fillWatcherStatus(&reply, stubWatcherStatus{})
+	if reply.WatcherLastOverflow != "" {
+		t.Errorf("WatcherLastOverflow = %q, want empty", reply.WatcherLastOverflow)
+	}
+}
+
+// TestStatusCallsTheWatcherFill is the control one level up: a Service holding
+// a REAL watcher with one subscribed repo must report it. This is what stops
+// the extraction above from being a helper nobody calls.
+func TestStatusCallsTheWatcherFill6921(t *testing.T) {
+	w, err := watch.NewWatcher(time.Hour, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	t.Cleanup(w.Stop)
+	if _, err := w.AddRepo(t.TempDir()); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+
+	s := &Service{watcher: w, startedAt: time.Now()}
+	var reply proto.StatusReply
+	if err := s.Status(&proto.StatusArgs{}, &reply); err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if reply.WatcherRepos != 1 {
+		t.Fatalf("StatusReply.WatcherRepos = %d, want 1 — Service.Status is not reporting the "+
+			"watcher at all, so every watcher counter (overflows included) is computed and "+
+			"then discarded before anyone sees it", reply.WatcherRepos)
+	}
+}

--- a/internal/daemon/watch/overflow.go
+++ b/internal/daemon/watch/overflow.go
@@ -1,0 +1,107 @@
+package watch
+
+// overflow.go — recovery from an fsnotify queue overflow (#6921).
+//
+// fsnotify reports ErrEventOverflow on its Errors channel when the backend's
+// queue could not hold everything the kernel produced:
+//
+//	inotify — IN_Q_OVERFLOW, raised once the per-instance queue exceeds
+//	          fs.inotify.max_queued_events (kernel default 16384)
+//	          (backend_inotify.go:397-400).
+//	windows — the ReadDirectoryChangesW buffer was too small to hold the
+//	          batch (backend_windows.go:580-583).
+//	kqueue, fen — never raised (fsnotify.go:262-270).
+//
+// It means an UNKNOWN set of events was dropped. fsnotify is edge-triggered, so
+// nothing redelivers them: without a rescan those files stay stale until some
+// unrelated event (a branch switch, a manual reindex, a daemon restart) happens
+// to re-cover them, and the watcher goes on reporting healthy the whole time.
+// That is the same silent outcome as the descriptor-exhaustion case in
+// fdbudget.go, arriving by a different road.
+//
+// SCOPE — why the rescan is every repo and not one. The queue that overflows
+// belongs to the fsnotify INSTANCE. grafel builds exactly one Watcher per
+// daemon process (internal/daemon/engineplane.go:203) and a Watcher owns one
+// *fsnotify.Watcher (w.fs) that every subscribed repo shares, so one overflow
+// invalidates every one of them. The event that overflowed the queue carries no
+// path — IN_Q_OVERFLOW has none — so there is no narrower scope available even
+// in principle.
+//
+// The recovery therefore reuses the hand-off restartBackend already uses for
+// the identical "we lost events" condition: ForceRescan, i.e. the
+// EventSink(repoPath, bulk=true) contract, which asks the scheduler for a full
+// repo reindex rather than a file-level diff. No second reindex path exists.
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// overflowRescanCooldown bounds the recovery's fan-out: at most one full rescan
+// of every subscribed repo per window, however many overflows arrive.
+//
+// An overflow storm must not become a reindex storm. inotify sets
+// IN_Q_OVERFLOW on the queue, not on one event, so a single burst — an
+// `npm install`, a codegen run, an agent rewriting a worktree — commonly
+// produces several in a row; one rescan each would reindex every repo in the
+// daemon several times over and generate exactly the churn that overflowed the
+// queue. Coalescing is safe because the rescans are IDENTICAL: a rescan covers
+// every path a later overflow in the same burst could have dropped, so the
+// second is not merely expensive, it is redundant.
+//
+// This is the same bound #5675's activation semaphore and quarantine.go put on
+// their fan-out — a ceiling on concurrent recovery work, not a retry budget.
+// A coalesced overflow is still COUNTED and still reported (OverflowStats), so
+// the user sees the burst even though the daemon acts on it once.
+const overflowRescanCooldown = 30 * time.Second
+
+// handleOverflow is the recovery. It runs on the loop goroutine, so it must not
+// block: that goroutine is the sole receiver on the backend's Events, and
+// fsnotify's Windows backend cannot complete an Add or a Remove while nobody is
+// draining (watcher.go:172-185). The sink fan-out is therefore dispatched to
+// its own goroutine, exactly as RescanRepo does.
+func (w *Watcher) handleOverflow() {
+	atomic.AddUint64(&w.overflows, 1)
+	now := w.clk.Now()
+
+	w.mu.Lock()
+	w.lastOverflowAt = now
+	if !w.lastOverflowRescanAt.IsZero() && now.Sub(w.lastOverflowRescanAt) < overflowRescanCooldown {
+		w.mu.Unlock()
+		atomic.AddUint64(&w.overflowsCoalesced, 1)
+		w.logger.Warn("watcher: fsnotify queue overflow — events were DROPPED; "+
+			"a full rescan is already in flight for this burst, coalescing",
+			"overflows", atomic.LoadUint64(&w.overflows))
+		return
+	}
+	w.lastOverflowRescanAt = now
+	repos := len(w.repos)
+	w.mu.Unlock()
+	atomic.AddUint64(&w.overflowRescans, 1)
+
+	w.logger.Warn("watcher: fsnotify queue overflow — an unknown set of file events was DROPPED "+
+		"and will never be redelivered; forcing a full reindex of every subscribed repo",
+		"repos", repos, "overflows", atomic.LoadUint64(&w.overflows))
+	go w.ForceRescan()
+}
+
+// OverflowStats reports the queue-overflow ledger for `grafel status` and
+// /diagnostics (#6921): how many overflows the backend reported, how many full
+// rescans they triggered, how many were coalesced into a rescan already in
+// flight, and when the last one arrived.
+//
+// It is surfaced rather than merely logged because the failure being reported
+// is silent staleness — a user staring at a graph that does not match their
+// tree has no way to tell an overflow from a healthy watcher, and a daemon log
+// nobody reads is not an answer. A non-zero count means "some window of edits
+// was dropped and re-covered by a rescan"; the last-overflow time is what
+// makes it correlatable with what the user was doing.
+func (w *Watcher) OverflowStats() (overflows, rescans, coalesced uint64, last time.Time) {
+	w.mu.Lock()
+	last = w.lastOverflowAt
+	w.mu.Unlock()
+	return atomic.LoadUint64(&w.overflows),
+		atomic.LoadUint64(&w.overflowRescans),
+		atomic.LoadUint64(&w.overflowsCoalesced),
+		last
+}

--- a/internal/daemon/watch/overflow_6921_test.go
+++ b/internal/daemon/watch/overflow_6921_test.go
@@ -1,0 +1,296 @@
+package watch
+
+// overflow_6921_test.go — #6921. fsnotify's ErrEventOverflow was consumed by
+// the same `logger.Error("watcher: error")` arm as every other backend error,
+// so an inotify IN_Q_OVERFLOW (or a Windows buffer overflow) dropped an UNKNOWN
+// set of events, was never redelivered — fsnotify is edge-triggered — and left
+// the graph silently stale while the watcher went on reporting healthy.
+//
+// SCOPE. The overflow is a property of the fsnotify INSTANCE, not of a repo:
+// the queue whose depth is exceeded is the one inotify keeps per inotify fd.
+// grafel constructs exactly one Watcher per daemon process
+// (internal/daemon/engineplane.go:203), and one Watcher owns one
+// *fsnotify.Watcher (Watcher.fs, watcher.go:180) shared by every subscribed
+// repo. So an overflow invalidates EVERY subscribed repo, which is what
+// TestQueueOverflowRescansEverySubscribedRepo pins — a per-repo rescan would be
+// a fix that leaves most of the staleness in place.
+//
+// The whole suite here drives the loop's error channel directly and asserts
+// against the injected clock, never a sleep. Nothing below is platform-gated:
+// kqueue and fen never RAISE ErrEventOverflow (fsnotify.go:262-270), but
+// grafel's handling of one is its own code and is required to behave
+// identically wherever it is compiled.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// overflowHarness is a Watcher whose loop goroutine drains channels the TEST
+// owns, so an ErrEventOverflow can be delivered on any platform without asking
+// the kernel to co-operate.
+//
+// The real backend stays live — AddRepo must subscribe a real watch set for
+// "every subscribed repo" to mean anything — and its own Events/Errors get a
+// discard sink for the lifetime of the test. Withholding events from the LOOP
+// is not the same as leaving the backend unread: on Windows an unread backend
+// deadlocks the next Add (see watcher.go:172-185 and #6380).
+type overflowHarness struct {
+	w    *Watcher
+	errs chan error
+	clk  *manualClock
+
+	mu      sync.Mutex
+	rescans []string
+	bulkAll bool // false once any sink call arrived with bulk=false
+	fired   chan string
+}
+
+func newOverflowHarness(t *testing.T) *overflowHarness {
+	t.Helper()
+	h := &overflowHarness{
+		bulkAll: true,
+		fired:   make(chan string, 64),
+	}
+	ev := make(chan fsnotify.Event)
+	errs := make(chan error)
+	w, err := NewWatcherConfig(Config{
+		Debounce:          time.Hour,
+		BulkThreshold:     10000,
+		HeartbeatInterval: time.Hour,
+		reconcileInterval: -1,
+		disableQuarantine: true,
+		testEvents:        ev,
+		testErrors:        errs,
+	}, func(repo string, bulk bool) {
+		h.mu.Lock()
+		h.rescans = append(h.rescans, repo)
+		if !bulk {
+			h.bulkAll = false
+		}
+		h.mu.Unlock()
+		h.fired <- repo
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	// Installed before any repo is subscribed, so nothing is ever armed against
+	// the real clock.
+	h.clk = newManualClock()
+	w.clk = h.clk
+	h.w, h.errs = w, errs
+
+	w.mu.Lock()
+	fw := w.fs
+	w.mu.Unlock()
+	drained := discardBackendChannels(fw.Events, fw.Errors)
+	realClose := w.closeBackend
+	w.closeBackend = func() error {
+		cerr := realClose()
+		select {
+		case <-drained:
+		case <-time.After(5 * time.Second):
+			t.Errorf("the backend discard sink outlived Close by 5s")
+		}
+		close(ev)
+		close(errs)
+		return cerr
+	}
+	t.Cleanup(w.Stop)
+	return h
+}
+
+// addRepo subscribes a fresh single-file repo and returns its absolute path.
+func (h *overflowHarness) addRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.w.AddRepo(dir); err != nil {
+		t.Fatalf("AddRepo(%s): %v", dir, err)
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return abs
+}
+
+// markStopping publishes the shutdown signal the way Stop's first statement
+// does, WITHOUT the rest of Stop. stopOnce is consumed here so the harness's
+// own t.Cleanup(w.Stop) becomes a no-op rather than a second close of stopCh;
+// the backend is instead released by the cleanup registered below, which runs
+// first (LIFO) and closes ev/errs, retiring the loop.
+func (h *overflowHarness) markStopping(t *testing.T) {
+	t.Helper()
+	h.w.stopOnce.Do(func() {
+		h.w.mu.Lock()
+		close(h.w.stopCh)
+		h.w.mu.Unlock()
+	})
+	t.Cleanup(func() { _ = h.w.closeBackend() })
+}
+
+// send delivers one error to the loop and returns only once the loop has
+// FINISHED handling it. errs is unbuffered, so the second send completes only
+// after the loop has come back around to its select — which is the
+// synchronisation point that lets the assertions below be exact rather than
+// polled. The sentinel is a plain error, which the fix must ignore.
+func (h *overflowHarness) send(err error) {
+	h.errs <- err
+	h.errs <- errors.New("sentinel: not an overflow")
+}
+
+// awaitRescans collects exactly n sink calls, failing if fewer arrive in time.
+// The rescan runs on its own goroutine (the loop goroutine must never block on
+// the sink: it is the sole receiver on the backend's Events), so this is a
+// bounded wait on a real signal, not a sleep.
+func (h *overflowHarness) awaitRescans(t *testing.T, n int) []string {
+	t.Helper()
+	var got []string
+	for i := 0; i < n; i++ {
+		select {
+		case r := <-h.fired:
+			got = append(got, r)
+		case <-time.After(10 * time.Second):
+			t.Fatalf("only %d of %d expected rescan sink calls arrived", len(got), n)
+		}
+	}
+	return got
+}
+
+// noMoreRescans asserts nothing further is queued. Safe to call immediately
+// after a send() returns: the counter mutations happen synchronously on the
+// loop goroutine, so a rescan that was going to be armed already has been.
+func (h *overflowHarness) noMoreRescans(t *testing.T) {
+	t.Helper()
+	select {
+	case r := <-h.fired:
+		t.Fatalf("unexpected extra rescan of %s", r)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestQueueOverflowRescansEverySubscribedRepo is the headline regression, and
+// the scope assertion: one overflow on the single shared fsnotify instance must
+// rescan BOTH subscribed repos with bulk=true — the EventSink(repo, true)
+// contract the heartbeat's restart path already uses for the same "we lost
+// events" condition. Before #6921 this arm only logged.
+func TestQueueOverflowRescansEverySubscribedRepo(t *testing.T) {
+	h := newOverflowHarness(t)
+	a := h.addRepo(t)
+	b := h.addRepo(t)
+
+	h.send(fsnotify.ErrEventOverflow)
+
+	got := h.awaitRescans(t, 2)
+	seen := map[string]bool{}
+	for _, r := range got {
+		seen[r] = true
+	}
+	if !seen[a] || !seen[b] {
+		t.Fatalf("overflow rescanned %v; want both %s and %s — the overflow is per fsnotify "+
+			"INSTANCE and grafel runs one instance for every repo, so a partial rescan leaves "+
+			"the rest of the daemon's repos silently stale", got, a, b)
+	}
+	h.mu.Lock()
+	bulk := h.bulkAll
+	h.mu.Unlock()
+	if !bulk {
+		t.Error("a recovery rescan was signalled with bulk=false: an overflow means the event " +
+			"history is INCOMPLETE, so a file-level diff has nothing to diff against")
+	}
+
+	overflows, rescans, coalesced, last := h.w.OverflowStats()
+	if overflows != 1 || rescans != 1 || coalesced != 0 {
+		t.Errorf("OverflowStats() = (overflows=%d rescans=%d coalesced=%d), want (1,1,0)",
+			overflows, rescans, coalesced)
+	}
+	if last.IsZero() {
+		t.Error("OverflowStats() reported no last-overflow time; `grafel status` has nothing to show")
+	}
+}
+
+// TestPlainBackendErrorNeverRescans is the over-firing guard. Recall alone
+// cannot catch a predicate that fires on everything, and every non-overflow
+// error still reaching this channel (EACCES on a watch, a syscall failure)
+// would then reindex the whole daemon.
+func TestPlainBackendErrorNeverRescans(t *testing.T) {
+	h := newOverflowHarness(t)
+	h.addRepo(t)
+
+	h.send(errors.New("permission denied"))
+	h.send(os.ErrPermission)
+
+	h.noMoreRescans(t)
+	overflows, rescans, coalesced, last := h.w.OverflowStats()
+	if overflows != 0 || rescans != 0 || coalesced != 0 || !last.IsZero() {
+		t.Fatalf("a non-overflow error was counted as an overflow: (overflows=%d rescans=%d "+
+			"coalesced=%d last=%v)", overflows, rescans, coalesced, last)
+	}
+}
+
+// TestOverflowStormCoalescesIntoOneRescan: an overflow storm must not become a
+// reindex storm. inotify raises IN_Q_OVERFLOW once per read that finds the flag
+// set, so a single burst can produce many; a rescan per overflow would reindex
+// every repo in the daemon several times over, generating exactly the churn
+// that overflowed the queue.
+//
+// Bound is a cooldown measured on the injected clock, so this test asserts the
+// window rather than outrunning it.
+func TestOverflowStormCoalescesIntoOneRescan(t *testing.T) {
+	h := newOverflowHarness(t)
+	h.addRepo(t)
+
+	for i := 0; i < 5; i++ {
+		h.send(fsnotify.ErrEventOverflow)
+	}
+	h.awaitRescans(t, 1)
+	h.noMoreRescans(t)
+
+	overflows, rescans, coalesced, _ := h.w.OverflowStats()
+	if overflows != 5 || rescans != 1 || coalesced != 4 {
+		t.Fatalf("OverflowStats() = (overflows=%d rescans=%d coalesced=%d), want (5,1,4)",
+			overflows, rescans, coalesced)
+	}
+
+	// Still inside the window: one tick short of the cooldown changes nothing.
+	h.clk.Advance(overflowRescanCooldown - time.Nanosecond)
+	h.send(fsnotify.ErrEventOverflow)
+	h.noMoreRescans(t)
+
+	// Past it: a genuinely new overflow is a genuinely new staleness event.
+	h.clk.Advance(time.Nanosecond)
+	h.send(fsnotify.ErrEventOverflow)
+	h.awaitRescans(t, 1)
+
+	overflows, rescans, coalesced, _ = h.w.OverflowStats()
+	if overflows != 7 || rescans != 2 || coalesced != 5 {
+		t.Fatalf("after the cooldown elapsed OverflowStats() = (overflows=%d rescans=%d "+
+			"coalesced=%d), want (7,2,5)", overflows, rescans, coalesced)
+	}
+}
+
+// TestOverflowDuringStopDoesNotRescan: Stop tears the backend down and the loop
+// keeps draining what the teardown pushes out (#6287). Acting on an overflow
+// there would arm a reindex against a watcher that is going away.
+func TestOverflowDuringStopDoesNotRescan(t *testing.T) {
+	h := newOverflowHarness(t)
+	h.addRepo(t)
+
+	h.markStopping(t)
+	h.send(fsnotify.ErrEventOverflow)
+
+	h.noMoreRescans(t)
+	if overflows, rescans, _, _ := h.w.OverflowStats(); overflows != 0 || rescans != 0 {
+		t.Fatalf("an overflow arriving during shutdown was acted on: overflows=%d rescans=%d",
+			overflows, rescans)
+	}
+}

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -386,6 +386,23 @@ type Watcher struct {
 	// unwatched until its repo is re-registered, so it is logged as well as
 	// counted.
 	droppedSubscribes uint64
+	// overflows counts fsnotify ErrEventOverflow reports (#6921);
+	// overflowRescans counts the full rescans they triggered, and
+	// overflowsCoalesced counts those folded into a rescan already in flight
+	// for the same burst. See overflow.go — the three are reported together
+	// because a raw overflow count alone cannot say whether anything RECOVERED
+	// the dropped events.
+	overflows          uint64
+	overflowRescans    uint64
+	overflowsCoalesced uint64
+	// lastOverflowAt and lastOverflowRescanAt are guarded by mu rather than
+	// atomic: they are read once per `grafel status` and written once per
+	// overflow, and lastOverflowRescanAt has to be tested-and-set as one step
+	// or two overflows arriving together would each start a rescan.
+	// Both are stamped from w.clk, the package's time seam, so the cooldown is
+	// asserted against controlled time in tests instead of a sleep.
+	lastOverflowAt       time.Time
+	lastOverflowRescanAt time.Time
 }
 
 // subscribeQueueCap bounds subCh. It is a var so a test can shrink it to
@@ -1369,9 +1386,19 @@ func (w *Watcher) loop() {
 				w.backendClosed()
 				return
 			}
-			if err != nil && !w.stopping() {
-				w.logger.Error("watcher: error", "err", err)
+			if err == nil || w.stopping() {
+				continue
 			}
+			// An overflow is not an error report about one path, it is the
+			// backend saying "your event history is incomplete" — so it gets a
+			// recovery, not a log line (#6921). See overflow.go for the scope
+			// argument and the cooldown that keeps a burst from becoming a
+			// reindex storm. Every other error keeps the old behaviour.
+			if errors.Is(err, fsnotify.ErrEventOverflow) {
+				w.handleOverflow()
+				continue
+			}
+			w.logger.Error("watcher: error", "err", err)
 		}
 	}
 }

--- a/internal/dashboard/handlers_diagnostics.go
+++ b/internal/dashboard/handlers_diagnostics.go
@@ -78,6 +78,16 @@ type DaemonDiagnostics struct {
 	WatcherFDUsed         int      `json:"watcher_fd_used,omitempty"`
 	WatcherFDLimit        int      `json:"watcher_fd_limit,omitempty"`
 	WatcherForceRescanOK  bool     `json:"watcher_force_rescan_available"`
+
+	// fsnotify queue overflows (#6921). A non-zero count means the backend
+	// dropped an unknown set of events; because fsnotify is edge-triggered they
+	// are never redelivered, so WatcherOverflowRescans is the recovery that
+	// re-covered them. Reported here as well as in `grafel status` because the
+	// symptom — a graph that does not match the tree — is otherwise
+	// indistinguishable from a healthy watcher.
+	WatcherOverflows       uint64 `json:"watcher_overflows,omitempty"`
+	WatcherOverflowRescans uint64 `json:"watcher_overflow_rescans,omitempty"`
+	WatcherLastOverflow    string `json:"watcher_last_overflow,omitempty"`
 }
 
 // GroupDiagnostics covers one group's health.
@@ -341,6 +351,14 @@ func (s *Server) buildDaemonDiagnostics() DaemonDiagnostics {
 		d.WatcherUnwatchedRepos = unwatchedRepos
 		d.WatcherFDUsed = fdUsed
 		d.WatcherFDLimit = fdLimit
+		// #6921: queue overflows dropped events permanently. The rescan count
+		// says whether anything recovered them.
+		overflows, overflowRescans, _, lastOverflow := s.watcher.OverflowStats()
+		d.WatcherOverflows = overflows
+		d.WatcherOverflowRescans = overflowRescans
+		if !lastOverflow.IsZero() {
+			d.WatcherLastOverflow = lastOverflow.UTC().Format(time.RFC3339)
+		}
 	}
 
 	return d

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -155,6 +155,11 @@ type watcherForceRescan interface {
 	// watcher's descriptor ledger (#6180). limit == 0 means the platform does
 	// not do descriptor accounting.
 	FDBudgetStats() (int, int, int, []string)
+	// OverflowStats returns (overflows, rescans, coalesced, lastOverflow) for
+	// fsnotify queue overflows (#6921). A non-zero overflow count means file
+	// events were dropped and never redelivered; rescans is how many full
+	// reindexes recovered them.
+	OverflowStats() (uint64, uint64, uint64, time.Time)
 }
 
 // webhookDispatcherIface is the subset of notifications.Dispatcher used by the

--- a/internal/dashboard/watcher_overflow_6921_test.go
+++ b/internal/dashboard/watcher_overflow_6921_test.go
@@ -1,0 +1,72 @@
+package dashboard
+
+// watcher_overflow_6921_test.go — #6921, the diagnostics fill.
+//
+// An fsnotify queue overflow drops file events permanently (fsnotify is
+// edge-triggered), and the watcher goes on reporting healthy through it. The
+// daemon now recovers with a full rescan, but a recovery the user cannot see is
+// still the defect: "my graph does not match my tree" has to be answerable.
+//
+// Graded at the CALL SITE — buildDaemonDiagnostics, the method that actually
+// fills the payload — rather than on a helper, so deleting the fill fails here.
+
+import (
+	"testing"
+	"time"
+)
+
+// overflowingWatcher is a watcherForceRescan that reports one overflow and one
+// recovery rescan. Every other method returns zeros: this test is about the
+// overflow fields and nothing else.
+type overflowingWatcher struct {
+	overflows, rescans, coalesced uint64
+	last                          time.Time
+}
+
+func (overflowingWatcher) ForceRescan()                           {}
+func (overflowingWatcher) Stats() (int, int, uint64, uint64, int) { return 0, 0, 0, 0, 0 }
+func (overflowingWatcher) FDBudgetStats() (int, int, int, []string) {
+	return 0, 0, 0, nil
+}
+func (o overflowingWatcher) OverflowStats() (uint64, uint64, uint64, time.Time) {
+	return o.overflows, o.rescans, o.coalesced, o.last
+}
+
+func TestDaemonDiagnosticsReportsQueueOverflows6921(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	last := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	s := &Server{watcher: overflowingWatcher{overflows: 3, rescans: 1, coalesced: 2, last: last}}
+
+	d := s.buildDaemonDiagnostics()
+
+	if d.WatcherOverflows != 3 {
+		t.Errorf("WatcherOverflows = %d, want 3 — the count is the only signal that a window of "+
+			"file events was dropped; without it an overflow is indistinguishable from a healthy watcher",
+			d.WatcherOverflows)
+	}
+	if d.WatcherOverflowRescans != 1 {
+		t.Errorf("WatcherOverflowRescans = %d, want 1 — the count says whether anything RECOVERED "+
+			"the dropped events", d.WatcherOverflowRescans)
+	}
+	if d.WatcherLastOverflow != "2026-09-06T12:00:00Z" {
+		t.Errorf("WatcherLastOverflow = %q, want RFC3339 2026-09-06T12:00:00Z", d.WatcherLastOverflow)
+	}
+}
+
+// TestDaemonDiagnosticsOmitsOverflowTimeWhenNoneHappened: a watcher that has
+// never overflowed must not publish a zero-value timestamp, which would read as
+// "an overflow happened in year 1".
+func TestDaemonDiagnosticsOmitsOverflowTimeWhenNoneHappened6921(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	s := &Server{watcher: overflowingWatcher{}}
+
+	d := s.buildDaemonDiagnostics()
+
+	if d.WatcherOverflows != 0 || d.WatcherOverflowRescans != 0 {
+		t.Errorf("counters non-zero on a watcher that never overflowed: %+v", d)
+	}
+	if d.WatcherLastOverflow != "" {
+		t.Errorf("WatcherLastOverflow = %q, want empty for a watcher that never overflowed",
+			d.WatcherLastOverflow)
+	}
+}


### PR DESCRIPTION
`internal/daemon/watch/watcher.go`'s error arm was the only consumer of fsnotify's error channel, and it treated an `ErrEventOverflow` exactly like any other backend error: one `logger.Error`, then carry on. An overflow means an **unknown set of events was dropped**, and fsnotify is edge-triggered — nothing redelivers them. The watcher kept reporting healthy and the graph stayed silently stale for every file whose event was lost.

## STEP 1 — the scope question the issue left open

**One fsnotify instance backs every repo.** Not inferred from a type name:

- `internal/daemon/engineplane.go:203` — `watch.NewWatcherConfig(...)` is the **only** non-test construction of a `Watcher` in `internal/` or `cmd/`, and it runs once per daemon process.
- `internal/daemon/watch/watcher.go:180` — that one `Watcher` holds a single `fs *fsnotify.Watcher`, shared by every repo `AddRepo` subscribes.
- `internal/daemon/watch/manager.go:6-12` says the same thing from the other end: pause/resume "delegate to those APIs rather than introducing a second Watcher instance."

So an overflow invalidates **everything currently watched**, and the rescan has to be all of it. `IN_Q_OVERFLOW` also carries no path, so no narrower scope exists even in principle.

## STEP 1 — reproduction: NOT reproduced, and why

Attempted, honestly, and it failed for a structural reason rather than a lack of pressure: **20 000 file creates in 2.7 s across 50 watched directories → 4481 events delivered, 0 overflows.** The positive control is in that same line — events flowed, so the harness was live.

This machine is macOS and no Linux container was available. fsnotify documents the reason at `fsnotify.go:262-270`: **"kqueue, fen: Not used."** Only `backend_inotify.go:397-400` and `backend_windows.go:580-583` ever raise it. The branch is therefore unreachable on darwin *by construction*, and the Linux/Windows behaviour here is reasoned from fsnotify's source, not observed. That is a real limit on the confidence of everything downstream and it is stated in the commit message too.

## STEP 2 — the fix

1. **Detect** — `errors.Is(err, fsnotify.ErrEventOverflow)` at the error-channel site. Every other error keeps the old behaviour.
2. **Recover** — `ForceRescan()`, i.e. the existing `EventSink(repoPath, bulk=true)` contract, which is precisely the hand-off `restartBackend` already uses for the identical "we lost events" condition. No second reindex path was invented. The fan-out is dispatched to its own goroutine: the loop goroutine is the sole receiver on the backend's `Events`, and blocking it deadlocks the Windows backend's next `Add` (the invariant at `watcher.go:172-185`).
3. **Report** — `OverflowStats()` → `StatusReply.Watcher{Overflows,OverflowRescans,LastOverflow}` → an **ungated** line in `grafel status`:

   ```
   watcher: 3 fsnotify queue overflow(s) — file events were DROPPED and never
   redelivered; 1 full rescan(s) triggered to recover (last: 2026-09-06T12:00:00Z)
   ```

   Ungated for the same reason the `#6180` descriptor line is: the `watcher:` activity block is gated on counters describing events that *did* arrive, and an overflow is about events that did not. The same three fields land in `/diagnostics`.

**The storm trap.** A burst raises several overflows and the rescans they ask for are identical, so all but the first inside `overflowRescanCooldown` (30 s, measured on the package's clock seam) are **coalesced — still counted, still reported, acted on once**. Same shape of bound as #5675's activation semaphore and `quarantine.go`'s tracker.

## Tests

Every timing outcome is asserted against the injected `manualClock`; there is not a `time.Sleep` in the suite. The harness points the loop at channels the test owns and gives the real backend a discard sink, so it is safe on Windows (#6380's lesson).

| Test | Pins |
|---|---|
| `TestQueueOverflowRescansEverySubscribedRepo` | **both** repos rescanned, `bulk=true` — the scope claim above |
| `TestPlainBackendErrorNeverRescans` | the over-firing direction: a plain error must not reindex the daemon |
| `TestOverflowStormCoalescesIntoOneRescan` | 5 overflows → 1 rescan; one tick short of the cooldown → still 1; past it → 2 |
| `TestOverflowDuringStopDoesNotRescan` | no reindex armed against a watcher being torn down |
| `TestDaemonDiagnosticsReportsQueueOverflows6921` + omission case | the `/diagnostics` fill, at `buildDaemonDiagnostics` |
| `TestPrintDaemonDetail_OverflowLine…` + silence case | the `grafel status` print gate (#6014's defect class) |
| `TestFillWatcherStatus…` + `TestStatusCallsTheWatcherFill6921` | the reply mapping **and** the call site — a real `*watch.Watcher` proves `Status` still calls it |

## Mutant table — 12 applied, 12 DEAD

Each applied by a script that refuses to write unless the anchor matches exactly once and the replacement lands exactly once; `go vet` before every score; `-count=1` throughout; restored by `cp` from shasum-verified backups (never `git checkout`), with a `diff` proving the restore.

| # | Mutant (call site) | Verdict | Killed by |
|---|---|---|---|
| M1 | delete the overflow detection in `loop` | **DEAD** | scope + storm tests |
| M2 | keep detection, drop `go w.ForceRescan()` (**the fifth no-op mode**) | **DEAD** | scope + storm tests |
| M3 | delete the cooldown → a rescan per overflow | **DEAD** | storm test |
| M4 | rescan only one repo instead of all | **DEAD** | scope test |
| M5 | drop the `stopping()` guard | **DEAD** | shutdown test |
| M6 | widen the predicate to `if true` | **DEAD** | plain-error test |
| M8 | drop `d.WatcherOverflows` in diagnostics | **DEAD** | dashboard test |
| M9 | delete the `grafel status` line | **DEAD** | CLI print-gate test |
| M10 | drop `reply.WatcherOverflows` | **DEAD** | fill test |
| M11 | stop calling `fillWatcherStatus` from `Status` | **DEAD** | real-watcher control |
| M12d / M12s | remove the `!last.IsZero()` guard (year-1 timestamps) | **DEAD** | the two omission tests |

No survivors, so there is no three-way verdict to render.

## Verification

`go vet ./internal/...` clean; `gofmt -l` clean. `go test -count=1` green on `./internal/daemon/watch/`, `./internal/daemon/`, `./internal/cli/`, `./internal/dashboard/`.

One caveat worth recording: a first full run showed 4 `TestStaleReindexGuard_*` failures that were **my own scratch `GRAFEL_DAEMON_ROOT` being reused across runs** — leftover request files, not this change. Re-run against a fresh root: green.

Nothing in the change is `runtime.GOOS`-conditional, so no `ci:full` label is needed on that account.

Closes #6921
