### PR TITLE
fix(#6929): TestStaleReindexGuard_* counted the durable reindex ledger absolutely — 428-vs-2 on a reused daemon root, green on a fresh one

### DIFF
--- a/internal/daemon/stale_reindex_6175_test.go
+++ b/internal/daemon/stale_reindex_6175_test.go
@@ -31,6 +31,7 @@ import (
 func TestStaleReindexGuard_DeclinedRepoIsNotRetriedForever(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 	t.Setenv(EnvRoot, t.TempDir())
+	led := newReindexLedger(t)
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 
 	const declined = "/repo/worktree"
@@ -62,7 +63,7 @@ func TestStaleReindexGuard_DeclinedRepoIsNotRetriedForever(t *testing.T) {
 	if admissions != 0 {
 		t.Errorf("a repo the scheduler declines to accept was admitted %d times over 12 simulated hours, want 0", admissions)
 	}
-	if n := countPendingReindex(t, declined); n != 0 {
+	if n := led.countNew(declined); n != 0 {
 		t.Errorf("wrote %d reindex request(s) for a repo whose enqueue the scheduler drops, want 0", n)
 	}
 	if !othersMigrated {

--- a/internal/daemon/stale_reindex_test.go
+++ b/internal/daemon/stale_reindex_test.go
@@ -18,17 +18,79 @@ import (
 	"github.com/cajasmota/grafel/internal/indexstate"
 )
 
-// countPendingReindex returns how many KindReindex requests are queued for
-// repoPath's control-plane requests dir.
-func countPendingReindex(t *testing.T, repoPath string) int {
+// pendingReindexIDs returns the IDs of the KindReindex requests currently
+// queued for repoPath's control-plane requests dir.
+func pendingReindexIDs(t *testing.T, repoPath string) map[string]bool {
 	t.Helper()
 	recs, err := requests.ListPending(requestsDirForRepo(repoPath))
 	if err != nil {
 		t.Fatalf("ListPending: %v", err)
 	}
-	n := 0
+	ids := make(map[string]bool, len(recs))
 	for _, r := range recs {
 		if r.Kind == requests.KindReindex && r.RepoPath == repoPath {
+			ids[r.ID] = true
+		}
+	}
+	return ids
+}
+
+// reindexLedger scopes durable request counts to the CURRENT RUN (#6929).
+//
+// The requests ledger is durable ON PURPOSE and its root is shared: repoBaseDir
+// keys off GRAFEL_DAEMON_ROOT when that is set and only falls back to
+// GRAFEL_HOME otherwise, so a test that isolates itself with
+// `t.Setenv("GRAFEL_HOME", t.TempDir())` alone still writes its requests into
+// whatever daemon root the developer's environment names. The fake repo paths
+// below ("/repo/000"…) are stable across tests AND across runs, so the requests
+// dir for a given fake repo accumulates one file per write, forever. An
+// absolute count therefore measured "every request ever written into this root
+// for this repo", not "the requests this test caused": green against a fresh
+// root, 144 / 286 / 428-vs-2 against a root reused for a 2nd / 3rd / 4th run.
+//
+// Scoping is by IDENTITY, not by clearing the root: the ledger snapshots the
+// request IDs already on disk when the test begins, and countNew reports only
+// IDs that were NOT in that snapshot. Requests are keyed by a fresh uuid per
+// write, so "not in the snapshot" is exactly "written during this test". The
+// assertions keep their full strength — a stampede that writes 140 requests
+// still reports 140 — and no other run's durable state is destroyed.
+//
+// Build the ledger BEFORE the action under test. If it is built afterwards the
+// test's own requests land in the baseline and countNew under-reports, which
+// fails the assertion loudly (0 vs the wanted 1) rather than passing vacuously.
+type reindexLedger struct {
+	t   *testing.T
+	pre map[string]bool
+}
+
+// newReindexLedger snapshots every reindex request ID already durably present
+// anywhere under the active requests root, so no caller has to enumerate the
+// repos it is about to touch.
+func newReindexLedger(t *testing.T) *reindexLedger {
+	t.Helper()
+	l := &reindexLedger{t: t, pre: map[string]bool{}}
+	dirs, err := discoverRequestsDirs(requestsRoot())
+	if err != nil {
+		t.Fatalf("discoverRequestsDirs: %v", err)
+	}
+	for _, d := range dirs {
+		recs, err := requests.ListPending(d)
+		if err != nil {
+			t.Fatalf("ListPending(%s): %v", d, err)
+		}
+		for _, r := range recs {
+			l.pre[r.ID] = true
+		}
+	}
+	return l
+}
+
+// countNew returns how many KindReindex requests THIS RUN added for repoPath.
+func (l *reindexLedger) countNew(repoPath string) int {
+	l.t.Helper()
+	n := 0
+	for id := range pendingReindexIDs(l.t, repoPath) {
+		if !l.pre[id] {
 			n++
 		}
 	}
@@ -40,6 +102,7 @@ func countPendingReindex(t *testing.T, repoPath string) int {
 // fingerprint) writes exactly ONE reindex request, not N.
 func TestStaleReindexGuard_ExactlyOnceAcrossHeartbeats(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
+	led := newReindexLedger(t)
 	const repo = "/repo/stale"
 	g := newStaleReindexGuard()
 
@@ -55,7 +118,7 @@ func TestStaleReindexGuard_ExactlyOnceAcrossHeartbeats(t *testing.T) {
 	if firing != 1 {
 		t.Errorf("maybeEnqueue returned true %d times across 12 heartbeats, want exactly 1", firing)
 	}
-	if got := countPendingReindex(t, repo); got != 1 {
+	if got := led.countNew(repo); got != 1 {
 		t.Fatalf("pending reindex requests = %d, want exactly 1 (no storm)", got)
 	}
 }
@@ -64,6 +127,7 @@ func TestStaleReindexGuard_ExactlyOnceAcrossHeartbeats(t *testing.T) {
 // current-format repo (required=false) never enqueues.
 func TestStaleReindexGuard_CurrentRepo_NoRequest(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
+	led := newReindexLedger(t)
 	const repo = "/repo/current"
 	g := newStaleReindexGuard()
 
@@ -72,7 +136,7 @@ func TestStaleReindexGuard_CurrentRepo_NoRequest(t *testing.T) {
 			t.Fatalf("current-format repo must never enqueue (heartbeat %d)", i)
 		}
 	}
-	if got := countPendingReindex(t, repo); got != 0 {
+	if got := led.countNew(repo); got != 0 {
 		t.Fatalf("pending reindex requests = %d, want 0 for a current repo", got)
 	}
 }
@@ -84,6 +148,7 @@ func TestStaleReindexGuard_CurrentRepo_NoRequest(t *testing.T) {
 // one fresh request. This is the anti-#5891 loop-guard end to end.
 func TestStaleReindexGuard_SelfClearsAfterReindex(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
+	led := newReindexLedger(t)
 	const repo = "/repo/lifecycle"
 	g := newStaleReindexGuard()
 
@@ -100,7 +165,7 @@ func TestStaleReindexGuard_SelfClearsAfterReindex(t *testing.T) {
 			t.Fatalf("in-flight heartbeat %d must not re-enqueue (same stale generation)", i)
 		}
 	}
-	if got := countPendingReindex(t, repo); got != 1 {
+	if got := led.countNew(repo); got != 1 {
 		t.Fatalf("after in-flight heartbeats, pending = %d, want 1", got)
 	}
 
@@ -119,7 +184,7 @@ func TestStaleReindexGuard_SelfClearsAfterReindex(t *testing.T) {
 			t.Fatalf("second-generation heartbeat %d must not re-enqueue", i)
 		}
 	}
-	if got := countPendingReindex(t, repo); got != 2 {
+	if got := led.countNew(repo); got != 2 {
 		t.Fatalf("total pending across two stale generations = %d, want 2 (one per generation)", got)
 	}
 }
@@ -182,6 +247,7 @@ func heartbeat(g *staleReindexGuard, repos []string, stale map[string]bool) []st
 // requests. Pre-fix this admits all 140.
 func TestStaleReindexGuard_FirstHeartbeatDoesNotStampede(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
+	led := newReindexLedger(t)
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 	g := newTestGuard(clk, 2, 30*time.Second, 15*time.Minute)
 
@@ -199,7 +265,7 @@ func TestStaleReindexGuard_FirstHeartbeatDoesNotStampede(t *testing.T) {
 
 	total := 0
 	for _, r := range repos {
-		total += countPendingReindex(t, r)
+		total += led.countNew(r)
 	}
 	if total != 2 {
 		t.Fatalf("durable pending reindex requests after one heartbeat = %d, want 2", total)
@@ -282,6 +348,7 @@ func TestStaleReindexGuard_IdleWindowBetweenBatches(t *testing.T) {
 // progress for the others, it does not retry the failure.
 func TestStaleReindexGuard_StuckSlotExpires(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
+	led := newReindexLedger(t)
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 	g := newTestGuard(clk, 1, 30*time.Second, 15*time.Minute)
 
@@ -309,7 +376,7 @@ func TestStaleReindexGuard_StuckSlotExpires(t *testing.T) {
 	if len(got) != 1 || got[0] != "/repo/next" {
 		t.Fatalf("after the slot TTL admitted %v, want [/repo/next] — a wedged repo must not block the migration", got)
 	}
-	if n := countPendingReindex(t, "/repo/wedged"); n != 1 {
+	if n := led.countNew("/repo/wedged"); n != 1 {
 		t.Fatalf("wedged repo has %d pending requests, want exactly 1 — TTL expiry must not re-enqueue a known failure", n)
 	}
 }
@@ -438,6 +505,7 @@ func restartGuard(clk *fakeClock, batch int, cooldown, ttl time.Duration, _ []st
 func TestStaleReindexGuard_RestartDoesNotDuplicateRequests(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 	t.Setenv(EnvRoot, t.TempDir())
+	led := newReindexLedger(t)
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 
 	repos := realRepoDirs(t, "a", "b", "c", "d")
@@ -468,7 +536,7 @@ func TestStaleReindexGuard_RestartDoesNotDuplicateRequests(t *testing.T) {
 
 	total := 0
 	for _, r := range repos {
-		total += countPendingReindex(t, r)
+		total += led.countNew(r)
 	}
 	if total != 2 {
 		t.Fatalf("durable requests after 6 restarts = %d, want 2 (progress must survive restart, not reset)", total)
@@ -526,6 +594,7 @@ func TestStaleReindexGuard_LaggardDoesNotStallWholeMigration(t *testing.T) {
 func TestStaleReindexGuard_FailedRepoIsRetriedThenReported(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 	t.Setenv(EnvRoot, t.TempDir())
+	led := newReindexLedger(t)
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 	g := newTestGuard(clk, 1, 45*time.Second, 10*time.Minute)
 	g.stalledGrace = 90 * time.Second
@@ -551,12 +620,12 @@ func TestStaleReindexGuard_FailedRepoIsRetriedThenReported(t *testing.T) {
 		t.Fatal("broken repo must be reported as migration-failed, not silently dropped")
 	}
 	// And once failed it must never be admitted again.
-	before := countPendingReindex(t, "/repo/broken")
+	before := led.countNew("/repo/broken")
 	for i := 0; i < 50; i++ {
 		clk.advance(time.Minute)
 		heartbeat(g, repos, stale)
 	}
-	if got := countPendingReindex(t, "/repo/broken"); got != before {
+	if got := led.countNew("/repo/broken"); got != before {
 		t.Errorf("failed repo re-admitted after giving up: %d -> %d", before, got)
 	}
 }
@@ -571,6 +640,7 @@ func TestStaleReindexGuard_FailedRepoIsRetriedThenReported(t *testing.T) {
 func TestStaleReindexGuard_RestartWithPartialBatchDoesNotDuplicate(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 	t.Setenv(EnvRoot, t.TempDir())
+	led := newReindexLedger(t)
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 
 	repos := realRepoDirs(t, "a", "b")
@@ -595,10 +665,10 @@ func TestStaleReindexGuard_RestartWithPartialBatchDoesNotDuplicate(t *testing.T)
 			t.Errorf("re-admitted %s, which already has a queued reindex — duplicate full reindex", repoA)
 		}
 	}
-	if n := countPendingReindex(t, repoA); n != 1 {
+	if n := led.countNew(repoA); n != 1 {
 		t.Fatalf("repo A pending requests = %d, want 1 (no duplicate across restart)", n)
 	}
-	if n := countPendingReindex(t, repoB); n != 1 {
+	if n := led.countNew(repoB); n != 1 {
 		t.Fatalf("repo B pending requests = %d, want 1 (the free slot must still be usable)", n)
 	}
 }
@@ -640,6 +710,7 @@ func drainAndAck(t *testing.T, repoPath string) {
 func TestStaleReindexGuard_RestartMidIndexDoesNotDuplicate(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 	t.Setenv(EnvRoot, t.TempDir())
+	led := newReindexLedger(t)
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 
 	repos := realRepoDirs(t, "a", "b", "c", "d")
@@ -673,7 +744,7 @@ func TestStaleReindexGuard_RestartMidIndexDoesNotDuplicate(t *testing.T) {
 	// than two would mean the recovery path rebuilt the backlog.
 	total := 0
 	for _, r := range repos {
-		total += countPendingReindex(t, r)
+		total += led.countNew(r)
 	}
 	if total != 2 {
 		t.Fatalf("reindex requests after 6 mid-index restarts = %d, want exactly 2 (one resume per orphaned repo)", total)
@@ -921,6 +992,7 @@ func TestStaleReindexGuard_RestartDoesNotBurnAttempts(t *testing.T) {
 func TestStaleReindexGuard_ReconcileReEnqueuesRecoveredRepos(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 	t.Setenv(EnvRoot, t.TempDir())
+	led := newReindexLedger(t)
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 
 	const repo = "/repo/orphaned"
@@ -934,7 +1006,7 @@ func TestStaleReindexGuard_ReconcileReEnqueuesRecoveredRepos(t *testing.T) {
 	// The drain applies and removes the request; the index dies with the daemon.
 	clk.advance(2 * time.Second)
 	drainAndAck(t, repo)
-	if n := countPendingReindex(t, repo); n != 0 {
+	if n := led.countNew(repo); n != 0 {
 		t.Fatalf("precondition: pending = %d, want 0 after the drain acked", n)
 	}
 
@@ -942,7 +1014,7 @@ func TestStaleReindexGuard_ReconcileReEnqueuesRecoveredRepos(t *testing.T) {
 	g2 := newTestGuard(clk, 2, 45*time.Second, 15*time.Minute)
 	heartbeat(g2, repos, stale)
 
-	if n := countPendingReindex(t, repo); n != 1 {
+	if n := led.countNew(repo); n != 1 {
 		t.Fatalf("pending requests after restart = %d, want 1 — a recovered slot must re-tell the scheduler", n)
 	}
 }

--- a/internal/daemon/stale_reindex_test.go
+++ b/internal/daemon/stale_reindex_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -63,9 +64,22 @@ type reindexLedger struct {
 	pre map[string]bool
 }
 
+// requestFileSuffix is the on-disk suffix requests.Write appends to the record
+// ID (requests.go:101, unexported there). The ID is the filename STEM, which is
+// all a baseline snapshot needs.
+const requestFileSuffix = ".request.json"
+
 // newReindexLedger snapshots every reindex request ID already durably present
 // anywhere under the active requests root, so no caller has to enumerate the
 // repos it is about to touch.
+//
+// It reads directory ENTRIES rather than calling requests.ListPending, because
+// ListPending is not a pure read: it deletes any request whose ack is already
+// on disk (requests.go:236) as exactly-once catch-up cleanup. Sweeping the
+// WHOLE root with it would make this helper WRITE into every repo directory in
+// a shared root, once per test — i.e. a fix for cross-run interference that
+// itself interferes across runs, which is how the next #6929 gets created.
+// TestReindexLedgerSnapshotIsPure pins that the snapshot mutates nothing.
 func newReindexLedger(t *testing.T) *reindexLedger {
 	t.Helper()
 	l := &reindexLedger{t: t, pre: map[string]bool{}}
@@ -74,15 +88,58 @@ func newReindexLedger(t *testing.T) *reindexLedger {
 		t.Fatalf("discoverRequestsDirs: %v", err)
 	}
 	for _, d := range dirs {
-		recs, err := requests.ListPending(d)
+		entries, err := os.ReadDir(d)
 		if err != nil {
-			t.Fatalf("ListPending(%s): %v", d, err)
+			t.Fatalf("ReadDir(%s): %v", d, err)
 		}
-		for _, r := range recs {
-			l.pre[r.ID] = true
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			if id, ok := strings.CutSuffix(e.Name(), requestFileSuffix); ok {
+				l.pre[id] = true
+			}
 		}
 	}
 	return l
+}
+
+// TestReindexLedgerSnapshotIsPure is the guard on the guard. newReindexLedger
+// sweeps the ENTIRE requests root, including repo directories belonging to
+// other tests and other runs, so its one non-negotiable property is that
+// taking a baseline changes nothing on disk. The file at risk is specifically
+// an ACKED request: that is the one requests.ListPending removes as catch-up
+// cleanup, so a ListPending-based sweep deletes another run's state as a side
+// effect of measuring it.
+func TestReindexLedgerSnapshotIsPure(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+
+	const other = "/repo/some-other-run"
+	dir := requestsDirForRepo(other)
+	id, err := requests.Write(dir, requests.Record{Kind: requests.KindReindex, RepoPath: other})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := requests.WriteAck(dir, id, requests.Ack{ID: id, Status: requests.StatusOK, AppliedAt: time.Now()}); err != nil {
+		t.Fatalf("WriteAck: %v", err)
+	}
+	path := filepath.Join(dir, id+requestFileSuffix)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("precondition: planted request is not on disk: %v", err)
+	}
+
+	led := newReindexLedger(t)
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("newReindexLedger destroyed another run's durable request %s: %v", path, err)
+	}
+	// Positive control. Without it the survival assertion above is satisfied by
+	// a snapshot that reads NOTHING — the vacuous pass that would let a future
+	// rewrite reintroduce the side effect undetected.
+	if !led.pre[id] {
+		t.Fatalf("baseline did not observe the planted request %s — the sweep read nothing, so purity is untested", id)
+	}
 }
 
 // countNew returns how many KindReindex requests THIS RUN added for repoPath.


### PR DESCRIPTION
## Both sides reproduced first

Same worktree, same binary, only the root differs. `GRAFEL_HOME` and
`GRAFEL_DAEMON_ROOT` both pointed at scratch dirs; the "reused" root is literally
the fresh one after one prior `go test` run.

| root | exit | result |
|---|---|---|
| fresh `GRAFEL_DAEMON_ROOT` | 0 | `ok  github.com/cajasmota/grafel/internal/daemon  5.074s` |
| same root, 2nd run | 1 | 4 failures (below) |

```
--- FAIL: TestStaleReindexGuard_ExactlyOnceAcrossHeartbeats
    pending reindex requests = 2, want exactly 1 (no storm)
--- FAIL: TestStaleReindexGuard_SelfClearsAfterReindex
    after in-flight heartbeats, pending = 3, want 1
--- FAIL: TestStaleReindexGuard_FirstHeartbeatDoesNotStampede
    durable pending reindex requests after one heartbeat = 144, want 2
--- FAIL: TestStaleReindexGuard_StuckSlotExpires
    wedged repo has 2 pending requests, want exactly 1
```

## The mechanism — verified, and one step deeper than the issue said

The issue's framing ("counts durable requests unscoped to the run") is correct as
far as it goes, but it does not say why the tests are exposed to another run's
state at all, given that they *do* isolate themselves. They isolate the wrong
variable:

- `repoBaseDir` (state_path.go:601) resolves `GRAFEL_DAEMON_ROOT` **first** and only
  falls back to `GRAFEL_HOME`/`StoreDir()`. The older members of the family set
  `t.Setenv("GRAFEL_HOME", t.TempDir())` and nothing else, so whenever
  `GRAFEL_DAEMON_ROOT` is set in the environment — which is what every agent and
  every isolated daemon does — that isolation is a **no-op** for the requests dir.
- The fake repo paths (`/repo/000`…`/repo/139`, `/repo/stale`, `/repo/wedged`) are
  constants, so every run hashes to the same `state/<hash>/refs/_unknown/requests`
  directory. Nothing ever drains those requests in a test, so the directory grows
  by one file per write, forever.
- `countPendingReindex` then counted the directory absolutely.

That also explains the exact numbers, which are not arbitrary. Within one run,
`FirstHeartbeatDoesNotStampede` writes 2 and `140RepoUpgrade_Simulation` writes 140
**for the same repo paths** — so each run leaves 142 behind: 2 → 144 → 286 → **428**,
the number in the issue, i.e. the 4th run in that root. (The review's own reused
root gave 570 — the 5th.) The count also confirms the issue's open question:
leftovers accumulate from **normal** runs, not only interrupted ones.

Not the mechanism, checked and ruled out: `reconcileLocked` (stale_reindex.go:377,
reached on first `maybeEnqueue`) globs the same shared root for durable
`migration.json` markers, which would be a *behavioural* leak rather than a
miscount. After 8 runs the root held **1665** leftover `*.request.json` files and
**0** markers — the markers are cleared on slot release, so that path never fired.
Worth knowing it exists (an interrupted run could strand one), but it is not this
defect.

## The fix: scope by identity, not by clearing

`reindexLedger` snapshots the request IDs already on disk when the test begins;
`countNew(repo)` reports only IDs absent from that snapshot. IDs are a fresh uuid
per `requests.Write`, so "not in the snapshot" is exactly "written by this test".

- **Nothing is weakened.** The absolute count only ever asserted "the dir started
  empty", which is not a property of a deliberately durable store. A stampede that
  writes 140 requests still reports 140 — see the mutants.
- **Nothing is cleared or reset.** No `t.TempDir()` was added, no root is wiped. The
  whole-root snapshot means no caller has to enumerate the repos it is about to
  touch, so the next test to use the helper is scoped by construction rather than
  by remembering to be.
- Building the ledger late fails **loudly** (0 vs the wanted 1), not vacuously.

### Review finding: the snapshot itself was not a pure read (fixed in c0ce5f2)

`requests.ListPending` **deletes** any request whose ack is already on disk
(requests.go:236) as exactly-once catch-up cleanup. The first version of
`newReindexLedger` called it over the **entire** daemon root, so taking a baseline
wrote into every repo directory in a shared root, 12× per package run — a fix for
cross-run interference that itself interfered across runs, and a direct
contradiction of this body's "nothing is cleared" claim. The snapshot now reads
directory entries with `os.ReadDir` and strips the suffix; the request ID is the
filename stem, which is all a baseline needs.

That property is now **pinned, not asserted in prose** —
`TestReindexLedgerSnapshotIsPure` plants an *acked* request (the one `ListPending`
removes) in an unrelated repo dir and requires it to survive the sweep, plus a
positive control that the baseline actually observed the planted ID. Without the
control, the survival assertion is satisfied by a snapshot that reads nothing.

## Siblings — checked, and the split is real

The `TestStaleReindexGuard_*` family is **33** tests; **15** call sites across 2 files
now go through the ledger.

- The *later* members, added in review rounds, already set
  `t.Setenv(EnvRoot, t.TempDir())` **and** use `realRepoDirs` (per-run `t.TempDir()`
  repo paths) — doubly isolated, never exposed.
- The 4 that failed, plus `CurrentRepo_NoRequest` and `stale_reindex_6175_test.go`'s
  `DeclinedRepoIsNotRetriedForever`, were exposed. The latter two are only
  *accidentally* safe: they assert 0 for a repo path nothing else writes to.
- **`IdleWindowBetweenBatches` and `140RepoUpgrade_Simulation` do NOT share the
  defect** — neither makes any durable-count assertion at all (`grep countNew|ListPending`
  over both function bodies: 0 hits). They are the **polluters**, not victims: the
  simulation is what writes the 140 requests, against the same constant repo paths
  the other tests use, that everything else then trips over. A future reader
  chasing accumulated cruft should look at *them*, and at nothing draining those
  requests — not at their assertions.

Swept the rest of `internal/daemon` for the same pattern —
`requests_drain_test.go`, `requests_drain_unblock_test.go`, `index_split_mode_test.go`
all read `requests.ListPending` absolutely, and all set `EnvRoot` to a `t.TempDir()`
**and** use a `t.TempDir()` repo path. The review extended the sweep to
`rebuild_wait_test.go` and `status_rebuild_inflight_6014_test.go` (the former isolated
through the `withSplitWaitTest` helper) and found them safe for the same reason.

## Mutants (all `-count=1`, each scored on BOTH a fresh and a reused root)

Every mutant edit was applied by a script that asserts an exact anchor occurrence
count of 1 before writing, and the applied text was then grepped back.

| # | mutant | verdict |
|---|---|---|
| A | drop the batch-admission gate (`if false && !g.admitLocked(...)`) | **DEAD** both roots — but killed by the `admitted 140 of 140` check at line 263, *before* the durable count. So it does not grade the changed line; A2 exists because of that. |
| A2 | duplicate the durable `requests.Write` (admissions unchanged at 2, ledger gets 4) | **DEAD** both roots, killed by the changed assertions themselves and with **identical messages on both**: `durable pending reindex requests after one heartbeat = 4, want 2`, plus 6 sibling assertions. This is the killing mutant: the guard's durable output genuinely breaks, admissions look fine, and the scoped count still catches it. |
| B | send the durable write to a different directory (guard admits but queues nothing) | **DEAD** both roots — `= 0, want 1` / `= 0, want 2`. Grades the under-count direction: the assertion observes the durable artefact, not the in-memory admission decision it could otherwise be re-asserting. |
| C | make `newReindexLedger` snapshot nothing (`pre` empty ⇒ the old absolute count) | **DEAD** on a reused root (`= 994, want 2`; `= 7, want 1`). **Equivalent on a pristine root** — necessarily so: that is exactly the defect's premise, and it is why the pre-fix suite was green for everyone who only ever ran it once. Reported as distinguishable-and-graded, not as a clean kill. |
| D | restore the `requests.ListPending` whole-root sweep (the reviewed defect) | **DEAD** — `newReindexLedger destroyed another run's durable request …: no such file or directory`. |
| E | the C mutant scored against the purity test's positive control | **DEAD** — `baseline did not observe the planted request … the sweep read nothing, so purity is untested`. Both halves of the new test are graded. |

`stale_reindex.go` is byte-identical to `HEAD` after the mutation round (`git status`
shows only the test files; `shasum` matched the pre-mutation backup).

## Verification

Full `./internal/daemon/` suite, `-count=1`, on the final head:

- reused root (holding 4 runs of leftovers): **PASS**, exit 0, 38.568s
- same root again: **PASS**, exit 0, 33.191s
- fresh root: **PASS**, exit 0, 30.113s

`gofmt -l internal/daemon/` clean; `go vet ./internal/daemon/` exit 0. Test-only
change; no package outside `internal/daemon` touched, and nothing under
`internal/daemon/watch` (#6935).

Closes #6929

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
