### PR TITLE
fix(#6812): OCaml's vendored tree-sitter grammar was compiled in and never asked for — wiring it takes `inherit` attribution from 48.3% precision to 100%

### DIFF
--- a/internal/extractors/ocaml/blocks.go
+++ b/internal/extractors/ocaml/blocks.go
@@ -1,0 +1,265 @@
+// blocks.go — CST-backed block spans for the OCaml extractor (#6812).
+//
+// # Why this file exists
+//
+// `struct … end`, `sig … end`, `object … end` and `begin … end` are the only
+// structural judgement this extractor owns, and until this file landed it was
+// made by a hand-rolled depth walker inside extractModuleBody: two regexes
+// re-run at every byte, counting `end` against `struct|sig|object|begin`.
+//
+// #6812 measured that walker against a clone of github.com/ocaml/ocaml at
+// 70165ff23e, over the 68 files that contain a real `inherit` token:
+//
+//   - 479 of 633 `object … end` blocks (75.7%) got the WRONG end;
+//   - of the 408 (block, inherit) pairs it attributed, 230 were wrong —
+//     recall 91.2% (19 missed), precision 48.3% (211 spurious).
+//
+// Four independent causes, three of which a concrete syntax tree removes by
+// construction:
+//
+//  1. the scan never terminated on a balanced block — the opener took depth
+//     0→1 and the matching `end` took it 1→0 without stopping, because the
+//     loop only broke on an `end` seen AT depth 0, so well-formed blocks
+//     always fell through to the indentation fallback;
+//  2. `\b` was evaluated against a SLICE, not the source: `openKW`/`closeKW`
+//     were re-run on `rest[i:]` and tested for `om[0] == 0`, and at offset 0
+//     of a slice start-of-string satisfies `\b`, so `append`, `send`,
+//     `backend`, `legend`, `myobject` all read as keywords;
+//  3. OCaml block comments NEST and the skipper stopped at the first `*)`;
+//  4. `{|…|}` quoted strings were unknown to it and scanned as code.
+//
+// (2), (3) and (4) are free here: the grammar tokenises. (1) does not arise:
+// a block's extent is a node span, not the output of a counter.
+//
+// The grammar itself was already vendored, registered at
+// internal/treesitter/adapters.go:69 and compiled in — it had simply never
+// been asked for. There was no adapter mismatch, no version pin and no build
+// tag standing in the way; the smoke test in
+// internal/treesitter/ts/grammars/ocaml has been parsing OCaml on every CI run
+// the whole time. The answer to "why was it registered and never used" is that
+// this extractor predates the grammar's arrival and nothing forced the two
+// together.
+//
+// # Contract
+//
+// blockIndex answers exactly one question, and deliberately the SAME question
+// the depth walker answered, so the #6812 measurement harness compares like
+// with like: given a position `from` from which the block's OPENING keyword is
+// still ahead (extractor.go hands it the end of the `module Foo =` match, with
+// `struct` still to come), where does that block's `end` token start?
+//
+// It does NOT bound how far ahead the opener may be. That is a deliberate
+// parity choice, not an oversight: `refMatchEnd`, the independent reference in
+// the measurement harness, has the same contract, and a `module Foo = Bar`
+// alias with no block of its own therefore still adopts the next block in the
+// file. That mis-span is pre-existing (the depth walker did the same thing),
+// it is one of #6939's four gaps, and closing it here would have made the
+// before/after figures incomparable.
+//
+// # When the CST cannot answer
+//
+// Three cases, all of which hand back to the indentation heuristic
+// (extractLetBody) — which is where the depth walker already sent the majority
+// of real blocks anyway, since defect (1) meant it almost never terminated:
+//
+//   - the grammar produced no tree at all;
+//   - no block opener exists at or after `from`;
+//   - the nearest opener has no `end` — either genuinely absent or supplied by
+//     tree-sitter as a zero-width MISSING node inside an ERROR subtree.
+//
+// The third is the one the corpus forced: `testsuite/tests/generated-parse-
+// errors/errors.ml` in the OCaml tree is generated, deliberately malformed
+// source with 256 `object` against 38 `end`. Answering it with the nearest
+// LATER block's `end` would be a fabricated span, so an unclosed opener is
+// reported as unclosed and the caller falls back. This is graded by
+// TestBlockIndex_MalformedInput_FallsBack.
+package ocaml
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tsgrammar "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/ocaml"
+	"github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// blockOpeners are the four anonymous tokens that open an `… end` block in the
+// tree-sitter-ocaml grammar. They appear as unnamed children of, respectively,
+// `structure`, `signature`, `object_expression`/`class_body_type` and
+// `parenthesized_expression`. Keying on the TOKEN rather than on the parent
+// node type is what keeps `( … )` — which shares parenthesized_expression with
+// `begin … end` — out of the index.
+var blockOpeners = map[string]bool{
+	"struct": true, "sig": true, "object": true, "begin": true,
+}
+
+// blockIndex records, for every block opener in a source file, the byte offset
+// at which its closing `end` token starts (or -1 when the block has none).
+type blockIndex struct {
+	// openers is ascending, so a lookup is a binary search.
+	openers []int
+	end     map[int]int
+	// parsed is false when the grammar produced no usable tree; every lookup
+	// then declines and the caller falls back.
+	parsed bool
+	// hasError records whether the tree contains an ERROR node anywhere, i.e.
+	// whether tree-sitter had to recover. It changes no answer this file gives
+	// — a recovered tree is still consulted, block by block — and exists so a
+	// caller can separate "this file is malformed" from "this block span is
+	// wrong". The #6812 corpus measurement uses it to assert that every
+	// residual disagreement with the reference is in a file the grammar itself
+	// reports as broken, which is a much stronger claim than a bounded count.
+	hasError bool
+}
+
+var (
+	ocamlAdapter = official.New()
+	ocamlGrammar = tsgrammar.Language()
+)
+
+// buildBlockIndex parses src with the vendored OCaml grammar and records every
+// block span in it.
+func buildBlockIndex(src string) *blockIndex {
+	bi := &blockIndex{end: make(map[int]int)}
+	parser, err := ocamlAdapter.NewParser(ocamlGrammar)
+	if err != nil {
+		return bi
+	}
+	defer parser.Close()
+
+	// #5630 — this is a second parse of a file the dispatcher has usually
+	// already parsed, so it must take the same daemon-wide parse slot that
+	// treesitter.ParserFactory.Parse takes. GOMAXPROCS does not bound cgo, so
+	// a parse outside the gate makes the in-process ceiling illusory. The slot
+	// is held around the parse ALONE (not the walk below), and released via
+	// defer inside the closure so a panic in Parse cannot leak it permanently.
+	tree, perr := func() (ts.Tree, error) {
+		indexstate.AcquireParseSlot()
+		defer indexstate.ReleaseParseSlot()
+		return parser.Parse([]byte(src))
+	}()
+	if perr != nil || tree == nil {
+		return bi
+	}
+	defer tree.Close()
+	root := tree.RootNode()
+	if root == nil {
+		return bi
+	}
+	bi.parsed = true
+	bi.collect(root)
+	sort.Ints(bi.openers)
+	return bi
+}
+
+// collect walks every node, named and anonymous, recording each block-opening
+// token against the `end` token of the same parent node.
+func (bi *blockIndex) collect(n ts.Node) {
+	if n.IsError() {
+		bi.hasError = true
+	}
+	opener, end := -1, -1
+	for i := 0; i < int(n.ChildCount()); i++ {
+		c := n.Child(i)
+		if c == nil {
+			continue
+		}
+		if !c.IsNamed() {
+			switch {
+			case blockOpeners[c.Type()] && opener < 0:
+				opener = int(c.StartByte())
+			case c.Type() == "end":
+				// A MISSING `end` inserted by tree-sitter's error recovery is
+				// zero-width. Treating it as a real closer would invent a span
+				// ending where the parser gave up, which is precisely the kind
+				// of fabricated answer this file exists to stop producing.
+				if c.EndByte() > c.StartByte() {
+					end = int(c.StartByte())
+				}
+			}
+		}
+		bi.collect(c)
+	}
+	if opener < 0 {
+		return
+	}
+	if _, seen := bi.end[opener]; !seen {
+		bi.openers = append(bi.openers, opener)
+	}
+	bi.end[opener] = end
+}
+
+// bodyEnd returns the byte offset at which the closing `end` of the first
+// block opening at or after `from` starts. ok is false when the index cannot
+// answer — see the "When the CST cannot answer" section of the package note.
+func (bi *blockIndex) bodyEnd(from int) (int, bool) {
+	if !bi.parsed {
+		return 0, false
+	}
+	i := sort.SearchInts(bi.openers, from)
+	if i >= len(bi.openers) {
+		return 0, false
+	}
+	e := bi.end[bi.openers[i]]
+	if e < from {
+		// Either the block is unclosed (-1) or the `end` precedes `from`,
+		// which would produce a negative-length body.
+		return 0, false
+	}
+	return e, true
+}
+
+// ---------------------------------------------------------------------------
+// Per-source memo
+// ---------------------------------------------------------------------------
+
+// extractModuleBody is called once per module entity and again per module from
+// addModuleContains, and the #6812 harness calls it once per block. Parsing on
+// every call would re-parse the same file up to a few dozen times, so the last
+// few indexes are memoised by their exact source text.
+//
+// Keyed on string EQUALITY, not on a hash: a hash collision would silently
+// hand one file's block spans to another, and this package has no way to
+// notice. Equality is cheap in the case that matters — every caller inside one
+// extraction passes the same string value, so the comparison short-circuits on
+// the data pointer.
+//
+// The ring is small on purpose. It is a re-parse avoider for one file being
+// walked, not a cache of the corpus; extraction workers run concurrently and a
+// large ring would pin whole files' worth of trees' worth of maps for as long
+// as the process lives.
+var blockCache struct {
+	mu   sync.Mutex
+	ring [8]blockCacheEntry
+	next int
+}
+
+type blockCacheEntry struct {
+	src string
+	idx *blockIndex
+}
+
+func blockIndexFor(src string) *blockIndex {
+	blockCache.mu.Lock()
+	for _, e := range blockCache.ring {
+		if e.idx != nil && e.src == src {
+			idx := e.idx
+			blockCache.mu.Unlock()
+			return idx
+		}
+	}
+	blockCache.mu.Unlock()
+
+	// Parse OUTSIDE the lock: it takes the parse gate, and holding a package
+	// mutex across a gated cgo call would serialise every OCaml extraction in
+	// the process behind one file.
+	idx := buildBlockIndex(src)
+
+	blockCache.mu.Lock()
+	blockCache.ring[blockCache.next] = blockCacheEntry{src: src, idx: idx}
+	blockCache.next = (blockCache.next + 1) % len(blockCache.ring)
+	blockCache.mu.Unlock()
+	return idx
+}

--- a/internal/extractors/ocaml/blocks_6812_test.go
+++ b/internal/extractors/ocaml/blocks_6812_test.go
@@ -235,3 +235,87 @@ func TestBlockIndex_EndBeforeFromIsRefused(t *testing.T) {
 		t.Fatalf("got (%d,%v), want (9,true)", e, ok)
 	}
 }
+
+// TestBlockIndex_NonBlockKeywordsAreNotOpeners pins blockOpeners in the
+// ADDITION direction. Review Q1.
+//
+// M2 and M3 delete `begin` and `sig` from the set and both die. Nothing
+// covered the other direction, and an over-broad opener is the more dangerous
+// mistake of the two: a phantom opener sitting BEFORE the real one wins the
+// "first opener at or after `from`" search, has no `end` of its own, and makes
+// bodyEnd decline — so the block silently falls back to the indentation
+// heuristic and its `inherit` is dropped. That shows up only as recall loss,
+// which is the direction recall-shaped assertions are structurally blind to
+// (#6902), and it is the same shape as #6943: one direction of a set graded,
+// its neighbour left open.
+//
+// The fixture is ENUMERATED rather than hand-picked at `then`, because a fence
+// aimed at one keyword is a fence one keyword wide. The source carries every
+// OCaml keyword that could plausibly be mistaken for a block opener —
+// including the four that legitimately introduce nesting in the surface syntax
+// (`then`, `else`, `do`, `with`) — so adding ANY of them to the set moves the
+// opener count off 1 and fails here.
+func TestBlockIndex_NonBlockKeywordsAreNotOpeners(t *testing.T) {
+	src := "let c = if cond then object\n" +
+		"    inherit base\n" +
+		"    method a = match x with Some y -> y | None -> 0\n" +
+		"    method b = try (fun z -> z) 1 with _ -> 0\n" +
+		"    method d = for i = 0 to 2 do ignore i done\n" +
+		"    method e = while false do () done\n" +
+		"    method f = let g = 1 in g\n" +
+		"  end else other\n"
+
+	bi := blockIndexFor(src)
+	if !bi.parsed {
+		t.Fatal("the grammar produced no tree")
+	}
+	if len(bi.openers) != 1 {
+		var got []string
+		for _, o := range bi.openers {
+			got = append(got, src[o:min(o+8, len(src))])
+		}
+		t.Fatalf("want exactly the `object` indexed as a block, got %d openers %v — a keyword that "+
+			"does not open an `… end` block is in blockOpeners", len(bi.openers), got)
+	}
+
+	// And the block is still answered from the index rather than declined. This
+	// is the half that catches an addition whose phantom opener precedes the
+	// real one: bodyEnd would return ok=false and extractModuleBody would fall
+	// back, which the opener count alone would not notice if the phantom
+	// happened to share a parent node.
+	end, ok := bi.bodyEnd(0)
+	if !ok {
+		t.Fatal("bodyEnd declined — a phantom opener before the `object` won the search")
+	}
+	if want := strings.Index(src, "  end else"); end != want+2 {
+		t.Fatalf("block end at %d, want %d (%q)", end, want+2, src[end:min(end+10, len(src))])
+	}
+	if !strings.Contains(src[:end], "inherit base") {
+		t.Fatalf("the block's span no longer contains its own `inherit`: %q", src[:end])
+	}
+}
+
+// TestBlockOpeners_ExactSet is the catch-all behind the test above, for a
+// keyword that fixture does not happen to contain. A set assertion on its own
+// would be a tautology restating the declaration; paired with the behavioural
+// test it is the residue — it says "four, and these four", and any fifth entry
+// has to argue for itself in a diff rather than arrive silently.
+func TestBlockOpeners_ExactSet(t *testing.T) {
+	want := map[string]bool{"struct": true, "sig": true, "object": true, "begin": true}
+	if len(blockOpeners) != len(want) {
+		t.Fatalf("blockOpeners has %d entries, want %d: %v", len(blockOpeners), len(want), blockOpeners)
+	}
+	for k := range want {
+		if !blockOpeners[k] {
+			t.Fatalf("blockOpeners is missing %q", k)
+		}
+	}
+	for k := range blockOpeners {
+		if !want[k] {
+			t.Fatalf("blockOpeners has an extra entry %q — every `… end` block in "+
+				"tree-sitter-ocaml opens with one of struct/sig/object/begin; a fifth entry "+
+				"either closes no block (and will decline, dropping the real block) or is a "+
+				"grammar change that needs its own fixture", k)
+		}
+	}
+}

--- a/internal/extractors/ocaml/blocks_6812_test.go
+++ b/internal/extractors/ocaml/blocks_6812_test.go
@@ -1,0 +1,237 @@
+// blocks_6812_test.go — unit grading for the CST-backed block index (#6812
+// arm 2). The before/after MEASUREMENT lives in
+// depth_walker_inherit_accuracy_6812_test.go; this file grades the wiring
+// itself — the parts of blocks.go that sit between the grammar and the answer
+// and that the grammar therefore cannot be credited for.
+package ocaml
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBlockIndex_AllFourOpeners is the coverage assertion for blockOpeners.
+//
+// The map has four entries and the two measurement tests exercise exactly one
+// of them: the enumeration generates `object` and nothing else. Deleting
+// "begin", "sig" or "struct" therefore left the entire package green, which
+// makes three quarters of the table ungraded — and `sig` in particular is the
+// one production actually reaches most often, via `module type T = sig … end`.
+//
+// Each case pins the exact body text rather than a length, so a span that is
+// off by the width of the opener keyword (the class of defect that lived
+// undetected in the harness's own reference for a week, as `i += 6`) fails
+// here rather than passing a byte count.
+func TestBlockIndex_AllFourOpeners(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		from int
+		want string
+	}{
+		{"struct", "module M = struct\n  let a = 1\n", 10, " struct\n  let a = 1\n"},
+		{"sig", "module type T = sig\n  val f : int\n", 15, " sig\n  val f : int\n"},
+		{"object", "let c = object\n  method a = 1\n", 7, " object\n  method a = 1\n"},
+		{"begin", "let x = begin\n  1\n", 7, " begin\n  1\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The `end` is appended here so the `want` above reads as the body
+			// and the test cannot accidentally assert the closer's position.
+			src := tc.src + "end\n"
+			bi := blockIndexFor(src)
+			if !bi.parsed {
+				t.Fatalf("the grammar produced no tree for %q", src)
+			}
+			if len(bi.openers) != 1 {
+				t.Fatalf("want exactly 1 block opener indexed, got %d: %v", len(bi.openers), bi.openers)
+			}
+			got := extractModuleBody(src, tc.from)
+			if got != tc.want {
+				t.Fatalf("body mismatch\n got: %q\nwant: %q", got, tc.want)
+			}
+			// And it came from the index, not from the indentation fallback:
+			// the fallback would stop at the column-0 `end` line and so would
+			// return the same text here. Asserting bodyEnd directly is what
+			// separates "the answer is right" from "the answer is right for
+			// the reason this file claims".
+			if _, ok := bi.bodyEnd(tc.from); !ok {
+				t.Fatalf("bodyEnd declined — %q was answered by the indentation fallback, "+
+					"so this opener is not in blockOpeners", tc.name)
+			}
+		})
+	}
+}
+
+// TestBlockIndex_NestedBlocksPairWithTheirOwnEnd pins the opener-to-`end`
+// pairing rule: an `end` closes the block opened by the SAME parent node, not
+// the nearest one in byte order. A `collect` that recorded the last `end` it
+// walked past — the obvious way to write it — gives the outer block the inner
+// block's closer.
+func TestBlockIndex_NestedBlocksPairWithTheirOwnEnd(t *testing.T) {
+	src := "module M = struct\n" +
+		"  let a = object\n" +
+		"    method x = 1\n" +
+		"  end\n" +
+		"  let b = 2\n" +
+		"end\n"
+	bi := blockIndexFor(src)
+	if len(bi.openers) != 2 {
+		t.Fatalf("want the struct and the object indexed, got %d: %v", len(bi.openers), bi.openers)
+	}
+	outer, ok := bi.bodyEnd(bi.openers[0])
+	if !ok {
+		t.Fatal("the outer struct has no end")
+	}
+	inner, ok := bi.bodyEnd(bi.openers[1])
+	if !ok {
+		t.Fatal("the inner object has no end")
+	}
+	if inner >= outer {
+		t.Fatalf("the inner object's end (%d) is not before the outer struct's (%d) — "+
+			"the two blocks share a closer", inner, outer)
+	}
+	if !strings.Contains(src[bi.openers[0]:outer], "let b = 2") {
+		t.Fatalf("the outer struct's body stops before `let b = 2`; it took the object's `end`: %q",
+			src[bi.openers[0]:outer])
+	}
+}
+
+// TestBlockIndex_ParenthesesAreNotBlocks pins why blockOpeners keys on the
+// TOKEN and not on the node type: `begin … end` and `( … )` are both
+// `parenthesized_expression` in this grammar, so a rule written over node
+// types would index every parenthesised expression in the file as a block.
+func TestBlockIndex_ParenthesesAreNotBlocks(t *testing.T) {
+	src := "let x = (1 + 2)\nlet y = (f (g 3))\n"
+	bi := blockIndexFor(src)
+	if !bi.parsed {
+		t.Fatal("the grammar produced no tree")
+	}
+	if len(bi.openers) != 0 {
+		t.Fatalf("parenthesised expressions were indexed as blocks: %v", bi.openers)
+	}
+}
+
+// TestBlockIndex_MalformedInput_FallsBack grades #6812's ERROR-node decision.
+//
+// The corpus that produced the headline figure contains exactly one file the
+// reference matcher could not read — testsuite/tests/generated-parse-errors/
+// errors.ml, generated deliberately-malformed OCaml with 256 `object` against
+// 38 `end`. tree-sitter does not refuse such input; it recovers, producing
+// ERROR subtrees and zero-width MISSING tokens. So the grammar WILL hand back
+// an answer for an unclosed block, and the decision is what to do with it.
+//
+// The decision: an opener whose `end` is absent or zero-width is reported as
+// unclosed, and extractModuleBody hands back to the indentation heuristic —
+// the same fallback the old code already used, and the one it in fact used for
+// the majority of real blocks. It does NOT adopt the next block's `end`, which
+// is the failure mode that would fabricate a span, and it does NOT return
+// nothing.
+func TestBlockIndex_MalformedInput_FallsBack(t *testing.T) {
+	// Two unclosed `object`s and a single `end`, the shape errors.ml is full of.
+	src := "let a = object\n" +
+		"  inherit parent_a\n" +
+		"  method x = 1\n" +
+		"let b = object\n" +
+		"  inherit parent_b\n" +
+		"end\n"
+
+	bi := blockIndexFor(src)
+	if !bi.parsed {
+		t.Fatal("premise: the grammar produced no tree for recoverable input — it is supposed to recover")
+	}
+	if len(bi.openers) != 2 {
+		t.Fatalf("premise: want both `object` openers indexed, got %d: %v", len(bi.openers), bi.openers)
+	}
+	first := bi.openers[0]
+	if e, ok := bi.bodyEnd(first); ok {
+		t.Fatalf("the unclosed first block was given an end at %d (%q) — that span is fabricated "+
+			"from a LATER block's `end` or from a zero-width MISSING token",
+			e, src[first:min(e+3, len(src))])
+	}
+
+	// And the caller falls back rather than returning nothing: the indentation
+	// heuristic stops at the next column-0 declaration, so the body is the two
+	// indented lines and not the whole file.
+	body := extractModuleBody(src, first)
+	if body == "" {
+		t.Fatal("extractModuleBody returned nothing for a block the CST could not close — " +
+			"silently returning nothing was explicitly rejected in #6812")
+	}
+	if strings.Contains(body, "parent_b") {
+		t.Fatalf("the fallback ran past the next column-0 `let` and swallowed the second block's "+
+			"inherit; body=%q", body)
+	}
+	if !strings.Contains(body, "parent_a") {
+		t.Fatalf("the fallback dropped the block's own inherit; body=%q", body)
+	}
+}
+
+// TestBlockIndex_UnparseableInput_FallsBack pins the other arm of the same
+// decision: when the grammar yields nothing usable at all, extractModuleBody
+// still answers from the indentation heuristic rather than returning "".
+// Asserted through a blockIndex with parsed=false rather than by hunting for
+// input tree-sitter refuses, because tree-sitter's recovery means such input
+// may not exist — and a guard that can only be reached by input nobody can
+// produce is a guard nothing grades.
+func TestBlockIndex_UnparseableInput_FallsBack(t *testing.T) {
+	bi := &blockIndex{end: map[int]int{0: 10}, openers: []int{0}}
+	if _, ok := bi.bodyEnd(0); ok {
+		t.Fatal("bodyEnd answered from an index whose parse failed")
+	}
+	bi.parsed = true
+	if e, ok := bi.bodyEnd(0); !ok || e != 10 {
+		t.Fatalf("the SAME index answers once parsed is set: got (%d,%v), want (10,true) — "+
+			"without this the check above could be passing for the wrong reason", e, ok)
+	}
+}
+
+// TestBlockIndex_HasErrorTracksRecovery grades the flag the corpus measurement
+// leans on, in BOTH directions. A hasError that were stuck true would make the
+// corpus's "zero disagreements on cleanly-parsed files" assertion vacuous by
+// classifying every file as malformed, and nothing in the env-gated test could
+// tell.
+func TestBlockIndex_HasErrorTracksRecovery(t *testing.T) {
+	clean := "module M = struct\n  let a = 1\nend\n"
+	if bi := blockIndexFor(clean); bi.hasError {
+		t.Fatalf("hasError is set on well-formed source: %q", clean)
+	}
+	// Input the grammar genuinely cannot recover from without an ERROR node.
+	// Worth recording what does NOT reach here, because the first four
+	// candidates tried were all parsed CLEANLY: `let a = object end while ;;`,
+	// an unclosed `object`, an unclosed `struct`, and errors.ml's own
+	// `if UIdent then with` line. tree-sitter-ocaml is a GLR parser and
+	// recovers most malformed OCaml into a plausible tree with MISSING tokens
+	// and no ERROR node at all — which is exactly why blockIndex declines on a
+	// zero-width `end` rather than trusting hasError to have flagged the file.
+	broken := "let ) = ( ;; %%%\n"
+	if bi := blockIndexFor(broken); !bi.hasError {
+		t.Fatalf("hasError is NOT set on source tree-sitter has to recover from: %q", broken)
+	}
+}
+
+// TestBlockIndex_EndBeforeFromIsRefused pins the lower bound in bodyEnd's
+// `e < from` guard, as distinct from `e < 0`.
+//
+// The two spellings are equivalent through buildBlockIndex — the binary search
+// returns an opener at or after `from`, and a real `end` is strictly after its
+// opener, so an end in [0, from) cannot arise. That made a mutant reducing the
+// guard to `e < 0` ALIVE against the whole package, and "unreachable through
+// today's constructor" is an argument, not a fence: bodyEnd is a method, the
+// guard is what stops `src[afterPos:end]` being a negative-length slice, and
+// the day the search changes the panic is what tells you.
+//
+// Cost of the kill, since "too expensive" is a claim that deserves a number:
+// nine lines and no production change.
+func TestBlockIndex_EndBeforeFromIsRefused(t *testing.T) {
+	bi := &blockIndex{parsed: true, openers: []int{5}, end: map[int]int{5: 2}}
+	if _, ok := bi.bodyEnd(5); ok {
+		t.Fatal("bodyEnd accepted an end that precedes `from`; the caller would slice src[5:2]")
+	}
+	// Positive control: the same index with a plausible end answers, so the
+	// refusal above is the guard firing and not the lookup missing.
+	bi.end[5] = 9
+	if e, ok := bi.bodyEnd(5); !ok || e != 9 {
+		t.Fatalf("got (%d,%v), want (9,true)", e, ok)
+	}
+}

--- a/internal/extractors/ocaml/depth_walker_inherit_accuracy_6812_test.go
+++ b/internal/extractors/ocaml/depth_walker_inherit_accuracy_6812_test.go
@@ -1,10 +1,17 @@
-// depth_walker_inherit_accuracy_6812_test.go — MEASUREMENT harness for the
-// hand-rolled depth walker at extractor.go:422 (`extractModuleBody`).
+// depth_walker_inherit_accuracy_6812_test.go — MEASUREMENT harness for
+// `extractModuleBody`, the one structural judgement the OCaml extractor owns.
 //
-// #6812 states plainly that nobody has measured how often that walker gets
-// `inherit` context wrong, and that the number must exist before committing to
-// a tree-sitter migration. This file is that measurement. It changes NO
-// production behaviour and adds no pattern to the extractor.
+// #6812 states plainly that nobody had measured how often the hand-rolled
+// depth walker got `inherit` context wrong, and that the number had to exist
+// before committing to a tree-sitter migration. Arm 1 of this file was that
+// measurement. ARM 2 IS THE MIGRATION, and this file is now a BEFORE-AND-AFTER
+// rather than a before: the retired walker is preserved verbatim as
+// legacyDepthWalkerBody and scored alongside the CST-backed
+// `extractModuleBody`, over the same inputs and the same reference, in a
+// single run. Without that, every figure #6812 rests on would be a claim in a
+// PR body that nothing in the repo can reproduce.
+//
+// It still adds no pattern to the extractor.
 //
 // # What "inherit context" means here, operationally
 //
@@ -17,20 +24,30 @@
 //	truth span    = [openerStart, offset of the block's real matching `end`)
 //	an `inherit` is MIS-ATTRIBUTED when exactly one of the two spans contains it.
 //
-// The walker is driven the way production drives it: `extractModuleBody` is
-// handed a position from which the block's OPENING keyword is still ahead
-// (extractor.go:153 passes the end of the `module Foo =` match, with `struct`
-// still to come), so the opener increments depth. That is not a detail — see
-// the divergence table below.
+// Both producers are driven the way production drives them: they are handed a
+// position from which the block's OPENING keyword is still ahead (extractor.go
+// passes the end of the `module Foo =` match, with `struct` still to come).
+// For the walker that is what makes the opener increment depth; for the
+// CST-backed implementation it is the "first opener at or after `from`"
+// contract in blocks.go. That is not a detail — see the divergence table
+// below.
 //
 // # Ground truth
 //
 // refMatchEnd below is a small OCaml block matcher written for this test only.
-// It differs from the production walker in four ways that are each an
-// independent defect of the production walker, so a positive control matters:
+// It differs from the RETIRED walker in four ways that are each an independent
+// defect of that walker, so a positive control matters:
 // TestReferenceBlockMatcher_PositiveControls pins it against hand-computed
 // answers, including every hazard class it is supposed to survive. A
 // measurement whose reference is unvalidated measures nothing.
+//
+// Its role changed in arm 2 and the change is stated in full on
+// TestDepthWalker_InheritAttribution_CorpusMeasurement: against a CST-backed
+// producer it is no longer an independent oracle (arm 1 established that
+// refMatchEnd and the grammar agree, 595/595), but it is not vacuous either —
+// it shares no line with blocks.go and still grades everything the wiring
+// added on top of the grammar. Read that note before quoting an agreement
+// figure from this file as a confirmation.
 //
 // # Corpus
 //
@@ -48,9 +65,92 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
+
+// ---------------------------------------------------------------------------
+// The retired depth walker, kept as the #6812 baseline
+// ---------------------------------------------------------------------------
+
+// legacyDepthWalkerBody is `extractModuleBody` EXACTLY as it stood at
+// 2de485618, the commit that measured it. It was deleted from production when
+// the vendored tree-sitter grammar was wired in (arm 2), and it lives on here
+// as test-only code for one reason: without it every figure in #6812 becomes a
+// claim in a PR body that nothing in the repo can reproduce.
+//
+// Keeping it means the enumeration and the corpus measurement below grade TWO
+// producers against one independent reference in a single run, so "the CST
+// implementation is better" is a measurement taken here rather than a
+// before/after taken across two checkouts. It is never called by production
+// code; `extractModuleBody` is.
+func legacyDepthWalkerBody(src string, afterPos int) string {
+	if afterPos >= len(src) {
+		return ""
+	}
+	rest := src[afterPos:]
+
+	depth := 0
+	found := false
+	endPos := 0
+
+	openKW := regexp.MustCompile(`\b(struct|sig|object|begin)\b`)
+	closeKW := regexp.MustCompile(`\bend\b`)
+
+	i := 0
+	for i < len(rest) {
+		if i+1 < len(rest) && rest[i] == '(' && rest[i+1] == '*' {
+			i += 2
+			for i < len(rest) {
+				if i+1 < len(rest) && rest[i] == '*' && rest[i+1] == ')' {
+					i += 2
+					break
+				}
+				i++
+			}
+			continue
+		}
+		if rest[i] == '"' {
+			i++
+			for i < len(rest) && rest[i] != '"' {
+				if rest[i] == '\\' {
+					i++
+				}
+				i++
+			}
+			i++
+			continue
+		}
+		if rest[i] == '\'' && i+2 < len(rest) && rest[i+2] == '\'' {
+			i += 3
+			continue
+		}
+
+		remaining := rest[i:]
+		if om := openKW.FindStringIndex(remaining); om != nil && om[0] == 0 {
+			depth++
+			i += om[1]
+			continue
+		}
+		if cm := closeKW.FindStringIndex(remaining); cm != nil && cm[0] == 0 {
+			if depth == 0 {
+				endPos = i
+				found = true
+				break
+			}
+			depth--
+			i += cm[1]
+			continue
+		}
+		i++
+	}
+
+	if found {
+		return rest[:endPos]
+	}
+	return extractLetBody(src, afterPos)
+}
 
 // ---------------------------------------------------------------------------
 // Reference OCaml block matcher (test-only ground truth)
@@ -348,6 +448,30 @@ func tail(src string, i int) string {
 // The DIVERGING SET is recorded below as a literal; a change to the walker
 // that moves any combination in or out of it fails this test, which is what
 // makes the #6812 finding reproducible without a network.
+//
+// # Re-derived for the grammar wiring (#6812 arm 2)
+//
+// The enumeration now runs BOTH producers over the same 32 inputs against the
+// same reference:
+//
+//   - legacyDepthWalkerBody — the retired regex depth walker, verbatim. Its
+//     diverging set is UNCHANGED at the recorded 18/32, so arm 1's finding is
+//     still reproducible in-repo rather than only in a PR body.
+//   - extractModuleBody — now CST-backed. Its diverging set is EMPTY, and that
+//     is recorded as its own literal.
+//
+// An empty set is a weak-looking assertion, so be precise about what it can
+// still catch: `endsAgree` fails on ANY disagreement in either direction, so a
+// producer that truncates, over-reaches, returns "" or silently falls back to
+// the indentation heuristic all land in cstDivergingCombinations6812 and fail
+// here. The direction that would be invisible — a producer that agrees for the
+// wrong reason — is exactly what running the legacy walker alongside it
+// answers: if the two sets ever coincide, the wiring has been reverted or
+// bypassed, and the 18-entry assertion fails first.
+//
+// Axis-E inertness and the E-symmetry count are asserted against the LEGACY
+// set, where they are non-vacuous. Asserting them over an empty set would be
+// two guards that pass by having nothing to look at.
 func TestDepthWalker_ObjectBlockEnd_EnumeratedSpace(t *testing.T) {
 	type axes struct{ closeAtCol0, endIdent, nestedComment, quotedString, trailer bool }
 	build := func(a axes) string {
@@ -390,16 +514,16 @@ func TestDepthWalker_ObjectBlockEnd_EnumeratedSpace(t *testing.T) {
 			flag(a.nestedComment, "C") + flag(a.quotedString, "D") + flag(a.trailer, "E")
 	}
 
-	// Recorded from the enumeration below at the commit that added this file,
-	// against a clone of github.com/ocaml/ocaml as the corpus for the headline
-	// figure. Written out rather than computed so a behaviour change is a
-	// diff and not a silently different pass.
-	wantDiverging := map[string]bool{}
-	for _, k := range divergingCombinations6812 {
-		wantDiverging[k] = true
+	producers := []struct {
+		name string
+		body func(string, int) string
+		got  []string
+		want []string
+	}{
+		{name: "legacy regex depth walker", body: legacyDepthWalkerBody, want: divergingCombinations6812},
+		{name: "CST-backed extractModuleBody", body: extractModuleBody, want: cstDivergingCombinations6812},
 	}
 
-	var got []string
 	for i := 0; i < 32; i++ {
 		a := axes{
 			closeAtCol0:   i&1 != 0,
@@ -417,39 +541,52 @@ func TestDepthWalker_ObjectBlockEnd_EnumeratedSpace(t *testing.T) {
 		if len(inh) != 1 {
 			t.Fatalf("%s: generator premise broken, want exactly 1 inherit, got %d", label(a), len(inh))
 		}
-		walkEnd := len(extractModuleBody(src, 0))
 		inTruth := inh[0] < truth
-		inWalker := inh[0] < walkEnd
 		if !inTruth {
 			t.Fatalf("%s: generator premise broken, the inherit is not inside the block", label(a))
 		}
-		// The criterion is block-end disagreement ALONE. It used to read
-		// `!endsAgree(...) || inTruth != inWalker`, and the second term was
-		// dead: a mutant deleting the first left the test unable to find any
-		// divergence at all, because NO generated input mis-attributes its
-		// `inherit` (review N2). The generator always writes the `inherit` as
-		// the first body line, so every span that disagrees still contains it.
-		// Asserting that positively, here, is what keeps the dead term from
-		// coming back as a claim nothing checks.
-		if inTruth != inWalker {
-			t.Fatalf("%s: this generator is not supposed to be able to produce an "+
-				"inherit MIS-ATTRIBUTION — it varies where the block ENDS, and the "+
-				"inherit is always the first body line. If it now can, the enumerated "+
-				"finding changed and both write-ups need re-deriving.", label(a))
+		for p := range producers {
+			walkEnd := len(producers[p].body(src, 0))
+			inWalker := inh[0] < walkEnd
+			// The criterion is block-end disagreement ALONE. It used to read
+			// `!endsAgree(...) || inTruth != inWalker`, and the second term was
+			// dead: a mutant deleting the first left the test unable to find any
+			// divergence at all, because NO generated input mis-attributes its
+			// `inherit` (review N2). The generator always writes the `inherit` as
+			// the first body line, so every span that disagrees still contains it.
+			// Asserting that positively, here, is what keeps the dead term from
+			// coming back as a claim nothing checks. It is asserted for BOTH
+			// producers: a CST-backed span that started BEFORE the `inherit`
+			// would break the premise just as surely as one that stopped short.
+			if inTruth != inWalker {
+				t.Fatalf("%s [%s]: this generator is not supposed to be able to produce an "+
+					"inherit MIS-ATTRIBUTION — it varies where the block ENDS, and the "+
+					"inherit is always the first body line. If it now can, the enumerated "+
+					"finding changed and both write-ups need re-deriving.", label(a), producers[p].name)
+			}
+			if !endsAgree(src, walkEnd, truth) {
+				producers[p].got = append(producers[p].got, label(a))
+				t.Logf("%s [%s] BLOCK-END DIVERGES: span end=%d, true end=%d (inherit@%d is inside both spans)",
+					label(a), producers[p].name, walkEnd, truth, inh[0])
+			}
 		}
-		if !endsAgree(src, walkEnd, truth) {
-			got = append(got, label(a))
-			t.Logf("%s BLOCK-END DIVERGES: walker end=%d, true end=%d (inherit@%d is inside both spans)",
-				label(a), walkEnd, truth, inh[0])
+	}
+	for p := range producers {
+		if strings.Join(producers[p].got, ",") != strings.Join(producers[p].want, ",") {
+			t.Fatalf("diverging set changed for %s.\n got: %v\nwant: %v",
+				producers[p].name, producers[p].got, producers[p].want)
 		}
 	}
-	if len(got) == 0 {
-		t.Fatalf("no combination diverged — extractModuleBody's behaviour changed; " +
-			"re-derive the #6812 figure rather than deleting this test")
+	// The whole point of running both is that they differ. Without this the two
+	// set assertions above could BOTH be satisfied by a producers table whose
+	// second entry had been pointed back at the first — the `want` literals
+	// would then simply be wrong together, and nothing would say so.
+	if len(producers[0].got) <= len(producers[1].got) {
+		t.Fatalf("the retired walker (%d diverging) is not doing worse than the CST-backed one (%d) — "+
+			"the wiring has been reverted or the table is pointed at one producer twice",
+			len(producers[0].got), len(producers[1].got))
 	}
-	if strings.Join(got, ",") != strings.Join(divergingCombinations6812, ",") {
-		t.Fatalf("diverging set changed.\n got: %v\nwant: %v", got, divergingCombinations6812)
-	}
+	got := producers[0].got
 	// Axis E is INERT, and that is asserted rather than left as padding. The
 	// review found E (and, before it was respelled, B) changed no outcome in
 	// any of the 16 pairs, which meant "32 combinations" overstated what was
@@ -473,10 +610,12 @@ func TestDepthWalker_ObjectBlockEnd_EnumeratedSpace(t *testing.T) {
 	if len(got)%2 != 0 {
 		t.Fatalf("axis E is documented INERT, so the diverging set must be E-symmetric, got %d entries", len(got))
 	}
-	t.Logf("%d/32 enumerated combinations put the WRONG END on the block. "+
-		"0/32 mis-attribute the `inherit` — see the guard above; inherit "+
+	t.Logf("retired regex depth walker: %d/32 enumerated combinations put the WRONG END on the block; "+
+		"CST-backed extractModuleBody: %d/32. "+
+		"0/32 mis-attribute the `inherit` for EITHER producer — see the guard above; inherit "+
 		"mis-attribution is carried by TestDepthWalker_InheritIsMisAttributed_Constructed "+
-		"and by the corpus measurement, not by this enumeration.", len(got))
+		"and by the corpus measurement, not by this enumeration.",
+		len(producers[0].got), len(producers[1].got))
 }
 
 // TestDepthWalker_InheritIsMisAttributed_Constructed is the smallest input
@@ -510,47 +649,104 @@ func TestDepthWalker_InheritIsMisAttributed_Constructed(t *testing.T) {
 		t.Fatalf("premise: want 2 object tokens, got %d", len(objs))
 	}
 
-	var mis int
-	for i, o := range objs {
-		truth := refMatchEnd(src, o)
-		if truth < 0 {
-			t.Fatalf("premise: reference failed on a constructed case")
-		}
-		walkEnd := o + len(extractModuleBody(src, o))
-		for j, in := range inherits {
-			inTruth := in >= o && in < truth
-			inWalker := in >= o && in < walkEnd
-			if inTruth != inWalker {
-				mis++
-				t.Logf("object #%d span [%d,%d) (true end %d) mis-attributes inherit #%d at %d: in_truth=%v in_walker=%v",
-					i, o, walkEnd, truth, j, in, inTruth, inWalker)
+	count := func(body func(string, int) string) int {
+		var mis int
+		for i, o := range objs {
+			truth := refMatchEnd(src, o)
+			if truth < 0 {
+				t.Fatalf("premise: reference failed on a constructed case")
+			}
+			walkEnd := o + len(body(src, o))
+			for j, in := range inherits {
+				inTruth := in >= o && in < truth
+				inWalker := in >= o && in < walkEnd
+				if inTruth != inWalker {
+					mis++
+					t.Logf("object #%d span [%d,%d) (true end %d) mis-attributes inherit #%d at %d: in_truth=%v in_walker=%v",
+						i, o, walkEnd, truth, j, in, inTruth, inWalker)
+				}
 			}
 		}
+		return mis
 	}
-	if mis == 0 {
-		t.Fatalf("NO MIS-ATTRIBUTION — the walker now agrees with the reference on this input. " +
-			"That is a behaviour change in extractModuleBody; re-derive the #6812 figure before deleting this test.")
+
+	// #6812 arm 2: the input is unchanged and so is the legacy verdict. What is
+	// asserted now is a PAIR — the retired walker still mis-attributes here, and
+	// the CST-backed producer does not. Asserting only the second would be an
+	// absence over a population that a broken generator could empty; asserting
+	// both means the fix is graded against a demonstrated failure on the same
+	// bytes rather than against a claim about them.
+	legacyMis := count(legacyDepthWalkerBody)
+	if legacyMis == 0 {
+		t.Fatalf("the RETIRED walker no longer mis-attributes on this input — legacyDepthWalkerBody " +
+			"is supposed to be extractModuleBody verbatim as of 2de485618. Either it was edited or " +
+			"the reference moved; either way the #6812 figure needs re-deriving, not this test deleting.")
 	}
-	t.Logf("constructed input: %d/%d (object, inherit) attributions wrong", mis, len(objs)*len(inherits))
+	cstMis := count(extractModuleBody)
+	if cstMis != 0 {
+		t.Fatalf("the CST-backed extractModuleBody mis-attributes %d/%d (object, inherit) pairs on the "+
+			"input the grammar wiring exists to fix", cstMis, len(objs)*len(inherits))
+	}
+	t.Logf("constructed input: retired walker %d/%d (object, inherit) attributions wrong, CST-backed %d/%d",
+		legacyMis, len(objs)*len(inherits), cstMis, len(objs)*len(inherits))
 }
 
 // ---------------------------------------------------------------------------
 // The measurement, on a real corpus (env-gated)
 // ---------------------------------------------------------------------------
 
+// TestDepthWalker_InheritAttribution_CorpusMeasurement is #6812's headline
+// figure, and since arm 2 it is a BEFORE and AFTER taken in one run: the
+// retired regex depth walker and the CST-backed extractModuleBody are scored
+// over the same files, the same blocks and the same reference.
+//
+// # What the reference is still for, now that the producer is CST-backed
+//
+// This deserves saying plainly rather than letting a tautology read as a pass.
+// Arm 1's reviewer cross-checked refMatchEnd against THIS repo's vendored
+// tree-sitter OCaml grammar over these same files: 595 blocks compared, 595
+// agree. So refMatchEnd and the grammar are known to answer the same question
+// the same way, and "the CST-backed producer agrees with refMatchEnd" is
+// therefore NOT the independent confirmation it was when the producer was a
+// regex walker.
+//
+// It is not vacuous either, and the distinction is the code in between.
+// refMatchEnd is a hand-written matcher that shares no line with blocks.go;
+// what it still grades is everything the wiring added on top of the grammar —
+// which node types count as openers, pairing an opener with the `end` of the
+// SAME parent node, rejecting zero-width MISSING closers, the binary search
+// for "first opener at or after `from`", and the per-source memo handing back
+// the right file's index. Every one of those is a place this arm could have
+// been wrong, and none of them is in the grammar.
+//
+// What the reference can no longer do is arbitrate a disagreement. If the two
+// ever differ, this test says so but cannot say which is right; that verdict
+// needs the grammar's own S-expression, not another run of this test.
 func TestDepthWalker_InheritAttribution_CorpusMeasurement(t *testing.T) {
 	root := os.Getenv("GRAFEL_OCAML_CORPUS")
 	if root == "" {
 		t.Skip("set GRAFEL_OCAML_CORPUS to a checkout of real OCaml source to run the measurement")
 	}
+
+	type score struct {
+		name            string
+		body            func(string, int) string
+		blockEndWrong   int
+		blockEndWrongOK int // …of which sit in a file the grammar parses CLEANLY
+		inheritEnclosed int
+		inheritMissed   int
+		inheritSpurious int
+	}
+	producers := []*score{
+		{name: "retired regex depth walker", body: legacyDepthWalkerBody},
+		{name: "CST-backed extractModuleBody", body: extractModuleBody},
+	}
+
 	var (
 		files, blocks, unmatched int
-		blockEndWrong            int
 		inheritTotal             int
-		inheritEnclosed          int
-		inheritMissed            int
-		inheritSpurious          int
 		filesWithInherit         int
+		filesWithErrors          int
 		unmatchedFiles           []string
 	)
 	err := filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
@@ -568,12 +764,20 @@ func TestDepthWalker_InheritAttribution_CorpusMeasurement(t *testing.T) {
 			// The question is about `inherit` context, so the population is the
 			// files that contain one. Scoped rather than sampled: EVERY such
 			// file in the corpus is measured. (It is also what keeps the run
-			// finishable — the production walker re-runs two regexes at every
-			// byte of the remaining file, so it is quadratic per block.)
+			// finishable — the retired walker re-runs two regexes at every byte
+			// of the remaining file, so it is quadratic per block.)
 			return nil
 		}
 		inheritTotal += len(inh)
 		filesWithInherit++
+		// Whether the GRAMMAR had to recover on this file, taken from the tree
+		// rather than from the file's name. errors.ml is the corpus's one
+		// deliberately-malformed file, and hard-coding its path here would make
+		// the assertion below true by naming rather than by measurement.
+		recovered := blockIndexFor(src).hasError
+		if recovered {
+			filesWithErrors++
+		}
 		for _, o := range objectOffsets(src) {
 			truth := refMatchEnd(src, o)
 			if truth < 0 {
@@ -584,29 +788,34 @@ func TestDepthWalker_InheritAttribution_CorpusMeasurement(t *testing.T) {
 				continue
 			}
 			blocks++
-			walkEnd := o + len(extractModuleBody(src, o))
-			if !endsAgree(src, walkEnd, truth) {
-				blockEndWrong++
-			}
-			for _, in := range inh {
-				inTruth := in >= o && in < truth
-				inWalker := in >= o && in < walkEnd
-				switch {
-				case inTruth && inWalker:
-					inheritEnclosed++
-				case inTruth && !inWalker:
-					// The walker's block stops SHORT of an inherit that is
-					// really inside the block: a real inheritance edge the
-					// regex path would not attribute.
-					inheritEnclosed++
-					inheritMissed++
-				case !inTruth && inWalker:
-					// The walker's block runs PAST its end and swallows an
-					// inherit belonging to a later block: an edge attributed to
-					// the wrong owner. Recall assertions are structurally blind
-					// to this direction (#6902), which is why it is counted
-					// separately rather than folded into one error figure.
-					inheritSpurious++
+			for _, s := range producers {
+				walkEnd := o + len(s.body(src, o))
+				if !endsAgree(src, walkEnd, truth) {
+					s.blockEndWrong++
+					if !recovered {
+						s.blockEndWrongOK++
+					}
+				}
+				for _, in := range inh {
+					inTruth := in >= o && in < truth
+					inWalker := in >= o && in < walkEnd
+					switch {
+					case inTruth && inWalker:
+						s.inheritEnclosed++
+					case inTruth && !inWalker:
+						// The span stops SHORT of an inherit that is really
+						// inside the block: a real inheritance edge this
+						// producer would not attribute.
+						s.inheritEnclosed++
+						s.inheritMissed++
+					case !inTruth && inWalker:
+						// The span runs PAST its end and swallows an inherit
+						// belonging to a later block: an edge attributed to the
+						// wrong owner. Recall assertions are structurally blind
+						// to this direction (#6902), which is why it is counted
+						// separately rather than folded into one error figure.
+						s.inheritSpurious++
+					}
 				}
 			}
 		}
@@ -626,29 +835,68 @@ func TestDepthWalker_InheritAttribution_CorpusMeasurement(t *testing.T) {
 	}
 	t.Logf("corpus=%s files=%d files_with_inherit=%d", root, files, filesWithInherit)
 	t.Logf("object blocks matched by reference=%d (unmatched, excluded=%d)", blocks, unmatched)
-	t.Logf("BLOCK-END WRONG: %d/%d (%s)", blockEndWrong, blocks, pct(blockEndWrong, blocks))
-	t.Logf("inherit tokens in those files=%d; (block,inherit) pairs truly enclosed=%d",
-		inheritTotal, inheritEnclosed)
-	// Recall and precision are reported separately and never summed into one
-	// rate. Adding them gave 230/216 = 106.5%, which is not a rate at all:
-	// `spurious` is drawn from every (block, inherit) pair in the file while
-	// `enclosed` counts only the truly-enclosed ones, so the two have different
-	// denominators (review).
-	correct := inheritEnclosed - inheritMissed
-	attributed := correct + inheritSpurious
-	t.Logf("INHERIT RECALL: %d/%d truly-enclosed pairs are inside the walker's span (%s); "+
-		"%d MISSED", correct, inheritEnclosed, pct(correct, inheritEnclosed), inheritMissed)
-	t.Logf("INHERIT PRECISION: %d/%d pairs the walker attributes are right (%s); "+
-		"%d SPURIOUS", correct, attributed, pct(correct, attributed), inheritSpurious)
-	t.Logf("so the walker attributes %d pairs, %d of them wrong — more wrong than right",
-		attributed, inheritSpurious+inheritMissed)
+	t.Logf("inherit tokens in those files=%d; files the grammar had to RECOVER on=%d", inheritTotal, filesWithErrors)
+	for _, s := range producers {
+		t.Logf("--- %s ---", s.name)
+		t.Logf("BLOCK-END WRONG: %d/%d (%s); of those, %d are in files the grammar parses cleanly",
+			s.blockEndWrong, blocks, pct(s.blockEndWrong, blocks), s.blockEndWrongOK)
+		// Recall and precision are reported separately and never summed into
+		// one rate. Adding them gave 230/216 = 106.5%, which is not a rate at
+		// all: `spurious` is drawn from every (block, inherit) pair in the file
+		// while `enclosed` counts only the truly-enclosed ones, so the two have
+		// different denominators (review).
+		correct := s.inheritEnclosed - s.inheritMissed
+		attributed := correct + s.inheritSpurious
+		t.Logf("(block,inherit) pairs truly enclosed=%d", s.inheritEnclosed)
+		t.Logf("INHERIT RECALL: %d/%d truly-enclosed pairs are inside the span (%s); %d MISSED",
+			correct, s.inheritEnclosed, pct(correct, s.inheritEnclosed), s.inheritMissed)
+		t.Logf("INHERIT PRECISION: %d/%d pairs attributed are right (%s); %d SPURIOUS",
+			correct, attributed, pct(correct, attributed), s.inheritSpurious)
+		t.Logf("attributes %d pairs, %d of them wrong", attributed, s.inheritSpurious+s.inheritMissed)
+	}
 	if len(unmatchedFiles) > 0 {
 		t.Logf("sample files holding a block the REFERENCE could not match (excluded from every "+
-			"figure above, so they neither help nor hurt the walker): %v", unmatchedFiles)
+			"figure above, so they neither help nor hurt either producer): %v", unmatchedFiles)
 	}
-	if blockEndWrong == 0 {
-		t.Fatalf("zero block-end errors over %d blocks — that contradicts the constructed cases; "+
-			"suspect the harness before believing it", blocks)
+	legacy, cst := producers[0], producers[1]
+	if legacy.blockEndWrong == 0 {
+		t.Fatalf("the RETIRED walker made zero block-end errors over %d blocks — that contradicts "+
+			"the constructed cases; suspect the harness before believing it", blocks)
+	}
+	// The acceptance criterion for #6812 arm 2, asserted rather than left to a
+	// reader of the log. Written as a strict improvement in BOTH directions
+	// because a producer can buy precision by attributing less: a span that
+	// stopped at the opener would have perfect precision and no recall.
+	if cst.blockEndWrong >= legacy.blockEndWrong {
+		t.Fatalf("the CST-backed producer put the wrong end on %d/%d blocks against the retired "+
+			"walker's %d — the wiring bought nothing", cst.blockEndWrong, blocks, legacy.blockEndWrong)
+	}
+	if cst.inheritMissed > legacy.inheritMissed {
+		t.Fatalf("the CST-backed producer MISSES more truly-enclosed inherits (%d) than the retired "+
+			"walker (%d) — precision was bought with recall", cst.inheritMissed, legacy.inheritMissed)
+	}
+	if cst.inheritSpurious >= legacy.inheritSpurious {
+		t.Fatalf("the CST-backed producer attributes %d spurious inherits against the retired "+
+			"walker's %d", cst.inheritSpurious, legacy.inheritSpurious)
+	}
+	// The strongest thing this corpus can say about the wiring, and much
+	// stronger than a bounded error count: on VALID OCaml the CST-backed
+	// producer and the independent reference do not disagree at all. Every
+	// residual disagreement is in a file tree-sitter itself reports as broken,
+	// which is where the two are entitled to differ — recovery is a heuristic
+	// and refMatchEnd is not the same heuristic.
+	//
+	// Asserted as an exact zero rather than a threshold. A threshold would let
+	// a real regression on valid source hide under a budget the malformed file
+	// already fills.
+	if cst.blockEndWrongOK != 0 {
+		t.Fatalf("the CST-backed producer disagrees with the reference on %d blocks in files the "+
+			"grammar parses WITHOUT error — those are not recovery artefacts and need explaining",
+			cst.blockEndWrongOK)
+	}
+	if filesWithErrors == 0 {
+		t.Fatalf("no file in the corpus needed recovery, so the assertion above was vacuous — " +
+			"this corpus is supposed to contain testsuite/tests/generated-parse-errors/errors.ml")
 	}
 }
 
@@ -678,3 +926,29 @@ var divergingCombinations6812 = []string{
 	"-----", "-BC--", "ABC--", "-B-D-", "AB-D-", "--CD-", "A-CD-", "-BCD-", "ABCD-",
 	"----E", "-BC-E", "ABC-E", "-B-DE", "AB-DE", "--CDE", "A-CDE", "-BCDE", "ABCDE",
 }
+
+// cstDivergingCombinations6812 is the re-derived diverging set for the
+// CST-backed extractModuleBody (#6812 arm 2). It is EMPTY: none of the 32
+// enumerated combinations puts the wrong end on the block once the span comes
+// from the grammar.
+//
+// Each of the four axes the enumeration crosses is one of the walker's four
+// measured defects, and the empty set is the per-axis account of why:
+//
+//	A  an INDENTED `end` — defect (1), the scan never terminating on a balanced
+//	   block, so every well-formed block fell through to the indentation
+//	   fallback and the fallback consumed past the `end` line. A node span has
+//	   no counter to fail to terminate.
+//	B  an identifier ENDING in `end` (`append`) — defect (2), `\b` evaluated at
+//	   offset 0 of a re-sliced string. The grammar tokenises, so `append` is a
+//	   method_name and never a closing keyword. Note this axis is where the
+//	   walker accidentally CANCELLED defect (1) on its own (`-B---` did not
+//	   diverge); the CST does not need the cancellation.
+//	C  a NESTED comment — defect (3). `(* (* q *) end *)` is one `comment` node.
+//	D  a `{|…|}` quoted string holding `end` — defect (4). It is a
+//	   `quoted_string` node with a `quoted_string_content` child.
+//
+// Recorded as a named empty literal rather than as `len(got) == 0` so that the
+// two producers are asserted the same way, and so the day a combination starts
+// diverging the failure reads as a diff against a recorded set.
+var cstDivergingCombinations6812 = []string{}

--- a/internal/extractors/ocaml/depth_walker_inherit_accuracy_6812_test.go
+++ b/internal/extractors/ocaml/depth_walker_inherit_accuracy_6812_test.go
@@ -710,6 +710,17 @@ func TestDepthWalker_InheritIsMisAttributed_Constructed(t *testing.T) {
 // therefore NOT the independent confirmation it was when the producer was a
 // regex walker.
 //
+// SAY THE ARITHMETIC, because it bounds the claim precisely and nobody
+// re-derives it from two comments in different files. Arm 1's equivalence was
+// established over 595 blocks. THIS measurement's population is 633. So 38
+// blocks were never inside the established equivalence, and the residual
+// disagreements number 37 — i.e. essentially all of them sit outside the range
+// where the reference and the grammar are known to coincide, and over the ~595
+// where they do coincide the agreement is definitional modulo the wiring.
+// That is the honest reading of the 100%/100% figures: they are a strong
+// result about the WIRING LAYER, and they are not 633 independent
+// confirmations of the grammar.
+//
 // It is not vacuous either, and the distinction is the code in between.
 // refMatchEnd is a hand-written matcher that shares no line with blocks.go;
 // what it still grades is everything the wiring added on top of the grammar —
@@ -894,9 +905,30 @@ func TestDepthWalker_InheritAttribution_CorpusMeasurement(t *testing.T) {
 			"grammar parses WITHOUT error — those are not recovery artefacts and need explaining",
 			cst.blockEndWrongOK)
 	}
+	// The zero above is only worth something if the classifier splits the
+	// corpus. It has TWO ways to be a no-op and both are checked, because a
+	// guard against one of them reads as a guard against the classifier
+	// (review Q2):
+	//
+	//   - nothing classified as recovered — then `blockEndWrongOK` counts every
+	//     disagreement and the assertion is merely strict;
+	//   - EVERYTHING classified as recovered — then `blockEndWrongOK` can never
+	//     be anything but 0 and the assertion is unreachable. This is the
+	//     dangerous direction, and the one the first version missed.
+	//
+	// The second is pinned through the LEGACY producer rather than through a
+	// file count: the retired walker is known to get block ends wrong on
+	// perfectly valid OCaml, so if not a single one of its 479 errors lands in
+	// a cleanly-parsed file, the classifier has swallowed the whole corpus.
 	if filesWithErrors == 0 {
 		t.Fatalf("no file in the corpus needed recovery, so the assertion above was vacuous — " +
 			"this corpus is supposed to contain testsuite/tests/generated-parse-errors/errors.ml")
+	}
+	if legacy.blockEndWrongOK == 0 {
+		t.Fatalf("not one of the retired walker's %d block-end errors is in a file the grammar "+
+			"parses cleanly — the ERROR classifier is bucketing the whole corpus as recovered, "+
+			"which makes the CST assertion above unreachable rather than true",
+			legacy.blockEndWrong)
 	}
 }
 

--- a/internal/extractors/ocaml/extractor.go
+++ b/internal/extractors/ocaml/extractor.go
@@ -1,4 +1,5 @@
-// Package ocaml implements a regex-based extractor for OCaml source files.
+// Package ocaml implements a mostly regex-based extractor for OCaml source
+// files, with block structure taken from the vendored tree-sitter grammar.
 //
 // Extracted entities:
 //   - Module declarations (`module Foo = struct ... end`, file-level) → SCOPE.Component (subtype="module")
@@ -8,10 +9,16 @@
 //   - Function calls → CALLS edges
 //   - CONTAINS edges (module → top-level declarations)
 //
-// No tree-sitter grammar for OCaml is bundled in smacker/go-tree-sitter, so
-// this extractor uses regular expressions. OCaml uses a layout-insensitive
-// syntax with explicit end/;; markers; for entity-discovery purposes we
-// detect top-level declarations by their starting at column 0.
+// Entity DISCOVERY is regex-based: OCaml uses a layout-insensitive syntax with
+// explicit end/;; markers, and for discovery purposes top-level declarations
+// are detected by their starting at column 0.
+//
+// Block STRUCTURE is not. `struct … end`, `sig … end`, `object … end` and
+// `begin … end` spans come from the vendored tree-sitter grammar (registered
+// at internal/treesitter/adapters.go:69) via blocks.go — see #6812 for the
+// measurement that motivated replacing the hand-rolled depth walker, and note
+// that the old package comment's premise ("no tree-sitter grammar for OCaml is
+// bundled") had been false since the grammar was vendored.
 //
 // Registers itself via init() and is imported by registry_gen.go.
 package ocaml
@@ -404,79 +411,27 @@ func extractLetBody(src string, afterPos int) string {
 	return strings.Join(body, "\n")
 }
 
-// extractModuleBody extracts the text of a module body between struct/sig and end.
-// Falls back to indentation heuristics if struct/sig not found.
+// extractModuleBody extracts the text of a module body between struct/sig and
+// end.
+//
+// #6812: this used to be a hand-rolled depth walker — two regexes re-run at
+// every byte of the remaining file, counting `end` against
+// `struct|sig|object|begin`. Measured against github.com/ocaml/ocaml it put
+// the wrong end on 479 of 633 `object … end` blocks (75.7%) and mis-attributed
+// 230 of the 408 (block, inherit) pairs it produced. It is now answered from
+// the vendored tree-sitter grammar; see blocks.go for the four causes, the
+// parity contract with the measurement harness's reference, and what happens
+// on input the grammar cannot parse.
+//
+// The signature is unchanged on purpose: the #6812 harness drives THIS
+// function, so the before/after figures are taken through the same entry point
+// with the same arguments.
 func extractModuleBody(src string, afterPos int) string {
 	if afterPos >= len(src) {
 		return ""
 	}
-	rest := src[afterPos:]
-
-	// Try to find the matching "end" keyword for struct/sig/object blocks.
-	// We do a simple depth-counting approach.
-	depth := 0
-	found := false
-	endPos := 0
-
-	// Keywords that open a new nesting level:
-	openKW := regexp.MustCompile(`\b(struct|sig|object|begin)\b`)
-	closeKW := regexp.MustCompile(`\bend\b`)
-
-	// Scan character by character to handle nesting, skipping strings/comments.
-	i := 0
-	for i < len(rest) {
-		// Check for block comment (* ... *)
-		if i+1 < len(rest) && rest[i] == '(' && rest[i+1] == '*' {
-			i += 2
-			for i < len(rest) {
-				if i+1 < len(rest) && rest[i] == '*' && rest[i+1] == ')' {
-					i += 2
-					break
-				}
-				i++
-			}
-			continue
-		}
-		// Check for string literal "..."
-		if rest[i] == '"' {
-			i++
-			for i < len(rest) && rest[i] != '"' {
-				if rest[i] == '\\' {
-					i++
-				}
-				i++
-			}
-			i++
-			continue
-		}
-		// Check for char literal '.'
-		if rest[i] == '\'' && i+2 < len(rest) && rest[i+2] == '\'' {
-			i += 3
-			continue
-		}
-
-		// Check for open/close keywords at current position.
-		remaining := rest[i:]
-		if om := openKW.FindStringIndex(remaining); om != nil && om[0] == 0 {
-			depth++
-			i += om[1]
-			continue
-		}
-		if cm := closeKW.FindStringIndex(remaining); cm != nil && cm[0] == 0 {
-			if depth == 0 {
-				endPos = i
-				found = true
-				break
-			}
-			depth--
-			i += cm[1]
-			continue
-		}
-		i++
-	}
-
-	if found {
-		return rest[:endPos]
+	if end, ok := blockIndexFor(src).bodyEnd(afterPos); ok {
+		return src[afterPos:end]
 	}
 	// Fallback: use indentation heuristics (same as extractLetBody).
 	return extractLetBody(src, afterPos)


### PR DESCRIPTION
Arm 2 of #6812 — the migration itself, now that arm 1 (`2de485618`, #6938) has measured what it replaces. Per the owner's decision on the issue: wire the grammar, add **no more regex** to `internal/extractors/ocaml`.

`extractModuleBody`'s hand-rolled depth walker is deleted from production and block spans come from `tsocaml.Language()` — the grammar registered at `internal/treesitter/adapters.go:69`, imported at `:22`, compiled in, and until now never asked for.

## Before / after, measured in one run

`github.com/ocaml/ocaml@70165ff23e` — 2420 files, the 68 containing a real `inherit` token, 633 reference-matched `object … end` blocks. Both producers scored over the same files, the same blocks and the same reference:

| | retired regex depth walker | CST-backed `extractModuleBody` |
|---|---|---|
| block end wrong | **479/633 (75.7%)** | **37/633 (5.8%)** |
| …of those, in files the grammar parses cleanly | 336 | **0** |
| `inherit` recall | 197/216 (91.2%), 19 missed | **216/216 (100%), 0 missed** |
| `inherit` precision | 197/408 (48.3%), 211 spurious | **216/216 (100%), 0 spurious** |
| attributions wrong | **230 of 408** | **0 of 216** |

> **Read the 100%/100% with this caveat, not without it** (it is the first thing anyone quoting this table needs, so it sits on the table rather than three paragraphs below): the reference matcher is **no longer an independent oracle for the grammar**, and the arithmetic bounds exactly how far that goes. Arm 1 established `refMatchEnd` ≡ the vendored grammar over **595** blocks (595/595). This measurement's population is **633**. So **38 blocks were never inside the established equivalence — and the residual disagreements number 37.** Essentially every disagreement sits outside the range where the two are known to coincide; over the ~595 where they do coincide, agreement is *definitional modulo the wiring*. What these figures genuinely grade is therefore the **wiring layer** — opener node types, same-parent `end` pairing, MISSING rejection, the binary search, the memo — which is where this arm could have been wrong, and none of which is in the grammar. They are a strong result about that layer; they are **not** 633 independent confirmations of the grammar. (Also in the corpus test's own doc comment, so it does not live only here.)

The legacy column reproduces arm 1 byte-for-byte on the same clone, which is the evidence that the harness was not quietly re-specified to make the new number look good.

**Every one of the 37 residual disagreements is in `testsuite/tests/generated-parse-errors/errors.ml`** — the corpus's one deliberately-malformed generated file. That is asserted rather than observed: the corpus test classifies each file by whether the *grammar* reports an ERROR node (never by filename) and requires **exactly zero** disagreements outside them, plus a vacuity guard that fails if no file in the corpus needed recovery. A threshold was rejected — it would let a real regression on valid source hide under a budget the malformed file already fills.

## Why the grammar was registered and never used

The issue asked for this before any of it was written, and *"nobody got round to it"* is a hypothesis. Checked: nothing was in the way. No adapter mismatch, no version pin blocking it, no build-tag path — `internal/treesitter/ts/grammars/ocaml`'s ABI smoke test has been parsing OCaml on every CI run the whole time, and `migratedLanguages` has routed `.ml` through it for the dispatcher's own parse. The extractor simply predates the grammar's arrival and nothing forced the two together. Its package comment still asserted *"No tree-sitter grammar for OCaml is bundled in smacker/go-tree-sitter"* — a premise that had been false since the grammar landed, and which is corrected in this diff.

## What the CST buys, defect by defect

Arm 1 named four independent causes. Three are free here because the grammar tokenises:

- **slice-relative `\b`** — `openKW`/`closeKW` were re-run on `rest[i:]` and tested for `om[0] == 0`, and at offset 0 of a slice start-of-string satisfies `\b`; `append`, `send`, `backend`, `legend`, `myobject` all read as closing keywords. Now `append` is a `method_name`.
- **non-nesting comment skipping** — `(* (* q *) end *)` is one `comment` node.
- **`{|…|}` quoted strings** — a `quoted_string` node with a `quoted_string_content` child.

The fourth, *the scan never terminating on a balanced block*, does not arise at all: a block's extent is a node span, not a counter's output.

## Scope — what was deliberately not done

- **No `EXTENDS`/`IMPLEMENTS`.** That is #6370's OCaml arm, which this unblocks. Hierarchy stays ungraded in the fixture, exactly as arm 1 left it.
- **#6939's four gaps are not fixed.** One falls out for free and is named rather than hunted: *every module in a file reporting the same end line* is now correct, because module `EndLine` derives from this span. The other three are untouched — functors are still invisible (`moduleRE` needs `=`/`:` immediately after the name), there is still no class vocabulary, and module `CONTAINS` is still dead (`letRE` is column-0-anchored, so an indented `let` inside a correct body still matches nothing).
- **Nothing else moved.** The wiring forced no rewrite: `extractLetBody`, `collectCalls`, `stripStringsAndComments`, the import/module/type/let discovery regexes and `depth.go` are untouched. `extractModuleBody` keeps its exact signature so the harness drives the new code through the same entry point with the same arguments.

## The parity choice, stated because it is a choice

`blockIndex` answers the same question the walker answered, including its unbounded one: *the first block opener at or after `from`*. It does not bound how far ahead that opener may be, so `module Foo = Bar` — an alias with no block of its own — still adopts the next block in the file. That mis-span is pre-existing, it is one of #6939's four, and bounding it here would have made the before/after figures incomparable. Named in `blocks.go` rather than left to be rediscovered.

## ERROR nodes — the decision, and it is graded

tree-sitter does not refuse malformed OCaml; it recovers, with ERROR subtrees and zero-width MISSING tokens. So the grammar *will* hand back an answer for an unclosed block and the question is what to do with it.

**Decision:** an opener whose `end` is absent or zero-width is reported as unclosed, and `extractModuleBody` hands back to the indentation heuristic — the same fallback the old code already used, and in fact the one it used for the *majority* of real blocks, since the non-terminating scan meant it almost never found a closer. It does **not** adopt a later block's `end` (a fabricated span) and it does **not** silently return nothing, which the brief explicitly rejected.

Graded by `TestBlockIndex_MalformedInput_FallsBack` (unclosed opener → declines, falls back, body stops at the next column-0 `let` and does not swallow the next block's `inherit`) and `TestBlockIndex_UnparseableInput_FallsBack` (an index with `parsed=false` declines; positive control that the *same* index answers once `parsed` is set, so the refusal is the guard firing and not the lookup missing).

Worth recording, because it shaped the design: **`hasError` is not a usable proxy for "this block is unclosed"**. Four candidate malformed inputs were tried before one produced an ERROR node — `let a = object end while ;;`, an unclosed `object`, an unclosed `struct`, and one of `errors.ml`'s own lines were all parsed *cleanly* into plausible trees with MISSING tokens. That is why the index declines on a zero-width `end` rather than trusting a file-level flag. `hasError` exists only so the corpus measurement can separate "this file is malformed" from "this span is wrong"; it is graded in both directions by `TestBlockIndex_HasErrorTracksRecovery`, since a `hasError` stuck true would make the corpus's zero-disagreement assertion vacuous.

## What happened to the harness, and to its reference matcher

This is the part the brief asked to be decided deliberately rather than allowed to become a tautology.

**The retired walker is preserved verbatim** as test-only `legacyDepthWalkerBody`. Without it every figure in #6812 becomes a claim in a PR body that nothing in the repo can reproduce. With it, the enumeration and the corpus measurement grade **two producers against one reference in a single run**, so "the CST implementation is better" is a measurement taken here, not a before/after taken across two checkouts.

**The reference matcher stays, and its role changed — say so, do not let an agreement read as a confirmation.** Arm 1's reviewer cross-checked `refMatchEnd` against this repo's own vendored grammar over these same files: 595 compared, 595 agree. So "the CST-backed producer agrees with `refMatchEnd`" is *not* the independent confirmation it was when the producer was a regex walker, and the corpus test now says that in full, in the test's own doc comment.

**The arithmetic that bounds it**, added at the reviewer's suggestion because it is more defensible than either "the reference is independent" or "the reference is no longer independent": arm 1's equivalence covered 595 blocks, arm 2's population is 633, so 38 blocks were never inside it — and there are 37 residual disagreements. That says exactly *where* the independence ran out.

It is not vacuous either, and the distinction is the code in between. `refMatchEnd` is hand-written and shares no line with `blocks.go`. What it still grades is everything the wiring added *on top of* the grammar: which node types count as openers, pairing an opener with the `end` of the **same parent node**, rejecting zero-width MISSING closers, the binary search for "first opener at or after `from`", and the per-source memo handing back the right file's index. Every one of those is a place this arm could have been wrong and none of them is in the grammar. What the reference can no longer do is *arbitrate* a disagreement — if the two differ, this test says so but cannot say which is right.

## The always-on enumeration: re-derived, not deleted

`TestDepthWalker_ObjectBlockEnd_EnumeratedSpace` now runs both producers over the same 32 inputs:

- **legacy: unchanged at the recorded 18/32.** Arm 1's finding is still reproducible in-repo.
- **CST: 0/32**, recorded as its own named empty literal `cstDivergingCombinations6812`, with the per-axis account of why each of the four axes (indented `end`, `append`, nested comment, quoted string) is one of the four measured defects and why each disappears.

An empty set looks weak, so: `endsAgree` fails on *any* disagreement in either direction, so a producer that truncates, over-reaches, returns `""` or silently falls back to the indentation heuristic all land in that set and fail. The direction that would be invisible — agreeing for the wrong reason — is what running the legacy walker alongside answers, and **a guard fails if the two sets ever coincide** (the wiring reverted, or the table pointed at one producer twice). The axis-E inertness and E-symmetry checks are asserted against the **legacy** set, where they are non-vacuous; over an empty set they would be two guards passing by having nothing to look at.

The 0/32 inherit-mis-attribution guard is kept and now applies to **both** producers — a CST-backed span starting *before* the `inherit` would break the generator's premise just as surely as one stopping short.

`TestDepthWalker_InheritIsMisAttributed_Constructed` keeps its input and now asserts a **pair**: the retired walker still mis-attributes on those bytes (1/4), the CST-backed producer does not (0/4). Asserting only the second would be an absence over a population a broken generator could empty.

## Verification

- `go test -count=1 ./internal/extractors/ocaml/ ./internal/quality/... ./cmd/grafel/` — all green. **`./cmd/grafel/` included and passing**: `custom_extractor_spans_6118_test.go` digest-pins the whole graph, nothing in the diff points at it, and the digest did **not** move, so no constant was bumped and there is no delta to enumerate.
- `scripts/quality/run.sh --ratchet` — `quality ratchet OK — 34 gated fixtures held their baseline (25 at 100% must-have recall)`.
- **Shrink enumerated by hand, since #6898 lets one pass silently.** Compared per-fixture `entity_found` / `relationship_found` / `entity_extracted_total` / `relationship_extracted_total` against `baseline.json` for all 34: five deltas, all three known python drifts (`python-django-mini` rel-total 255→251; `python-fastapi-mini` 28→27 / 57→54; `python-rq-mini` 22→20 / 43→39). **Proved pre-existing** by building `origin/main@2e68fb052` into a separate binary and re-running the ratchet against it with `GRAFEL_BIN`: identical five deltas, and **branch vs pre-change binary is 0 deltas across all 34 fixtures on all six counters**. Restore, do not record.
- **Corpus-size guards re-derived from disk, not from the diff**: `ls internal/quality/golden/` is 34 directories; the three guards (`absent_relationships_6490_test.go:232`, `subtype_assertion_6488_test.go:291`, `zero_relationships_6490_test.go:181`) all say 34. This diff adds no fixture, so none moves.
- `ocaml-objects-mini`: 19/19 entities, 6/6 relationships, 0 forbidden hits, **zero expectation changes** — no row was rewritten, so nothing here asserts the one-week-old fixture was wrong. Its `entity_extracted_total` (28) and `relationship_extracted_total` (68) are byte-identical to origin/main.

### Review follow-ups (Q1, Q2), applied

- **Q1 — `blockOpeners` was pinned only in the deletion direction.** M2/M3 delete `begin`/`sig` and die; adding an entry was ALIVE, and it is the more dangerous mistake: a phantom opener sitting *before* the real one wins the "first opener at or after `from`" search, has no `end`, makes `bodyEnd` decline, and the block silently falls back — visible only as recall loss, the direction recall-shaped assertions are blind to (#6902). Same shape as the axis lesson from #6943. Fixed with two paired assertions rather than one: `TestBlockIndex_NonBlockKeywordsAreNotOpeners` is **enumerated, not hand-picked at `then`** — the fixture carries `if/then/else`, `match/with`, `try/with`, `fun`, `for/do/done`, `while/do/done` and `let/in` around an `object … end` holding an `inherit`, and asserts the opener count is exactly 1, that `bodyEnd` still answers (the half that catches a phantom preceding the real opener), and that the span still contains its own `inherit`. `TestBlockOpeners_ExactSet` is the residue for a keyword the fixture does not happen to contain.
- **Q2 — the vacuity guard on the corpus assertion was one-sided.** `blockEndWrongOK != 0` was guarded against *nothing* being classified as recovered, but not against *everything* being so classified — in which case the zero is unreachable and the assertion passes by never being able to fail. The five-ways-to-be-a-no-op shape. Now also requires `legacy.blockEndWrongOK > 0`, pinned through the **legacy producer** rather than a file count: the retired walker is known to get block ends wrong on valid OCaml, so if not one of its 479 errors lands in a cleanly-parsed file, the classifier has swallowed the corpus. **Proved reachable, not asserted:** a mutant forcing `recovered := true` for every file fails the corpus test on this new guard specifically.

### Mutants — 9 scored, 9 DEAD

Each applied to a hash-verified pristine tree, occurrence count asserted **exactly 1** before and 0 after, an **independent** site-verification script (grepping all eight mutation sites from disk) confirming the mutant landed, and the unmutated suite proven **green immediately before every verdict**.

| | mutant | verdict | killed by |
|---|---|---|---|
| M1 | accept a zero-width MISSING `end` as a real closer | DEAD | `TestBlockIndex_MalformedInput_FallsBack` |
| M2 | drop `begin` from `blockOpeners` | DEAD | `TestBlockIndex_AllFourOpeners` |
| M3 | drop `sig` from `blockOpeners` | DEAD | `TestBlockIndex_AllFourOpeners` |
| M4 | do not recurse into children | DEAD | 5 tests, incl. `…NestedBlocksPairWithTheirOwnEnd` |
| M5 | answer from an index whose parse failed | DEAD | `TestBlockIndex_UnparseableInput_FallsBack` |
| M6 | always take the file's FIRST opener | DEAD | `…NestedBlocksPairWithTheirOwnEnd`, `…InheritIsMisAttributed_Constructed` |
| M7 | accept an `end` that precedes `from` | DEAD | `TestBlockIndex_EndBeforeFromIsRefused` |
| M8 | memo ignores its key | DEAD | `TestBlockIndex_AllFourOpeners` |
| M9 | no fallback when the CST declines | DEAD | `TestBlockIndex_MalformedInput_FallsBack` |

Three of these are worth calling out:

- **M2 and M3 are why `TestBlockIndex_AllFourOpeners` exists.** The enumeration generates `object` and nothing else, so deleting `begin`, `sig` or `struct` left the whole package green — three quarters of the table ungraded, and `sig` is the entry production reaches most often via `module type T = sig … end`. The new test pins the exact body text per opener, not a length, so a span off by the width of the opener keyword (the class of defect that lived undetected in the harness's own reference as `i += 6`) fails rather than passing a byte count.
- **M7 was ALIVE and was killed rather than argued equivalent.** `e < from` and `e < 0` are equivalent through `buildBlockIndex` — the binary search returns an opener at or after `from`, and a real `end` is strictly after its opener — but "unreachable through today's constructor" is an argument, not a fence: `bodyEnd` is a method and the guard is what stops `src[afterPos:end]` being a negative-length slice. Cost of the kill, since *"too expensive"* deserves a number: **nine lines and no production change**.
- **The first two mutant runs are void and are reported as such.** The scoring harness silently left a mutant applied, so a subsequent "DEAD" was scored against an already-red tree and meant nothing. Caught by adding a per-mutant positive control (unmutated suite must be green *immediately before* each verdict) and an independent on-disk site check that must **notice** every mutant and must confirm every restore. The table above is from the rebuilt harness; the tree was re-verified pristine on all eight sites and green before committing.

Closes #6812
Refs #6370
Refs #6939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
