### PR TITLE
fix(#6931,#6922): the walker consulted .gitignore for directories only, and never read the other two ignore sources git has

### DIFF
--- a/internal/daemon/walk/gitexclude.go
+++ b/internal/daemon/walk/gitexclude.go
@@ -1,0 +1,173 @@
+// Package walk — gitexclude.go
+//
+// #6922: git reads THREE ignore sources, not one.
+//
+//  1. .gitignore files in the tree      (deepest first — highest precedence)
+//  2. .git/info/exclude                 (per-clone, uncommitted)
+//  3. core.excludesFile                 (per-user global — lowest precedence)
+//
+// The walker read only the first, so a file excluded via .git/info/exclude was
+// indexed by grafel and reported by `git status` at no -u level. This file
+// resolves sources 2 and 3 and hands them to the walker as ordinary IgnoreFile
+// values, so they go through the same parser, the same precedence stack and the
+// same SkipEntry reporting as .gitignore.
+package walk
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/gitmeta"
+)
+
+// gitExcludeSourceInfo is the label used for .git/info/exclude in SkipEntry
+// rules; gitExcludeSourceGlobal is the label for core.excludesFile.
+const (
+	gitExcludeSourceInfo   = "info/exclude"
+	gitExcludeSourceGlobal = "core.excludesFile"
+)
+
+// gitExcludeIgnoreFiles returns the non-.gitignore ignore sources for the repo
+// containing root, ordered LOWEST precedence first — core.excludesFile, then
+// .git/info/exclude — so a caller can Push them onto an IgnoreStack before the
+// tree's own .gitignore files, which must outrank both.
+//
+// Entries that do not exist, are empty, or contain no patterns are omitted, so
+// a non-git directory yields nil and costs two bounded git calls.
+//
+// Patterns in both files are anchored at the git TOP-LEVEL. When root is a
+// subdirectory of the top-level (a monorepo registered by package root) the
+// patterns are rewritten relative to root by the same helper that handles
+// inherited .grafelignore files, so an anchored `/build` in info/exclude does
+// not silently become "anything named build" under the child root.
+// gitExcludeIgnoreFiles returns the non-.gitignore ignore sources for the repo
+// at root, ordered LOWEST precedence first — core.excludesFile, then
+// .git/info/exclude — so a caller can Push them onto an IgnoreStack before the
+// tree's own .gitignore files, which must outrank both.
+//
+// Entries that do not exist, are empty, or contain no patterns are omitted, so
+// a non-git directory yields nil and costs one bounded git call.
+//
+// SCOPE, deliberately: patterns in both files are anchored at the git
+// TOP-LEVEL, so they are applied ONLY when root IS the top-level. A walk rooted
+// at a subdirectory (a monorepo registered by package root) gets neither — the
+// same treatment root .gitignore already gets, which is read from root and not
+// inherited from the top-level either. The one inheriting layer, .grafelignore,
+// rewrites its patterns through rewriteInheritedIgnoreLine, and that rewrite
+// DROPS anchoring: `/sub/x.go` under relRoot `sub` becomes the un-anchored
+// `x.go`, which then matches at any depth. Reusing it here would trade an
+// under-exclusion for an over-exclusion, so it is not reused. Applying the
+// patterns unrewritten would mis-anchor them just as badly.
+func gitExcludeIgnoreFiles(root string) []*IgnoreFile {
+	// RunGit, not Capture: only the top-level is needed here and Capture costs
+	// five git invocations to answer four questions this function never asks.
+	topLevel := gitmeta.RunGit(root, "rev-parse", "--show-toplevel")
+	if topLevel == "" {
+		return nil // not a git repo (or git unavailable) — nothing to read
+	}
+	if !isSamePathResolved(topLevel, root) {
+		return nil // see SCOPE above
+	}
+
+	var out []*IgnoreFile
+	if ig := parseExcludeFile(globalExcludesPath(root), gitExcludeSourceGlobal); ig != nil {
+		out = append(out, ig)
+	}
+	if ig := parseExcludeFile(infoExcludePath(root), gitExcludeSourceInfo); ig != nil {
+		out = append(out, ig)
+	}
+	return out
+}
+
+// isSamePathResolved reports whether a and b name the same directory once both
+// are made absolute and symlink-resolved (macOS /var → /private/var).
+func isSamePathResolved(a, b string) bool {
+	resolve := func(p string) string {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return ""
+		}
+		if r, err := filepath.EvalSymlinks(abs); err == nil {
+			abs = r
+		}
+		return filepath.Clean(abs)
+	}
+	ra, rb := resolve(a), resolve(b)
+	if ra == "" || rb == "" {
+		return false
+	}
+	return samePath(ra, rb)
+}
+
+// parseExcludeFile reads path as gitignore syntax and returns an IgnoreFile
+// anchored at the repo root, or nil when the file is absent, unreadable or pattern-free.
+//
+// readIgnoreFile (not os.ReadFile) because this is a NAME-CHOSEN read that runs
+// before the walk, so the entry-type gate has nothing to say about it — the
+// same hazard #6416 fixed for .grafelignore applies verbatim to a
+// `mkfifo .git/info/exclude`.
+func parseExcludeFile(path, source string) *IgnoreFile {
+	if path == "" {
+		return nil
+	}
+	b, err := readIgnoreFile(path)
+	if err != nil || len(b) == 0 {
+		return nil
+	}
+	ig, err := parseIgnoreReader("", source, strings.NewReader(string(b)))
+	if err != nil || ig == nil || len(ig.patterns) == 0 {
+		return nil
+	}
+	return ig
+}
+
+// infoExcludePath returns the absolute path of <git-common-dir>/info/exclude,
+// or "" when the git dir cannot be resolved.
+//
+// git-common-dir, not git-dir: a linked worktree has its own git dir but shares
+// the main clone's info/exclude, and git honours the shared one.
+func infoExcludePath(root string) string {
+	common := gitmeta.RunGit(root, "rev-parse", "--git-common-dir")
+	if common == "" {
+		return ""
+	}
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(root, common)
+	}
+	return filepath.Join(common, "info", "exclude")
+}
+
+// globalExcludesPath resolves core.excludesFile for the repo at root, falling
+// back to git's own default of $XDG_CONFIG_HOME/git/ignore (then
+// ~/.config/git/ignore) when the config key is unset.
+//
+// It is a CONFIG read, not a fixed path: a developer who points
+// core.excludesFile somewhere else gets that file, which is the whole reason
+// #6922 asks for the config lookup rather than a hardcoded ~/.config path.
+func globalExcludesPath(root string) string {
+	if p := gitmeta.RunGit(root, "config", "--get", "core.excludesFile"); p != "" {
+		return expandTilde(p)
+	}
+	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+		return filepath.Join(xdg, "git", "ignore")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config", "git", "ignore")
+}
+
+// expandTilde expands a leading "~/" using the current user's home directory,
+// matching git's own expansion of core.excludesFile.
+func expandTilde(p string) string {
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			return p
+		}
+		return filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(p, "~"), "/"))
+	}
+	return p
+}

--- a/internal/daemon/walk/gitexclude.go
+++ b/internal/daemon/walk/gitexclude.go
@@ -29,25 +29,15 @@ const (
 )
 
 // gitExcludeIgnoreFiles returns the non-.gitignore ignore sources for the repo
-// containing root, ordered LOWEST precedence first — core.excludesFile, then
-// .git/info/exclude — so a caller can Push them onto an IgnoreStack before the
-// tree's own .gitignore files, which must outrank both.
-//
-// Entries that do not exist, are empty, or contain no patterns are omitted, so
-// a non-git directory yields nil and costs two bounded git calls.
-//
-// Patterns in both files are anchored at the git TOP-LEVEL. When root is a
-// subdirectory of the top-level (a monorepo registered by package root) the
-// patterns are rewritten relative to root by the same helper that handles
-// inherited .grafelignore files, so an anchored `/build` in info/exclude does
-// not silently become "anything named build" under the child root.
-// gitExcludeIgnoreFiles returns the non-.gitignore ignore sources for the repo
 // at root, ordered LOWEST precedence first — core.excludesFile, then
 // .git/info/exclude — so a caller can Push them onto an IgnoreStack before the
 // tree's own .gitignore files, which must outrank both.
 //
-// Entries that do not exist, are empty, or contain no patterns are omitted, so
-// a non-git directory yields nil and costs one bounded git call.
+// Entries that do not exist, are empty, or contain no patterns are omitted. The
+// cost is at most THREE bounded git calls per WalkRepo — `rev-parse
+// --show-toplevel`, `config --get core.excludesFile`, `rev-parse
+// --git-common-dir` — all outside the WalkDir callback, so it is per walk and
+// not per entry. A non-git directory yields nil after the first.
 //
 // SCOPE, deliberately: patterns in both files are anchored at the git
 // TOP-LEVEL, so they are applied ONLY when root IS the top-level. A walk rooted

--- a/internal/daemon/walk/gitexclude_fifo_6416_test.go
+++ b/internal/daemon/walk/gitexclude_fifo_6416_test.go
@@ -1,0 +1,121 @@
+//go:build unix
+
+package walk
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestIgnoredFIFOIsReportedAsAHazardNotAsIgnored_6931 grades the ORDER of the
+// new file-branch ignore check against the entry-type gate.
+//
+// The walker's comment argues the check "runs AFTER the entry-type gate so a
+// FIFO is still reported as the hazard it is rather than disappearing under an
+// ignore rule". Nothing observed that: both orderings `return nil`, so the walked
+// SET is identical and only the REPORTED REASON differs. Swapping the two blocks
+// left the whole package green — prose asserting what no test observes.
+//
+// A FIFO planted in a source tree is exactly the thing someone has to explain,
+// and `*.pb.go` is exactly the pattern a repo ignores, so the two overlap in
+// practice. Under the swapped order the operator is told the file was ignored by
+// their own .gitignore and never learns a named pipe is sitting in their tree.
+//
+// VARIED: the entry type only. HELD CONSTANT: the name `ignored.pb.go` matches
+// the ignore rule in BOTH rows, so the control cannot pass by name.
+func TestIgnoredFIFOIsReportedAsAHazardNotAsIgnored_6931(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("*.pb.go\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Row 1: a FIFO whose name matches the ignore rule.
+	mkfifoInWalkTemp(t, root, "ignored.pb.go")
+	// Row 2: a REGULAR file whose name matches the same rule.
+	if err := os.WriteFile(filepath.Join(root, "regular.pb.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var files []string
+	var skipped []SkipEntry
+	mustReturnWalk(t, "WalkRepo over an ignored FIFO", func() {
+		files, skipped, _ = WalkRepo(root, nil)
+	})
+
+	rules := map[string]string{}
+	for _, s := range skipped {
+		rel, _ := filepath.Rel(root, s.AbsPath)
+		rules[filepath.ToSlash(rel)] = s.Rule
+	}
+	if got := rules["ignored.pb.go"]; !strings.HasPrefix(got, "irregular:") {
+		t.Errorf("FIFO ignored.pb.go reported with rule %q, want an irregular: hazard — "+
+			"the ignore layer must not swallow the entry-type gate's reason", got)
+	}
+	if got := rules["regular.pb.go"]; !strings.Contains(got, ".gitignore") {
+		t.Errorf("regular.pb.go reported with rule %q, want the .gitignore rule", got)
+	}
+	// Both are still omitted from the walked set — only the reason differs.
+	for _, f := range files {
+		if f == "ignored.pb.go" || f == "regular.pb.go" {
+			t.Errorf("%s should not be walked", f)
+		}
+	}
+}
+
+// TestInfoExcludeFIFODoesNotHang_6416 grades the reason parseExcludeFile reads
+// through readIgnoreFile rather than os.ReadFile.
+//
+// .git/info/exclude is a NAME-CHOSEN read that runs BEFORE the walk, so the
+// entry-type gate #6468 added has nothing to say about it — the #6416 hazard
+// verbatim. os.ReadFile on a FIFO does not fail, it parks in open(2) waiting
+// for a writer: no timeout, no error, no log line, and `grafel index` never
+// returns. Both the PR body and the doc comment named that hazard and no test
+// observed it, so the mutant survived.
+//
+// It is a hang, so the pin is a deadline plus the always-on report — the
+// mutant produces no value to assert on.
+func TestInfoExcludeFIFODoesNotHang_6416(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	hermeticGitEnv(t)
+	root := t.TempDir()
+	mustGit(t, root, "init", "-q")
+
+	// git init writes a regular .git/info/exclude; replace it with a FIFO.
+	excl := filepath.Join(root, ".git", "info", "exclude")
+	if err := os.Remove(excl); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove %s: %v", excl, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(excl), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(excl, 0o600); err != nil {
+		t.Fatalf("mkfifo %s: %v", excl, err)
+	}
+	t.Cleanup(func() { _ = os.Remove(excl) })
+
+	if err := os.WriteFile(filepath.Join(root, "keep.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	restore := setIgnoreSkipOutput(&buf)
+	defer restore()
+
+	var files []string
+	mustReturnWalk(t, "WalkRepo with a FIFO .git/info/exclude", func() {
+		files, _, _ = WalkRepo(root, nil)
+	})
+
+	if len(files) == 0 {
+		t.Fatal("walk produced nothing; the refused exclude file must not stop the walk")
+	}
+	if !strings.Contains(buf.String(), excl) {
+		t.Errorf("refused .git/info/exclude was not reported; got %q", buf.String())
+	}
+}

--- a/internal/daemon/walk/gitignore.go
+++ b/internal/daemon/walk/gitignore.go
@@ -192,6 +192,18 @@ func ParseIgnoreFile(dir, path, source string) (*IgnoreFile, error) {
 // Returns (skip=true, lineNum) when the last matching pattern is a
 // positive (non-negated) rule.
 func (ig *IgnoreFile) MatchDir(relPath string) (bool, int) {
+	return ig.MatchPath(relPath, true)
+}
+
+// MatchPath is MatchDir generalised to an entry that may be a FILE.
+//
+// isDir is load-bearing for exactly one pattern form: a trailing-slash rule
+// (`build/`) matches a DIRECTORY named build and never a file named build.
+// Every other form applies to both kinds. Before #6931 the walker only ever
+// asked about directories, so dirOnly was parsed and never consulted; once the
+// file branch consults the stack it becomes the difference between git's answer
+// and an over-broad one.
+func (ig *IgnoreFile) MatchPath(relPath string, isDir bool) (bool, int) {
 	if len(ig.patterns) == 0 {
 		return false, 0
 	}
@@ -216,6 +228,9 @@ func (ig *IgnoreFile) MatchDir(relPath string) (bool, int) {
 	matchedLine := 0
 
 	for _, pat := range ig.patterns {
+		if pat.dirOnly && !isDir {
+			continue
+		}
 		var ok bool
 		if pat.anchored {
 			// Anchored: match against path-from-dir using full path match.
@@ -345,11 +360,25 @@ func (s *IgnoreStack) Pop() {
 // pattern in a child IgnoreFile overrides a positive match in a parent.
 // Returns (skip=true, "source:lineN") when the final decision is to skip.
 func (s *IgnoreStack) Match(relPath string) (bool, string) {
+	return s.MatchPath(relPath, true)
+}
+
+// MatchFile is Match for a regular file. It exists so the walker's file branch
+// reads as deliberately as its directory branch — before #6931 the file branch
+// consulted no ignore layer at all, so `*.pb.go` in .gitignore was matched by
+// `git check-ignore` and indexed by grafel.
+func (s *IgnoreStack) MatchFile(relPath string) (bool, string) {
+	return s.MatchPath(relPath, false)
+}
+
+// MatchPath is Match with an explicit entry kind. See IgnoreFile.MatchPath for
+// why the kind matters (trailing-slash, directory-only patterns).
+func (s *IgnoreStack) MatchPath(relPath string, isDir bool) (bool, string) {
 	// Walk the stack from bottom (root) to top (most-nested).
 	matched := false
 	rule := ""
 	for _, ig := range s.files {
-		ok, line := ig.MatchDir(relPath)
+		ok, line := ig.MatchPath(relPath, isDir)
 		if ok {
 			matched = true
 			rule = ruleLabel(ig.Source, line)

--- a/internal/daemon/walk/gitignore_files_6931_test.go
+++ b/internal/daemon/walk/gitignore_files_6931_test.go
@@ -1,0 +1,350 @@
+package walk
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// --- #6931 / #6922 -----------------------------------------------------------
+//
+// WalkRepo applied the ignore stack in the d.IsDir() branch only, so a
+// file-level .gitignore pattern (`*.pb.go`, `graph.json`, ...) was matched by
+// `git check-ignore` and INDEXED by grafel (#6931). The other two ignore
+// sources git reads — `.git/info/exclude` and `core.excludesFile` — were read
+// by nothing at all (#6922).
+//
+// The fixture below enumerates the pattern space rather than hand-picking a
+// few cases, and asserts the walked set EXACTLY (set equality, not "contains"),
+// so over-exclusion is graded as loudly as under-exclusion (#6902).
+//
+// VARIED, one axis per row:
+//   - pattern form: bare name, rooted `/name`, glob, negation `!`,
+//     trailing-slash dir-only
+//   - pattern SOURCE: root .gitignore, nested .gitignore, .git/info/exclude,
+//     core.excludesFile
+//   - entry type for one identical name (`dironly.go` as a file vs as a dir)
+//   - depth of the matched path (repo root vs nested) for each of the bare,
+//     rooted and glob forms
+//   - precedence between adjacent sources, in BOTH directions
+//
+// HELD CONSTANT: file extension (.go) for every row so the extension filter
+// can never be the thing doing the work; no sparse checkout; no .grafelignore;
+// a single repo root that IS the git top-level.
+
+// writeFile writes p (relative to root) with trivial content.
+func writeIgnoreFixtureFile(t *testing.T, root, p, content string) {
+	t.Helper()
+	abs := filepath.Join(root, filepath.FromSlash(p))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", abs, err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", abs, err)
+	}
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// ignoreSourceFixture builds a git repo exercising every ignore pattern form
+// across all three git ignore sources, and returns (root, wantWalked).
+func ignoreSourceFixture(t *testing.T) (string, []string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	root := t.TempDir()
+	mustGit(t, root, "init", "-q")
+
+	// ---- source 1: root .gitignore -------------------------------------
+	writeIgnoreFixtureFile(t, root, ".gitignore", strings.Join([]string{
+		"bare_ignored.go",    // bare name — matches at ANY depth
+		"/rooted_ignored.go", // rooted — repo root ONLY
+		"*.gen.go",           // glob
+		"!kept.gen.go",       // negation of the glob above
+		"dironly.go/",        // trailing slash — DIRECTORIES only
+		"!prec_a.go",         // beats .git/info/exclude (precedence, direction 1)
+	}, "\n")+"\n")
+
+	// ---- source 2: nested .gitignore -----------------------------------
+	writeIgnoreFixtureFile(t, root, "pkg/sub/.gitignore", strings.Join([]string{
+		"!bare_ignored.go", // child un-ignores what the parent ignored
+		"nested_only.go",   // and ignores something the parent does not
+	}, "\n")+"\n")
+
+	// ---- source 3: .git/info/exclude (#6922) ---------------------------
+	writeIgnoreFixtureFile(t, root, ".git/info/exclude", strings.Join([]string{
+		"excluded_by_info.go",
+		"prec_a.go",  // loses to root .gitignore's "!prec_a.go"
+		"!prec_b.go", // beats core.excludesFile (precedence, direction 2)
+	}, "\n")+"\n")
+
+	// ---- source 4: core.excludesFile (#6922) ---------------------------
+	// Set at the LOCAL config level so the test never reads or writes the
+	// developer's real global git config.
+	globalIgnore := filepath.Join(t.TempDir(), "global_ignore")
+	if err := os.WriteFile(globalIgnore, []byte("excluded_by_global.go\nprec_b.go\n"), 0o644); err != nil {
+		t.Fatalf("write global ignore: %v", err)
+	}
+	mustGit(t, root, "config", "core.excludesFile", globalIgnore)
+
+	// ---- the tree ------------------------------------------------------
+	for _, p := range []string{
+		// must be SKIPPED
+		"bare_ignored.go",
+		"pkg/bare_ignored.go",
+		"rooted_ignored.go",
+		"a.gen.go",
+		"pkg/b.gen.go",
+		"pkg/dironly.go/inside.go",
+		"pkg/sub/nested_only.go",
+		"excluded_by_info.go",
+		"excluded_by_global.go",
+		// must be WALKED
+		"keep.go",
+		"pkg/keep.go",
+		"kept.gen.go",
+		"dironly.go",
+		"nested_only.go",
+		"prec_a.go",
+		"prec_b.go",
+		"pkg/rooted_ignored.go",
+		"pkg/sub/bare_ignored.go",
+	} {
+		writeIgnoreFixtureFile(t, root, p, "package p\n")
+	}
+
+	want := []string{
+		".gitignore",
+		"dironly.go",
+		"keep.go",
+		"kept.gen.go",
+		"nested_only.go",
+		"pkg/keep.go",
+		"pkg/rooted_ignored.go",
+		"pkg/sub/.gitignore",
+		"pkg/sub/bare_ignored.go",
+		"prec_a.go",
+		"prec_b.go",
+	}
+	sort.Strings(want)
+	return root, want
+}
+
+func TestWalkRepo_AppliesIgnoreStackToFiles_6931(t *testing.T) {
+	root, want := ignoreSourceFixture(t)
+
+	got, _, err := WalkRepo(root, nil)
+	if err != nil {
+		t.Fatalf("WalkRepo: %v", err)
+	}
+	sort.Strings(got)
+
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("walked set mismatch\n got: %v\nwant: %v\nmissing (over-excluded): %v\nextra (under-excluded): %v",
+			got, want, diffSet(want, got), diffSet(got, want))
+	}
+}
+
+// TestWalkRepo_IgnoredFilesAreReported pins that a file dropped by the ignore
+// stack is REPORTED as a SkipEntry rather than vanishing silently (#6338's
+// class of defect), and that the reported rule names the source.
+func TestWalkRepo_IgnoredFilesAreReported_6931(t *testing.T) {
+	root, _ := ignoreSourceFixture(t)
+
+	_, skipped, err := WalkRepo(root, nil)
+	if err != nil {
+		t.Fatalf("WalkRepo: %v", err)
+	}
+	rules := map[string]string{}
+	for _, s := range skipped {
+		rel, _ := filepath.Rel(root, s.AbsPath)
+		rules[filepath.ToSlash(rel)] = s.Rule
+	}
+	for _, want := range []struct{ path, source string }{
+		{"bare_ignored.go", ".gitignore"},
+		{"excluded_by_info.go", "info/exclude"},
+		{"excluded_by_global.go", "core.excludesFile"},
+		{"pkg/sub/nested_only.go", ".gitignore"},
+	} {
+		rule, ok := rules[want.path]
+		if !ok {
+			t.Errorf("%s was dropped but not reported as a SkipEntry", want.path)
+			continue
+		}
+		if !strings.Contains(rule, want.source) {
+			t.Errorf("%s reported with rule %q, want it to name %q", want.path, rule, want.source)
+		}
+	}
+}
+
+// TestIgnoreFile_DirOnlyPatternNeverMatchesAFile is the unit-level control for
+// the one rule that only becomes observable once the stack is consulted for
+// files: `foo/` matches a directory named foo and NOT a file named foo.
+func TestIgnoreFile_DirOnlyPatternNeverMatchesAFile_6931(t *testing.T) {
+	ig, err := parseIgnoreReader("", ".gitignore", strings.NewReader("dironly.go/\nboth.go\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if skip, _ := ig.MatchPath("dironly.go", true); !skip {
+		t.Error("dironly.go/ should match a DIRECTORY named dironly.go")
+	}
+	if skip, _ := ig.MatchPath("dironly.go", false); skip {
+		t.Error("dironly.go/ must NOT match a FILE named dironly.go")
+	}
+	// A pattern without the trailing slash matches both kinds.
+	if skip, _ := ig.MatchPath("both.go", true); !skip {
+		t.Error("both.go should match a directory")
+	}
+	if skip, _ := ig.MatchPath("both.go", false); !skip {
+		t.Error("both.go should match a file")
+	}
+}
+
+func diffSet(a, b []string) []string {
+	in := map[string]bool{}
+	for _, s := range b {
+		in[s] = true
+	}
+	var out []string
+	for _, s := range a {
+		if !in[s] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// TestInfoExcludeIsSharedWithLinkedWorktrees_6922 pins the git-common-dir
+// resolution: a linked worktree has its OWN git dir but shares the main
+// clone's .git/info/exclude, and git honours the shared one. Resolving via
+// `rev-parse --git-dir` instead would read <main>/.git/worktrees/<name>/info/
+// exclude, which does not exist — so the whole layer would silently vanish for
+// every worktree lane.
+func TestInfoExcludeIsSharedWithLinkedWorktrees_6922(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	main := t.TempDir()
+	mustGit(t, main, "init", "-q")
+	mustGit(t, main, "config", "user.email", "t@example.com")
+	mustGit(t, main, "config", "user.name", "t")
+	writeIgnoreFixtureFile(t, main, "seed.go", "package p\n")
+	mustGit(t, main, "add", "-A")
+	mustGit(t, main, "commit", "-qm", "seed")
+	writeIgnoreFixtureFile(t, main, ".git/info/exclude", "excluded_by_info.go\n")
+
+	linked := filepath.Join(t.TempDir(), "wt")
+	mustGit(t, main, "worktree", "add", "-q", "-b", "lane", linked)
+
+	writeIgnoreFixtureFile(t, linked, "excluded_by_info.go", "package p\n")
+	writeIgnoreFixtureFile(t, linked, "keep.go", "package p\n")
+
+	got, _, err := WalkRepo(linked, nil)
+	if err != nil {
+		t.Fatalf("WalkRepo: %v", err)
+	}
+	in := map[string]bool{}
+	for _, f := range got {
+		in[f] = true
+	}
+	if in["excluded_by_info.go"] {
+		t.Error("linked worktree indexed a file excluded by the main clone's .git/info/exclude")
+	}
+	if !in["keep.go"] || !in["seed.go"] {
+		t.Errorf("over-excluded in a linked worktree: got %v", got)
+	}
+}
+
+// TestExcludeSourcesAreNotAppliedBelowTopLevel_6922 pins the deliberate scope
+// limit documented on gitExcludeIgnoreFiles: patterns in .git/info/exclude are
+// anchored at the git top-level, so a walk rooted at a SUBDIRECTORY does not
+// apply them. Rewriting them for the child root is what would be needed, and
+// the one existing rewrite (rewriteInheritedIgnoreLine, used for .grafelignore)
+// drops anchoring — see the doc comment. This test exists so that inheriting
+// them later is a deliberate change with a failing test, not a silent drift.
+func TestExcludeSourcesAreNotAppliedBelowTopLevel_6922(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	top := t.TempDir()
+	mustGit(t, top, "init", "-q")
+	writeIgnoreFixtureFile(t, top, ".git/info/exclude", "excluded_by_info.go\n")
+	writeIgnoreFixtureFile(t, top, "pkg/excluded_by_info.go", "package p\n")
+	writeIgnoreFixtureFile(t, top, "pkg/keep.go", "package p\n")
+
+	got, _, err := WalkRepo(filepath.Join(top, "pkg"), nil)
+	if err != nil {
+		t.Fatalf("WalkRepo: %v", err)
+	}
+	sort.Strings(got)
+	want := []string{"excluded_by_info.go", "keep.go"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("sub-root walk = %v, want %v", got, want)
+	}
+	// ...and the same tree walked from the top-level DOES apply it, so the
+	// difference above is the root choice and nothing else.
+	fromTop, _, err := WalkRepo(top, nil)
+	if err != nil {
+		t.Fatalf("WalkRepo(top): %v", err)
+	}
+	for _, f := range fromTop {
+		if f == "pkg/excluded_by_info.go" {
+			t.Error("top-level walk failed to apply .git/info/exclude")
+		}
+	}
+}
+
+// TestGlobalExcludesPath_ConfigThenXDGFallback_6922 grades the resolution order
+// for core.excludesFile: the git config value wins, and when it is unset the
+// path falls back to git's own default of $XDG_CONFIG_HOME/git/ignore. A
+// hardcoded ~/.config/git/ignore would pass the second row and fail the first.
+func TestGlobalExcludesPath_ConfigThenXDGFallback_6922(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	repo := t.TempDir()
+	mustGit(t, repo, "init", "-q")
+
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	if got, want := globalExcludesPath(repo), filepath.Join(xdg, "git", "ignore"); got != want {
+		t.Errorf("unset core.excludesFile: got %q, want the XDG fallback %q", got, want)
+	}
+
+	configured := filepath.Join(t.TempDir(), "mine")
+	mustGit(t, repo, "config", "core.excludesFile", configured)
+	if got := globalExcludesPath(repo); got != configured {
+		t.Errorf("configured core.excludesFile: got %q, want %q", got, configured)
+	}
+}
+
+// TestExpandTilde_6922 pins the "~/" expansion git performs on
+// core.excludesFile. Without it a configured `~/.gitignore_global` is opened
+// as a literal directory named "~" and the whole layer silently no-ops.
+func TestExpandTilde_6922(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	if got, want := expandTilde("~/ig"), filepath.Join(home, "ig"); got != want {
+		t.Errorf("expandTilde(~/ig) = %q, want %q", got, want)
+	}
+	if got := expandTilde("/abs/ig"); got != "/abs/ig" {
+		t.Errorf("expandTilde must leave an absolute path alone, got %q", got)
+	}
+	if got := expandTilde("rel~ative/ig"); got != "rel~ative/ig" {
+		t.Errorf("expandTilde must only expand a LEADING ~, got %q", got)
+	}
+}

--- a/internal/daemon/walk/gitignore_files_6931_test.go
+++ b/internal/daemon/walk/gitignore_files_6931_test.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // --- #6931 / #6922 -----------------------------------------------------------
@@ -76,14 +78,25 @@ func writeIgnoreFixtureFile(t *testing.T, root, p, content string) {
 // Both were found by scoring an environment mutant, not by reading the code.
 func hermeticGitEnv(t *testing.T) string {
 	t.Helper()
-	home := t.TempDir()
-	// UserHomeDir reads $HOME on unix and %USERPROFILE% on Windows; expandTilde
-	// goes through it, so both must be pinned or the tilde row is platform-lucky.
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	// Empty files, not os.DevNull: git accepts a missing path here, but a real
-	// empty file is the same on every platform and cannot be a device special.
+	// IsolateHome, not a hand-rolled t.Setenv("HOME", ...): redirecting HOME
+	// alone trips the #6735 sweep guard, and for a real reason — registry.HomeDir
+	// prefers GRAFEL_HOME and only falls back to the OS home, so a fixture that
+	// moves HOME while an ambient GRAFEL_HOME survives has the code under test
+	// reading a different directory than the fixture wrote to. IsolateHome sets
+	// HOME, USERPROFILE, GRAFEL_HOME, GRAFEL_DAEMON_ROOT and both XDG vars
+	// together, and asserts the redirect actually left the real user home.
+	//
+	// It matters here beyond hygiene: expandTilde resolves through
+	// os.UserHomeDir (HOME on unix, %USERPROFILE% on Windows), and the
+	// core.excludesFile fallback reads $XDG_CONFIG_HOME — both are fixture
+	// inputs, not incidental environment.
+	home := testsupport.IsolateHome(t)
+	// IsolateHome does NOT touch git's own config resolution, so these stay:
+	// they are what neutralises a hostile ~/.gitconfig (a global
+	// core.excludesFile, or a global ignore holding *.go that makes the
+	// fixtures' own `git add` skip the seed files). Empty files, not
+	// os.DevNull: git accepts a missing path here, but a real empty file is the
+	// same on every platform and cannot be a device special.
 	for _, kv := range [][2]string{
 		{"GIT_CONFIG_GLOBAL", filepath.Join(home, "gitconfig")},
 		{"GIT_CONFIG_SYSTEM", filepath.Join(home, "gitsystem")},

--- a/internal/daemon/walk/gitignore_files_6931_test.go
+++ b/internal/daemon/walk/gitignore_files_6931_test.go
@@ -21,6 +21,16 @@ import (
 // few cases, and asserts the walked set EXACTLY (set equality, not "contains"),
 // so over-exclusion is graded as loudly as under-exclusion (#6902).
 //
+// TWO AXES ARE KNOWINGLY UNGRADED, and the claim is bounded accordingly: the
+// nested-.gitignore rows below use BARE-NAME patterns only. nested x anchored
+// (`/x.go`) and nested x slash-bearing glob (`sub/x.go`) cannot be graded here
+// because IgnoreFile.Dir is dead — filepath.Rel(d, filepath.Join(d, rel)) is
+// rel for every input, so a nested file's patterns are matched against the
+// ROOT-relative path and no anchored nested rule fires at all. That is a
+// pre-existing UNDER-exclusion, filed as #6936; fixing it would change
+// MatchDir too, which is exactly the directory behaviour this change is
+// careful not to touch.
+//
 // VARIED, one axis per row:
 //   - pattern form: bare name, rooted `/name`, glob, negation `!`,
 //     trailing-slash dir-only
@@ -47,6 +57,45 @@ func writeIgnoreFixtureFile(t *testing.T, root, p, content string) {
 	}
 }
 
+// hermeticGitEnv gives the calling test its own HOME, its own XDG config root
+// and its own (empty) global + system git config, and returns the fake home.
+//
+// It is not hygiene, it is correctness for THIS feature. #6922 makes WalkRepo's
+// output a function of `core.excludesFile`, which git resolves from the
+// developer's own global config, and of $XDG_CONFIG_HOME/git/ignore when that
+// key is unset. Without this, two failures land on contributors and on nobody
+// here:
+//
+//   - a machine with core.excludesFile set (the spelling git's own docs
+//     recommend) makes the unset-key row of the fallback test unreachable, so
+//     the test is RED there and green here;
+//   - a machine with `*.go` in its global ignore file makes the fixtures' own
+//     `git add` skip the seed files, so `git commit` fails with "nothing to
+//     commit" and the test dies before it tests anything.
+//
+// Both were found by scoring an environment mutant, not by reading the code.
+func hermeticGitEnv(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	// UserHomeDir reads $HOME on unix and %USERPROFILE% on Windows; expandTilde
+	// goes through it, so both must be pinned or the tilde row is platform-lucky.
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	// Empty files, not os.DevNull: git accepts a missing path here, but a real
+	// empty file is the same on every platform and cannot be a device special.
+	for _, kv := range [][2]string{
+		{"GIT_CONFIG_GLOBAL", filepath.Join(home, "gitconfig")},
+		{"GIT_CONFIG_SYSTEM", filepath.Join(home, "gitsystem")},
+	} {
+		if err := os.WriteFile(kv[1], nil, 0o644); err != nil {
+			t.Fatalf("write %s: %v", kv[1], err)
+		}
+		t.Setenv(kv[0], kv[1])
+	}
+	return home
+}
+
 func mustGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
@@ -63,6 +112,7 @@ func ignoreSourceFixture(t *testing.T) (string, []string) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not on PATH")
 	}
+	home := hermeticGitEnv(t)
 	root := t.TempDir()
 	mustGit(t, root, "init", "-q")
 
@@ -90,13 +140,20 @@ func ignoreSourceFixture(t *testing.T) (string, []string) {
 	}, "\n")+"\n")
 
 	// ---- source 4: core.excludesFile (#6922) ---------------------------
-	// Set at the LOCAL config level so the test never reads or writes the
-	// developer's real global git config.
-	globalIgnore := filepath.Join(t.TempDir(), "global_ignore")
-	if err := os.WriteFile(globalIgnore, []byte("excluded_by_global.go\nprec_b.go\n"), 0o644); err != nil {
+	// Written under the FAKE home and configured as `~/global_ignore`, not as
+	// an absolute path. That spelling is the one git's own documentation uses
+	// (`core.excludesFile = ~/.gitignore_global`), and it is what drives
+	// expandTilde END TO END: with an absolute value here, deleting the
+	// expandTilde CALL in globalExcludesPath leaves the whole package green
+	// while a real user's entire global ignore layer silently no-ops. The
+	// helper having its own unit test does not pin the call site.
+	//
+	// Set at the LOCAL config level, on top of the hermetic global/system
+	// config, so the test neither reads nor writes the developer's real one.
+	if err := os.WriteFile(filepath.Join(home, "global_ignore"), []byte("excluded_by_global.go\nprec_b.go\n"), 0o644); err != nil {
 		t.Fatalf("write global ignore: %v", err)
 	}
-	mustGit(t, root, "config", "core.excludesFile", globalIgnore)
+	mustGit(t, root, "config", "core.excludesFile", "~/global_ignore")
 
 	// ---- the tree ------------------------------------------------------
 	for _, p := range []string{
@@ -235,6 +292,7 @@ func TestInfoExcludeIsSharedWithLinkedWorktrees_6922(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not on PATH")
 	}
+	hermeticGitEnv(t)
 	main := t.TempDir()
 	mustGit(t, main, "init", "-q")
 	mustGit(t, main, "config", "user.email", "t@example.com")
@@ -277,6 +335,7 @@ func TestExcludeSourcesAreNotAppliedBelowTopLevel_6922(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not on PATH")
 	}
+	hermeticGitEnv(t)
 	top := t.TempDir()
 	mustGit(t, top, "init", "-q")
 	writeIgnoreFixtureFile(t, top, ".git/info/exclude", "excluded_by_info.go\n")
@@ -313,11 +372,11 @@ func TestGlobalExcludesPath_ConfigThenXDGFallback_6922(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not on PATH")
 	}
+	hermeticGitEnv(t)
 	repo := t.TempDir()
 	mustGit(t, repo, "init", "-q")
 
-	xdg := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", xdg)
+	xdg := os.Getenv("XDG_CONFIG_HOME") // pinned by hermeticGitEnv
 
 	if got, want := globalExcludesPath(repo), filepath.Join(xdg, "git", "ignore"); got != want {
 		t.Errorf("unset core.excludesFile: got %q, want the XDG fallback %q", got, want)
@@ -334,10 +393,7 @@ func TestGlobalExcludesPath_ConfigThenXDGFallback_6922(t *testing.T) {
 // core.excludesFile. Without it a configured `~/.gitignore_global` is opened
 // as a literal directory named "~" and the whole layer silently no-ops.
 func TestExpandTilde_6922(t *testing.T) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skip("no home dir")
-	}
+	home := hermeticGitEnv(t)
 	if got, want := expandTilde("~/ig"), filepath.Join(home, "ig"); got != want {
 		t.Errorf("expandTilde(~/ig) = %q, want %q", got, want)
 	}

--- a/internal/daemon/walk/gitignore_nested_pop_6931_test.go
+++ b/internal/daemon/walk/gitignore_nested_pop_6931_test.go
@@ -1,0 +1,59 @@
+package walk
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestWalkRepo_NestedIgnoreDoesNotLeakToSiblingFiles_6931 is the regression for
+// the over-exclusion the file branch made live.
+//
+// WalkRepo popped nested ignore files ONLY inside the d.IsDir() branch, so a
+// nested .gitignore stayed on the stack while filepath.WalkDir visited every
+// FILE that sorts after that subdirectory. While the stack only decided
+// directories the staleness was invisible — a directory entry pops first — and
+// the moment files consult it, a rule two levels down starts deleting files it
+// has no authority over.
+//
+// The ordering IS the bug, so every row here is chosen for its position in
+// lexical DFS order, not for its name:
+//
+//	pkg/sub/.gitignore   ignores "victim.go"
+//	pkg/sub/inside.go    inside the subtree      -> walked (rule does not match)
+//	pkg/victim.go        sibling of sub/, sorts AFTER "sub"   -> MUST be walked
+//	victim.go            repo root, sorts AFTER "pkg"         -> MUST be walked
+//	pkg/sub/victim.go    genuinely governed                    -> must be SKIPPED
+//
+// VARIED: the depth at which the file is visited relative to the ignore file's
+// own directory (inside it, a sibling one level up, the repo root two levels
+// up). HELD CONSTANT: the basename `victim.go` for all four rows, so the only
+// thing separating a correct skip from an over-exclusion is position — a row
+// that passed by name would prove nothing.
+func TestWalkRepo_NestedIgnoreDoesNotLeakToSiblingFiles_6931(t *testing.T) {
+	root := t.TempDir()
+	writeIgnoreFixtureFile(t, root, "pkg/sub/.gitignore", "victim.go\n")
+	for _, p := range []string{
+		"pkg/sub/inside.go",
+		"pkg/sub/victim.go",
+		"pkg/victim.go",
+		"victim.go",
+	} {
+		writeIgnoreFixtureFile(t, root, p, "package p\n")
+	}
+
+	got, skipped, err := WalkRepo(root, nil)
+	if err != nil {
+		t.Fatalf("WalkRepo: %v", err)
+	}
+	sort.Strings(got)
+	want := []string{"pkg/sub/.gitignore", "pkg/sub/inside.go", "pkg/victim.go", "victim.go"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		for _, s := range skipped {
+			rel, _ := filepath.Rel(root, s.AbsPath)
+			t.Logf("skipped %s rule=%s", filepath.ToSlash(rel), s.Rule)
+		}
+		t.Errorf("walked = %v, want %v", got, want)
+	}
+}

--- a/internal/daemon/walk/walker.go
+++ b/internal/daemon/walk/walker.go
@@ -150,6 +150,32 @@ func WalkRepo(root string, opts *Options) ([]string, []SkipEntry, error) {
 			return nil
 		}
 
+		// Pop the nested ignore files of every directory this entry is no
+		// longer inside.
+		//
+		// This runs for BOTH entry kinds, and that is the whole point (#6931).
+		// It used to live inside the d.IsDir() branch, which is correct only
+		// while the stack decides directories: filepath.WalkDir is lexical DFS,
+		// so after a subtree finishes, every FILE visited before the next
+		// DIRECTORY entry still saw that subtree's .gitignore on the stack.
+		// Harmless while nothing asked it about files — a directory entry pops
+		// first — and an over-exclusion the moment the file branch asks. A
+		// `pkg/sub/.gitignore` holding `victim.go` deleted `pkg/victim.go` and
+		// the repo-root `victim.go`, neither of which git considers ignored,
+		// because "sub" sorts before "victim.go" and no directory intervened.
+		for len(depthEntries) > 0 {
+			top := depthEntries[len(depthEntries)-1]
+			// If the current path is NOT under the tracked dir, pop.
+			if !strings.HasPrefix(absPath+string(filepath.Separator), top.absDir+string(filepath.Separator)) {
+				for i := 0; i < top.count; i++ {
+					igStack.Pop()
+				}
+				depthEntries = depthEntries[:len(depthEntries)-1]
+			} else {
+				break
+			}
+		}
+
 		if d.IsDir() {
 			base := d.Name()
 
@@ -181,20 +207,6 @@ func WalkRepo(root string, opts *Options) ([]string, []SkipEntry, error) {
 					}
 					skipped = append(skipped, SkipEntry{AbsPath: absPath, Rule: "dir-cap"})
 					return filepath.SkipDir
-				}
-			}
-
-			// Pop entries for directories we've left.
-			for len(depthEntries) > 0 {
-				top := depthEntries[len(depthEntries)-1]
-				// If the current path is NOT under the tracked dir, pop.
-				if !strings.HasPrefix(absPath+string(filepath.Separator), top.absDir+string(filepath.Separator)) {
-					for i := 0; i < top.count; i++ {
-						igStack.Pop()
-					}
-					depthEntries = depthEntries[:len(depthEntries)-1]
-				} else {
-					break
 				}
 			}
 

--- a/internal/daemon/walk/walker.go
+++ b/internal/daemon/walk/walker.go
@@ -112,6 +112,13 @@ func WalkRepo(root string, opts *Options) ([]string, []SkipEntry, error) {
 	// root-level .gitignore and .grafelignore. This matters when a monorepo is
 	// registered as package roots (for example <repo>/src): the top-level
 	// .grafelignore should still govern those child roots.
+	//
+	// Order is git's precedence, lowest first (#6922): core.excludesFile and
+	// .git/info/exclude sit BELOW everything in the tree, so any .gitignore or
+	// .grafelignore rule — including a negation — outranks them.
+	for _, ex := range gitExcludeIgnoreFiles(root) {
+		igStack.Push(ex)
+	}
 	for _, parent := range inheritedGrafelIgnores(root) {
 		igStack.Push(parent)
 	}
@@ -271,6 +278,29 @@ func WalkRepo(root string, opts *Options) ([]string, []SkipEntry, error) {
 		// to explain. It goes through the same SkipEntry + PrintSkipped channel
 		// as every other skip layer in this walk.
 		if rule, skip := irregularSkipRule(absPath, d); skip {
+			skipped = append(skipped, SkipEntry{AbsPath: absPath, Rule: rule})
+			if opts.PrintSkipped != nil {
+				fmt.Fprintf(opts.PrintSkipped, "[skip] %s (rule: %s)\n", absPath, rule)
+			}
+			return nil
+		}
+
+		// Layers 1+3 (P0/P2) for FILES (#6931). Everything above this line
+		// branched only on d.IsDir(), so the ignore stack was consulted for
+		// directories and NEVER for files: `*.pb.go`, `graph.json` or
+		// `dist/**/*.js` in .gitignore were matched by `git check-ignore` and
+		// indexed by grafel anyway. Generated code is exactly what a file-level
+		// .gitignore pattern is usually for.
+		//
+		// It runs AFTER the entry-type gate so a FIFO is still reported as the
+		// hazard it is rather than disappearing under an ignore rule, and BEFORE
+		// the sparse filter so an ignored path is attributed to the ignore rule
+		// that a user can act on rather than to sparse checkout's deliberate
+		// silence.
+		//
+		// The skip is REPORTED, never silent — same SkipEntry + PrintSkipped
+		// channel as every other layer (#6338).
+		if skip, rule := igStack.MatchFile(rel); skip {
 			skipped = append(skipped, SkipEntry{AbsPath: absPath, Rule: rule})
 			if opts.PrintSkipped != nil {
 				fmt.Fprintf(opts.PrintSkipped, "[skip] %s (rule: %s)\n", absPath, rule)

--- a/internal/daemon/watch/walker_agreement_6931_test.go
+++ b/internal/daemon/watch/walker_agreement_6931_test.go
@@ -1,0 +1,76 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/walk"
+)
+
+// TestWalkerAndEventBoundaryAgreeOnIgnoredFiles pins the property #6931's fix
+// establishes: for a FILE matched by a root .gitignore pattern, the indexer's
+// walker and the watcher's event boundary reach the SAME verdict.
+//
+// Before the fix they disagreed. ShouldSkipPathForRepo already consulted the
+// root .gitignore for the full relative path (skip.go walks every prefix,
+// including the last), so the watcher dropped the event — while walk.WalkRepo
+// consulted the ignore stack only inside its d.IsDir() branch and indexed the
+// file anyway. The watcher was the stricter of the two, which is why the
+// divergence never showed up as reindex churn.
+//
+// VARIED: pattern form (bare name, glob) and path depth (root, nested).
+// HELD CONSTANT: extension (.go / .json are both indexable), one repo root,
+// no nested .gitignore — the watcher only reads the ROOT one, so a nested rule
+// would test a divergence this test does not claim to close.
+func TestWalkerAndEventBoundaryAgreeOnIgnoredFiles_6931(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, body string) {
+		abs := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".gitignore", "graph.json\n*.gen.go\n")
+	cases := map[string]bool{ // rel path → want skipped
+		"graph.json":        true,
+		"pkg/graph.json":    true,
+		"a.gen.go":          true,
+		"pkg/b.gen.go":      true,
+		"keep.go":           false,
+		"pkg/keep.go":       false,
+		"pkg/graph.json.go": false, // control: the pattern is not a prefix rule
+	}
+	for rel := range cases {
+		write(rel, "x\n")
+	}
+	// The cache is process-wide and keyed by repo path; a fresh TempDir is a
+	// fresh key, but evict anyway so a re-run inside one process is honest.
+	evictRepoIgnoreState(root)
+
+	walked, _, err := walk.WalkRepo(root, nil)
+	if err != nil {
+		t.Fatalf("WalkRepo: %v", err)
+	}
+	inWalk := map[string]bool{}
+	for _, f := range walked {
+		inWalk[f] = true
+	}
+
+	for rel, wantSkip := range cases {
+		walkerSkipped := !inWalk[rel]
+		watcherSkipped := ShouldSkipPathForRepo(root, filepath.Join(root, filepath.FromSlash(rel)))
+		if walkerSkipped != wantSkip {
+			t.Errorf("%s: walker skipped=%v, want %v", rel, walkerSkipped, wantSkip)
+		}
+		if watcherSkipped != wantSkip {
+			t.Errorf("%s: watcher skipped=%v, want %v", rel, watcherSkipped, wantSkip)
+		}
+		if walkerSkipped != watcherSkipped {
+			t.Errorf("%s: walker and watcher DISAGREE (walker=%v watcher=%v)", rel, walkerSkipped, watcherSkipped)
+		}
+	}
+}


### PR DESCRIPTION
Arm C of #6932. Both defects share one seam, so they land together — fixing either alone leaves the gap open.

> **Revised after REQUEST-CHANGES** (`af23b5560`). All seven items addressed; the shrink section below is re-measured on the main clone and the earlier numbers in it were wrong. Two findings from the redo are filed as #6936 and #6937 rather than folded in — **#6937 needs a coordinator decision**, see the last section.

## The defect

`walk.WalkRepo` called `igStack.Match(rel)` **inside** the `d.IsDir()` branch. The file branch below it consulted the extension filter, the entry-type gate and the sparse filter, and **no ignore layer at all**. `.gitignore` pruned ignored *directories* and never excluded an ignored *file* (#6931). Separately, git reads three ignore sources and grafel read one — `.git/info/exclude` and `core.excludesFile` appeared nowhere in `internal/daemon/walk/` or `internal/daemon/watch/` (#6922).

## The fix

- **`IgnoreFile.MatchPath(rel, isDir)` / `IgnoreStack.MatchFile`.** `MatchDir` is now `MatchPath(rel, true)`, so directory behaviour is unchanged by construction. `isDir` is load-bearing for exactly one pattern form: `dirOnly` (`build/`) was parsed and never consulted, which is harmless while only directories ask and becomes an over-exclusion the moment files do.
- **The walker's file branch consults the stack** — after the entry-type gate and before the sparse filter, and the skip is **reported** through the same `SkipEntry` + `PrintSkipped` channel as every other layer (#6338).
- **The nested-ignore pop now runs for both entry kinds** (blocker 1 below).
- **`gitexclude.go`** resolves `.git/info/exclude` via `rev-parse --git-common-dir` (a linked worktree shares the main clone's) and `core.excludesFile` via `git config --get` with git's own `$XDG_CONFIG_HOME/git/ignore` fallback and `~/` expansion. Both are pushed **below** everything in the tree, so any `.gitignore` or `.grafelignore` rule — including a negation — outranks them. Both are read through `readIgnoreFile`, not `os.ReadFile`.

---

## Review items — all seven

### 1. BLOCKER — new over-exclusion: a nested `.gitignore` deleted files above itself. FIXED.

`WalkRepo` popped nested ignore files only inside the `d.IsDir()` branch. `filepath.WalkDir` is lexical DFS, so after a subtree finished, every **file** visited before the next **directory** entry still saw that subtree's `.gitignore` on the stack. Harmless while the stack only decided directories — a directory entry pops first — and live the moment the file branch asks.

Reproduced from the reviewer's probe before touching the code:

```
skipped pkg/sub/victim.go rule=.gitignore line 1
skipped pkg/victim.go     rule=.gitignore line 1   <- git keeps it
skipped victim.go         rule=.gitignore line 1   <- repo root, killed from two levels down
walked = [pkg/sub/.gitignore pkg/sub/inside.go]
```

The pop loop is hoisted out of the `IsDir` branch and now runs for every entry, before either branch. `TestWalkRepo_NestedIgnoreDoesNotLeakToSiblingFiles_6931` pins it with an exact-set assertion; **M12** (revert the hoist) is DEAD.

The ordering *is* the bug, so every row is chosen for its DFS position, not its name — and all four rows share the basename `victim.go`, so a row that passed by name would prove nothing:

| row | position relative to `pkg/sub/.gitignore` | verdict |
|---|---|---|
| `pkg/sub/inside.go` | inside the subtree | walked (rule does not match it) |
| `pkg/sub/victim.go` | inside the subtree | **skipped** — genuinely governed |
| `pkg/victim.go` | sibling one level up, sorts after `sub` | **walked** |
| `victim.go` | repo root, sorts after `pkg` | **walked** |

### 2. BLOCKER — claims 5 and 6 were false. RE-MEASURED on the main clone.

The reviewer is right about the cause and right that the direction was wrong; the corrected figure is **larger than either of us had**. My first measurement ran inside a linked worktree. The reviewer's correction was taken on the main clone but reused my `2` for the `.gitignore` half, so the published total of 7 is also short.

Re-measured on `/Users/jorgecajas/Projects/archigraph`, three builds, same tree, read-only:

| build | walked |
|---|---|
| C — `main` | 7090 |
| B — this branch, `gitExcludeIgnoreFiles` returning nil | 7084 |
| A — this branch as-is | **7079** |

**Total shrink 11 files. Nothing added** (`A − C` is empty). Complete, both directions, each attributed by `git check-ignore -v`:

| file | rule | source |
|---|---|---|
| `.DS_Store` | `.gitignore:35` | #6931 |
| `grafel` | `.gitignore:15` `/grafel` | #6931 |
| `mcp.test` | `.gitignore:19` `*.test` | #6931 |
| `webui-v2/tsconfig.tsbuildinfo` | `webui-v2/.gitignore:7` `*.tsbuildinfo` (nested) | #6931 |
| `cmd/grafel/testdata/audit_mount_prefix_retry/consumer/graph.json` | `.gitignore` `graph.json` | #6931 — **see #6937** |
| `cmd/grafel/testdata/audit_mount_prefix_retry/producer/graph.json` | `.gitignore` `graph.json` | #6931 — **see #6937** |
| `presentation-kit/01-what-is-grafel.md` … `05-talking-points-and-faq.md` (5) | `.git/info/exclude:19` `presentation-kit/` | #6922 |

**#6931 alone: 6 files. #6922 alone: 5 files.** Claim 6 ("#6922 contributes zero here") was false; the linked worktree simply does not contain `presentation-kit/`.

**Entity delta re-derived: 7, not 0.** Measured, not argued — six of the eleven are classifier-skipped (`unsupported_extension` for `.DS_Store` / `grafel` / `mcp.test` / `.tsbuildinfo`, `vendor_testdata` for both `graph.json`), so they contribute nothing. The five `presentation-kit/*.md` classify as `markdown` and do reach an extractor; running it over them yields **1+1+1+3+1 = 7** Pass-1 entities. The `cmd/grafel` whole-graph digest is unchanged and the ratchet holds, consistent with the two `graph.json` files being `vendor_testdata`-skipped either way.

Both figures are **machine-relative**, and that is inherent to #6922: `presentation-kit/`, `.DS_Store`, `grafel` and `mcp.test` are untracked local state, and `core.excludesFile` is per-developer. On CI the shrink is smaller.

### 3. Test environment isolation. FIXED via `testsupport.IsolateHome`, with both controls re-established.

`hermeticGitEnv(t)` calls `testsupport.IsolateHome(t)` — which sets `HOME`, `USERPROFILE`, `GRAFEL_HOME`, `GRAFEL_DAEMON_ROOT` and both XDG vars together and asserts the redirect actually left the real user home — and keeps its own `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` empty-file pins, which `IsolateHome` does not touch and which are what neutralise a hostile global git config.

The first attempt redirected `HOME` by hand and was **red in CI** on `internal/registry`'s #6735 sweep guard. The guard is right about the mechanism, not merely about style: `registry.HomeDir()` prefers `GRAFEL_HOME` and only falls back to the OS home, so a fixture that moves `HOME` while an ambient `GRAFEL_HOME` survives has the code under test resolving against a directory the fixture never wrote to — and the sandbox recipe used here sets `GRAFEL_HOME`. Not added to `grafelHomePinDeferred` and not `deliberatelyUnpinnedHome`: this fixture asserts nothing about home resolution, it only needs isolation.

Worth recording: the guard is a **static sweep over test sources**, not a runtime check, which is why it caught this in CI even though CI never sets `GRAFEL_HOME` and so could never have reproduced the failure it prevents.

Both controls verified **after** the swap rather than assumed:

1. **Hostile environment** — `XDG_CONFIG_HOME` pointing at a dir whose `git/ignore` holds `*.go` and `*.json`, plus a `GIT_CONFIG_GLOBAL` setting `core.excludesFile`: `./internal/daemon/walk/` green, whole package. On the pre-fix tests the same environment produced `--- FAIL: TestInfoExcludeIsSharedWithLinkedWorktrees_6922` (its own `git add` skipped the seed files, so the seed commit was empty) and `--- FAIL: TestGlobalExcludesPath_ConfigThenXDGFallback_6922`.
2. **MC-4** — the XDG pin removed. It now lives inside `IsolateHome`, so the equivalent mutant overrides `XDG_CONFIG_HOME` back to empty immediately after the call. Still **RED on a clean environment**, still on `TestGlobalExcludesPath_ConfigThenXDGFallback_6922`. The grading did not move: the kill rests on the XDG-before-home *ordering*, and `HOME` stays pinned either way, so the pin remains self-graded rather than a manual procedure.

M12, R2, R3 and MC-2b were re-scored after the swap — all still DEAD.

### 4. MC-2b — the tilde was graded only as a helper. FIXED at the call site.

The fixture now writes the global ignore under the fake home and configures `core.excludesFile = ~/global_ignore` — the spelling git's own docs use — instead of an absolute path, driving `expandTilde` end to end. **MC-2b is now DEAD** (kills `TestWalkRepo_AppliesIgnoreStackToFiles_6931` and `…IgnoredFilesAreReported…`), and MC-2 with it.

### 5. R2 and R3 — both ALIVE mutants graded. Two FIFO tests, both under `t.TempDir()`.

- **R2** — `TestIgnoredFIFOIsReportedAsAHazardNotAsIgnored_6931`: `mkfifo ignored.pb.go` with `*.pb.go` ignored. Both orderings `return nil`, so only the reported reason differs: head reports `irregular:…`, the mutant reports `.gitignore line 1`. The fixture holds the *name* constant across a FIFO row and a regular-file row and varies only the entry type, so the control cannot pass by name. **DEAD.**
- **R3** — `TestInfoExcludeFIFODoesNotHang_6416`: `mkfifo .git/info/exclude`. Pinned as a deadline plus the always-on `reportIgnoreSkip` line, because the mutant produces no value to assert on. Under `os.ReadFile` it parks in `open(2)`: `HANG: WalkRepo with a FIFO .git/info/exclude did not return within 10s`. **DEAD.**

### 6. The stale doc block. DELETED, count corrected.

The orphaned first block on `gitExcludeIgnoreFiles` — which asserted the rewrite is reused, the opposite of the code — is gone. The surviving block now states the cost as **three** bounded git calls (`rev-parse --show-toplevel`, `config --get core.excludesFile`, `rev-parse --git-common-dir`), all outside the `WalkDir` callback, per walk and not per entry.

### 7. `IgnoreFile.Dir` is dead. FILED as #6936; the claim is softened, in the test file and here.

**Chosen: file, not fix.** The reason is not size. `filepath.Rel(d, filepath.Join(d, rel))` is `rel` for every input, so `ig.Dir` never applies — but the fix has to change `MatchPath`, and `MatchDir` is `MatchPath(rel, true)`. This PR's central safety property, the one the reviewer independently verified, is that **directory behaviour is unchanged by construction**; a `Dir` fix breaks that guarantee and needs its own directory-side measurement and its own shrink enumeration, in the same direction (it removes more files, so the growth-only ratchet stays silent, #6898).

The claim is now bounded rather than restated: the fixture's nested rows are **bare-name patterns only**, and *nested × anchored* and *nested × slash-bearing glob* are knowingly ungraded, with the reason written at the top of the test file.

---

## Fixture: what is varied, what is held constant

One fixture, asserted as **exact set equality**, so over-exclusion fails as loudly as under-exclusion (#6902) — every kept file is a forbidden row for the ignore predicate.

| form | pattern | positive row | forbidden row (must still be walked) |
|---|---|---|---|
| bare name | `bare_ignored.go` | `bare_ignored.go`, `pkg/bare_ignored.go` | — |
| rooted | `/rooted_ignored.go` | `rooted_ignored.go` | `pkg/rooted_ignored.go` |
| glob | `*.gen.go` | `a.gen.go`, `pkg/b.gen.go` | — |
| negation | `!kept.gen.go` | — | `kept.gen.go` |
| dir-only | `dironly.go/` | `pkg/dironly.go/inside.go` (a DIR) | `dironly.go` (a FILE, same name) |
| nested overriding a parent | `pkg/sub/.gitignore`: `!bare_ignored.go` | — | `pkg/sub/bare_ignored.go` |
| nested scope does not leak up | `pkg/sub/.gitignore`: `nested_only.go` | `pkg/sub/nested_only.go` | `nested_only.go` at root |
| `.git/info/exclude` | `excluded_by_info.go` | `excluded_by_info.go` | — |
| `core.excludesFile`, via `~/` | `excluded_by_global.go` | `excluded_by_global.go` | — |
| precedence `.gitignore` > `info/exclude` | `!prec_a.go` vs `prec_a.go` | — | `prec_a.go` |
| precedence `info/exclude` > `core.excludesFile` | `!prec_b.go` vs `prec_b.go` | — | `prec_b.go` |
| plain control | — | — | `keep.go`, `pkg/keep.go` |

Plus, in their own tests: nested-ignore DFS position (4 rows, one basename); FIFO vs regular file under one ignore rule; `.git/info/exclude` through a real `git worktree add`; the top-level-only scope limit; `core.excludesFile` config-vs-XDG order; `~/` expansion.

**Held constant:** extension `.go` on every row of the main fixture, so the extension filter can never be the thing doing the work; one repo root that IS the git top-level; no sparse checkout; no `.grafelignore`; a fully pinned git environment.

**Knowingly ungraded:** nested × anchored and nested × slash-bearing glob (#6936).

## Mutants — 15, all DEAD

Every mutant is at the call site, applied by exact-occurrence-count assertion, and restored by `cp` from a shasum-verified backup.

| # | mutant | killed by |
|---|---|---|
| M1 | delete the file-branch ignore check (the #6931 fix) | exact-set + report + watch agreement |
| M2 | `MatchFile` → `Match` (isDir=true) at the call site | exact-set (`dironly.go`) |
| M3 | delete the `gitExcludeIgnoreFiles` push (the #6922 fix) | exact-set + report |
| M4 | push the exclude sources ABOVE `.gitignore` | exact-set (`prec_a.go`) |
| M5 | swap `info/exclude` vs `core.excludesFile` order | exact-set (`prec_b.go`) |
| M6 | invert the dirOnly guard | exact-set + dirOnly unit |
| M7 | drop ignored files silently (no `SkipEntry`) | report test |
| M8 | `--git-dir` instead of `--git-common-dir` | linked-worktree test |
| M9 | drop the `core.excludesFile` config lookup | exact-set + resolution order |
| M10 | `expandTilde` helper is a no-op | expandTilde unit |
| M11 | drop the top-level gate | sub-root scope test |
| **M12** | **revert the pop hoist (back inside `d.IsDir`)** | **nested-pop test** |
| **R2** | **ignore block above the entry-type gate** | **ignored-FIFO test** |
| **R3** | **`readIgnoreFile` → `os.ReadFile`** | **FIFO-hang deadline** |
| **MC-2b** | **`expandTilde` CALL SITE deleted, helper intact** | **exact-set (tilde-configured fixture)** |

R1, R4, R5 and MC-1 were already DEAD against the reviewer's and coordinator's own scoring and are unchanged by this commit.

## Verification

`-count=1`, full suites: `./internal/daemon/walk/`, `./internal/daemon/watch/`, `./internal/registry/` (the #6735 guard's package), `./internal/gitmeta/`, `./internal/classifier/`, `./internal/extractors/` — all ok. `./cmd/grafel/` ok (148 s), digest unchanged. `scripts/quality/run.sh --ratchet`: 32 fixtures held. `gofmt -l` clean, `go vet ./internal/daemon/...` clean. Plus the hostile-environment run in item 3.

## Findings filed, not folded in

- **#6936** — `IgnoreFile.Dir` is dead; nested anchored rules never fire. Pre-existing, an under-exclusion, and it cannot be fixed without changing `MatchDir`.
- **#6937** — **needs a decision.** grafel's ignore layers are index-unaware, and git never ignores a **tracked** file. Both `graph.json` files above are **tracked** (`git ls-files --error-unmatch` matches them; `git check-ignore` reports them NOT ignored, because it excludes tracked paths by default). So this PR drops two committed files that git keeps. This also **corrects #6931's own ground truth** — that issue cites the pair as `check-ignore`-positive, and they are not. The entity cost here is 0 (both are `vendor_testdata`-skipped, which is why no test caught it) and it does not threaten arm A, whose requirement is that grafel's set be a *subset* of git's. But it is an over-exclusion of committed content, and the fix — an index read vetoing the ignore decision — is a design change I did not make unilaterally. Say the word and I will do it in this PR or a follow-up.

## Answers the brief asked for either way

- **`ShouldSkipPathForRepo` does apply the root `.gitignore` to files** (it walks every prefix *including the full path*), so the walker and watcher disagreed before this PR, with the watcher stricter — which is why it never surfaced as churn. `TestWalkerAndEventBoundaryAgreeOnIgnoredFiles_6931` pins the agreement; M1 kills it. Residual watcher divergences filed as **#6934**.
- **The watcher's directory-subscription path has no file/directory asymmetry** — `subscribeRepo`'s `WalkDir` callback returns early on `!d.IsDir()` (`watcher.go:707`). Nothing to fix, nothing to file.
- **Incidental for arm A**: `WalkRepo` rooted below the repo root does **not** inherit the top-level `.gitignore`, and the one inheriting rewrite (`rewriteInheritedIgnoreLine`) **drops anchoring** — measured, `/sub/x.go` under relRoot `sub` becomes the un-anchored `x.go`. The exclude sources are therefore applied only at the git top-level, documented and pinned by `TestExcludeSourcesAreNotAppliedBelowTopLevel_6922` (which also asserts the same tree walked from the top-level *does* apply them), killed by M11.
- **Not established, unchanged:** `.grafelignore` interaction with the two new sources beyond stack ordering, sparse checkout, submodules, symlinks, any corpus count beyond this repo.

Closes #6931
Closes #6922
Refs #6932, #6898, #6902, #6338, #6416, #6934, #6936, #6937

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
