### PR TITLE
feat(#6932) arm A: the polling change-detector as an opt-in mode — a container cannot raise the inotify pool it is silently exhausting

### DIFF
--- a/cmd/grafel/changedetection_6932_test.go
+++ b/cmd/grafel/changedetection_6932_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -38,4 +41,81 @@ func TestResolveChangeDetection(t *testing.T) {
 			}
 		})
 	}
+}
+
+// writeFleet lays down an isolated GRAFEL_HOME holding registry.json plus one
+// group config per body, and returns nothing — daemonChangeDetection reads it
+// through the real registry loader.
+func writeFleet(t *testing.T, groupBodies ...string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+
+	type ref struct {
+		Name       string `json:"name"`
+		ConfigPath string `json:"config_path"`
+	}
+	var refs []ref
+	for i, body := range groupBodies {
+		name := "g" + string(rune('a'+i))
+		p := filepath.Join(home, name+".json")
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		refs = append(refs, ref{Name: name, ConfigPath: p})
+	}
+	reg := map[string]any{"version": 1, "groups": refs}
+	b, err := json.Marshal(reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "registry.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// #6932 review, V3: resolveChangeDetection was split out and is well tested,
+// but daemonChangeDetection — the half that actually READS the fleet — had one
+// production call site and zero tests. Under a mutant returning (false, 0),
+// `"change_detection": "poll"` in fleet.json did nothing and the whole suite
+// stayed green: both ends of the boot wiring ungraded while only the extracted
+// middle was pinned (#6533).
+func TestDaemonChangeDetection_ReadsTheFleet(t *testing.T) {
+	t.Run("poll group turns it on with its interval", func(t *testing.T) {
+		writeFleet(t,
+			`{"group":"ga","features":{"change_detection":"poll","change_poll_interval_seconds":7}}`,
+			`{"group":"gb","features":{"watchers":true}}`,
+		)
+		poll, iv := daemonChangeDetection()
+		if !poll || iv != 7*time.Second {
+			t.Fatalf("got (%v, %v), want (true, 7s)", poll, iv)
+		}
+	})
+	t.Run("no poll group leaves it off", func(t *testing.T) {
+		writeFleet(t,
+			`{"group":"ga","features":{"change_detection":"fsnotify"}}`,
+			`{"group":"gb","features":{"change_detection":"auto"}}`,
+		)
+		poll, iv := daemonChangeDetection()
+		if poll || iv != 0 {
+			t.Fatalf("got (%v, %v), want (false, 0)", poll, iv)
+		}
+	})
+	t.Run("an unreadable group config does not hide a poll group", func(t *testing.T) {
+		writeFleet(t,
+			`{ this is not json`,
+			`{"group":"gb","features":{"change_detection":"poll"}}`,
+		)
+		poll, iv := daemonChangeDetection()
+		if !poll || iv != registry.DefaultChangePollInterval {
+			t.Fatalf("got (%v, %v), want (true, %v)", poll, iv, registry.DefaultChangePollInterval)
+		}
+	})
+	t.Run("empty fleet", func(t *testing.T) {
+		writeFleet(t)
+		poll, iv := daemonChangeDetection()
+		if poll || iv != 0 {
+			t.Fatalf("got (%v, %v), want (false, 0)", poll, iv)
+		}
+	})
 }

--- a/cmd/grafel/changedetection_6932_test.go
+++ b/cmd/grafel/changedetection_6932_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+func groupWith(mode string, seconds int) *registry.GroupConfig {
+	c := &registry.GroupConfig{}
+	c.Features.ChangeDetection = mode
+	c.Features.ChangePollIntervalSeconds = seconds
+	return c
+}
+
+func TestResolveChangeDetection(t *testing.T) {
+	cases := []struct {
+		name     string
+		cfgs     []*registry.GroupConfig
+		wantPoll bool
+		wantIv   time.Duration
+	}{
+		{"no groups", nil, false, 0},
+		{"all fsnotify", []*registry.GroupConfig{groupWith("", 0), groupWith("fsnotify", 0)}, false, 0},
+		{"auto does not enable poll in arm A", []*registry.GroupConfig{groupWith("auto", 0)}, false, 0},
+		{"one poll group, default interval", []*registry.GroupConfig{groupWith("poll", 0)}, true, registry.DefaultChangePollInterval},
+		{"one poll group among fsnotify ones", []*registry.GroupConfig{groupWith("fsnotify", 0), groupWith("poll", 5)}, true, 5 * time.Second},
+		{"smallest interval wins", []*registry.GroupConfig{groupWith("poll", 60), groupWith("poll", 5), groupWith("poll", 120)}, true, 5 * time.Second},
+		{"a non-polling group's interval is ignored", []*registry.GroupConfig{groupWith("fsnotify", 1), groupWith("poll", 60)}, true, 60 * time.Second},
+		{"nil entries are skipped", []*registry.GroupConfig{nil, groupWith("poll", 10)}, true, 10 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			poll, iv := resolveChangeDetection(tc.cfgs)
+			if poll != tc.wantPoll || iv != tc.wantIv {
+				t.Fatalf("got (%v, %v), want (%v, %v)", poll, iv, tc.wantPoll, tc.wantIv)
+			}
+		})
+	}
+}

--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -787,6 +787,7 @@ func runDaemonMode(argv []string, runMode daemonRunMode) error {
 	// Captured by value here; the pointer below is the sole owner (issue #2406).
 	extractorCfg := extractor.ConfigFromEnv()
 
+	pollMode, pollInterval := daemonChangeDetection()
 	cfg := daemon.Config{
 		Layout:       layout,
 		Logger:       logger,
@@ -810,10 +811,15 @@ func runDaemonMode(argv []string, runMode daemonRunMode) error {
 		// #3353/#3354: linked-worktree discovery + working-tree watching.
 		// Only groups with track_worktrees or watchers enabled are returned;
 		// nil → discovery not started.
-		WorktreeParents:    daemonWorktreeParents,
-		SchedulerIndex:     daemonSchedulerIndex,
-		SchedulerLinks:     daemonSchedulerLinks,
-		SchedulerGroupAlgo: daemonSchedulerGroupAlgo,
+		WorktreeParents: daemonWorktreeParents,
+		// #6932 arm A: opt-in polling change detection. pollMode is true only
+		// when some registered group sets features.change_detection = "poll";
+		// "auto" is accepted and resolves to fsnotify until arm B.
+		ChangeDetectionPoll: pollMode,
+		ChangePollInterval:  pollInterval,
+		SchedulerIndex:      daemonSchedulerIndex,
+		SchedulerLinks:      daemonSchedulerLinks,
+		SchedulerGroupAlgo:  daemonSchedulerGroupAlgo,
 		// #5403: settled-group overlay-freshness sweep. The scheduler polls this
 		// on GRAFEL_OVERLAY_SWEEP_INTERVAL (default 10m; "0" disables) and re-arms
 		// a debounced + CPU-capped group-algo pass for each stale group.
@@ -1121,6 +1127,59 @@ func groupHasIndexedMember(group string) bool {
 		return false
 	}
 	return len(mt) > 0
+}
+
+// daemonChangeDetection resolves the daemon-wide change-detection mode from
+// the fleet (#6932 arm A). Polling is enabled when ANY registered group sets
+// features.change_detection = "poll"; the interval is the smallest one those
+// groups ask for.
+//
+// Daemon-wide, not per-group, for the reason recorded on
+// daemon.Config.ChangeDetectionPoll: there is one Watcher for the whole
+// daemon, and the inotify pool the mode exists to protect is per-UID and
+// host-level — it is not partitioned by group either.
+//
+// "auto" is accepted, normalised and IGNORED here. GroupConfig.PollingEnabled
+// is the single place that decides what runs today, so arm B's budget probe
+// changes that function and nothing else.
+func daemonChangeDetection() (bool, time.Duration) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return false, 0
+	}
+	cfgs := make([]*registry.GroupConfig, 0, len(groups))
+	for _, g := range groups {
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			continue
+		}
+		cfgs = append(cfgs, cfg)
+	}
+	return resolveChangeDetection(cfgs)
+}
+
+// resolveChangeDetection is the decision daemonChangeDetection loads for: poll
+// mode is on when ANY group asks for it, and the interval is the SMALLEST any
+// asking group requested.
+//
+// Smallest, not largest or first: the interval is a staleness bound, so
+// honouring the tightest request satisfies every group at once, and the cost of
+// doing so is the ~0.2%-of-a-core-per-worktree figure in #6932's table rather
+// than anything a user would notice. Split out from the fleet load so the rule
+// is graded on its own, without a registry on disk.
+func resolveChangeDetection(cfgs []*registry.GroupConfig) (bool, time.Duration) {
+	poll := false
+	var interval time.Duration
+	for _, cfg := range cfgs {
+		if cfg == nil || !cfg.PollingEnabled() {
+			continue
+		}
+		poll = true
+		if iv := cfg.ChangePollInterval(); interval == 0 || iv < interval {
+			interval = iv
+		}
+	}
+	return poll, interval
 }
 
 // daemonWorktreeParents returns the registered repos whose group opts into

--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -200,12 +200,48 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 		}
 
 		wcfg := cfg.WatcherConfig
-		watcher, werr := watch.NewWatcherConfig(wcfg, func(repo string, bulk bool) {
+		// The one sink both detectors share. #6932 arm A is explicit that poll
+		// mode must NOT invent a second reindex path: whichever detector is
+		// live, a settled repo becomes exactly this scheduler enqueue.
+		indexSink := func(repo string, bulk bool) {
 			if bulk {
 				logger.Info("watcher: bulk trigger — enqueuing full reindex", "repo", repo)
 			}
 			scheduler.Enqueue(repo)
-		}, logger)
+		}
+
+		// #6932 arm A — poll mode. Opt-in only (features.change_detection =
+		// "poll"); "auto" resolves to fsnotify until arm B builds the budget
+		// probe, so nothing changes here for anyone who does not set the flag.
+		//
+		// The poller is installed as the Watcher's subscription DELEGATE
+		// rather than as a parallel subsystem, so every existing subscribe
+		// path (DefaultManager.Resume, SubscribeGroup, the worktree activation
+		// handler) routes to it without knowing it exists — and takes zero
+		// inotify watch descriptors doing so.
+		var changePoller *watch.ChangePoller
+		if cfg.ChangeDetectionPoll {
+			changePoller = watch.NewChangePoller(watch.ChangePollerConfig{
+				Interval:      cfg.ChangePollInterval,
+				BulkThreshold: wcfg.BulkThreshold,
+				// The manifest is per (repo, ref): a linked worktree on another
+				// branch has its own file-index.json, and diffing a worktree
+				// against the primary's manifest would report the whole branch
+				// delta on every cycle.
+				StateDir: func(repoPath string) string {
+					ref := gitmeta.Capture(repoPath).Ref
+					if sd := StateDirForRepoRef(repoPath, ref); sd != "" {
+						return sd
+					}
+					return StateDirForRepo(repoPath)
+				},
+			}, indexSink, logger)
+			wcfg.Delegate = changePoller
+			logger.Info("watcher: change detection = poll (#6932) — fsnotify subscriptions disabled, 0 watch descriptors",
+				"interval", cfg.ChangePollInterval.String())
+		}
+
+		watcher, werr := watch.NewWatcherConfig(wcfg, indexSink, logger)
 		if werr != nil {
 			logger.Warn("watcher: disabled", "err", werr)
 		} else {
@@ -213,6 +249,10 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 				svc.watcher = watcher
 			}
 			ep.add(watcher.Stop)
+			if changePoller != nil {
+				changePoller.Start()
+				ep.add(changePoller.Stop)
+			}
 
 			// PH1b (Option B): start the .git/HEAD poller alongside the
 			// fsnotify watcher. .git/ remains in SkipDirs (no fsnotify

--- a/internal/daemon/pollmode_6932_test.go
+++ b/internal/daemon/pollmode_6932_test.go
@@ -1,0 +1,116 @@
+package daemon_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/watch"
+)
+
+// bootWatcher boots a daemon with the given poll setting and returns the live
+// Watcher the engine plane constructed.
+func bootWatcher(t *testing.T, poll bool) *watch.Watcher {
+	t.Helper()
+	isolateDaemonEnv(t)
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if err := daemon.EnsureLayout(layout); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	ready := make(chan *watch.Watcher, 1)
+	cfg := daemon.Config{
+		Layout:              layout,
+		GroupsForRepo:       func(string) []string { return nil },
+		SchedulerIndex:      func(context.Context, string, string) error { return nil },
+		SchedulerLinks:      func(context.Context, string) error { return nil },
+		SchedulerGroupAlgo:  func(context.Context, string) error { return nil },
+		ChangeDetectionPoll: poll,
+		// An hour: this test drives AddRepo directly, never the ticker.
+		ChangePollInterval: time.Hour,
+		OnWatcherReady: func(w *watch.Watcher) {
+			select {
+			case ready <- w:
+			default:
+			}
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = daemon.Run(ctx, cfg) }()
+
+	select {
+	case w := <-ready:
+		return w
+	case <-time.After(30 * time.Second):
+		t.Fatal("watcher never became ready")
+		return nil
+	}
+}
+
+func pollModeRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, d := range []string{"a", "b", "a/c", "a/c/d"} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "a", "x.go"), []byte("package a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// #6932 arm A, end to end through the engine plane: with
+// Config.ChangeDetectionPoll set, every existing subscribe path (they all go
+// through Watcher.AddRepo) takes ZERO fs watch descriptors. That is the entire
+// point of the mode — on Linux each of those descriptors is one inotify watch
+// out of a per-UID, host-level, non-namespaced pool a container cannot raise.
+func TestEnginePlane_PollModeTakesNoWatchDescriptors(t *testing.T) {
+	w := bootWatcher(t, true)
+	repo := pollModeRepo(t)
+	n, err := w.AddRepo(repo)
+	if err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("poll mode subscribed %d directories; must be 0", n)
+	}
+	if _, dirs, _, _, _ := w.Stats(); dirs != 0 {
+		t.Fatalf("poll mode holds %d directory subscriptions; must be 0", dirs)
+	}
+	// The configured cadence must reach the poller. bootWatcher asks for an
+	// hour, which is nothing like watch.DefaultChangePollInterval, so a
+	// dropped Config.ChangePollInterval cannot pass for the default.
+	cp, ok := w.ChangeDelegate().(*watch.ChangePoller)
+	if !ok {
+		t.Fatalf("delegate is %T, want *watch.ChangePoller", w.ChangeDelegate())
+	}
+	if got := cp.Interval(); got != time.Hour {
+		t.Fatalf("poll interval = %v, want the configured 1h", got)
+	}
+}
+
+// The control. Without the flag the engine plane is byte-for-byte the
+// pre-#6932 daemon and still subscribes — otherwise the assertion above is
+// measuring a broken watcher rather than a working mode.
+func TestEnginePlane_DefaultModeStillSubscribes(t *testing.T) {
+	w := bootWatcher(t, false)
+	repo := pollModeRepo(t)
+	n, err := w.AddRepo(repo)
+	if err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("default (fsnotify) mode subscribed 0 directories — the control is vacuous")
+	}
+	if d := w.ChangeDelegate(); d != nil {
+		t.Fatalf("default mode installed a change delegate: %T", d)
+	}
+}

--- a/internal/daemon/pollmode_6932_test.go
+++ b/internal/daemon/pollmode_6932_test.go
@@ -3,17 +3,26 @@ package daemon_test
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/walk"
 	"github.com/cajasmota/grafel/internal/daemon/watch"
+	"github.com/cajasmota/grafel/internal/gitmeta"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
 )
 
 // bootWatcher boots a daemon with the given poll setting and returns the live
 // Watcher the engine plane constructed.
 func bootWatcher(t *testing.T, poll bool) *watch.Watcher {
+	t.Helper()
+	return bootWatcherCfg(t, poll, time.Hour)
+}
+
+func bootWatcherCfg(t *testing.T, poll bool, iv time.Duration) *watch.Watcher {
 	t.Helper()
 	isolateDaemonEnv(t)
 	layout, err := daemon.DefaultLayout()
@@ -31,8 +40,7 @@ func bootWatcher(t *testing.T, poll bool) *watch.Watcher {
 		SchedulerLinks:      func(context.Context, string) error { return nil },
 		SchedulerGroupAlgo:  func(context.Context, string) error { return nil },
 		ChangeDetectionPoll: poll,
-		// An hour: this test drives AddRepo directly, never the ticker.
-		ChangePollInterval: time.Hour,
+		ChangePollInterval:  iv,
 		OnWatcherReady: func(w *watch.Watcher) {
 			select {
 			case ready <- w:
@@ -51,6 +59,12 @@ func bootWatcher(t *testing.T, poll bool) *watch.Watcher {
 		t.Fatal("watcher never became ready")
 		return nil
 	}
+}
+
+// bootWatcherInterval is bootWatcher with a caller-chosen cadence.
+func bootWatcherInterval(t *testing.T, poll bool, iv time.Duration) *watch.Watcher {
+	t.Helper()
+	return bootWatcherCfg(t, poll, iv)
 }
 
 func pollModeRepo(t *testing.T) string {
@@ -112,5 +126,100 @@ func TestEnginePlane_DefaultModeStillSubscribes(t *testing.T) {
 	}
 	if d := w.ChangeDelegate(); d != nil {
 		t.Fatalf("default mode installed a change delegate: %T", d)
+	}
+}
+
+// gitRepoWithManifest builds a real git repo and seeds the manifest at the
+// per-(repo, ref) state dir the engine plane's StateDir closure resolves to.
+// It returns the repo path and that state dir.
+func gitRepoWithManifest(t *testing.T) (string, string) {
+	t.Helper()
+	repo := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repo, "alpha.go"), []byte("package a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "-A")
+	run("commit", "-q", "-m", "init")
+
+	ref := gitmeta.Capture(repo).Ref
+	if ref == "" {
+		t.Fatal("fixture premise broken: no ref captured for the repo")
+	}
+	state := daemon.StateDirForRepoRef(repo, ref)
+	if state == "" {
+		t.Fatal("StateDirForRepoRef returned empty")
+	}
+	// Premise for the V2 grade below: the per-ref dir must differ from the
+	// ref-less one, or a mutant that drops the ref would land in the same place.
+	if refless := daemon.StateDirForRepoRef(repo, ""); refless == state {
+		t.Fatalf("fixture premise broken: ref and ref-less state dirs are identical (%s)", state)
+	}
+	files, _, err := walk.WalkRepo(repo, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := diff.LoadManifest(state)
+	changed, _ := diff.Filter(repo, files, m)
+	diff.UpdateManifestScoped(repo, changed, files, m)
+	if err := diff.SaveManifestAtCommit(state, m, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	return repo, state
+}
+
+// #6932 review, V1 + V2: the two ends of the boot wiring. Asserting that poll
+// mode subscribes 0 directories and that the interval reached the poller says
+// nothing about whether a cycle EVER RUNS — under a mutant that deletes
+// changePoller.Start(), poll mode subscribes nothing AND detects nothing, i.e.
+// the daemon runs with no change detector at all: the exact silent
+// half-failure #6932 exists to remove. And under a mutant that drops the ref
+// from the StateDir closure, the poller sweeps the wrong manifest.
+//
+// So this asserts the observable consequence — a detector that detects — end
+// to end through daemon.Run, on a real repo with a real seeded manifest.
+func TestEnginePlane_PollModeActuallyDetects(t *testing.T) {
+	w := bootWatcherInterval(t, true, 25*time.Millisecond)
+	repo, _ := gitRepoWithManifest(t)
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	cp, ok := w.ChangeDelegate().(*watch.ChangePoller)
+	if !ok {
+		t.Fatalf("delegate is %T", w.ChangeDelegate())
+	}
+
+	// Quiescent first: no submission may happen before there is a change.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && cp.Cycles() < 3 {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if cp.Cycles() < 3 {
+		t.Fatalf("the poll loop never ran: cycles=%d (is changePoller.Start() wired?)", cp.Cycles())
+	}
+	if n := cp.Submits(); n != 0 {
+		t.Fatalf("poller submitted %d reindex requests on a quiescent repo", n)
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "alpha.go"), []byte("package a\n\nfunc A() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	deadline = time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) && cp.Submits() == 0 {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if cp.Submits() == 0 {
+		t.Fatalf("poll mode detected nothing after a real edit (cycles=%d) — the daemon is running with no change detector", cp.Cycles())
 	}
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -204,6 +204,23 @@ type Config struct {
 	// watcher_bulk_threshold). Added in #1270.
 	WatcherConfig watch.Config
 
+	// ChangeDetectionPoll selects the descriptor-free polling change detector
+	// instead of fsnotify subscriptions (#6932 arm A). It is derived from
+	// features.change_detection == "poll" on any registered group; see
+	// daemonChangeDetectionPoll in cmd/grafel/daemon.go.
+	//
+	// It is daemon-wide, not per-group, because there is ONE Watcher for the
+	// whole daemon and the inotify pool it draws from is per-UID and
+	// host-level — the resource the mode exists to protect is not partitioned
+	// by group either. Opting one group in therefore opts the daemon in, which
+	// is the conservative direction: poll mode is complete (it is what #6932
+	// measured hybrid B for), just coarser.
+	ChangeDetectionPoll bool
+
+	// ChangePollInterval is the poll cadence when ChangeDetectionPoll is set.
+	// Zero selects watch.DefaultChangePollInterval (30 s).
+	ChangePollInterval time.Duration
+
 	// OnWatcherReady is called with the live watcher after it is
 	// successfully created and repos are subscribed. Allows callers
 	// (e.g. cmd/grafel) to wire the watcher into the dashboard

--- a/internal/daemon/walk/indexable_entrytype_6932_unix_test.go
+++ b/internal/daemon/walk/indexable_entrytype_6932_unix_test.go
@@ -1,0 +1,168 @@
+//go:build unix
+
+package walk
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// IndexableEntryType is an EXPORTED cross-package contract, and the export is
+// the contract — grading it only through its one consumer (the change-poller
+// in internal/daemon/watch) is the wrong way round: it leaves the walk package
+// free to change the exported behaviour and stay green, and it means a reader
+// of this package cannot see what the function promises. #6932 review RV-3
+// showed exactly that: making the Lstat error path return true was DEAD in
+// `watch` and left `walk` GREEN.
+//
+// AXES. Varied: the entry TYPE, over the whole space the type bits can express
+// plus both symlink-resolution failures. Held constant: the extension (every
+// name ends .go, so the extension filter is never the reason for a verdict),
+// the ignore state (no .gitignore anywhere in the fixture), and the sparse
+// state (no sparse checkout). That is deliberate — those three gates are NOT
+// part of this function's contract, and holding them constant is what makes a
+// failure here attributable to the entry-type rule.
+func TestIndexableEntryType(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "tree")
+	if err := os.MkdirAll(filepath.Join(dir, "realdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(rel string) string {
+		p := filepath.Join(dir, rel)
+		if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	link := func(target, rel string) string {
+		p := filepath.Join(dir, rel)
+		if err := os.Symlink(target, p); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		return p
+	}
+
+	regular := write("regular.go")
+	nested := write("realdir/target.go")
+	fifo := testsupport.MkfifoInTemp(t, root, "tree", "fifo.go")
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"regular file", regular, true},
+		{"regular file in a subdirectory", nested, true},
+		{"symlink to a regular file", link(regular, "link-to-regular.go"), true},
+		{"symlink to a symlink to a regular file", link(filepath.Join(dir, "link-to-regular.go"), "link2.go"), true},
+		{"symlink with a relative target", link("regular.go", "rel-link.go"), true},
+		{"dangling symlink", link(filepath.Join(dir, "nope.go"), "dangling.go"), false},
+		{"symlink to a directory", link(filepath.Join(dir, "realdir"), "link-to-dir.go"), false},
+		{"plain directory", filepath.Join(dir, "realdir"), false},
+		{"the walk root itself", dir, false},
+		{"named pipe", fifo, false},
+		{"symlink to a named pipe", link(fifo, "link-to-fifo.go"), false},
+		{"character device", "/dev/null", false},
+		{"absent path", filepath.Join(dir, "absent.go"), false},
+		{"empty path", "", false},
+	}
+	// The symlink loop needs both halves to exist before either resolves.
+	link(filepath.Join(dir, "loop-b.go"), "loop-a.go")
+	link(filepath.Join(dir, "loop-a.go"), "loop-b.go")
+	cases = append(cases, struct {
+		name string
+		path string
+		want bool
+	}{"symlink loop (ELOOP)", filepath.Join(dir, "loop-a.go"), false})
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got bool
+			// A regression that OPENED the entry would park in open(2) on the
+			// FIFO cases forever; fail with attribution instead of wedging the
+			// binary until the -timeout watchdog kills it with none.
+			testsupport.MustReturn(t, "IndexableEntryType("+tc.path+")", func() {
+				got = IndexableEntryType(tc.path)
+			})
+			if got != tc.want {
+				t.Fatalf("IndexableEntryType(%s) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// The contract is "the entry-type gate, and nothing else". This pins the
+// "nothing else" half against the three gates the doc comment disclaims, so a
+// future reader cannot mistake the function for "would WalkRepo index this?" —
+// and so that a change which quietly folds one of them in is caught here.
+//
+// Each path below is one WalkRepo REFUSES and IndexableEntryType ACCEPTS. The
+// asymmetry is the point: this predicate is a strictly weaker condition, and
+// its answer is a superset of the walker's.
+func TestIndexableEntryType_DoesNotReproduceTheOtherGates(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(rel, body string) string {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	mk(".gitignore", "ignored.go\n")
+	png := mk("photo.png", "not really a png")
+	ignored := mk("ignored.go", "package p\n")
+	kept := mk("keep.go", "package p\n")
+
+	walked, _, err := WalkRepo(dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexed := make(map[string]bool, len(walked))
+	for _, f := range walked {
+		indexed[f] = true
+	}
+	if !indexed["keep.go"] {
+		t.Fatalf("fixture premise broken: the walker indexed nothing normal; walked=%v", walked)
+	}
+
+	for _, tc := range []struct {
+		rel  string
+		abs  string
+		gate string
+	}{
+		{"photo.png", png, "the indexed-extension filter (#1629)"},
+		{"ignored.go", ignored, "the file-level ignore layer (#6931/#6933)"},
+	} {
+		if indexed[tc.rel] {
+			t.Fatalf("fixture premise broken: WalkRepo did not refuse %s via %s; walked=%v", tc.rel, tc.gate, walked)
+		}
+		if !IndexableEntryType(tc.abs) {
+			t.Fatalf("%s: IndexableEntryType refused it, so it DOES reproduce %s — the doc comment disclaims that gate and must be corrected", tc.rel, tc.gate)
+		}
+	}
+
+	// And the control: the entry-type gate IS reproduced, so the two are not
+	// simply unrelated functions.
+	if !IndexableEntryType(kept) {
+		t.Fatal("IndexableEntryType refused an ordinary indexed file")
+	}
+	var refusedByWalker []string
+	for _, f := range []string{"photo.png", "ignored.go"} {
+		if !indexed[f] {
+			refusedByWalker = append(refusedByWalker, f)
+		}
+	}
+	sort.Strings(refusedByWalker)
+	if len(refusedByWalker) != 2 {
+		t.Fatalf("fixture premise broken: expected both paths refused, got %s", strings.Join(refusedByWalker, ","))
+	}
+}

--- a/internal/daemon/walk/irregular.go
+++ b/internal/daemon/walk/irregular.go
@@ -52,7 +52,19 @@ import (
 // side closes it: internal/safeio opens with O_NONBLOCK and re-checks the type
 // with fstat on the descriptor.
 func irregularSkipRule(absPath string, d fs.DirEntry) (string, bool) {
-	mode := d.Type()
+	return irregularSkipRuleMode(absPath, d.Type())
+}
+
+// irregularSkipRuleMode is irregularSkipRule's body, taking the LSTAT-SHAPED
+// type bits directly instead of an fs.DirEntry.
+//
+// Split out so a caller that holds a PATH rather than a walk entry can ask the
+// walker the same question and get the same answer — see IndexableEntryType.
+// The two must not be able to drift: the poller in internal/daemon/watch
+// admits a git-reported path to its candidate set only if the walker would
+// index it, and any divergence is a file one half indexes and the other half
+// never notices changing (#6932 review, MA-1).
+func irregularSkipRuleMode(absPath string, mode fs.FileMode) (string, bool) {
 	if mode&os.ModeSymlink != 0 {
 		fi, err := os.Stat(absPath)
 		if err != nil {
@@ -77,6 +89,38 @@ func irregularSkipRule(absPath string, d fs.DirEntry) (string, bool) {
 		return "symlink-to-directory", true
 	}
 	return "irregular:" + irregularKind(mode), true
+}
+
+// IndexableEntryType reports whether the entry at absPath is one WalkRepo would
+// hand to an extractor, deciding from the path alone.
+//
+// It is the walker's own entry-type gate, reached from outside the walk: it
+// Lstats the path to recover the type bits filepath.WalkDir would have handed
+// irregularSkipRule, then applies that identical rule — including the os.Stat
+// resolution of a symlink, so a link to a regular file is indexable and a
+// dangling link, a link to a directory, and a FIFO are not.
+//
+// WHY IT IS SHARED RATHER THAN REIMPLEMENTED (#6932 review, MA-1). The polling
+// change-detector needs exactly this predicate to decide whether a path git
+// reported can ever acquire a manifest stamp. Its first version asked
+// os.Lstat().Mode().IsRegular() instead, which answers about the LINK rather
+// than its target, so a newly created symlink-to-source in a tracked directory
+// was refused as a candidate while WalkRepo indexed it with no skip entry: a
+// file the index contains and the poller can never see change. Two predicates
+// answering "would grafel index this?" is one predicate too many, and the
+// agreement is asserted over an enumerated entry-type space rather than
+// assumed — see TestExistsOnDisk_AgreesWithWalker.
+//
+// A path that does not exist, or that cannot be Lstat-ed at all, is not
+// indexable. It never opens the entry, so — like the gate it delegates to — it
+// cannot itself block on a FIFO.
+func IndexableEntryType(absPath string) bool {
+	fi, err := os.Lstat(absPath)
+	if err != nil {
+		return false
+	}
+	_, skip := irregularSkipRuleMode(absPath, fi.Mode().Type())
+	return !skip
 }
 
 // irregularKind names the entry type for the skip report. The names are

--- a/internal/daemon/walk/irregular.go
+++ b/internal/daemon/walk/irregular.go
@@ -91,32 +91,59 @@ func irregularSkipRuleMode(absPath string, mode fs.FileMode) (string, bool) {
 	return "irregular:" + irregularKind(mode), true
 }
 
-// IndexableEntryType reports whether the entry at absPath is one WalkRepo would
-// hand to an extractor, deciding from the path alone.
+// IndexableEntryType reports whether the entry at absPath passes WalkRepo's
+// ENTRY-TYPE gate — and nothing else.
 //
-// It is the walker's own entry-type gate, reached from outside the walk: it
-// Lstats the path to recover the type bits filepath.WalkDir would have handed
-// irregularSkipRule, then applies that identical rule — including the os.Stat
-// resolution of a symlink, so a link to a regular file is indexable and a
-// dangling link, a link to a directory, and a FIFO are not.
+// It is exactly irregularSkipRule, reached from a path instead of from a walk
+// entry: Lstat recovers the type bits filepath.WalkDir would have supplied,
+// then the identical rule runs, including the os.Stat resolution of a symlink.
+// So a link to a regular file passes; a dangling link, a symlink loop, a link
+// to a directory, a directory, a FIFO, a device and a socket do not, and
+// neither does a path that cannot be Lstat-ed at all.
 //
-// WHY IT IS SHARED RATHER THAN REIMPLEMENTED (#6932 review, MA-1). The polling
-// change-detector needs exactly this predicate to decide whether a path git
-// reported can ever acquire a manifest stamp. Its first version asked
-// os.Lstat().Mode().IsRegular() instead, which answers about the LINK rather
-// than its target, so a newly created symlink-to-source in a tracked directory
-// was refused as a candidate while WalkRepo indexed it with no skip entry: a
-// file the index contains and the poller can never see change. Two predicates
-// answering "would grafel index this?" is one predicate too many, and the
-// agreement is asserted over an enumerated entry-type space rather than
-// assumed — see TestExistsOnDisk_AgreesWithWalker.
+// WHAT IT DOES NOT SEE. WalkRepo's file branch applies FOUR gates in order,
+// and this reproduces one of them:
 //
-// A path that does not exist, or that cannot be Lstat-ed at all, is not
-// indexable. It never opens the entry, so — like the gate it delegates to — it
-// cannot itself block on a FIFO.
+//  1. shouldSkipFileByExt  — the indexed-extension filter (#1629). NOT here:
+//     IndexableEntryType(".../photo.png") is true and WalkRepo skips it.
+//  2. irregularSkipRule    — the entry-type gate (#6416). THIS IS THE ONE.
+//  3. igStack.MatchFile    — the file-level .gitignore/.grafelignore layer
+//     (#6931/#6933). NOT here: it needs the walk's inherited ignore stack,
+//     which is built by descending from the root and cannot be reconstructed
+//     from a single path.
+//  4. the sparse-checkout filter (#2181). NOT here: it needs opts.Sparse.
+//
+// A caller that needs "would WalkRepo index this path?" must not use this
+// function for that question — it answers a strictly weaker one, and the
+// difference is a superset, not a subset. Callers relying on the weaker answer
+// should say which of the other three gates their own input has already
+// excluded. The polling change-detector in internal/daemon/watch is the
+// current caller; see existsOnDisk for what it does and does not establish.
+//
+// WHY IT IS SHARED RATHER THAN REIMPLEMENTED (#6932 review, MA-1). That
+// consumer needs the entry-type gate specifically, and its first version
+// reimplemented it as os.Lstat().Mode().IsRegular() — which answers about the
+// LINK rather than its target. WalkRepo indexed a symlink-to-source with no
+// skip entry while the poller refused it as a candidate, so the index held a
+// file whose changes nothing could observe. Two predicates answering one
+// question is one too many; the agreement is now pinned over an enumerated
+// entry-type space by TestExistsOnDisk_AgreesWithWalker.
+//
+// It never opens the entry, so — like the gate it delegates to — it cannot
+// itself block on a FIFO.
 func IndexableEntryType(absPath string) bool {
 	fi, err := os.Lstat(absPath)
 	if err != nil {
+		return false
+	}
+	// A real directory never reaches WalkRepo's file branch at all — WalkDir
+	// sends it down the directory branch — so the file-branch rule has no
+	// verdict to give about one. irregularSkipRuleMode happens to return
+	// skip=true for it via its symlink-to-directory case, which is the right
+	// answer for the wrong reason: two independent decisions coinciding. Decide
+	// it here instead, so widening that branch cannot silently change what this
+	// function says about a plain directory.
+	if fi.IsDir() {
 		return false
 	}
 	_, skip := irregularSkipRuleMode(absPath, fi.Mode().Type())

--- a/internal/daemon/watch/change_poller.go
+++ b/internal/daemon/watch/change_poller.go
@@ -380,24 +380,36 @@ func (p *ChangePoller) pollRepo(abs string) []string {
 	return changed
 }
 
-// existsOnDisk reports whether rel names an entry inside repoRoot that the
-// INDEXER would index — which is the only question the candidate set cares
-// about, in both directions:
+// existsOnDisk reports whether rel names an entry inside repoRoot that passes
+// the walker's ENTRY-TYPE gate — see walk.IndexableEntryType, which it is.
 //
-//   - A path the indexer will never stamp must not enter the candidate set, or
-//     it reads as new on every cycle forever (blocker 1 above).
+// It is a NECESSARY condition for a git-reported path to become a candidate,
+// not a sufficient one. It is the entry-type axis only, and the candidate set
+// wants that axis in both directions:
+//
+//   - A path the indexer will never stamp must not enter the set, or it reads
+//     as new on every cycle forever (blocker 1 above). The entry-type axis of
+//     that is a FIFO or a dangling link git reports.
 //   - A path the indexer WILL stamp must not be refused, or a change to it is
-//     never noticed while a full walk would have picked it up.
+//     never noticed while a full walk would have picked it up. The entry-type
+//     axis of that is a symlink to a source file (#6932 review, MA-1: this
+//     asked os.Lstat().Mode().IsRegular(), which answers about the LINK, while
+//     the walker resolves the link and indexes it).
 //
-// So it delegates to walk.IndexableEntryType — the walker's OWN entry-type
-// gate — rather than deciding for itself. An earlier version asked
-// os.Lstat().Mode().IsRegular() here, which answers about the LINK and not its
-// target, and diverged from walk.irregularSkipRule (which resolves a symlink
-// with os.Stat and indexes a link to a regular file). The result was the second
-// bullet: a new symlink-to-source in a tracked directory, reported by git as
-// untracked, refused here, indexed by every full walk (#6932 review, MA-1).
-// TestExistsOnDisk_AgreesWithWalker pins the agreement over an enumerated
-// entry-type space, so the two cannot drift apart again in either direction.
+// WHAT IT DOES NOT ESTABLISH, and therefore what this function does NOT
+// promise: WalkRepo applies three further gates the predicate cannot see — the
+// indexed-extension filter, the file-level ignore layer (#6931/#6933), and the
+// sparse-checkout filter. A git-reported path that clears the entry-type gate
+// and is then refused by one of those three still enters the candidate set and
+// still cannot converge. An untracked `photo.png` is the driven example; a
+// tracked-but-gitignored file is the second, widened by #6933. That residual is
+// filed as #6940 and deliberately NOT fixed here —
+// closing it means teaching the poller the walk's inherited ignore stack and
+// sparse state, which is a different change with a different cost.
+//
+// The delegation is what keeps the one axis it DOES decide from drifting: the
+// poller's entry-type test IS the walker's, and TestExistsOnDisk_AgreesWithWalker
+// pins the agreement over an enumerated entry-type space rather than assuming it.
 func existsOnDisk(repoRoot, rel string) bool {
 	return walk.IndexableEntryType(filepath.Join(repoRoot, filepath.FromSlash(rel)))
 }

--- a/internal/daemon/watch/change_poller.go
+++ b/internal/daemon/watch/change_poller.go
@@ -1,0 +1,431 @@
+// Package watch — ChangePoller: the polling change-detector (#6932, arm A).
+//
+// WHY IT EXISTS. On Linux, inotify costs one watch descriptor per DIRECTORY,
+// recursively. Measured through the real Watcher.AddRepo on this repo: 976
+// directories per worktree, and GRAFEL_MAX_WORKTREES_PER_REPO defaults to 10,
+// so one lane can reach ~10,700 descriptors. fs.inotify.max_user_watches is
+// per-UID, host-level and NOT namespaced — every container running as the same
+// UID draws from one pool, and a container cannot raise it. The failure mode is
+// a watcher that is registered and receives no events: silent.
+//
+// This poller is the escape hatch. It costs ZERO watch descriptors.
+//
+// THE MECHANISM — "hybrid B" of #6932, the variant a 14-case spike measured
+// against real fsnotify, real git and grafel's real diff.Filter/walk.WalkRepo:
+//
+//  1. DISCOVERY: `git status --porcelain -z -unormal` per worktree. -unormal
+//     collapses an untracked subtree to a single `dir/` line and stays flat at
+//     ~60 ms whether there are 0 or 20,000 untracked files. Each reported
+//     untracked DIRECTORY is expanded with walk.WalkRepo rooted at the subtree.
+//     `-uall` was measured and rejected: it is a full tree readdir in C
+//     (~130 ms floor at zero untracked files), so it rents git's walk rather
+//     than escaping it.
+//
+//  2. THE CHANGE DECISION: a stat-sweep of the MANIFEST'S OWN KEY SET, through
+//     internal/indexer/diff (LoadManifest + Filter). This is the half that
+//     makes the poller complete, and it is not optional:
+//
+//     - `git status` reports state relative to HEAD, not change since the last
+//     poll. An untracked file edited twice yields `?? foo.go` both times; a
+//     tracked file edited twice yields ` M a.go` both times. A git-only poller
+//     is blind to an agent repeatedly saving the file it is working on, which
+//     is the most common action there is.
+//
+//     - Worse, a git-derived CANDIDATE set (hybrid A) fails edit-then-revert as
+//     a PERMANENT silent corruption: once the bytes match HEAD again git
+//     reports the tree clean, the file leaves the candidate set forever, and
+//     the manifest keeps the edited SHA. Sweeping the manifest's keys converges
+//     it. See TestChangePoller_EditThenRevertConverges.
+//
+//     Going through diff.Filter also preserves its cross-file basename
+//     invalidation, so the poller's changed set matches what a full walk would
+//     have produced.
+//
+//  3. SUBMISSION: on a non-empty changed set the poller calls the SAME
+//     EventSink(repo, bulk) contract the fsnotify watcher satisfies. There is
+//     no second reindex path, and the poller NEVER writes the manifest —
+//     re-stamping is the indexer's job. (The #6932 spike learned this the hard
+//     way: it called UpdateManifestScoped(repo, changed, nil, m), which wiped
+//     the whole manifest via reconcileMembership, and its 14-case HIT/MISS
+//     matrix was byte-identical before and after the fix.)
+//
+// LEVEL-TRIGGERED, NOT EDGE-TRIGGERED. The poller holds no "seen" set. Its
+// state IS the manifest, and it re-submits every cycle for as long as the
+// manifest and the disk disagree. Over-firing costs a debounced, circuit-broken
+// scheduler enqueue; under-firing is the silent corruption this whole issue is
+// about. The asymmetry is deliberate.
+//
+// WARM-UP (arm D of #6932). A fresh worktree's first `git status` costs
+// 2.4-9.0 s until git's untracked cache exists; every subsequent one is ~60 ms.
+// AddRepo therefore sets core.untrackedCache=true and runs one throwaway
+// `git status`, so the first real cycle is not mistaken for a hang.
+//
+// COST. 60 ms per cycle per worktree: at a 2 s interval that is ~3% of a core
+// per worktree; at the 30 s default, ~0.2% (~2% across ten worktrees).
+//
+// MEASUREMENT CAVEAT, carried verbatim from #6932: every number above is
+// macOS/APFS. Nothing was measured on Linux or in a container, and the two
+// readdir-bound figures (the rejected full sweep, the rejected -uall floor)
+// will be worse on overlayfs. Hybrid B's advantage should widen there because
+// it replaces the walk entirely — but that is reasoning, not measurement.
+package watch
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/walk"
+	"github.com/cajasmota/grafel/internal/gitmeta"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// DefaultChangePollInterval is the poll cadence used when none is configured.
+//
+// 30 s, from #6932's cost table. A cycle is ~60 ms per worktree, so 30 s is
+// ~0.2% of a core per worktree (~2% for ten) against ~3% at 2 s. Immediacy buys
+// nothing here: an agent already knows the file it just wrote, and the changes
+// it CANNOT predict — checkout, merge, rebase — are covered by git hooks and by
+// GitHeadPoller's own 2 s .git/HEAD poll, not by this. grafel also already
+// ships a bounded-staleness contract (reloadBeforeCall, debounced at 2000 ms,
+// documented as "bounded staleness <= window"), so seconds-scale detection is
+// the existing shape, not a regression.
+const DefaultChangePollInterval = 30 * time.Second
+
+// defaultChangeBulkThreshold matches the fsnotify watcher's BulkThreshold: at
+// or above this many changed files the sink is told to do a repo-level reindex
+// rather than a file-level diff.
+const defaultChangeBulkThreshold = 50
+
+// ChangePollerConfig holds the poller's tunables. The zero value is valid
+// except for StateDir, which has no sensible default inside this package.
+type ChangePollerConfig struct {
+	// Interval is the poll cadence. Zero selects DefaultChangePollInterval.
+	Interval time.Duration
+
+	// BulkThreshold is the changed-file count at or above which the sink is
+	// called with bulk=true. Zero selects defaultChangeBulkThreshold.
+	BulkThreshold int
+
+	// StateDir maps an absolute repo path to the directory holding that repo's
+	// file-index.json (i.e. daemon.StateDirForRepoRef's output). It is injected
+	// rather than imported because internal/daemon imports this package, not
+	// the other way round. A nil StateDir, or one returning "", disables
+	// polling for that repo — there is no manifest to diff against.
+	StateDir func(repoPath string) string
+
+	// DisableWarmUp skips the arm-D untracked-cache warm-up at AddRepo time.
+	// Production never sets it; it exists for tests that must not shell out.
+	DisableWarmUp bool
+}
+
+// ChangePoller detects working-tree changes without any fs watch descriptors
+// and submits them through the standard EventSink contract. See the package
+// doc above for the mechanism and why each half of it is load-bearing.
+type ChangePoller struct {
+	interval      time.Duration
+	bulkThreshold int
+	stateDir      func(string) string
+	disableWarmUp bool
+	sink          EventSink
+	logger        *slog.Logger
+
+	mu    sync.Mutex
+	repos map[string]struct{}
+
+	cycles  uint64 // atomic — completed poll cycles
+	submits uint64 // atomic — sink invocations
+
+	stopOnce sync.Once
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+}
+
+// NewChangePoller constructs a poller. sink must be non-nil; logger may be nil.
+func NewChangePoller(cfg ChangePollerConfig, sink EventSink, logger *slog.Logger) *ChangePoller {
+	if cfg.Interval <= 0 {
+		cfg.Interval = DefaultChangePollInterval
+	}
+	if cfg.BulkThreshold <= 0 {
+		cfg.BulkThreshold = defaultChangeBulkThreshold
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "change-poller")
+	}
+	return &ChangePoller{
+		interval:      cfg.Interval,
+		bulkThreshold: cfg.BulkThreshold,
+		stateDir:      cfg.StateDir,
+		disableWarmUp: cfg.DisableWarmUp,
+		sink:          sink,
+		logger:        logger,
+		repos:         make(map[string]struct{}),
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+	}
+}
+
+// Start begins the polling loop. Call at most once; Stop shuts it down.
+func (p *ChangePoller) Start() { go p.loop() }
+
+// Stop halts the poller and waits for the loop goroutine to exit. Safe to call
+// repeatedly, and safe to call on a poller that was never Started (the loop
+// goroutine closes doneCh; a never-started poller closes it here).
+func (p *ChangePoller) Stop() {
+	p.stopOnce.Do(func() { close(p.stopCh) })
+	select {
+	case <-p.doneCh:
+	case <-time.After(2 * time.Second):
+		// The loop was never started, or is mid-cycle. Either way we do not
+		// hold the caller: a poller only reads.
+	}
+}
+
+// AddRepo registers repoPath for polling and performs the arm-D warm-up.
+// Idempotent.
+func (p *ChangePoller) AddRepo(repoPath string) error {
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		return err
+	}
+	p.mu.Lock()
+	_, already := p.repos[abs]
+	p.repos[abs] = struct{}{}
+	p.mu.Unlock()
+	if already {
+		return nil
+	}
+	if !p.disableWarmUp {
+		p.warmUp(abs)
+	}
+	p.logger.Info("change-poller: registered", "repo", abs, "interval", p.interval.String())
+	return nil
+}
+
+// RemoveRepo deregisters repoPath. Safe on unknown paths.
+func (p *ChangePoller) RemoveRepo(repoPath string) {
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		return
+	}
+	p.mu.Lock()
+	delete(p.repos, abs)
+	p.mu.Unlock()
+}
+
+// Repos returns a snapshot of the polled repo paths.
+func (p *ChangePoller) Repos() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, 0, len(p.repos))
+	for r := range p.repos {
+		out = append(out, r)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Interval returns the poll cadence this poller ticks at.
+func (p *ChangePoller) Interval() time.Duration { return p.interval }
+
+// Cycles returns the number of COMPLETED poll cycles.
+func (p *ChangePoller) Cycles() uint64 { return atomic.LoadUint64(&p.cycles) }
+
+// Submits returns the number of index requests handed to the sink.
+func (p *ChangePoller) Submits() uint64 { return atomic.LoadUint64(&p.submits) }
+
+// warmUp is arm D of #6932: enable git's untracked cache for this worktree and
+// pay its one-off build cost (2.4-9.0 s on a fresh worktree) here, at
+// registration, rather than on the first poll cycle where it would look like a
+// hang. Both calls are best-effort — a repo whose git refuses the config still
+// polls correctly, just slower.
+func (p *ChangePoller) warmUp(abs string) {
+	t0 := time.Now()
+	if _, ok := gitmeta.RunGitBoundedC(abs, "config", "core.untrackedCache", "true"); !ok {
+		p.logger.Warn("change-poller: could not enable core.untrackedCache — first status per cycle will be slow", "repo", abs)
+	}
+	if _, ok := gitmeta.RunGitBoundedC(abs, "status", "--porcelain", "-z", "-unormal"); !ok {
+		p.logger.Warn("change-poller: warm-up git status failed", "repo", abs)
+	}
+	p.logger.Info("change-poller: untracked-cache warm-up done", "repo", abs, "took", time.Since(t0).Truncate(time.Millisecond).String())
+}
+
+func (p *ChangePoller) loop() {
+	defer close(p.doneCh)
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.stopCh:
+			return
+		case <-ticker.C:
+			p.PollOnce()
+		}
+	}
+}
+
+// PollOnce runs exactly one cycle over every registered repo, submits an index
+// request for each repo with a non-empty changed set, and returns the changed
+// sets keyed by repo path. Exported so tests drive cycles deterministically
+// instead of racing a ticker.
+func (p *ChangePoller) PollOnce() map[string][]string {
+	defer atomic.AddUint64(&p.cycles, 1)
+
+	p.mu.Lock()
+	repos := make([]string, 0, len(p.repos))
+	for r := range p.repos {
+		repos = append(repos, r)
+	}
+	p.mu.Unlock()
+	sort.Strings(repos)
+
+	out := make(map[string][]string, len(repos))
+	for _, abs := range repos {
+		changed := p.pollRepo(abs)
+		if len(changed) == 0 {
+			continue
+		}
+		out[abs] = changed
+		bulk := len(changed) >= p.bulkThreshold
+		atomic.AddUint64(&p.submits, 1)
+		p.logger.Info("change-poller: changes detected — enqueuing reindex",
+			"repo", abs, "changed", len(changed), "bulk", bulk)
+		p.sink(abs, bulk)
+	}
+	return out
+}
+
+// pollRepo computes the changed set for one repo. Both halves of hybrid B live
+// here: git for DISCOVERY of paths the manifest has never heard of, and the
+// manifest's own key set for the CHANGE DECISION.
+func (p *ChangePoller) pollRepo(abs string) []string {
+	if p.stateDir == nil {
+		return nil
+	}
+	stateDir := p.stateDir(abs)
+	if stateDir == "" {
+		return nil
+	}
+	m := diff.LoadManifest(stateDir)
+	if len(m.Files) == 0 {
+		// No baseline: the repo has never been indexed (or its manifest is
+		// unreadable). Every file would read as new and the poller would ask
+		// for a reindex on every cycle forever. Initial indexing belongs to the
+		// scheduler, not here.
+		return nil
+	}
+
+	cand := make(map[string]struct{}, len(m.Files)+16)
+	// Half 1 — the manifest's key set. This is what converges edit-then-revert
+	// and any other change git no longer reports.
+	for rel := range m.Files {
+		cand[rel] = struct{}{}
+	}
+
+	// Half 2 — discovery. Paths git knows about that the manifest does not.
+	files, dirs, ok := gitStatusDiscovery(abs)
+	if !ok {
+		p.logger.Warn("change-poller: git status failed — sweeping the manifest key set only", "repo", abs)
+	}
+	for _, f := range files {
+		cand[f] = struct{}{}
+	}
+	for _, d := range dirs {
+		for _, rel := range walkUntrackedSubtree(abs, d) {
+			cand[rel] = struct{}{}
+		}
+	}
+
+	rels := make([]string, 0, len(cand))
+	for rel := range cand {
+		rels = append(rels, rel)
+	}
+	sort.Strings(rels)
+
+	changed, _ := diff.Filter(abs, rels, m)
+	sort.Strings(changed)
+	return changed
+}
+
+// gitStatusDiscovery runs `git status --porcelain -z -unormal` in repoRoot and
+// splits its report into individual FILE paths and collapsed untracked
+// DIRECTORY paths (the ones ending in "/").
+//
+// -z is used deliberately: porcelain v1's default output quotes and
+// C-escapes any path with a space or a non-ASCII byte, and a mis-unquoted path
+// is a silently dropped file. With -z the paths are literal and
+// NUL-terminated, and a rename/copy record simply carries a second
+// NUL-terminated origin path which is consumed here as an extra candidate.
+func gitStatusDiscovery(repoRoot string) (files, dirs []string, ok bool) {
+	raw, ok := gitmeta.RunGitBoundedC(repoRoot, "status", "--porcelain", "-z", "-unormal")
+	if !ok {
+		return nil, nil, false
+	}
+	recs := bytes.Split(raw, []byte{0})
+	for i := 0; i < len(recs); i++ {
+		rec := recs[i]
+		if len(rec) < 4 {
+			continue // "XY " + at least one path byte
+		}
+		x := rec[0]
+		path := string(rec[3:])
+		// A rename/copy record is followed by its origin path as a bare,
+		// status-less record. Consume it as a candidate too: the origin path
+		// is now absent from disk and its manifest entry must be re-examined.
+		if x == 'R' || x == 'C' {
+			if i+1 < len(recs) && len(recs[i+1]) > 0 {
+				files = append(files, string(recs[i+1]))
+				i++
+			}
+		}
+		if strings.HasSuffix(path, "/") {
+			dirs = append(dirs, path)
+			continue
+		}
+		files = append(files, path)
+	}
+	return files, dirs, true
+}
+
+// walkUntrackedSubtree expands one collapsed `dir/` line from git's untracked
+// report into the repo-relative file paths grafel would index inside it, using
+// the production walker rather than a bespoke one — so the poller's candidate
+// set and the indexer's walked set agree on the skip layers.
+//
+// walk.Options is nil here on purpose. The only field the indexer sets is
+// Sparse, and sparse-checkout filters TRACKED files against patterns expressed
+// relative to the repo ROOT; this walk is rooted at a subtree, so those
+// patterns would be matched against the wrong strings, and the subtree is
+// untracked by construction so sparse-checkout has no bearing on it anyway.
+//
+// #6932 flagged "WalkRepo rooted below the repo root" as unverified. What it
+// does is pinned by TestChangePoller_SubtreeWalkAppliesSkipLayers: the
+// hardcoded skip list and any .gitignore INSIDE the subtree apply; the repo
+// ROOT's .gitignore stack is not inherited. That direction is safe — git has
+// already excluded root-ignored paths from the untracked report it hands us, so
+// the worst case is over-inclusion of a path git chose to report.
+func walkUntrackedSubtree(repoRoot, relDir string) []string {
+	relDir = strings.TrimSuffix(relDir, "/")
+	if relDir == "" || relDir == "." {
+		return nil
+	}
+	sub := filepath.Join(repoRoot, filepath.FromSlash(relDir))
+	found, _, err := walk.WalkRepo(sub, nil)
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(found))
+	for _, f := range found {
+		out = append(out, relDir+"/"+f)
+	}
+	return out
+}
+
+// ChangePoller is what a Watcher in poll mode delegates its subscriptions to.
+var _ SubscriptionDelegate = (*ChangePoller)(nil)

--- a/internal/daemon/watch/change_poller.go
+++ b/internal/daemon/watch/change_poller.go
@@ -55,6 +55,16 @@
 // scheduler enqueue; under-firing is the silent corruption this whole issue is
 // about. The asymmetry is deliberate.
 //
+// That statement is only true if the changed set can actually reach empty, so
+// "level-triggered" is a claim about CONVERGENCE and it is tested as one. The
+// first version of this file did not converge on an uncommitted deletion or a
+// staged rename: a path git reports, disk does not have, and the index pass
+// prunes from the manifest read as new on every cycle forever, so the poller
+// re-fired while manifest and disk AGREED. See existsOnDisk, and
+// TestChangePoller_DeletionConverges / _StagedRenameConverges — both assert a
+// bounded number of cycles, not first-cycle detection, because first-cycle
+// detection is exactly what hid the bug.
+//
 // WARM-UP (arm D of #6932). A fresh worktree's first `git status` costs
 // 2.4-9.0 s until git's untracked cache exists; every subsequent one is ~60 ms.
 // AddRepo therefore sets core.untrackedCache=true and runs one throwaway
@@ -329,12 +339,29 @@ func (p *ChangePoller) pollRepo(abs string) []string {
 	}
 
 	// Half 2 — discovery. Paths git knows about that the manifest does not.
+	//
+	// A discovered path is taken as a candidate ONLY when it exists on disk.
+	// Without that filter an uncommitted deletion — `rm foo.go`, or the origin
+	// half of a staged `git mv`, which is what every refactor looks like for
+	// minutes at a time — never converges: git reports it until the commit, it
+	// is absent from disk, and the very index pass the poller asks for PRUNES it
+	// from the manifest. diff.isChanged then calls it "new" forever, and poll
+	// mode enqueues a full reindex every interval for a repo whose manifest and
+	// disk already agree. That is the #5665/#5667 loop shape, entering through
+	// the git half instead of the walk half.
+	//
+	// Dropping it costs nothing: a deletion of an INDEXED file is still caught,
+	// because the path is a manifest key and half 1 sweeps those
+	// unconditionally — it just stops being reported once the manifest no
+	// longer claims it, which is exactly convergence.
 	files, dirs, ok := gitStatusDiscovery(abs)
 	if !ok {
 		p.logger.Warn("change-poller: git status failed — sweeping the manifest key set only", "repo", abs)
 	}
 	for _, f := range files {
-		cand[f] = struct{}{}
+		if _, known := cand[f]; known || existsOnDisk(abs, f) {
+			cand[f] = struct{}{}
+		}
 	}
 	for _, d := range dirs {
 		for _, rel := range walkUntrackedSubtree(abs, d) {
@@ -351,6 +378,16 @@ func (p *ChangePoller) pollRepo(abs string) []string {
 	changed, _ := diff.Filter(abs, rels, m)
 	sort.Strings(changed)
 	return changed
+}
+
+// existsOnDisk reports whether rel names a REGULAR file inside repoRoot.
+//
+// Lstat, not Stat: a dangling symlink must read as absent, and walk.WalkRepo
+// hands nothing but regular files to the indexer either, so a path that is not
+// one can never acquire a manifest stamp and would be permanently dirty.
+func existsOnDisk(repoRoot, rel string) bool {
+	fi, err := os.Lstat(filepath.Join(repoRoot, filepath.FromSlash(rel)))
+	return err == nil && fi.Mode().IsRegular()
 }
 
 // gitStatusDiscovery runs `git status --porcelain -z -unormal` in repoRoot and

--- a/internal/daemon/watch/change_poller.go
+++ b/internal/daemon/watch/change_poller.go
@@ -380,14 +380,26 @@ func (p *ChangePoller) pollRepo(abs string) []string {
 	return changed
 }
 
-// existsOnDisk reports whether rel names a REGULAR file inside repoRoot.
+// existsOnDisk reports whether rel names an entry inside repoRoot that the
+// INDEXER would index — which is the only question the candidate set cares
+// about, in both directions:
 //
-// Lstat, not Stat: a dangling symlink must read as absent, and walk.WalkRepo
-// hands nothing but regular files to the indexer either, so a path that is not
-// one can never acquire a manifest stamp and would be permanently dirty.
+//   - A path the indexer will never stamp must not enter the candidate set, or
+//     it reads as new on every cycle forever (blocker 1 above).
+//   - A path the indexer WILL stamp must not be refused, or a change to it is
+//     never noticed while a full walk would have picked it up.
+//
+// So it delegates to walk.IndexableEntryType — the walker's OWN entry-type
+// gate — rather than deciding for itself. An earlier version asked
+// os.Lstat().Mode().IsRegular() here, which answers about the LINK and not its
+// target, and diverged from walk.irregularSkipRule (which resolves a symlink
+// with os.Stat and indexes a link to a regular file). The result was the second
+// bullet: a new symlink-to-source in a tracked directory, reported by git as
+// untracked, refused here, indexed by every full walk (#6932 review, MA-1).
+// TestExistsOnDisk_AgreesWithWalker pins the agreement over an enumerated
+// entry-type space, so the two cannot drift apart again in either direction.
 func existsOnDisk(repoRoot, rel string) bool {
-	fi, err := os.Lstat(filepath.Join(repoRoot, filepath.FromSlash(rel)))
-	return err == nil && fi.Mode().IsRegular()
+	return walk.IndexableEntryType(filepath.Join(repoRoot, filepath.FromSlash(rel)))
 }
 
 // gitStatusDiscovery runs `git status --porcelain -z -unormal` in repoRoot and

--- a/internal/daemon/watch/change_poller_6932_test.go
+++ b/internal/daemon/watch/change_poller_6932_test.go
@@ -1,0 +1,605 @@
+package watch
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/walk"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// --- fixture helpers -------------------------------------------------------
+
+func cpGitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+// cpNewRepo builds a git repo with two committed source files and returns
+// (repoPath, stateDir). The state dir is EMPTY — call cpIndexPass to seed it.
+func cpNewRepo(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	state := filepath.Join(root, "state")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(state, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cpGitRun(t, repo, "init", "-q", "-b", "main")
+	cpWriteFile(t, repo, "alpha.go", "package a\n\nfunc Alpha() {}\n")
+	cpWriteFile(t, repo, "beta.go", "package a\n\nfunc Beta() {}\n")
+	cpGitRun(t, repo, "add", "-A")
+	cpGitRun(t, repo, "commit", "-q", "-m", "init")
+	return repo, state
+}
+
+func cpWriteFile(t *testing.T, repo, rel, content string) {
+	t.Helper()
+	abs := filepath.Join(repo, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// cpIndexPass mirrors what the real incremental indexer does to the manifest
+// (internal/extractors/incremental.go:640-643): walk, Filter, re-stamp only the
+// changed set, reconcile membership against the full walked set, save.
+func cpIndexPass(t *testing.T, repo, state string) []string {
+	t.Helper()
+	files, _, err := walk.WalkRepo(repo, nil)
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	m := diff.LoadManifest(state)
+	changed, _ := diff.Filter(repo, files, m)
+	diff.UpdateManifestScoped(repo, changed, files, m)
+	if err := diff.SaveManifestAtCommit(state, m, "", ""); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	sort.Strings(changed)
+	return changed
+}
+
+// cpManifestFiles reads the on-disk file-index.json and returns its Files map.
+// It deliberately reads the RAW FILE rather than trusting an in-memory
+// Manifest: the #6932 spike's bug (a manifest wiped by reconcileMembership)
+// was invisible to a HIT/MISS matrix and visible only on disk.
+func cpManifestFiles(t *testing.T, state string) map[string]diff.FileEntry {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(state, "file-index.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var m struct {
+		Files map[string]diff.FileEntry `json:"files"`
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	return m.Files
+}
+
+func cpManifestKeys(t *testing.T, state string) []string {
+	t.Helper()
+	var out []string
+	for k := range cpManifestFiles(t, state) {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// cpNewTestPoller returns a poller wired to state, plus a pointer to the
+// recorded sink submissions.
+func cpNewTestPoller(t *testing.T, repo, state string) (*ChangePoller, *[]string) {
+	t.Helper()
+	var submits []string
+	p := NewChangePoller(ChangePollerConfig{
+		StateDir: func(string) string { return state },
+	}, func(rp string, bulk bool) {
+		submits = append(submits, rp)
+	}, nil)
+	if err := p.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	t.Cleanup(func() { p.Stop() })
+	return p, &submits
+}
+
+// cpCycle runs one poll cpCycle and returns the changed set for repo.
+func cpCycle(t *testing.T, p *ChangePoller, repo string) []string {
+	t.Helper()
+	res := p.PollOnce()
+	got := res[repo]
+	sort.Strings(got)
+	return got
+}
+
+func cpContains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// --- the manifest-population assertion ------------------------------------
+
+// TestChangePoller_LeavesManifestPopulationIntact is the assertion #6932 asks
+// for by name. A HIT/MISS matrix cannot see a manifest wipe; this reads
+// file-index.json off disk before and after a run of detections and requires
+// the key set AND every entry to be identical.
+//
+// The poller is a DETECTOR: it submits an index request through the
+// EventSink(repo, bulk) contract the fsnotify watcher already satisfies, and
+// it never writes the manifest itself. That is what this pins.
+func TestChangePoller_LeavesManifestPopulationIntact(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpWriteFile(t, repo, "sub/gamma.go", "package sub\n")
+	cpIndexPass(t, repo, state)
+
+	before := cpManifestFiles(t, state)
+	if len(before) < 3 {
+		t.Fatalf("fixture: manifest should hold >=3 files, got %d: %v", len(before), cpManifestKeys(t, state))
+	}
+
+	p, submits := cpNewTestPoller(t, repo, state)
+
+	// Drive several detections without any index pass in between.
+	cpWriteFile(t, repo, "alpha.go", "package a\n\nfunc Alpha() { println(1) }\n")
+	_ = cpCycle(t, p, repo)
+	cpWriteFile(t, repo, "untracked.go", "package a\n")
+	_ = cpCycle(t, p, repo)
+	cpWriteFile(t, repo, "alpha.go", "package a\n\nfunc Alpha() { println(2) }\n")
+	_ = cpCycle(t, p, repo)
+
+	if len(*submits) != 3 {
+		t.Fatalf("expected 3 sink submissions, got %d", len(*submits))
+	}
+
+	after := cpManifestFiles(t, state)
+	if len(after) != len(before) {
+		t.Fatalf("manifest POPULATION changed: %d -> %d\nbefore=%v\nafter=%v",
+			len(before), len(after), cpManifestKeys(t, state), cpManifestKeys(t, state))
+	}
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("manifest CONTENT changed.\nbefore=%#v\nafter=%#v", before, after)
+	}
+}
+
+// --- the four driven cases -------------------------------------------------
+
+// Case 1 — an untracked file edited a SECOND time. Kills git-status-only
+// polling: `git status` reports `?? untracked.go` identically both times, so
+// the report alone carries no "changed since last poll" information. The
+// change decision comes from the manifest stamp.
+func TestChangePoller_UntrackedFileEditedTwice(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+
+	cpWriteFile(t, repo, "untracked.go", "package a\n// v1\n")
+	if got := cpCycle(t, p, repo); !cpContains(got, "untracked.go") {
+		t.Fatalf("first edit not detected: %v", got)
+	}
+	cpIndexPass(t, repo, state)
+	if got := cpCycle(t, p, repo); len(got) != 0 {
+		t.Fatalf("after index pass the repo must be quiescent, got %v", got)
+	}
+
+	// Second edit — git's report is byte-identical to the first.
+	porcelain := cpGitRun(t, repo, "status", "--porcelain", "-unormal")
+	cpWriteFile(t, repo, "untracked.go", "package a\n// v2\n")
+	porcelain2 := cpGitRun(t, repo, "status", "--porcelain", "-unormal")
+	if porcelain != porcelain2 {
+		t.Fatalf("fixture premise broken: git's report differed between the two edits\n1=%q\n2=%q", porcelain, porcelain2)
+	}
+
+	if got := cpCycle(t, p, repo); !cpContains(got, "untracked.go") {
+		t.Fatalf("SECOND edit of an untracked file not detected: %v", got)
+	}
+}
+
+// Case 2 — edit, index, then revert to byte-identical HEAD content. Kills
+// hybrid A (`git status -uall` for candidates): after the revert git reports
+// the tree CLEAN, so a git-derived candidate set is empty and the file is
+// never re-examined, while the manifest still holds the edited SHA — a
+// permanent, silent divergence. The manifest-key sweep is what converges it.
+func TestChangePoller_EditThenRevertConverges(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+
+	orig, err := os.ReadFile(filepath.Join(repo, "alpha.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cpWriteFile(t, repo, "alpha.go", "package a\n\nfunc Alpha() { println(1) }\n")
+	if got := cpCycle(t, p, repo); !cpContains(got, "alpha.go") {
+		t.Fatalf("edit not detected: %v", got)
+	}
+	// The index pass runs on the EDITED bytes; the manifest now records them.
+	cpIndexPass(t, repo, state)
+
+	// Revert to the exact HEAD bytes.
+	if err := os.WriteFile(filepath.Join(repo, "alpha.go"), orig, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Premise: git now considers the working tree clean, so a git-only
+	// candidate set is empty.
+	if out := strings.TrimSpace(cpGitRun(t, repo, "status", "--porcelain", "-unormal")); out != "" {
+		t.Fatalf("fixture premise broken: git still reports the revert: %q", out)
+	}
+	if got := cpCycle(t, p, repo); !cpContains(got, "alpha.go") {
+		t.Fatalf("edit-then-revert NOT detected — this is the hybrid-A permanent corruption: %v", got)
+	}
+}
+
+// Case 3 — the same tracked file modified twice, with an index pass between.
+func TestChangePoller_TrackedFileModifiedTwice(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+
+	cpWriteFile(t, repo, "beta.go", "package a\n\nfunc Beta() { println(1) }\n")
+	if got := cpCycle(t, p, repo); !cpContains(got, "beta.go") {
+		t.Fatalf("first modification not detected: %v", got)
+	}
+	cpIndexPass(t, repo, state)
+
+	cpWriteFile(t, repo, "beta.go", "package a\n\nfunc Beta() { println(2) }\n")
+	if got := cpCycle(t, p, repo); !cpContains(got, "beta.go") {
+		t.Fatalf("SECOND modification not detected: %v", got)
+	}
+}
+
+// Case 4 — a same-SIZE content edit. The only stat-level signal is mtime.
+//
+// ASSUMPTION, stated per #6932: the filesystem's mtime granularity is finer
+// than the interval between the index pass and the edit. On APFS/ext4
+// (nanosecond stamps) this holds. On a coarse-granularity filesystem (HFS+ at
+// 1 s, some network mounts, some container overlay configurations) a same-size
+// edit landing inside the same mtime tick is invisible to diff.Filter's fast
+// path and WOULD be missed — by the poller AND by every other grafel path that
+// uses diff.Filter, including the fsnotify one. This is a property of
+// diff.isChanged, not of the poller; the poller inherits it exactly.
+func TestChangePoller_SameSizeEdit(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+
+	before, err := os.Stat(filepath.Join(repo, "alpha.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same byte length, different content: "Alpha" -> "Alphb".
+	cpWriteFile(t, repo, "alpha.go", "package a\n\nfunc Alphb() {}\n")
+	after, err := os.Stat(filepath.Join(repo, "alpha.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Size() != after.Size() {
+		t.Fatalf("fixture premise broken: size changed %d -> %d", before.Size(), after.Size())
+	}
+	if before.ModTime().UnixNano() == after.ModTime().UnixNano() {
+		t.Skip("filesystem mtime granularity too coarse to distinguish this edit — see the doc comment")
+	}
+	if got := cpCycle(t, p, repo); !cpContains(got, "alpha.go") {
+		t.Fatalf("same-size edit not detected: %v", got)
+	}
+}
+
+// --- discovery half --------------------------------------------------------
+
+// An untracked SUBTREE is collapsed by `git status -unormal` to a single
+// `dir/` line. The poller must expand it via walk.WalkRepo rooted at the
+// subtree, or every file inside a new package is invisible.
+func TestChangePoller_UntrackedSubtreeIsWalked(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+
+	cpWriteFile(t, repo, "newpkg/one.go", "package newpkg\n")
+	cpWriteFile(t, repo, "newpkg/deep/two.go", "package deep\n")
+
+	// Premise: git collapses the subtree to one line.
+	out := strings.TrimSpace(cpGitRun(t, repo, "status", "--porcelain", "-unormal"))
+	if out != "?? newpkg/" {
+		t.Fatalf("fixture premise broken: expected a single collapsed line, got %q", out)
+	}
+
+	got := cpCycle(t, p, repo)
+	for _, want := range []string{"newpkg/one.go", "newpkg/deep/two.go"} {
+		if !cpContains(got, want) {
+			t.Fatalf("collapsed untracked subtree not expanded: missing %q in %v", want, got)
+		}
+	}
+}
+
+// walk.WalkRepo rooted BELOW the repo root was flagged in #6932 as unverified.
+// The property that actually matters is not "which skip layers fire" in the
+// abstract — it is AGREEMENT: the poller's subtree expansion must produce
+// exactly the paths the indexer's own full-repo walk produces under that
+// subtree. Any path the poller adds that the indexer will never stamp is a file
+// that reads as new on every single cycle, i.e. a permanent reindex storm (the
+// #5665 defect shape).
+//
+// This pins agreement rather than a hand-picked skip list, so it stays true
+// when the walker's layers change (e.g. when #6931 makes .gitignore apply to
+// FILES and not just directories — today it does not, and both sides are
+// equally affected, which is the point).
+func TestChangePoller_SubtreeWalkAgreesWithFullWalk(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	_, _ = cpNewTestPoller(t, repo, state)
+
+	cpWriteFile(t, repo, "newpkg/keep.go", "package newpkg\n")
+	cpWriteFile(t, repo, "newpkg/deep/two.go", "package deep\n")
+	cpWriteFile(t, repo, "newpkg/node_modules/junk.go", "package junk\n")
+	cpWriteFile(t, repo, "newpkg/.gitignore", "ignored.go\n")
+	cpWriteFile(t, repo, "newpkg/ignored.go", "package newpkg\n")
+
+	// What the indexer's own full-repo walk yields under newpkg/.
+	full, _, err := walk.WalkRepo(repo, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wantUnderSubtree []string
+	for _, f := range full {
+		if strings.HasPrefix(f, "newpkg/") {
+			wantUnderSubtree = append(wantUnderSubtree, f)
+		}
+	}
+	sort.Strings(wantUnderSubtree)
+	if len(wantUnderSubtree) == 0 {
+		t.Fatal("fixture premise broken: the full walk sees nothing under newpkg/")
+	}
+	if cpContains(wantUnderSubtree, "newpkg/node_modules/junk.go") {
+		t.Fatal("fixture premise broken: the full walk did not skip node_modules")
+	}
+
+	got := walkUntrackedSubtree(repo, "newpkg/")
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, wantUnderSubtree) {
+		t.Fatalf("subtree expansion disagrees with the full walk\n subtree=%v\n    full=%v", got, wantUnderSubtree)
+	}
+}
+
+// The consequence of that agreement, observed end-to-end: once the untracked
+// subtree has been indexed the poller goes quiet. A subtree expansion that
+// over-included even one path the indexer never stamps would re-fire forever.
+func TestChangePoller_ConvergesAfterUntrackedSubtreeIndexed(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, submits := cpNewTestPoller(t, repo, state)
+
+	cpWriteFile(t, repo, "newpkg/keep.go", "package newpkg\n")
+	cpWriteFile(t, repo, "newpkg/deep/two.go", "package deep\n")
+	cpWriteFile(t, repo, "newpkg/node_modules/junk.go", "package junk\n")
+	cpWriteFile(t, repo, "newpkg/.gitignore", "ignored.go\n")
+	cpWriteFile(t, repo, "newpkg/ignored.go", "package newpkg\n")
+
+	if got := cpCycle(t, p, repo); len(got) == 0 {
+		t.Fatal("new untracked subtree not detected")
+	}
+	cpIndexPass(t, repo, state)
+	if got := cpCycle(t, p, repo); len(got) != 0 {
+		t.Fatalf("poller did NOT converge after the subtree was indexed — it would re-fire forever: %v", got)
+	}
+	if n := len(*submits); n != 1 {
+		t.Fatalf("expected exactly 1 submission, got %d", n)
+	}
+}
+
+// --- the reverse direction: no over-firing ---------------------------------
+
+func TestChangePoller_QuiescentRepoDoesNotSubmit(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, submits := cpNewTestPoller(t, repo, state)
+
+	for i := 0; i < 3; i++ {
+		if got := cpCycle(t, p, repo); len(got) != 0 {
+			t.Fatalf("cpCycle %d on a quiescent repo reported %v", i, got)
+		}
+	}
+	if len(*submits) != 0 {
+		t.Fatalf("quiescent repo submitted %d index requests", len(*submits))
+	}
+}
+
+// A repo with NO manifest has no baseline to diff against; every file would
+// read as new and the poller would ask for a reindex on every single cpCycle.
+// It stands down instead and leaves initial indexing to the scheduler.
+func TestChangePoller_NoManifestNoSubmit(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	p, submits := cpNewTestPoller(t, repo, state)
+
+	// The tree must be DIRTY, or the guard is never reached: with no manifest
+	// the key-set half contributes nothing, so only git's report can supply a
+	// candidate. Without the guard these two are enqueued on every cycle.
+	cpWriteFile(t, repo, "untracked.go", "package a\n")
+	cpWriteFile(t, repo, "alpha.go", "package a\n// edited\n")
+	if out := strings.TrimSpace(cpGitRun(t, repo, "status", "--porcelain", "-unormal")); out == "" {
+		t.Fatal("fixture premise broken: git reports a clean tree, so the guard is untested")
+	}
+
+	if got := cpCycle(t, p, repo); len(got) != 0 {
+		t.Fatalf("un-indexed repo reported %v", got)
+	}
+	if len(*submits) != 0 {
+		t.Fatalf("un-indexed repo submitted %d index requests", len(*submits))
+	}
+}
+
+// Filter's cross-file basename invalidation must survive the candidate-set
+// construction: editing alpha.go must also pull sub/alpha.py into the changed
+// set, exactly as the full-walk path does.
+func TestChangePoller_PreservesCrossFileInvalidation(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpWriteFile(t, repo, "sub/alpha.py", "x = 1\n")
+	cpGitRun(t, repo, "add", "-A")
+	cpGitRun(t, repo, "commit", "-q", "-m", "add py")
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+
+	cpWriteFile(t, repo, "alpha.go", "package a\n\nfunc Alpha() { println(1) }\n")
+	got := cpCycle(t, p, repo)
+	if !cpContains(got, "sub/alpha.py") {
+		t.Fatalf("cross-file basename invalidation lost: %v", got)
+	}
+}
+
+// --- warm-up (arm D) -------------------------------------------------------
+
+func TestChangePoller_WarmUpSetsUntrackedCache(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	cpNewTestPoller(t, repo, state)
+
+	out := strings.TrimSpace(cpGitRun(t, repo, "config", "--local", "core.untrackedCache"))
+	if out != "true" {
+		t.Fatalf("AddRepo did not enable core.untrackedCache (arm D): got %q", out)
+	}
+}
+
+// --- the loop --------------------------------------------------------------
+
+func TestChangePoller_LoopSubmitsOnInterval(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+
+	got := make(chan string, 8)
+	p := NewChangePoller(ChangePollerConfig{
+		Interval: 10 * time.Millisecond,
+		StateDir: func(string) string { return state },
+	}, func(rp string, bulk bool) {
+		select {
+		case got <- rp:
+		default:
+		}
+	}, nil)
+	if err := p.AddRepo(repo); err != nil {
+		t.Fatal(err)
+	}
+	cpWriteFile(t, repo, "alpha.go", "package a\n\nfunc Alpha() { println(1) }\n")
+	p.Start()
+	defer p.Stop()
+
+	select {
+	case r := <-got:
+		if r != repo {
+			t.Fatalf("sink got %q want %q", r, repo)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("poll loop never submitted")
+	}
+}
+
+// bulk=true asks the sink for a repo-level reindex instead of a file-level
+// diff, exactly as the fsnotify watcher's bulk trigger does. The boundary is
+// "at or above the threshold", which is what the fsnotify path means by it too.
+func TestChangePoller_BulkThresholdBoundary(t *testing.T) {
+	run := func(t *testing.T, nFiles, threshold int) bool {
+		t.Helper()
+		repo, state := cpNewRepo(t)
+		cpIndexPass(t, repo, state)
+		var bulks []bool
+		p := NewChangePoller(ChangePollerConfig{
+			BulkThreshold: threshold,
+			StateDir:      func(string) string { return state },
+			DisableWarmUp: true,
+		}, func(_ string, bulk bool) { bulks = append(bulks, bulk) }, nil)
+		if err := p.AddRepo(repo); err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < nFiles; i++ {
+			cpWriteFile(t, repo, "new"+string(rune('a'+i))+".go", "package a\n")
+		}
+		got := cpCycle(t, p, repo)
+		if len(got) != nFiles {
+			t.Fatalf("fixture premise broken: %d changed files, want %d: %v", len(got), nFiles, got)
+		}
+		if len(bulks) != 1 {
+			t.Fatalf("expected one submission, got %d", len(bulks))
+		}
+		return bulks[0]
+	}
+	if run(t, 2, 3) {
+		t.Fatal("2 changed files under a threshold of 3 must not be bulk")
+	}
+	if !run(t, 3, 3) {
+		t.Fatal("3 changed files at a threshold of 3 must be bulk")
+	}
+}
+
+// DisableWarmUp is the control for the warm-up test: it must actually suppress
+// the git config write, or TestChangePoller_WarmUpSetsUntrackedCache proves
+// nothing about AddRepo doing it.
+func TestChangePoller_DisableWarmUpSuppressesIt(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p := NewChangePoller(ChangePollerConfig{
+		StateDir:      func(string) string { return state },
+		DisableWarmUp: true,
+	}, func(string, bool) {}, nil)
+	if err := p.AddRepo(repo); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "config", "--local", "core.untrackedCache")
+	cmd.Dir = repo
+	out, _ := cmd.CombinedOutput()
+	if strings.TrimSpace(string(out)) == "true" {
+		t.Fatal("DisableWarmUp did not suppress the warm-up — the warm-up test is vacuous")
+	}
+}
+
+// Porcelain v1 QUOTES and C-escapes any path with a space or a non-ASCII byte
+// unless -z is used. A mis-unquoted path is a file that is silently never
+// re-indexed, so the -z choice in gitStatusDiscovery is load-bearing.
+func TestChangePoller_DiscoversPathsNeedingQuoting(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+
+	cpWriteFile(t, repo, "has space.go", "package a\n")
+	cpWriteFile(t, repo, "ünïcode.go", "package a\n")
+
+	// Premise: without -z git would quote both of these.
+	quoted := cpGitRun(t, repo, "status", "--porcelain", "-unormal")
+	if !strings.Contains(quoted, `"`) {
+		t.Fatalf("fixture premise broken: git did not quote anything: %q", quoted)
+	}
+
+	got := cpCycle(t, p, repo)
+	for _, want := range []string{"has space.go", "ünïcode.go"} {
+		if !cpContains(got, want) {
+			t.Fatalf("path needing quoting was not discovered: missing %q in %v", want, got)
+		}
+	}
+}

--- a/internal/daemon/watch/change_poller_6932_test.go
+++ b/internal/daemon/watch/change_poller_6932_test.go
@@ -603,3 +603,159 @@ func TestChangePoller_DiscoversPathsNeedingQuoting(t *testing.T) {
 		}
 	}
 }
+
+// --- convergence on removals (#6932 review, blocker 1) ---------------------
+
+// cpConverges runs cycles until the changed set is empty, up to maxCycles, and
+// returns the number of cycles that still reported something.
+//
+// The assertion is CONVERGENCE, not first-cycle detection. First-cycle
+// detection is what every other case in this file asserts, and it is exactly
+// what hid the non-converging deletion: cycle 1 was correct.
+func cpConverges(t *testing.T, p *ChangePoller, repo string, maxCycles int) int {
+	t.Helper()
+	n := 0
+	for i := 0; i < maxCycles; i++ {
+		got := cpCycle(t, p, repo)
+		if len(got) == 0 {
+			return n
+		}
+		n++
+		if i == maxCycles-1 {
+			t.Fatalf("did NOT converge after %d cycles — still reporting %v (a full reindex enqueued every interval, forever)", maxCycles, got)
+		}
+	}
+	return n
+}
+
+// An uncommitted deletion is what every refactor looks like for minutes at a
+// time. git reports it until the commit, disk does not have it, and the index
+// pass the poller asks for PRUNES it from the manifest — so a candidate set
+// that takes git's report unconditionally calls it new forever.
+func TestChangePoller_DeletionConverges(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, submits := cpNewTestPoller(t, repo, state)
+
+	if err := os.Remove(filepath.Join(repo, "alpha.go")); err != nil {
+		t.Fatal(err)
+	}
+	// Premise: git reports the deletion, and keeps reporting it (uncommitted).
+	if out := strings.TrimSpace(cpGitRun(t, repo, "status", "--porcelain", "-unormal")); !strings.Contains(out, "alpha.go") {
+		t.Fatalf("fixture premise broken: git does not report the deletion: %q", out)
+	}
+	// Cycle 1 must SEE it: the file is still a manifest key.
+	if got := cpCycle(t, p, repo); !cpContains(got, "alpha.go") {
+		t.Fatalf("deletion not detected on the first cycle: %v", got)
+	}
+	// The index pass prunes it. Disk and manifest now agree.
+	cpIndexPass(t, repo, state)
+	if keys := cpManifestKeys(t, state); cpContains(keys, "alpha.go") {
+		t.Fatalf("fixture premise broken: the index pass did not prune the deleted file: %v", keys)
+	}
+	// git STILL reports it — this is what the candidate set must not take.
+	if out := strings.TrimSpace(cpGitRun(t, repo, "status", "--porcelain", "-unormal")); !strings.Contains(out, "alpha.go") {
+		t.Fatalf("fixture premise broken: git stopped reporting the deletion, so the loop is untested: %q", out)
+	}
+
+	before := len(*submits)
+	if n := cpConverges(t, p, repo, 6); n != 0 {
+		t.Fatalf("post-prune cycles still reported the deletion %d times", n)
+	}
+	if after := len(*submits); after != before {
+		t.Fatalf("poller submitted %d more reindex requests after convergence", after-before)
+	}
+}
+
+// The other half of the same record shape: a staged rename's ORIGIN path. It is
+// added deliberately (the origin's manifest entry must be re-examined) — right
+// for one cycle, wrong for every cycle after the entry is gone.
+func TestChangePoller_StagedRenameConverges(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+
+	cpGitRun(t, repo, "mv", "alpha.go", "renamed alpha.go")
+	out := strings.TrimSpace(cpGitRun(t, repo, "status", "--porcelain", "-unormal"))
+	if !strings.HasPrefix(out, "R") {
+		t.Fatalf("fixture premise broken: expected a rename record, got %q", out)
+	}
+	got := cpCycle(t, p, repo)
+	for _, want := range []string{"alpha.go", "renamed alpha.go"} {
+		if !cpContains(got, want) {
+			t.Fatalf("rename: %q missing from the first changed set %v", want, got)
+		}
+	}
+	cpIndexPass(t, repo, state)
+	if keys := cpManifestKeys(t, state); cpContains(keys, "alpha.go") {
+		t.Fatalf("fixture premise broken: the index pass did not prune the rename origin: %v", keys)
+	}
+	if n := cpConverges(t, p, repo, 6); n != 0 {
+		t.Fatalf("post-prune cycles still reported the rename origin %d times", n)
+	}
+}
+
+// The `-z` rename record is two NUL-separated paths, and the parser must
+// CONSUME the second one. Without that, the origin record is re-read as a
+// status record and rec[3:] chops its first three bytes, manufacturing a path
+// ("ha.go") that is on no disk and in no manifest — blocker 1's loop, by
+// parser bug. Asserted on the exact discovered set, not on a superset.
+func TestGitStatusDiscovery_RenameRecordShape(t *testing.T) {
+	repo, _ := cpNewRepo(t)
+	cpGitRun(t, repo, "mv", "alpha.go", "renamed alpha.go")
+
+	files, dirs, ok := gitStatusDiscovery(repo)
+	if !ok {
+		t.Fatal("gitStatusDiscovery failed")
+	}
+	if len(dirs) != 0 {
+		t.Fatalf("unexpected untracked dirs: %v", dirs)
+	}
+	sort.Strings(files)
+	want := []string{"alpha.go", "renamed alpha.go"}
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("rename record parsed as %v, want exactly %v", files, want)
+	}
+}
+
+// A discovered path that is not a REGULAR file can never acquire a manifest
+// stamp, so taking it as a candidate is permanent dirt. Lstat, so a dangling
+// symlink reads as absent rather than as its (missing) target.
+func TestChangePoller_DanglingSymlinkDoesNotStickDirty(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+
+	if err := os.Symlink(filepath.Join(repo, "does-not-exist.go"), filepath.Join(repo, "dangling.go")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if out := strings.TrimSpace(cpGitRun(t, repo, "status", "--porcelain", "-unormal")); !strings.Contains(out, "dangling.go") {
+		t.Fatalf("fixture premise broken: git does not report the symlink: %q", out)
+	}
+	if n := cpConverges(t, p, repo, 4); n != 0 {
+		t.Fatalf("a dangling symlink stayed dirty for %d cycles", n)
+	}
+}
+
+// --- V4: the documented zero-interval default ------------------------------
+
+// Config.ChangePollInterval / ChangePollerConfig.Interval are both documented
+// as "zero selects the default". A zero reaching time.NewTicker panics the loop
+// goroutine, so the default is a contract, not a nicety.
+func TestNewChangePoller_IntervalDefaults(t *testing.T) {
+	for _, in := range []time.Duration{0, -1, -time.Hour} {
+		p := NewChangePoller(ChangePollerConfig{Interval: in}, func(string, bool) {}, nil)
+		if got := p.Interval(); got != DefaultChangePollInterval {
+			t.Fatalf("Interval(%v) = %v, want the default %v", in, got, DefaultChangePollInterval)
+		}
+	}
+	p := NewChangePoller(ChangePollerConfig{Interval: 7 * time.Second}, func(string, bool) {}, nil)
+	if got := p.Interval(); got != 7*time.Second {
+		t.Fatalf("an explicit interval was overridden: %v", got)
+	}
+	// The consequence: a zero-interval poller can actually be Started without
+	// panicking its loop goroutine.
+	z := NewChangePoller(ChangePollerConfig{}, func(string, bool) {}, nil)
+	z.Start()
+	z.Stop()
+}

--- a/internal/daemon/watch/entrytype_agreement_6932_unix_test.go
+++ b/internal/daemon/watch/entrytype_agreement_6932_unix_test.go
@@ -1,0 +1,169 @@
+//go:build unix
+
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/walk"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// TestExistsOnDisk_AgreesWithWalker is the #6932 MA-1 pin.
+//
+// The poller admits a git-reported path to its candidate set through
+// existsOnDisk; the indexer decides what to index through walk.WalkRepo. Two
+// predicates answering "would grafel index this?" is one too many, and a
+// divergence is a defect in EITHER direction:
+//
+//   - poller says yes, walker says no  -> a path that can never be stamped,
+//     dirty on every cycle forever (blocker 1's shape).
+//   - poller says no, walker says yes  -> a file the index CONTAINS whose
+//     changes the poller can never see (MA-1's shape: existsOnDisk used
+//     os.Lstat, which answers about the LINK, while irregularSkipRule resolves
+//     a symlink with os.Stat and indexes a link to a regular file).
+//
+// So the assertion is AGREEMENT, over an ENUMERATED entry-type space rather
+// than a hand-picked list, and the walker's verdict is DERIVED from a real
+// WalkRepo run rather than restated — the test cannot encode a belief about
+// what the walker does.
+func TestExistsOnDisk_AgreesWithWalker(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(filepath.Join(repo, "realdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(rel, body string) {
+		if err := os.WriteFile(filepath.Join(repo, rel), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	link := func(target, rel string) {
+		if err := os.Symlink(target, filepath.Join(repo, rel)); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+	}
+
+	// The entry-type space, enumerated. Every distinct shape the type bits can
+	// take for a non-directory entry, plus a directory and both symlink
+	// resolution failures.
+	write("regular.go", "package p\n")
+	write("realdir/target.go", "package p\n")
+	link(filepath.Join(repo, "regular.go"), "link-to-regular.go")
+	link(filepath.Join(repo, "link-to-regular.go"), "link-to-link-to-regular.go")
+	link(filepath.Join(repo, "no-such-file.go"), "dangling.go")
+	link(filepath.Join(repo, "realdir"), "link-to-dir.go")
+	link(filepath.Join(repo, "loop-b.go"), "loop-a.go")
+	link(filepath.Join(repo, "loop-a.go"), "loop-b.go")
+	testsupport.MkfifoInTemp(t, root, "repo", "fifo.go")
+	link(filepath.Join(repo, "fifo.go"), "link-to-fifo.go")
+
+	candidates := []string{
+		"regular.go",
+		"realdir",
+		"realdir/target.go",
+		"link-to-regular.go",
+		"link-to-link-to-regular.go",
+		"dangling.go",
+		"link-to-dir.go",
+		"loop-a.go",
+		"loop-b.go",
+		"fifo.go",
+		"link-to-fifo.go",
+		"absent.go", // never created: both halves must say no
+	}
+
+	// The walker's verdict, derived from a real walk. testsupport.MustReturn
+	// bounds it: under a regression that opens the FIFO this would park in
+	// open(2) forever and wedge the binary with no attribution.
+	var walked []string
+	var skips []walk.SkipEntry
+	testsupport.MustReturn(t, "WalkRepo over the entry-type fixture", func() {
+		var err error
+		walked, skips, err = walk.WalkRepo(repo, nil)
+		if err != nil {
+			t.Errorf("WalkRepo: %v", err)
+		}
+	})
+	indexed := make(map[string]bool, len(walked))
+	for _, f := range walked {
+		indexed[f] = true
+	}
+
+	// Premises: the fixture must actually EXERCISE the space, or agreement is
+	// vacuous. At least one entry on each side of the walker's verdict, and the
+	// symlink-to-regular case must be one the walker INDEXES — that is the
+	// asymmetry MA-1 lived in.
+	if !indexed["link-to-regular.go"] {
+		t.Fatalf("fixture premise broken: the walker does not index a symlink to a regular file; walked=%v skips=%v", walked, skips)
+	}
+	if indexed["fifo.go"] {
+		t.Fatal("fixture premise broken: the walker indexed a FIFO")
+	}
+
+	var disagreements []string
+	for _, rel := range candidates {
+		wantIndexed := indexed[rel]
+		gotAdmitted := existsOnDisk(repo, rel)
+		if wantIndexed != gotAdmitted {
+			disagreements = append(disagreements,
+				rel+": walker indexes="+boolStr(wantIndexed)+" poller admits="+boolStr(gotAdmitted))
+		}
+	}
+	if len(disagreements) > 0 {
+		sort.Strings(disagreements)
+		t.Fatalf("existsOnDisk and walk.WalkRepo disagree on %d entr(ies):\n  %s\nwalked=%v",
+			len(disagreements), strings.Join(disagreements, "\n  "), walked)
+	}
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// The consequence, driven end to end rather than argued: a NEW symlink to a
+// source file inside a tracked directory is reported by git as untracked, is
+// indexed by a full walk, and therefore must be detected by the poller — and
+// must then converge once the index pass has stamped it.
+//
+// The reviewer proved the two predicates disagreed on the same path but did not
+// drive the cycle through to the missed reindex. This is that step.
+func TestChangePoller_NewSymlinkToSourceIsDetected(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+
+	if err := os.Symlink(filepath.Join(repo, "alpha.go"), filepath.Join(repo, "linked.go")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	// Premise 1: git reports it, so it reaches the git half of discovery.
+	out := strings.TrimSpace(cpGitRun(t, repo, "status", "--porcelain", "-unormal"))
+	if !strings.Contains(out, "linked.go") {
+		t.Fatalf("fixture premise broken: git does not report the symlink: %q", out)
+	}
+	// Premise 2: a full walk INDEXES it, so refusing it is a missed change and
+	// not a conservative skip.
+	files, _, err := walk.WalkRepo(repo, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cpContains(files, "linked.go") {
+		t.Fatalf("fixture premise broken: the walker does not index the symlink; walked=%v", files)
+	}
+
+	if got := cpCycle(t, p, repo); !cpContains(got, "linked.go") {
+		t.Fatalf("a new symlink to a source file was NOT detected — the index contains a file the poller cannot see change: %v", got)
+	}
+	cpIndexPass(t, repo, state)
+	if n := cpConverges(t, p, repo, 4); n != 0 {
+		t.Fatalf("the symlink stayed dirty for %d cycles after being indexed", n)
+	}
+}

--- a/internal/daemon/watch/entrytype_agreement_6932_unix_test.go
+++ b/internal/daemon/watch/entrytype_agreement_6932_unix_test.go
@@ -31,6 +31,15 @@ import (
 // than a hand-picked list, and the walker's verdict is DERIVED from a real
 // WalkRepo run rather than restated — the test cannot encode a belief about
 // what the walker does.
+//
+// AXES. Varied: the entry TYPE. Held constant, deliberately: the extension
+// (every name ends .go), the ignore state (no .gitignore in the fixture) and
+// the sparse state (not a sparse checkout). Those three are WalkRepo's other
+// file-branch gates and existsOnDisk does not reproduce any of them — see its
+// doc comment. Holding them constant is what makes a failure here attributable
+// to the entry-type rule; it is NOT a claim that the two predicates agree in
+// general, and they do not: an untracked photo.png is walker-refused and
+// existsOnDisk-admitted, which is #6940.
 func TestExistsOnDisk_AgreesWithWalker(t *testing.T) {
 	root := t.TempDir()
 	repo := filepath.Join(root, "repo")

--- a/internal/daemon/watch/poll_delegate_6932_test.go
+++ b/internal/daemon/watch/poll_delegate_6932_test.go
@@ -142,3 +142,110 @@ func TestWatcher_NoDelegate_StillSubscribes(t *testing.T) {
 		t.Fatal("fsnotify mode subscribed 0 directories — the control is vacuous")
 	}
 }
+
+// backendWatchList asks FSNOTIFY what it subscribed, not grafel's own counter.
+// A counter a component keeps about itself is a diagnostic signature; the
+// library's record of what it handed the kernel is the artefact.
+func backendWatchList(w *Watcher) int {
+	w.mu.Lock()
+	fs := w.fs
+	w.mu.Unlock()
+	if fs == nil {
+		return 0
+	}
+	return len(fs.WatchList())
+}
+
+// #6932 review, blocker 2: restartBackend is a SECOND subscribe path. It walks
+// w.repos and calls subscribeRepo directly, never AddRepo — and poll mode
+// deliberately populates w.repos so Repos()/Stats() stay truthful. Without the
+// guard, one backend restart converts a poll-mode daemon into a full fsnotify
+// subscriber: ~976 descriptors per worktree, in exactly the container whose
+// inotify pool cannot be raised, with the poller never told.
+func TestWatcher_PollDelegate_BackendRestartResubscribesNothing(t *testing.T) {
+	repo := delegateRepo(t)
+	d := &recordingDelegate{}
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour, Delegate: d}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if n := backendWatchList(w); n != 0 {
+		t.Fatalf("fsnotify backend already holds %d paths before the restart", n)
+	}
+	// Premise: the repo IS in w.repos, so the re-subscribe loop has something
+	// to iterate. Otherwise this test passes for the wrong reason.
+	if repos := w.Repos(); len(repos) != 1 {
+		t.Fatalf("fixture premise broken: w.repos holds %v, so restartBackend would iterate nothing", repos)
+	}
+
+	if !w.restartBackend() {
+		t.Fatal("restartBackend reported a stop was in flight")
+	}
+
+	if n := backendWatchList(w); n != 0 {
+		t.Fatalf("a backend restart subscribed %d paths in poll mode; must be 0", n)
+	}
+	if _, dirs, _, _, _ := w.Stats(); dirs != 0 {
+		t.Fatalf("a backend restart left %d directory subscriptions in poll mode", dirs)
+	}
+}
+
+// The control. Without a delegate, restartBackend DOES re-subscribe — so the
+// assertion above measures the guard, not a watcher that cannot subscribe.
+func TestWatcher_NoDelegate_BackendRestartResubscribes(t *testing.T) {
+	repo := delegateRepo(t)
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	before := backendWatchList(w)
+	if before == 0 {
+		t.Fatal("fsnotify mode subscribed nothing — the control is vacuous")
+	}
+	if !w.restartBackend() {
+		t.Fatal("restartBackend reported a stop was in flight")
+	}
+	if after := backendWatchList(w); after != before {
+		t.Fatalf("backend re-subscribed %d paths after a restart, want %d", after, before)
+	}
+}
+
+// The seam's own claim, at the backend rather than at grafel's counter:
+// AddRepo in delegate mode hands fsnotify nothing at all.
+func TestWatcher_PollDelegate_BackendWatchListIsZero(t *testing.T) {
+	repo := delegateRepo(t)
+	d := &recordingDelegate{}
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour, Delegate: d}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if n := backendWatchList(w); n != 0 {
+		t.Fatalf("fsnotify backend WatchList = %d in poll mode; must be 0", n)
+	}
+
+	ctrl, err := NewWatcherConfig(Config{Debounce: time.Hour}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer ctrl.Stop()
+	if _, err := ctrl.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if n := backendWatchList(ctrl); n == 0 {
+		t.Fatal("fsnotify backend WatchList = 0 in fsnotify mode — the comparison is vacuous")
+	}
+}

--- a/internal/daemon/watch/poll_delegate_6932_test.go
+++ b/internal/daemon/watch/poll_delegate_6932_test.go
@@ -1,0 +1,144 @@
+package watch
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+type recordingDelegate struct {
+	mu      sync.Mutex
+	added   []string
+	removed []string
+	err     error
+}
+
+func (d *recordingDelegate) AddRepo(p string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.err != nil {
+		return d.err
+	}
+	d.added = append(d.added, p)
+	return nil
+}
+
+func (d *recordingDelegate) RemoveRepo(p string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.removed = append(d.removed, p)
+}
+
+func (d *recordingDelegate) snapshot() ([]string, []string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.added...), append([]string(nil), d.removed...)
+}
+
+func delegateRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, d := range []string{"a", "b", "a/c"} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "a", "x.go"), []byte("package a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// The whole point of poll mode is that ZERO fs watch descriptors are taken.
+// With a delegate installed, AddRepo must route the repo to the delegate and
+// subscribe nothing — while still reporting the repo as watched, because it IS
+// watched, by the poller.
+func TestWatcher_PollDelegate_TakesNoSubscriptions(t *testing.T) {
+	repo := delegateRepo(t)
+	d := &recordingDelegate{}
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour, Delegate: d}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+
+	n, err := w.AddRepo(repo)
+	if err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("delegate mode subscribed %d directories; must be 0", n)
+	}
+	_, dirs, _, _, _ := w.Stats()
+	if dirs != 0 {
+		t.Fatalf("delegate mode holds %d fsnotify directory subscriptions; must be 0", dirs)
+	}
+	added, _ := d.snapshot()
+	abs, _ := filepath.Abs(repo)
+	if len(added) != 1 || added[0] != abs {
+		t.Fatalf("delegate did not receive the repo: %v", added)
+	}
+	if repos := w.Repos(); len(repos) != 1 || repos[0] != abs {
+		t.Fatalf("watcher does not report the delegated repo as watched: %v", repos)
+	}
+
+	// Idempotent: a second AddRepo must not re-register with the delegate.
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("second AddRepo: %v", err)
+	}
+	added, _ = d.snapshot()
+	if len(added) != 1 {
+		t.Fatalf("delegate AddRepo not idempotent: %v", added)
+	}
+
+	w.RemoveRepo(repo)
+	_, removed := d.snapshot()
+	if len(removed) != 1 || removed[0] != abs {
+		t.Fatalf("delegate did not receive the removal: %v", removed)
+	}
+	if repos := w.Repos(); len(repos) != 0 {
+		t.Fatalf("repo still reported after RemoveRepo: %v", repos)
+	}
+}
+
+// A delegate that refuses a repo must leave the watcher reporting NOTHING for
+// it. Reporting it as watched while nothing observes it is exactly the silent
+// half-failure #6932 is about.
+func TestWatcher_PollDelegate_FailureIsNotReportedAsWatched(t *testing.T) {
+	repo := delegateRepo(t)
+	d := &recordingDelegate{err: errors.New("nope")}
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour, Delegate: d}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+
+	if _, err := w.AddRepo(repo); err == nil {
+		t.Fatal("AddRepo must surface the delegate's error")
+	}
+	if repos := w.Repos(); len(repos) != 0 {
+		t.Fatalf("a repo the delegate refused is reported as watched: %v", repos)
+	}
+}
+
+// Without a delegate the watcher behaves exactly as before: it subscribes.
+// This is the control that stops the delegate branch from passing vacuously.
+func TestWatcher_NoDelegate_StillSubscribes(t *testing.T) {
+	repo := delegateRepo(t)
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+
+	n, err := w.AddRepo(repo)
+	if err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("fsnotify mode subscribed 0 directories — the control is vacuous")
+	}
+}

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -105,6 +105,37 @@ type Config struct {
 	// starts. Assigning w.quarantine afterwards would be an unsynchronised
 	// write to a field that goroutine reads on every event.
 	disableQuarantine bool
+
+	// Delegate, when non-nil, replaces this Watcher's fsnotify subscription
+	// with an alternative change detector (#6932 arm A — poll mode).
+	//
+	// It is a SEAM, not a second Watcher. Every path that subscribes a repo
+	// today — DefaultManager.Resume, DefaultManager.SubscribeGroup, the
+	// worktree activation handler — goes through Watcher.AddRepo, so routing
+	// there routes all of them at once and nothing else in the daemon has to
+	// know which detector is live. The Watcher keeps its repos map (so
+	// Repos()/Stats() still answer "is this repo observed?" truthfully), keeps
+	// its sink, and simply takes no watch descriptors.
+	//
+	// Nil is the default and is byte-for-byte the pre-#6932 behaviour.
+	//
+	// Note that the fsnotify backend handle is still opened in poll mode: that
+	// is ONE inotify instance for the daemon with zero watches on it, against
+	// the ~976 watch descriptors PER WORKTREE that subscribing costs. Removing
+	// the handle entirely would mean not constructing the Watcher at all, which
+	// is a restructure of the engine plane, not a mode.
+	Delegate SubscriptionDelegate
+}
+
+// SubscriptionDelegate is the alternative change detector a Watcher hands its
+// repos to when Config.Delegate is set. *ChangePoller implements it.
+//
+// AddRepo returns an error when the repo could not be taken on; the Watcher
+// then does NOT record the repo, because a repo listed as watched that nothing
+// observes is the silent half-failure #6932 exists to remove.
+type SubscriptionDelegate interface {
+	AddRepo(repoPath string) error
+	RemoveRepo(repoPath string)
 }
 
 func (c *Config) debounce() time.Duration {
@@ -561,6 +592,14 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 // transparency surface / CLI (Q2). May be nil if the feature is disabled.
 func (w *Watcher) Quarantine() *QuarantineTracker { return w.quarantine }
 
+// ChangeDelegate returns the alternative change detector this Watcher routes
+// subscriptions to, or nil when it uses fsnotify (#6932 arm A).
+//
+// It answers "which detector is actually live?", which is the question #6932
+// arm B must ANSWER OUT LOUD in `grafel status` and /diagnostics — a mode
+// switch nobody can see is no improvement on a watcher nobody can see failing.
+func (w *Watcher) ChangeDelegate() SubscriptionDelegate { return w.cfg.Delegate }
+
 // quarantineSweep periodically re-evaluates quarantined directories and
 // auto-un-quarantines any that have gone quiet (self-heal). The interval is a
 // fraction of the heal window so recovery is responsive without busy-looping.
@@ -618,6 +657,25 @@ func (w *Watcher) AddRepo(repoPath string) (int, error) {
 	}
 	w.repos[abs] = &repoState{path: abs}
 	w.mu.Unlock()
+
+	// Poll mode (#6932 arm A): hand the repo to the delegate and subscribe
+	// NOTHING. Returns 0 directories because 0 directories were subscribed —
+	// the count is the descriptor cost, and in this mode it is genuinely zero.
+	if d := w.cfg.Delegate; d != nil {
+		if err := d.AddRepo(abs); err != nil {
+			w.mu.Lock()
+			if rs, ok := w.repos[abs]; ok {
+				if rs.timer != nil {
+					rs.timer.Stop()
+				}
+				delete(w.repos, abs)
+			}
+			w.mu.Unlock()
+			return 0, err
+		}
+		w.logger.Info("watcher: registered via change-detection delegate — 0 fs watch descriptors", "repo", abs)
+		return 0, nil
+	}
 
 	added, err := w.subscribeRepo(abs)
 	if err != nil {
@@ -900,6 +958,13 @@ func (w *Watcher) RemoveRepo(repoPath string) {
 	abs, err := filepath.Abs(repoPath)
 	if err != nil {
 		return
+	}
+	// Poll mode (#6932 arm A). The rest of this function is a no-op for a
+	// delegated repo — it subscribed no directories and reserved no
+	// descriptors — but it is left to run rather than short-circuited so a
+	// watcher that switched modes mid-life still unwinds whatever it holds.
+	if d := w.cfg.Delegate; d != nil {
+		d.RemoveRepo(abs)
 	}
 	w.mu.Lock()
 	if rs, ok := w.repos[abs]; ok {

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -109,13 +109,32 @@ type Config struct {
 	// Delegate, when non-nil, replaces this Watcher's fsnotify subscription
 	// with an alternative change detector (#6932 arm A — poll mode).
 	//
-	// It is a SEAM, not a second Watcher. Every path that subscribes a repo
-	// today — DefaultManager.Resume, DefaultManager.SubscribeGroup, the
-	// worktree activation handler — goes through Watcher.AddRepo, so routing
-	// there routes all of them at once and nothing else in the daemon has to
-	// know which detector is live. The Watcher keeps its repos map (so
+	// It is a SEAM, not a second Watcher. The Watcher keeps its repos map (so
 	// Repos()/Stats() still answer "is this repo observed?" truthfully), keeps
 	// its sink, and simply takes no watch descriptors.
+	//
+	// There are THREE paths in this file that hand a directory to the backend,
+	// not one, and the delegate has to be honoured at all three. Enumerated,
+	// with how each was verified:
+	//
+	//   1. AddRepo -> subscribeRepo. The only path the daemon's callers reach:
+	//      DefaultManager.Resume, DefaultManager.SubscribeGroup, and the
+	//      worktree activation handler all call AddRepo. Verified by
+	//      TestWatcher_PollDelegate_TakesNoSubscriptions and, end to end
+	//      through the engine plane, by TestEnginePlane_PollModeTakesNoWatchDescriptors.
+	//
+	//   2. restartBackend -> subscribeRepo, over w.repos DIRECTLY. It does not
+	//      go through AddRepo, and poll mode populates w.repos, so before
+	//      #6932's review this converted a poll-mode daemon into a full
+	//      fsnotify subscriber on one backend restart. Verified by
+	//      TestWatcher_PollDelegate_BackendRestartResubscribesNothing.
+	//
+	//   3. subscribeDirRecursive, from a Create event. Unreachable in poll mode
+	//      today because a backend with zero watches delivers no events —
+	//      guarded by accident, so it is now guarded by a decision instead.
+	//      NOT independently verified: constructing a Create event for a
+	//      directory in a mode that subscribes nothing means driving the
+	//      backend directly, and the guard is a bare early return.
 	//
 	// Nil is the default and is byte-for-byte the pre-#6932 behaviour.
 	//
@@ -1383,6 +1402,23 @@ func (w *Watcher) restartBackend() bool {
 		w.mu.Unlock()
 
 		// Re-subscribe.
+		//
+		// #6932 arm A, review blocker 2: this is a SECOND subscribe path. It
+		// does not go through AddRepo, and poll mode deliberately keeps its
+		// repos in w.repos (so Repos()/Stats() stay truthful), so without this
+		// guard one backend restart silently converts a poll-mode daemon into a
+		// full fsnotify subscriber — ~976 descriptors per worktree, in exactly
+		// the container whose pool cannot be raised, with the poller never told.
+		//
+		// Not reachable today (a backend holding zero watches has little reason
+		// to close its channel), but arm B's runtime auto-switch makes it live,
+		// and the guard is cheaper than the note explaining why it is safe
+		// without one. The delegate is unaffected by a backend restart: it holds
+		// its own repo set and its own loop.
+		if w.cfg.Delegate != nil {
+			repos = nil
+			w.logger.Info("watcher: backend restarted in delegate (poll) mode — nothing to re-subscribe")
+		}
 		for _, abs := range repos {
 			if n, err := w.subscribeRepo(abs); err != nil {
 				w.logger.Error("watcher: restart re-subscribe failed", "repo", abs, "err", err)
@@ -1986,6 +2022,13 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 	// would make chargeEventOpen keep recording markers for a walk that is over,
 	// and those markers are consumed by nothing (#6493).
 	defer w.releaseInFlight(root)
+	// #6932 arm A: the third subscribe path. Unreachable in delegate (poll)
+	// mode today only because a backend with zero watches delivers no Create
+	// events to enqueue this walk — i.e. it is guarded by an accident, not by a
+	// decision. Make it a decision, for the same reason as restartBackend.
+	if w.cfg.Delegate != nil {
+		return
+	}
 	repo := w.repoFor(filepath.Join(root, "_"))
 	if repo == "" {
 		return

--- a/internal/registry/changedetection.go
+++ b/internal/registry/changedetection.go
@@ -1,0 +1,61 @@
+package registry
+
+import (
+	"strings"
+	"time"
+)
+
+// Change-detection modes for GroupConfig.Features.ChangeDetection (#6932).
+const (
+	// ChangeDetectionFsnotify is the fs watcher — the default, and the
+	// behaviour of every grafel before 0.3.3.
+	ChangeDetectionFsnotify = "fsnotify"
+	// ChangeDetectionPoll is the descriptor-free polling change detector
+	// (watch.ChangePoller). Opt-in; this is the container lane.
+	ChangeDetectionPoll = "poll"
+	// ChangeDetectionAuto is reserved for #6932 arm B (the inotify-budget
+	// probe and the announced auto-switch). Arm A accepts it and resolves it
+	// to fsnotify — see PollingEnabled.
+	ChangeDetectionAuto = "auto"
+)
+
+// DefaultChangePollInterval is the poll cadence used when
+// features.change_poll_interval_seconds is unset or non-positive. See the
+// field's doc comment in GroupConfig for the cost arithmetic behind 30 s.
+const DefaultChangePollInterval = 30 * time.Second
+
+// ChangeDetectionMode returns the normalised change-detection mode for this
+// group. Whitespace and case are tolerated; anything unrecognised — including
+// the empty string — resolves to ChangeDetectionFsnotify, because a typo in
+// fleet.json must degrade to the historical behaviour, never to "no detector".
+func (c *GroupConfig) ChangeDetectionMode() string {
+	switch strings.ToLower(strings.TrimSpace(c.Features.ChangeDetection)) {
+	case ChangeDetectionPoll:
+		return ChangeDetectionPoll
+	case ChangeDetectionAuto:
+		return ChangeDetectionAuto
+	default:
+		return ChangeDetectionFsnotify
+	}
+}
+
+// PollingEnabled reports whether this group asks for the polling change
+// detector RIGHT NOW.
+//
+// It is deliberately not "mode != fsnotify". ChangeDetectionAuto is a valid,
+// accepted, documented value whose probe does not exist yet (#6932 arm B), and
+// arm A promises that setting it changes nothing for anyone. The two questions
+// — "what did the user write?" and "what runs today?" — are separate, and
+// keeping them separate is what lets arm B change only this function.
+func (c *GroupConfig) PollingEnabled() bool {
+	return c.ChangeDetectionMode() == ChangeDetectionPoll
+}
+
+// ChangePollInterval returns the configured poll cadence, or
+// DefaultChangePollInterval when unset or non-positive.
+func (c *GroupConfig) ChangePollInterval() time.Duration {
+	if n := c.Features.ChangePollIntervalSeconds; n > 0 {
+		return time.Duration(n) * time.Second
+	}
+	return DefaultChangePollInterval
+}

--- a/internal/registry/changedetection_6932_test.go
+++ b/internal/registry/changedetection_6932_test.go
@@ -1,0 +1,79 @@
+package registry
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestChangeDetectionMode_DefaultIsFsnotify(t *testing.T) {
+	var c GroupConfig
+	if got := c.ChangeDetectionMode(); got != ChangeDetectionFsnotify {
+		t.Fatalf("unset change_detection must mean fsnotify, got %q", got)
+	}
+}
+
+func TestChangeDetectionMode_ParsesFromJSON(t *testing.T) {
+	cases := map[string]string{
+		`{"features":{"change_detection":"poll"}}`:     ChangeDetectionPoll,
+		`{"features":{"change_detection":"fsnotify"}}`: ChangeDetectionFsnotify,
+		`{"features":{"change_detection":"auto"}}`:     ChangeDetectionAuto,
+		`{"features":{"change_detection":"  POLL  "}}`: ChangeDetectionPoll,
+		`{"features":{"change_detection":"nonsense"}}`: ChangeDetectionFsnotify,
+		`{"features":{"change_detection":""}}`:         ChangeDetectionFsnotify,
+		`{"features":{"track_worktrees":true}}`:        ChangeDetectionFsnotify,
+	}
+	for body, want := range cases {
+		var c GroupConfig
+		if err := json.Unmarshal([]byte(body), &c); err != nil {
+			t.Fatalf("%s: %v", body, err)
+		}
+		if got := c.ChangeDetectionMode(); got != want {
+			t.Fatalf("%s: mode = %q, want %q", body, got, want)
+		}
+	}
+}
+
+// ARM A ships fsnotify and poll only. "auto" is accepted and documented, and
+// until arm B lands (the inotify-budget probe and the announced switch) it
+// resolves to fsnotify — the pre-#6932 behaviour — so nobody who writes it
+// today silently gets a mode that has no probe behind it.
+func TestChangeDetection_AutoBehavesAsFsnotifyUntilArmB(t *testing.T) {
+	var c GroupConfig
+	c.Features.ChangeDetection = ChangeDetectionAuto
+	if got := c.ChangeDetectionMode(); got != ChangeDetectionAuto {
+		t.Fatalf("auto must round-trip as a valid mode, got %q", got)
+	}
+	if c.PollingEnabled() {
+		t.Fatal("auto must NOT enable polling in arm A")
+	}
+	c.Features.ChangeDetection = ChangeDetectionPoll
+	if !c.PollingEnabled() {
+		t.Fatal("poll must enable polling")
+	}
+	c.Features.ChangeDetection = ChangeDetectionFsnotify
+	if c.PollingEnabled() {
+		t.Fatal("fsnotify must not enable polling")
+	}
+}
+
+func TestChangePollInterval(t *testing.T) {
+	var c GroupConfig
+	if got := c.ChangePollInterval(); got != DefaultChangePollInterval {
+		t.Fatalf("unset interval = %v, want %v", got, DefaultChangePollInterval)
+	}
+	c.Features.ChangePollIntervalSeconds = 5
+	if got := c.ChangePollInterval(); got != 5*time.Second {
+		t.Fatalf("interval = %v, want 5s", got)
+	}
+	// A non-positive value is a typo, not a request for a hot loop.
+	c.Features.ChangePollIntervalSeconds = -1
+	if got := c.ChangePollInterval(); got != DefaultChangePollInterval {
+		t.Fatalf("negative interval = %v, want the default %v", got, DefaultChangePollInterval)
+	}
+	// And it is floored, so a "1ms" typo cannot pin a core per worktree.
+	c.Features.ChangePollIntervalSeconds = 0
+	if got := c.ChangePollInterval(); got != DefaultChangePollInterval {
+		t.Fatalf("zero interval = %v, want the default %v", got, DefaultChangePollInterval)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -192,6 +192,43 @@ type GroupConfig struct {
 		// the cross-host rules block. Default false: it is opt-in to avoid
 		// nagging users who don't want it (#4273).
 		AgentHooks bool `json:"agent_hooks,omitempty"`
+		// ChangeDetection selects which change detector observes this group's
+		// working trees (#6932). One of:
+		//
+		//   "fsnotify" (default) — the fs watcher. Costs one inotify watch
+		//       descriptor per DIRECTORY on Linux, recursively: 976 per
+		//       worktree measured on this repo, and up to ~10,700 for one lane
+		//       at GRAFEL_MAX_WORKTREES_PER_REPO=10.
+		//   "poll"     — the descriptor-free ChangePoller (hybrid B of #6932):
+		//       `git status --porcelain -unormal` for discovery plus a
+		//       stat-sweep of the index manifest's own key set for the change
+		//       decision. Zero watch descriptors. This is the container lane:
+		//       fs.inotify.max_user_watches is per-UID, host-level and NOT
+		//       namespaced, so every container running as the same UID draws
+		//       from one pool and none of them can raise it.
+		//   "auto"     — reserved for #6932 arm B, which will project the
+		//       inotify cost before subscribing and switch on the BUDGET (not
+		//       on repo size), ANNOUNCING the switch in `grafel status` and
+		//       /diagnostics. Arm A accepts the value and resolves it to
+		//       "fsnotify"; see ChangeDetectionMode / PollingEnabled.
+		//
+		// An unrecognised value resolves to "fsnotify" rather than failing the
+		// group: a typo must not leave a group with no detector at all.
+		//
+		// Example fleet JSON:
+		//   "features": { "change_detection": "poll" }
+		ChangeDetection string `json:"change_detection,omitempty"`
+		// ChangePollIntervalSeconds is the poll cadence for
+		// change_detection="poll". Zero or negative selects
+		// DefaultChangePollInterval (30 s).
+		//
+		// A cycle costs ~60 ms per worktree (macOS/APFS; #6932's table is
+		// unvalidated on Linux/overlayfs), so 2 s is ~3% of a core per
+		// worktree and 30 s is ~0.2% (~2% across ten worktrees). Immediacy is
+		// not the point: checkout/merge/rebase are already covered by git
+		// hooks and GitHeadPoller's 2 s .git/HEAD poll, and grafel already
+		// documents a bounded-staleness contract at 2 s (reloadBeforeCall).
+		ChangePollIntervalSeconds int `json:"change_poll_interval_seconds,omitempty"`
 	} `json:"features"`
 	// Tools is the set of AI coding tools this group's install targets,
 	// identified by ToolAdapter ID (e.g. "claude", "cursor", "copilot").


### PR DESCRIPTION
## What this is

**Arm A of #6932 only**: the polling change-detector as an **explicit opt-in mode**, plus **arm D** (the untracked-cache warm-up, without which the mode is unusable). No auto-switch, no budget probe — that is arm B. Nothing changes for anyone who does not set the flag.

`Refs #6932`

## The mechanism — hybrid B, as measured

`internal/daemon/watch/change_poller.go` (`ChangePoller`):

1. **Discovery** — `git status --porcelain -z -unormal` per worktree. `-unormal` collapses an untracked subtree to a single `dir/` line and stays flat at ~60 ms from 0 to 20,000 untracked files. Each reported untracked *directory* is expanded with `walk.WalkRepo` rooted at that subtree.
2. **Change decision** — a stat-sweep of the **manifest's own key set** through `internal/indexer/diff` (`LoadManifest` + `Filter`), which is what makes the poller complete where a git-only poller is not, and what preserves `Filter`'s cross-file basename invalidation.
3. **Submission** — the existing `EventSink(repo, bulk)` contract. Both detectors now share one `indexSink` closure in `engineplane.go`; there is no second reindex path, and the poller **never writes the manifest**.

`-uall` (hybrid A) is **not** implemented: #6932 records it as dominated on both cost and correctness, failing edit-then-revert as permanent silent corruption.

**Level-triggered, not edge-triggered.** The poller keeps no "seen" set — its state *is* the manifest — so it re-submits every cycle for as long as manifest and disk disagree. Over-firing costs a debounced, circuit-broken enqueue; under-firing is the corruption the issue is about.

## How it is wired (the seam)

`watch.Config.Delegate` (`SubscriptionDelegate`). When set, `Watcher.AddRepo` hands the repo to the delegate and **subscribes nothing**; `RemoveRepo` deregisters. Every path that subscribes a repo today — `DefaultManager.Resume`, `SubscribeGroup`, the worktree activation handler — already goes through `AddRepo`, so one seam routes all of them and nothing else in the daemon needs to know which detector is live. `Delegate == nil` is byte-for-byte the pre-#6932 behaviour.

One honest caveat, documented at the field: the fsnotify *backend handle* is still opened in poll mode — one inotify instance with zero watches on it, against ~976 watch descriptors **per worktree** that subscribing costs. Removing it entirely means not constructing the `Watcher` at all, which is a restructure of the engine plane, not a mode.

## Config

`features.change_detection` beside `features.track_worktrees` (`internal/registry/registry.go`), three values:

- `fsnotify` (default, and what any unrecognised value resolves to — a typo must degrade to the historical behaviour, never to "no detector")
- `poll` — the container lane
- `auto` — **accepted and documented, behaves as fsnotify**, with `PollingEnabled()` as the single function arm B changes

`features.change_poll_interval_seconds`, **default 30 s**. From #6932's cost table: a cycle is ~60 ms per worktree, so 30 s is ~0.2% of a core per worktree (~2% across ten) against ~3% at 2 s. Immediacy buys nothing — an agent already knows the file it just wrote, and the changes it cannot predict (checkout/merge/rebase) are covered by git hooks and `GitHeadPoller`'s 2 s `.git/HEAD` poll. grafel already documents a 2 s bounded-staleness contract (`reloadBeforeCall`). Non-positive values fall back to the default rather than becoming a hot loop.

The mode is daemon-wide (one `Watcher`, and the inotify pool is per-UID and host-level — not partitioned by group either). `resolveChangeDetection` is split out of the fleet load so the rule is graded without a registry on disk: any group asking for `poll` turns it on, and the **smallest** requested interval wins.

## Reused, not rebuilt

`diff.Filter` / `LoadManifest` / `SaveManifestAtCommit` · per-worktree state dirs via `StateDirForRepoRef` · `walk.WalkRepo` · `gitmeta.RunGitBoundedC` (bounded external git, #5286) · `EventSink` · `githead_poller.go` as the structural template.

## The test that matters most

**`TestChangePoller_LeavesManifestPopulationIntact`** reads `file-index.json` **off disk** before and after a run of detections and requires the key set *and every entry* to be identical. The #6932 spike's bug — `UpdateManifestScoped(repo, changed, nil, m)` wiping the manifest via `reconcileMembership` — was invisible to its 14-case HIT/MISS matrix and visible only by dumping the manifest.

Mutant **M15** re-introduces that exact bug at this call site. It is **DEAD**, killed by that assertion. The assertion is the deliverable, and it is graded.

### The four driven cases

| case | test | what it kills |
|---|---|---|
| untracked file edited a second time | `UntrackedFileEditedTwice` (asserts git's report is *byte-identical* across both edits) | git-status-only polling |
| edit → index → revert to byte-identical HEAD content | `EditThenRevertConverges` (asserts git reports the tree clean, then requires detection anyway) | hybrid A's permanent silent corruption |
| same tracked file modified twice | `TrackedFileModifiedTwice` | edge-triggered designs |
| same-size content edit (mtime-only signal) | `SameSizeEdit` | stat-size-only comparison |

**Stated assumption for the same-size case:** mtime granularity finer than the gap between the index pass and the edit. On APFS/ext4 (ns stamps) this holds; the test asserts the premise and `t.Skip`s if the filesystem cannot distinguish them. On a coarse filesystem (HFS+ at 1 s, some network mounts) such an edit inside one tick is invisible — but to `diff.isChanged`, i.e. to **every** grafel path including the fsnotify one, not to the poller specifically. The poller inherits it exactly.

### Also driven

Collapsed-untracked-subtree expansion · **subtree-walk agreement** (`walkUntrackedSubtree` must produce *exactly* the paths the indexer's own full walk yields under that subtree — anything extra reads as new on every cycle, i.e. a permanent reindex storm, the #5665 shape) · convergence after the subtree is indexed · quiescent repo submits nothing · no-manifest repo stands down (with a **dirty** tree, so the guard is actually reached) · cross-file basename invalidation preserved · paths needing quoting (`has space.go`, `ünïcode.go` — why `-z` is load-bearing) · bulk boundary · warm-up sets `core.untrackedCache` (with `DisableWarmUp` as its control) · delegate takes 0 subscriptions / a refused delegate is not reported as watched / **no delegate still subscribes** (the control) · engine-plane boot in each mode.

#6932 flagged "`WalkRepo` rooted below the repo root" as unverified. It is now pinned as *agreement with the full walk* rather than as a hand-picked skip list, so it stays true when the walker's layers change — notably when #6931 makes `.gitignore` apply to files and not just directories. Today it does not, and **both sides are equally affected**, which is exactly why agreement is the right property.

## Mutant table

Every mutant was applied through a script that **gates on the match count before and after the edit** (exact pre-count, then new-count ≥ 1 and old-count == 0) and printed that gate — a silently unapplied edit cannot read as ALIVE here. `go vet` before every score; `-count=1` always; restores by `cp` from shasum-verified backups, never `git checkout`.

| # | site | mutation | verdict | killed by |
|---|---|---|---|---|
| M1 | `PollOnce` | drop `p.sink(abs, bulk)` — poller is a no-op, detection intact | **DEAD** | ManifestPopulationIntact, LoopSubmitsOnInterval, +2 |
| M2 | `pollRepo` | drop the **manifest-key half** | **DEAD** | **EditThenRevertConverges**, PreservesCrossFileInvalidation |
| M3 | `pollRepo` | drop the **git discovery half** | **DEAD** | UntrackedFileEditedTwice, BulkThresholdBoundary |
| M4 | `pollRepo` | never expand collapsed untracked subtrees | **DEAD** | UntrackedSubtreeIsWalked, ConvergesAfter… |
| M5 | `pollRepo` | remove the no-baseline (`len(m.Files)==0`) guard | **DEAD** *(see note)* | NoManifestNoSubmit |
| M6 | `warmUp` | drop `core.untrackedCache=true` (arm D) | **DEAD** | WarmUpSetsUntrackedCache |
| M7 | `PollOnce` | bulk boundary `>=` → `>` | **DEAD** | BulkThresholdBoundary |
| M8 | `Watcher.AddRepo` | delegate registered but fsnotify subscription **not** skipped | **DEAD** | PollDelegate_TakesNoSubscriptions |
| M9 | `Watcher.RemoveRepo` | delegate never told about removals | **DEAD** | PollDelegate_TakesNoSubscriptions |
| M10 | `PollingEnabled` | `== poll` → `!= fsnotify` (i.e. `auto` enables polling) | **DEAD** | AutoBehavesAsFsnotifyUntilArmB |
| M11 | `ChangePollInterval` | drop the `n > 0` floor | **DEAD** | TestChangePollInterval |
| M12 | `ChangeDetectionMode` | unknown value → `poll` instead of `fsnotify` | **DEAD** | 3 registry tests |
| M13 | `gitStatusDiscovery` | drop `-z` | **DEAD** | DiscoversPathsNeedingQuoting, +4 |
| M14 | `PollOnce` | remove the empty-changed-set guard (always submit) | **DEAD** | QuiescentRepoDoesNotSubmit, NoManifestNoSubmit, +1 |
| M15 | `pollRepo` | **re-introduce the spike's `UpdateManifestScoped(…, nil, m)` manifest wipe** | **DEAD** | **LeavesManifestPopulationIntact** |
| M16 | `engineplane.go` | delegate never installed on the watcher config | **DEAD** *(see note)* | EnginePlane_PollModeTakesNoWatchDescriptors |
| M17 | `resolveChangeDetection` | first interval wins instead of smallest | **DEAD** | TestResolveChangeDetection |
| M18 | `engineplane.go` | configured interval dropped (`Interval: 0`) | **DEAD** *(see note)* | EnginePlane_PollModeTakesNoWatchDescriptors |

**No survivors** — but three verdicts flipped only after the suite was strengthened, and that is part of the result:

- **M5 was ALIVE first.** `TestChangePoller_NoManifestNoSubmit` used a *clean* fixture, so with no manifest the candidate set was empty for a second reason and the guard was never reached. The test now dirties the tree and asserts that premise. Re-scored: DEAD.
- **M16 and M18 were ungraded** until `TestEnginePlane_*` existed: nothing exercised the engine-plane wiring. Added a boot test in each mode (poll → 0 directories subscribed, plus the interval actually reaching the poller; default → still subscribes and installs no delegate). Re-scored: DEAD. This required two small accessors, `Watcher.ChangeDelegate()` and `ChangePoller.Interval()` — the first of which arm B needs anyway to *announce* the live mode.
- **M2's killing case is not the one the brief predicted.** Dropping the manifest half does **not** break the untracked-re-edit case: git reports `?? foo.go` on both edits, so the path is a candidate either way and `diff.Filter` catches it. What it breaks is **edit-then-revert**, where git reports nothing at all. That is the same failure hybrid A was rejected for, reached from the other direction.

## Verification

macOS 26.6.2 / arm64 / go1.26.4 / APFS.

`go vet ./...` clean. `go test -count=1` green on every touched package: `internal/daemon/watch`, `internal/registry`, `internal/daemon`, `cmd/grafel` (run in full, not by test selector, with `GRAFEL_HOME` and `GRAFEL_DAEMON_ROOT` under a fresh scratch root). `cmd/grafel` is included because it digest-pins the whole graph.

One caveat on the isolation, worth recording: a `./internal/daemon/` run against a **reused** `GRAFEL_DAEMON_ROOT` produced 4 `TestStaleReindexGuard_*` failures. Re-run against a **fresh** root, the same package is green (`exit=0`, full suite). That is #6929, not this change — none of the four touches anything in this diff.

### What I did NOT run or establish

- **Nothing was measured on Linux, in a container, or on overlayfs.** #6932's whole cost table is macOS/APFS and so is every number quoted above. The ~60 ms discovery figure and the 30 s default's justification both need re-measuring on the target before they are quoted as fact. The readdir-bound figures (the rejected full sweep, the `-uall` floor) will be *worse* on overlayfs, which should widen hybrid B's margin — reasoning, not measurement.
- **No concurrency measurement.** Single-repo, single-process throughout. Whether N worktrees each sweeping contend on the git index lock, page cache, or disk is unknown — and `git status` with `core.untrackedCache` **writes the index**, which may serialise against a concurrent git in the same worktree. This is the first thing real container lanes should report.
- **No performance benchmark of `pollRepo` at all.** No assertion anywhere in this PR is timing-based.
- **Arm C's completeness prerequisites (#6922, #6931) are untouched.** Hybrid B's residual gap — creating a file git excludes but grafel indexes — is still open. It is bounded (2 of 7069 files on this repo) and unchanged by this PR.
- **`core.fsmonitor` was not tried.**
- **The 976-descriptor figure is inherited from #6932, not re-measured here.**
- Arm B (budget probe, auto-switch, the announced mode in `grafel status` / `/diagnostics`) is deliberately absent.
