### PR TITLE
fix(#6927): GitHub Actions `^` anchors were start-of-TEXT — three of six rules could never fire, and three more were plain YAML the anchor was gating by accident

### DIFF
--- a/internal/engine/github_actions_multiline_anchor_6927_test.go
+++ b/internal/engine/github_actions_multiline_anchor_6927_test.go
@@ -1,0 +1,429 @@
+package engine
+
+import (
+	"context"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+)
+
+// #6927 — the cicd arm. The same defect #6917 fixed for sinatra and #6943 for
+// python, in rules/cicd/frameworks/github_actions.yaml. detector.go compiles
+// rule patterns with plain regexp.Compile at :156 and :177, so `^` means START
+// OF TEXT. Six patterns were affected:
+//
+//	^name:\s+["']?([^"'\n]+)                       -> Service
+//	^\s{2}(\w[\w-]*):\s*\n\s+(?:runs-on|uses):     -> Operation
+//	^\s+-\s+name:\s+["']?([^"'\n]+)                -> Task
+//	^on:\s*\n\s+(\w+):                             -> Config
+//	^on:\s+(\w+)                                   -> Config
+//	^env:\s*\n\s+(\w+):                            -> Config
+//
+// Three of them could never fire AT ALL — `\s{2}`, `\s+-` and a preceding
+// `env:` block all require something before the match, and start-of-text
+// forbids it. The other three fired only on a file whose very first byte was
+// `name:` or `on:`.
+//
+// Two things are graded here that the golden fixture
+// (internal/quality/golden/github-actions-workflows-mini) structurally cannot
+// see, and that is why this file exists alongside it:
+//
+//  1. The Task rule's blast radius. ansible_core.yaml carries an UN-anchored
+//     `-\s+name:` -> Task rule in the same `yaml` bucket, so every Task the
+//     GitHub Actions rule could over-emit is already in the graph from the
+//     other rule file. At graph level the gate is invisible; against a
+//     detector holding ONLY this rule set it is not.
+//  2. Which RULE produced an entity. The fixture asserts what the graph
+//     contains; these tests assert what this one rule file contributes.
+//
+// Graded in BOTH directions (#6902), because a recall assertion is
+// structurally blind to over-firing.
+
+// ghaOnlyRules returns the loaded rule map reduced to the GitHub Actions rule
+// set alone. The rules are the REAL embedded YAML — the defect IS the shipped
+// pattern text, so a hand-written copy would leave the shipped one unobserved
+// — but every other yaml rule set is dropped, so nothing another rule file
+// mints can be mistaken for evidence about this one.
+func ghaOnlyRules(t *testing.T) map[string][]FrameworkRule {
+	t.Helper()
+	all, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	out := map[string][]FrameworkRule{}
+	for lang, frs := range all {
+		for _, fr := range frs {
+			if fr.Frameworks.Name == "GitHub Actions" {
+				out[lang] = append(out[lang], fr)
+			}
+		}
+	}
+	// The loader keys rule sets by their BUCKET directory (`cicd`); it is
+	// compile() that aliases the bucket onto the `yaml` language via
+	// dormantBucketAliases, which is why these tests hand Detect a
+	// Language of "yaml" while the map key stays "cicd". If that stops being
+	// true the tests are measuring nothing, so it is asserted rather than
+	// assumed.
+	if len(out["cicd"]) != 1 {
+		t.Fatalf("expected exactly one GitHub Actions rule set in the cicd bucket, got %d",
+			len(out["cicd"]))
+	}
+	return out
+}
+
+func detect6927GHA(t *testing.T, path, src string) *DetectResult {
+	t.Helper()
+	det := New(ghaOnlyRules(t))
+	res, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "yaml",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	return res
+}
+
+func has6927GHA(res *DetectResult, kind, name string) bool {
+	for _, e := range res.Entities {
+		if e.Kind == kind && e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func names6927GHA(res *DetectResult, kind string) []string {
+	var out []string
+	for _, e := range res.Entities {
+		if e.Kind == kind {
+			out = append(out, e.Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// gha6927Workflow is the fixture's build.yml, held here as a const so the
+// engine-level assertions and the golden fixture describe the SAME source. It
+// opens with a comment header — the shape every real workflow has, and the
+// reason start-of-text found a `name:` in only 99 of the 269 workflow files in
+// the measured corpus.
+const gha6927Workflow = `# Storefront build pipeline.
+#
+# Deliberately NOT under .github/.
+name: Storefront CI
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+env:
+  REGISTRY: ghcr.io
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build and test
+    env:
+      BUNDLE_PATH: vendor/bundle
+    strategy:
+      matrix:
+        runs-on: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile assets
+        run: make assets
+      # - name: Deploy to staging
+      #   run: make deploy
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Upload bundle
+        run: make upload
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/upload-artifact@v4
+      - name: Push image
+        run: docker push "$REGISTRY/storefront"
+  notification:
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post build result
+        run: ./ci/notify.sh
+`
+
+// gha6927ReusableCaller exercises the `uses:` half of the job rule's
+// alternation: a reusable-workflow call has no `runs-on:` anywhere in the job.
+const gha6927ReusableCaller = `# Nightly smoke run.
+name: Nightly Smoke
+on: workflow_dispatch
+jobs:
+  smoke:
+    uses: ./.github/workflows/build.yml
+env:
+  SMOKE_REGION: eu-west-1
+`
+
+// TestIssue6927_GitHubActions_WorkflowYieldsJobsTriggersAndEnv is the recall
+// direction. Vertical position is the axis it varies: nothing sits on line 1,
+// the second job is far down the file, and the reusable caller's `env:` block
+// is the last construct in its file.
+func TestIssue6927_GitHubActions_WorkflowYieldsJobsTriggersAndEnv(t *testing.T) {
+	res := detect6927GHA(t, "ci/workflows/build.yml", gha6927Workflow)
+
+	for _, want := range []struct{ kind, name string }{
+		{"Service", "Storefront CI"},
+		{"Operation", "build"},
+		{"Operation", "publish"},
+		{"Config", "pull_request"},
+		{"Config", "REGISTRY"},
+		{"Task", "Compile assets"},
+		{"Task", "Upload bundle"},
+		{"Task", "Push image"},
+		{"Task", "Post build result"},
+	} {
+		if !has6927GHA(res, want.kind, want.name) {
+			t.Errorf("%s %q not extracted from a realistic workflow; Services=%v Operations=%v "+
+				"Configs=%v Tasks=%v", want.kind, want.name,
+				names6927GHA(res, "Service"), names6927GHA(res, "Operation"),
+				names6927GHA(res, "Config"), names6927GHA(res, "Task"))
+		}
+	}
+
+	res2 := detect6927GHA(t, "ci/workflows/nightly.yml", gha6927ReusableCaller)
+	for _, want := range []struct{ kind, name string }{
+		{"Service", "Nightly Smoke"},
+		// The `uses:` half of `(?:runs-on|uses)`. Without this the alternation
+		// is graded on one branch only.
+		{"Operation", "smoke"},
+		// `on: <event>` on one line, which the block-form rule cannot reach.
+		{"Config", "workflow_dispatch"},
+		// Last construct in the file — the far end of the vertical axis.
+		{"Config", "SMOKE_REGION"},
+	} {
+		if !has6927GHA(res2, want.kind, want.name) {
+			t.Errorf("%s %q not extracted from a reusable-workflow caller; Services=%v "+
+				"Operations=%v Configs=%v", want.kind, want.name,
+				names6927GHA(res2, "Service"), names6927GHA(res2, "Operation"),
+				names6927GHA(res2, "Config"))
+		}
+	}
+}
+
+// TestIssue6927_GitHubActions_AnchorsHoldInsideAWorkflow is the forbidden
+// direction on the ANCHOR axis, inside a file that SATISFIES the framework
+// gate. Every row here is held by `^` alone; none of them is held by
+// requires_framework, which is what keeps the two fences distinguishable.
+func TestIssue6927_GitHubActions_AnchorsHoldInsideAWorkflow(t *testing.T) {
+	res := detect6927GHA(t, "ci/workflows/build.yml", gha6927Workflow)
+
+	for _, bad := range []struct{ kind, name, why string }{
+		{"Service", "Compile assets",
+			"`^name:` is column-0 only; a step's indented `name:` is a Task, not the workflow"},
+		{"Service", "Push image", "same, for a step in the second job"},
+		{"Service", "Build and test",
+			"a JOB's indented `name:` — the display-name key every workflow may carry. This is " +
+				"the row that kills `^name:` -> `^\\s*name:`: a step's `- name:` opens with a " +
+				"dash, so `\\s*` alone cannot reach it and the mutant survived every other row"},
+		{"Config", "BUNDLE_PATH",
+			"`^env:` distinguishes the WORKFLOW-level env block from the job-level one this key sits in"},
+		{"Operation", "matrix",
+			"`\\s{2}` is exactly two; `strategy.matrix` is deeper and is not a job"},
+		{"Operation", "strategy", "same, one level up"},
+		{"Config", "needs",
+			"`notification:` is a legal job name ENDING in `on:`; without `^` both on: rules read the next key"},
+		{"Config", "20",
+			"`node-version: 20` contains the substring `on: 20`; without `^` the single-event rule mints it"},
+		{"Task", "Deploy to staging",
+			"a commented-out step. `^\\s+-` requires the dash to open the line's content"},
+	} {
+		if has6927GHA(res, bad.kind, bad.name) {
+			t.Errorf("over-fire: %s %q was extracted from a workflow — %s", bad.kind, bad.name, bad.why)
+		}
+	}
+}
+
+// gha6927HelmChart, gha6927AnsiblePlay and gha6927TravisConfig are plain YAML.
+// None names GitHub Actions anywhere, and each carries one of the three shapes
+// the widened patterns would otherwise claim.
+const gha6927HelmChart = `apiVersion: v2
+name: storefront-chart
+description: Storefront deployment chart
+type: application
+version: 0.4.1
+`
+
+const gha6927AnsiblePlay = `- hosts: web
+  become: true
+  tasks:
+    - name: Install nginx
+      apt:
+        name: nginx
+        state: present
+    - name: Restart nginx
+      service:
+        name: nginx
+        state: restarted
+`
+
+const gha6927TravisConfig = `language: ruby
+rvm:
+  - 3.1
+env:
+  MATRIX_KEY: fast
+script:
+  - bundle exec rake
+`
+
+// TestIssue6927_GitHubActions_GateHoldsPlainYAML is the forbidden direction on
+// the FRAMEWORK-GATE axis, and the reason this change is not `(?m)` alone.
+//
+// `^name:`, `^\s+- name:` and `^env:` are plain YAML with nothing about GitHub
+// Actions in them, and Detect resolves rule sets by file.Language while the
+// cicd bucket is aliased onto `yaml`, so under `(?m)` alone every chart,
+// playbook and CI config in a repo would be typed as workflow parts. Measured
+// on 671 real YAML files from 59 upstream repos: 34 `^name:` matches in 34
+// non-workflow files, 194 step matches in 49, 3 env matches in 3 — against
+// ZERO for all three once `requires_framework: true` is on.
+//
+// The Task half of this cannot be graded by the golden fixture at all:
+// ansible_core.yaml's un-anchored `- name:` rule mints those Tasks anyway, so
+// the graph looks identical with the gate on or off. Here it does not.
+func TestIssue6927_GitHubActions_GateHoldsPlainYAML(t *testing.T) {
+	for _, tc := range []struct {
+		path, src string
+		bad       []struct{ kind, name string }
+	}{
+		{"deploy/helm/Chart.yaml", gha6927HelmChart, []struct{ kind, name string }{
+			{"Service", "storefront-chart"},
+		}},
+		{"ops/provision.yml", gha6927AnsiblePlay, []struct{ kind, name string }{
+			{"Task", "Install nginx"},
+			{"Task", "Restart nginx"},
+		}},
+		{"ops/legacy-ci.yml", gha6927TravisConfig, []struct{ kind, name string }{
+			{"Service", "language"},
+			{"Config", "MATRIX_KEY"},
+		}},
+	} {
+		res := detect6927GHA(t, tc.path, tc.src)
+		for _, bad := range tc.bad {
+			if has6927GHA(res, bad.kind, bad.name) {
+				t.Errorf("over-fire: %s %q extracted from %s, which names GitHub Actions "+
+					"nowhere — requires_framework is not holding", bad.kind, bad.name, tc.path)
+			}
+		}
+		if len(res.Entities) != 0 {
+			var got []string
+			for _, e := range res.Entities {
+				got = append(got, e.Kind+":"+e.Name)
+			}
+			sort.Strings(got)
+			t.Errorf("%s: the GitHub Actions rule set extracted %d entities from plain YAML: %v",
+				tc.path, len(res.Entities), got)
+		}
+	}
+}
+
+// ghaSourcePatterns returns the shipped GitHub Actions source_patterns.
+func ghaSourcePatterns(t *testing.T) []SourcePattern {
+	t.Helper()
+	return ghaOnlyRules(t)["cicd"][0].SourcePatterns
+}
+
+// TestIssue6927_GitHubActions_NoDollarInWidenedPatterns pins the reason the fix
+// is per-pattern rather than at the compile site. `(?m)` changes `$` as well as
+// `^`, and this repo ships ungated `$`-bearing patterns elsewhere (#6927 names
+// docker_compose and ansible_core). None of the patterns in THIS file carries a
+// `$`, so the second effect cannot reach them — asserted rather than claimed,
+// because a later edit that adds one would otherwise change the meaning of
+// every `(?m)` here silently.
+func TestIssue6927_GitHubActions_NoDollarInWidenedPatterns(t *testing.T) {
+	multiline := 0
+	for _, sp := range ghaSourcePatterns(t) {
+		if !strings.HasPrefix(sp.Pattern, "(?m)") {
+			continue
+		}
+		multiline++
+		if strings.Contains(sp.Pattern, "$") {
+			t.Errorf("pattern %q is (?m) AND carries a `$` — under (?m) that becomes "+
+				"end-of-LINE, which is a behaviour change nothing here grades", sp.Pattern)
+		}
+	}
+	if multiline != 6 {
+		t.Errorf("found %d (?m) source_patterns in github_actions.yaml, want 6 — the sweep in "+
+			"#6927 counted six `^`-anchored patterns in this file, so a different number means "+
+			"this test's coverage claim needs re-deriving", multiline)
+	}
+}
+
+// TestIssue6927_GitHubActions_GatedPatternsAreLoaded is the #6152-shaped half:
+// requires_framework is inert without import_markers (detector.go logs it and
+// frameworkPresent then returns false for every file), so a gate that looks
+// applied in the YAML can be a no-op. Both halves are asserted.
+func TestIssue6927_GitHubActions_GatedPatternsAreLoaded(t *testing.T) {
+	fr := ghaOnlyRules(t)["cicd"][0]
+	if len(fr.Frameworks.Detection.ImportMarkers) == 0 {
+		t.Fatal("github_actions.yaml declares no frameworks.detection.import_markers, so every " +
+			"requires_framework pattern in it can never fire")
+	}
+	var gated []string
+	for _, sp := range fr.SourcePatterns {
+		if sp.RequiresFramework {
+			gated = append(gated, sp.Pattern)
+		}
+	}
+	sort.Strings(gated)
+	if len(gated) != 3 {
+		t.Errorf("expected 3 requires_framework patterns (the workflow name, the step name and "+
+			"the workflow-level env block — the three that are plain YAML), got %d: %v",
+			len(gated), gated)
+	}
+	// And the markers must actually select a workflow. A marker set that
+	// matches nothing is the same no-op wearing a different hat.
+	det := New(ghaOnlyRules(t))
+	res, err := det.Detect(context.Background(), extractor.FileInput{
+		Path: "ci/workflows/build.yml", Content: []byte(gha6927Workflow), Language: "yaml",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has6927GHA(res, "Service", "Storefront CI") {
+		t.Error("the marker set does not admit a realistic workflow, so the gate is not a gate " +
+			"but an off switch")
+	}
+}
+
+// TestIssue6927_GitHubActions_SingleEventRuleAlsoReadsBlockForm pins a property
+// the old `# on: single event` comment denied: `\s` matches a newline, so
+// `^on:\s+(\w+)` reads the FIRST event of a block-form trigger too. That is why
+// its corpus count (235 matches) is one ABOVE the block-form rule's (234)
+// rather than complementary to it, and it is asserted against the shipped
+// pattern text because at entity level the two rules mint the same Config and
+// the duplicate folds away — leaving the claim unobservable.
+func TestIssue6927_GitHubActions_SingleEventRuleAlsoReadsBlockForm(t *testing.T) {
+	var single string
+	for _, sp := range ghaSourcePatterns(t) {
+		if strings.Contains(sp.Pattern, `^on:\s+(\w+)`) {
+			single = sp.Pattern
+		}
+	}
+	if single == "" {
+		t.Fatal("the single-event on: pattern is no longer in github_actions.yaml")
+	}
+	re := regexp.MustCompile(single)
+	m := re.FindStringSubmatch("name: CI\non:\n  push:\n    branches: [main]\n")
+	if m == nil {
+		t.Fatalf("%q did not match a block-form trigger; the rule's own comment says it does", single)
+	}
+	if m[1] != "push" {
+		t.Errorf("block-form capture = %q, want %q", m[1], "push")
+	}
+}

--- a/internal/engine/github_actions_multiline_anchor_6927_test.go
+++ b/internal/engine/github_actions_multiline_anchor_6927_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -401,29 +402,239 @@ func TestIssue6927_GitHubActions_GatedPatternsAreLoaded(t *testing.T) {
 	}
 }
 
+// TestIssue6927_GitHubActions_EachImportMarkerAdmitsAWorkflowAlone grades the
+// marker set MARKER BY MARKER, in the recall direction.
+//
+// PR #6945 review M2: the only marker mutant originally scored was "replace the
+// set with one that matches nothing", and deleting a SINGLE marker was ALIVE at
+// the engine suite, the fixture gate AND the ratchet ceiling. The fixture's
+// workflows are over-determined — build.yml satisfies three markers at once and
+// nightly.yml satisfies `.github/workflows/` through its `uses:` target — so
+// dropping any one of them changes nothing anywhere, while the input that
+// exercises it is the most ordinary workflow there is: `runs-on:` is the only
+// marker a `run:`-only workflow carries, and under that deletion it loses its
+// Service and every step Task.
+//
+// Each case therefore carries EXACTLY ONE marker, and that premise is asserted
+// rather than eyeballed: a case that quietly grew a second marker would grade
+// the set again instead of the marker, which is the defect this test exists to
+// close.
+func TestIssue6927_GitHubActions_EachImportMarkerAdmitsAWorkflowAlone(t *testing.T) {
+	markers := ghaOnlyRules(t)["cicd"][0].Frameworks.Detection.ImportMarkers
+	if len(markers) != 4 {
+		t.Fatalf("expected 4 import_markers, got %d: %v — this test carries one minimal "+
+			"workflow per marker and a new one would be ungraded", len(markers), markers)
+	}
+
+	cases := []struct {
+		marker string
+		src    string
+		// want is one gated entity the workflow must yield. A gated pattern is
+		// the only thing the marker can affect, so an un-gated one would pass
+		// with the gate wide open.
+		wantKind, wantName string
+	}{
+		{
+			marker: "runs-on:",
+			// The plainest workflow there is: no marketplace action, no
+			// expression, no reusable call. `runs-on:` is its ONLY marker.
+			src: `name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build it
+        run: make
+`,
+			wantKind: "Service", wantName: "CI",
+		},
+		{
+			marker: "uses: actions/",
+			src: `name: Checkout only
+on: push
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v4
+`,
+			wantKind: "Service", wantName: "Checkout only",
+		},
+		{
+			marker: "${{",
+			src: `name: Expression only
+on: push
+jobs:
+  deploy:
+    steps:
+      - name: Print the sha
+        run: echo ${{ github.sha }}
+`,
+			wantKind: "Task", wantName: "Print the sha",
+		},
+		{
+			marker: ".github/workflows/",
+			src: `name: Reusable caller
+on: workflow_dispatch
+jobs:
+  call:
+    uses: ./.github/workflows/build.yml
+`,
+			wantKind: "Service", wantName: "Reusable caller",
+		},
+	}
+
+	if len(cases) != len(markers) {
+		t.Fatalf("%d cases for %d markers", len(cases), len(markers))
+	}
+	for _, tc := range cases {
+		// Premise: exactly one marker, and it is the one this case is for.
+		var present []string
+		for _, m := range markers {
+			if strings.Contains(tc.src, m) {
+				present = append(present, m)
+			}
+		}
+		if len(present) != 1 || present[0] != tc.marker {
+			t.Errorf("case %q carries markers %v, want exactly [%q] — it grades the marker SET, "+
+				"not this marker", tc.marker, present, tc.marker)
+			continue
+		}
+		res := detect6927GHA(t, "ci/workflows/case.yml", tc.src)
+		if !has6927GHA(res, tc.wantKind, tc.wantName) {
+			t.Errorf("marker %q alone did not admit a workflow: %s %q missing. Deleting this one "+
+				"marker silently drops every gated entity from a workflow that carries only it",
+				tc.marker, tc.wantKind, tc.wantName)
+		}
+	}
+}
+
+// TestIssue6927_GitHubActions_JobRuleReadsOnlyRunsOnAndUses grades the
+// `(?:runs-on|uses)` alternation, which is the ENTIRE justification for leaving
+// the job rule ungated: the argument for no requires_framework there is that
+// the regex names GitHub Actions' own job vocabulary itself.
+//
+// PR #6945 review M3: widening it to `(?:runs-on|uses|needs)` was ALIVE at the
+// engine suite AND at the fixture gate, and died only incidentally on the
+// ratchet's generic entity-count ceiling — which fires for any extra entity and
+// would not fire at all for a same-count substitution. An aggregate that
+// somebody will eventually re-baseline must not be the only thing holding a
+// rule's blast radius.
+//
+// Asserted as an EXACT set rather than as "contains build": a membership check
+// is blind to exactly the direction this mutant moves in.
+func TestIssue6927_GitHubActions_JobRuleReadsOnlyRunsOnAndUses(t *testing.T) {
+	got := names6927GHA(detect6927GHA(t, "ci/workflows/build.yml", gha6927Workflow), "Operation")
+	want := []string{"build", "publish"}
+	if !slices.Equal(got, want) {
+		t.Errorf("job rule minted Operations %v, want exactly %v. `notification:` is a job whose "+
+			"first key is `needs:`, so the rule must NOT see it; anything else here means the "+
+			"alternation reads a key that is not `runs-on:` or `uses:`", got, want)
+	}
+
+	got2 := names6927GHA(detect6927GHA(t, "ci/workflows/nightly.yml", gha6927ReusableCaller), "Operation")
+	want2 := []string{"smoke"}
+	if !slices.Equal(got2, want2) {
+		t.Errorf("job rule minted Operations %v in the reusable caller, want exactly %v", got2, want2)
+	}
+}
+
+// gha6927OnRules returns the shipped `on:`-trigger rules, selected by BEHAVIOUR
+// rather than by pattern text.
+//
+// PR #6945 review M4/M5: the previous version of this helper found its rule
+// with strings.Contains(sp.Pattern, `^on:\s+(\w+)`) and t.Fatal'd when that
+// missed. That made its verdict a fact about the pattern's SPELLING. A real
+// anchor weakening (`(?m)^on:` -> `(?m)^\s*on:`) turned the test red with "the
+// pattern is no longer in github_actions.yaml" — it had lost its selector, not
+// observed a behaviour change — and a behaviour-PRESERVING rewrite
+// (`(\w+)` -> `([\w]+)`) produced the identical failure. A test that goes red
+// when you rename something and green-for-the-wrong-reason when you break
+// something is worse than no test, because it reads as coverage.
+//
+// Selecting on what the compiled pattern DOES survives any rewrite that keeps
+// the behaviour and survives none that changes it.
+func gha6927OnRules(t *testing.T) (single, block *regexp.Regexp) {
+	t.Helper()
+	// Deliberately carry NOTHING but the trigger: a `name:` line would be read
+	// by the workflow-name rule and the classification below would pick it up
+	// as an `on:` rule.
+	const singleForm = "on: push\n"
+	const blockForm = "on:\n  push:\n    branches: [main]\n"
+	for _, sp := range ghaSourcePatterns(t) {
+		re, err := regexp.Compile(sp.Pattern)
+		if err != nil {
+			t.Fatalf("shipped pattern does not compile: %q: %v", sp.Pattern, err)
+		}
+		switch {
+		case re.MatchString(singleForm):
+			if single != nil {
+				t.Fatalf("two rules read a single-line `on: push`: %q and %q", single, sp.Pattern)
+			}
+			single = re
+		case re.MatchString(blockForm):
+			if block != nil {
+				t.Fatalf("two rules read ONLY a block-form trigger: %q and %q", block, sp.Pattern)
+			}
+			block = re
+		}
+	}
+	if single == nil || block == nil {
+		t.Fatalf("github_actions.yaml no longer carries two `on:` rules (single=%v block=%v)",
+			single, block)
+	}
+	return single, block
+}
+
 // TestIssue6927_GitHubActions_SingleEventRuleAlsoReadsBlockForm pins a property
 // the old `# on: single event` comment denied: `\s` matches a newline, so
 // `^on:\s+(\w+)` reads the FIRST event of a block-form trigger too. That is why
 // its corpus count (235 matches) is one ABOVE the block-form rule's (234)
-// rather than complementary to it, and it is asserted against the shipped
-// pattern text because at entity level the two rules mint the same Config and
-// the duplicate folds away — leaving the claim unobservable.
+// rather than complementary to it. It is asserted against the compiled pattern
+// because at entity level the two rules mint the same Config for the same file
+// and the duplicate folds away, leaving the claim unobservable.
 func TestIssue6927_GitHubActions_SingleEventRuleAlsoReadsBlockForm(t *testing.T) {
-	var single string
-	for _, sp := range ghaSourcePatterns(t) {
-		if strings.Contains(sp.Pattern, `^on:\s+(\w+)`) {
-			single = sp.Pattern
-		}
-	}
-	if single == "" {
-		t.Fatal("the single-event on: pattern is no longer in github_actions.yaml")
-	}
-	re := regexp.MustCompile(single)
-	m := re.FindStringSubmatch("name: CI\non:\n  push:\n    branches: [main]\n")
+	single, _ := gha6927OnRules(t)
+	m := single.FindStringSubmatch("on:\n  push:\n    branches: [main]\n")
 	if m == nil {
-		t.Fatalf("%q did not match a block-form trigger; the rule's own comment says it does", single)
+		t.Fatal("the single-event on: rule did not match a block-form trigger; its own comment " +
+			"says it does, and the corpus counts (235 vs 234) rest on it")
 	}
 	if m[1] != "push" {
 		t.Errorf("block-form capture = %q, want %q", m[1], "push")
+	}
+}
+
+// TestIssue6927_GitHubActions_OnRulesAreColumnZeroOnly grades the half of the
+// `on:` anchors that the fixture's forbidden rows do not reach.
+//
+// `Config:needs` and `Config:20` grade removing `^` OUTRIGHT. They say nothing
+// about WEAKENING it: `(?m)^on:` -> `(?m)^\s*on:` keeps the line anchor and
+// still reads an indented `on:` key, and both `on:` rules are ungated — so
+// under that weakening they fire on any indented `on:` in any YAML file in any
+// indexed repo, which is the blast radius the column-0 anchor exists to
+// prevent. PR #6945 review M4 found that ALIVE at the fixture gate.
+func TestIssue6927_GitHubActions_OnRulesAreColumnZeroOnly(t *testing.T) {
+	single, block := gha6927OnRules(t)
+	// An indented `on:` in each of the two trigger shapes. Both are ordinary
+	// YAML that any repo can hold under a key of its own.
+	const indentedSingle = "jobs:\n  build:\n    on: push\n"
+	const indentedBlock = "jobs:\n  build:\n    on:\n      push:\n"
+	for _, tc := range []struct {
+		name string
+		re   *regexp.Regexp
+		src  string
+	}{
+		{"single-event rule, indented single form", single, indentedSingle},
+		{"single-event rule, indented block form", single, indentedBlock},
+		{"block-form rule, indented block form", block, indentedBlock},
+		{"block-form rule, indented single form", block, indentedSingle},
+	} {
+		if m := tc.re.FindStringSubmatch(tc.src); m != nil {
+			t.Errorf("%s: matched an INDENTED `on:` and captured %q. Column 0 is the whole fence "+
+				"on these two rules — they carry no requires_framework — so a weakened anchor "+
+				"reads a nested `on:` key in every YAML file the cicd bucket is offered",
+				tc.name, m[len(m)-1])
+		}
 	}
 }

--- a/internal/engine/rules/cicd/frameworks/github_actions.yaml
+++ b/internal/engine/rules/cicd/frameworks/github_actions.yaml
@@ -5,6 +5,25 @@ frameworks:
   config_file: .github/workflows/*.yml
   adopted_by: GitHub repositories (native integration)
   vera_scope: Service (pipeline as Service, job as Operation)
+  # Presence signals for the requires_framework gate on the three patterns
+  # below whose regex is plain YAML and says nothing about GitHub Actions
+  # (#6927). Literal substrings, matched against whole file content by
+  # compiledRuleSet.frameworkPresent.
+  #
+  # Measured over every .yml/.yaml in a real corpus of 59 upstream repos
+  # (starter-workflows, argocd-example-apps, prometheus-helm, awesome-compose,
+  # kafka, django, rails, ...): 671 files, of which 269 sit where GitHub keeps
+  # workflows and composite actions and 402 do not. This marker set selects 265
+  # of the 269 and ZERO of the 402. The 4 it declines are not workflows at all
+  # — dependabot.yml, labeler.yml, auto_assign.yml and .pre-commit-config.yaml,
+  # which merely live in .github/ — so no workflow in the corpus is declined
+  # and no non-workflow is admitted.
+  detection:
+    import_markers:
+      - "runs-on:"
+      - "uses: actions/"
+      - "${{"
+      - ".github/workflows/"
   characteristics:
     - Event-driven (push, pull_request, schedule, workflow_dispatch)
     - Multi-job parallelism by default
@@ -34,13 +53,41 @@ file_conventions:
     name_from: filename
 
 source_patterns:
-  # Workflow name
-  - pattern: "^name:\\s+[\"']?([^\"'\\n]+)"
+  # Workflow name.
+  #
+  # `(?m)` (#6927): compiled with plain regexp.Compile at detector.go:156, so
+  # `^` meant start of TEXT. Every real workflow opens with a comment header or
+  # `name:` is preceded by one, so this fired only on the minority whose very
+  # first byte is `name:` — 99 of 269 workflow files in the corpus. Carries no
+  # `$`, so `(?m)`'s other effect cannot reach it.
+  #
+  # `requires_framework` (#6927): `^name:` is a plain column-0 YAML key with
+  # nothing about GitHub Actions in it, and the cicd bucket is aliased onto the
+  # `yaml` language (detector.go dormantBucketAliases), so ungated it types
+  # every helm Chart.yaml, pubspec.yaml and compose.yaml in the repo as a
+  # Service. Measured: 34 matches in 34 non-workflow files ungated, ZERO under
+  # the marker gate, and the gate costs nothing on the workflow side — 264
+  # matches in 264 files either way. Same shape and same remedy as #6152's
+  # falcon/cherrypy gate.
+  - pattern: "(?m)^name:\\s+[\"']?([^\"'\\n]+)"
     entity_type: Service
     name_group: 1
     scope: file
-  # Job definition
-  - pattern: "^\\s{2}(\\w[\\w-]*):\\s*\\n\\s+(?:runs-on|uses):"
+    requires_framework: true
+  # Job definition.
+  #
+  # `(?m)` (#6927). Under start-of-text this could NEVER fire: it requires two
+  # leading spaces, and a file whose first two bytes are spaces is not a
+  # workflow. Measured on the corpus: 0 matches before, 152 in 131 files after.
+  #
+  # NOT gated, and that is measured rather than assumed: the regex names
+  # `runs-on:`/`uses:` on the very next line, which is GitHub Actions' own job
+  # vocabulary, and across 402 non-workflow YAML files in the corpus the
+  # widened pattern matched ZERO times. `\s{2}` — exactly two — is what keeps
+  # it off deeper keys such as a `strategy.matrix` whose axis is named
+  # `runs-on`; widening it to `\s+` mints an Operation called `matrix`, which
+  # is a forbidden row in github-actions-workflows-mini.
+  - pattern: "(?m)^\\s{2}(\\w[\\w-]*):\\s*\\n\\s+(?:runs-on|uses):"
     entity_type: Operation
     name_group: 1
     scope: file
@@ -49,26 +96,82 @@ source_patterns:
     entity_type: Dependency
     name_group: 1
     scope: file
-  # Step with name:
-  - pattern: "^\\s+-\\s+name:\\s+[\"']?([^\"'\\n]+)"
+  # Step with name:.
+  #
+  # `(?m)` (#6927): 0 matches before, 1332 in 281 files after.
+  #
+  # `requires_framework` (#6927): `- name:` is a plain YAML list item and this
+  # rule set sees EVERY yaml file, so ungated the widened pattern types every
+  # ansible task, helm template and k8s container as a GitHub Actions step —
+  # 194 matches in 49 non-workflow files, against 1138 in 232 workflow files
+  # that the gate keeps whole.
+  #
+  # Recorded because it is invisible in the graph: those 194 Task entities are
+  # minted TODAY anyway, by ansible_core.yaml's un-anchored `- name:` -> Task
+  # rule, which carries no anchor at all, sits in the same `yaml` bucket and
+  # subsumes this pattern outright. So the gate here removes no
+  # entity the graph currently has, and a golden fixture cannot observe it. It
+  # is graded at the engine level instead, against a detector holding only this
+  # rule set (TestIssue6927_GitHubActions_GateHoldsPlainYAML). The gate is
+  # still the right call: it stops this file from depending on another rule
+  # file's accident for its own blast radius, and #6927's ansible arm is going
+  # to narrow that pattern.
+  - pattern: "(?m)^\\s+-\\s+name:\\s+[\"']?([^\"'\\n]+)"
     entity_type: Task
     name_group: 1
     scope: file
-  # on: trigger events
-  - pattern: "^on:\\s*\\n\\s+(\\w+):"
+    requires_framework: true
+  # on: trigger events (block form).
+  #
+  # `(?m)` (#6927): 1 match in 671 files before, 234 in 234 after.
+  #
+  # NOT gated: `on:` at column 0 is GitHub Actions' trigger key and nothing
+  # else writes it — ZERO matches across the corpus's 402 non-workflow YAML
+  # files. The column-0 anchor is doing real work and is graded by a forbidden
+  # row: `notification:` is a legal job name that ENDS in `on:`, so without the
+  # anchor this rule reads the job's next key and mints a Config called
+  # `needs`.
+  - pattern: "(?m)^on:\\s*\\n\\s+(\\w+):"
     entity_type: Config
     name_group: 1
     scope: file
-  # on: single event
-  - pattern: "^on:\\s+(\\w+)"
+  # on: single event.
+  #
+  # `(?m)` (#6927): 1 match in 671 files before, 235 in 235 after.
+  #
+  # It does not only match the single-event form. `\s` matches a newline, so
+  # `on:\n  push:` satisfies `^on:\s+(\w+)` too and this rule captures the
+  # FIRST event of a block-form trigger as well — which is why its corpus count
+  # (235) sits one above the block-form rule's (234) rather than complementing
+  # it. The two then mint the same Config for the same file and the duplicate
+  # folds away. Stated because the old `# on: single event` comment claimed a
+  # split that does not exist, and pinned by
+  # TestIssue6927_GitHubActions_SingleEventRuleAlsoReadsBlockForm.
+  #
+  # NOT gated, for the same measured reason as the block-form rule, and its
+  # anchor is graded by the same `notification:` forbidden row plus a second on
+  # a different shape: `node-version: 20` contains the substring `on: 20`, so
+  # dropping the anchor mints a Config called `20`.
+  - pattern: "(?m)^on:\\s+(\\w+)"
     entity_type: Config
     name_group: 1
     scope: file
-  # env: at workflow level
-  - pattern: "^env:\\s*\\n\\s+(\\w+):"
+  # env: at workflow level.
+  #
+  # `(?m)` (#6927): 0 matches before, 38 in 38 files after.
+  #
+  # `requires_framework` (#6927): a column-0 `env:` with an indented key under
+  # it is plain YAML — travis, eslint and semaphore configs all write it — and
+  # the gate is free here, keeping all 35 workflow-side matches while dropping
+  # the 3 non-workflow ones. `^env:` (column 0) is what distinguishes the
+  # WORKFLOW-level env block from a job-level or step-level one, and that half
+  # is graded by a forbidden row: `BUNDLE_PATH` sits under an indented,
+  # job-level `env:` in the fixture's build.yml.
+  - pattern: "(?m)^env:\\s*\\n\\s+(\\w+):"
     entity_type: Config
     name_group: 1
     scope: file
+    requires_framework: true
   # secrets reference
   - pattern: "secrets\\.(\\w+)"
     entity_type: Config

--- a/internal/engine/rules/cicd/frameworks/github_actions.yaml
+++ b/internal/engine/rules/cicd/frameworks/github_actions.yaml
@@ -18,6 +18,25 @@ frameworks:
   # — dependabot.yml, labeler.yml, auto_assign.yml and .pre-commit-config.yaml,
   # which merely live in .github/ — so no workflow in the corpus is declined
   # and no non-workflow is admitted.
+  #
+  # Zero of 402 is a measurement, not a proof, and the set is NOT exhaustive in
+  # either direction. Two shapes outside that corpus, named so the list does not
+  # read as closed (neither is a defect today; both are what the next arm should
+  # re-measure against):
+  #
+  #   * `${{` is not GitHub-only. Azure Pipelines template expressions are
+  #     written `${{ ... }}` too, and an azure-pipelines.yml carries a column-0
+  #     `name:` (the build-number format) and a `- name:` variables list — i.e.
+  #     both gated rules would over-fire on one.
+  #   * a COMPOSITE action.yml whose steps are all `run:` carries none of these
+  #     four: a composite action has no `runs-on:`. Such a file is declined, and
+  #     its `name:` is then extracted by nothing.
+  #
+  # Each marker is load-bearing on its own, which is graded marker by marker
+  # rather than as a set: deleting only `runs-on:` costs a `run:`-only workflow
+  # its Service and every step Task, and the set is over-determined on the
+  # fixture, so the fixture cannot see it
+  # (TestIssue6927_GitHubActions_EachImportMarkerAdmitsAWorkflowAlone).
   detection:
     import_markers:
       - "runs-on:"
@@ -87,6 +106,14 @@ source_patterns:
   # it off deeper keys such as a `strategy.matrix` whose axis is named
   # `runs-on`; widening it to `\s+` mints an Operation called `matrix`, which
   # is a forbidden row in github-actions-workflows-mini.
+  #
+  # That two-key vocabulary IS the ungated verdict, so it is graded as an exact
+  # set and not by membership: adding a third key mints an Operation for the
+  # fixture's `notification:` job, which is forbidden there and pinned by
+  # TestIssue6927_GitHubActions_JobRuleReadsOnlyRunsOnAndUses. The rule only
+  # inspects the IMMEDIATELY-next line, so a job whose first key is `needs:` or
+  # `if:` is missed; that is a recall gap, not a widening, and the fixture
+  # records it through the structured extractor's CONTAINS edge instead.
   - pattern: "(?m)^\\s{2}(\\w[\\w-]*):\\s*\\n\\s+(?:runs-on|uses):"
     entity_type: Operation
     name_group: 1
@@ -152,6 +179,12 @@ source_patterns:
   # anchor is graded by the same `notification:` forbidden row plus a second on
   # a different shape: `node-version: 20` contains the substring `on: 20`, so
   # dropping the anchor mints a Config called `20`.
+  #
+  # Those two rows grade REMOVING `^`. Weakening it to `^\s*on:` keeps the line
+  # anchor and still reads an indented `on:` key — and with no framework gate on
+  # either `on:` rule, that is every nested `on:` in every YAML file the cicd
+  # bucket is offered. Graded separately by
+  # TestIssue6927_GitHubActions_OnRulesAreColumnZeroOnly.
   - pattern: "(?m)^on:\\s+(\\w+)"
     entity_type: Config
     name_group: 1

--- a/internal/quality/absent_relationships_6490_test.go
+++ b/internal/quality/absent_relationships_6490_test.go
@@ -229,8 +229,8 @@ func TestEveryGoldenFixtureDeclaresExpectedRelationships_6490(t *testing.T) {
 	// Checked only after `missing` is reported, because a fixture that failed
 	// the key check never reached the counter — this is the number of fixtures
 	// actually INSPECTED, not the number of files opened.
-	if fixtures != 34 {
-		t.Fatalf("inspected %d golden fixtures, want 34 — the corpus size changed, so this "+
+	if fixtures != 35 {
+		t.Fatalf("inspected %d golden fixtures, want 35 — the corpus size changed, so this "+
 			"test's coverage claim needs re-deriving rather than silently shrinking", fixtures)
 	}
 	// A FAILURE, not a t.Logf. It was a log while arm A only required the key

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -69,6 +69,14 @@
       "entity_extracted_total": 41,
       "relationship_extracted_total": 93
     },
+    "github-actions-workflows-mini": {
+      "entity_found": 12,
+      "entity_expected": 12,
+      "relationship_found": 3,
+      "relationship_expected": 3,
+      "entity_extracted_total": 55,
+      "relationship_extracted_total": 72
+    },
     "go-chi-mini": {
       "entity_found": 20,
       "entity_expected": 20,

--- a/internal/quality/golden/github-actions-workflows-mini/expected.json
+++ b/internal/quality/golden/github-actions-workflows-mini/expected.json
@@ -1,0 +1,175 @@
+{
+  "fixture_name": "github-actions-workflows-mini",
+  "language": "cicd",
+  "description": "GitHub Actions rule patterns (#6927, cicd arm). Six `^`-anchored patterns in rules/cicd/frameworks/github_actions.yaml were compiled without `(?m)` (detector.go:156 uses plain regexp.Compile), so `^` meant start of TEXT. Three of them could NEVER fire — `^\\s{2}...`, `^\\s+-\\s+name:` and `^env:` all need something before them — and the other three fired only on a file whose very first byte was `name:` or `on:`. Measured on 671 real YAML files from 59 upstream repos: 0 job, 0 step and 0 env matches, and 99 of 269 workflow files yielding a name. The fixture varies vertical position deliberately (nothing on line 1, the second workflow's env block last in file) and, separately, the ANCHOR axis (a job-level `env:`, a step-level `name:`, a `strategy.matrix` key) from the FRAMEWORK-GATE axis (three non-workflow YAML files that name GitHub Actions nowhere). It grades BOTH directions: a recall assertion is structurally blind to over-firing (#6902), and three of these six patterns are plain YAML that start-of-text had been gating by accident — the sqlalchemy finding from #6943, in a second language.",
+  "expected_entities": [
+    {
+      "name": "Storefront CI",
+      "kind": "Service",
+      "source_file": "ci/workflows/build.yml",
+      "must_exist": true,
+      "note": "#6927 recall arm for `(?m)^name:`. Line 8, under a seven-line comment header — the shape every real workflow has, and the reason start-of-text found only 99 of 269 workflow files in the corpus."
+    },
+    {
+      "name": "Nightly Smoke",
+      "kind": "Service",
+      "source_file": "ci/workflows/nightly.yml",
+      "must_exist": true,
+      "note": "Same rule, second file, so one workflow's layout cannot be what carries the row."
+    },
+    {
+      "name": "build",
+      "kind": "Operation",
+      "source_file": "ci/workflows/build.yml",
+      "must_exist": true,
+      "note": "#6927 recall arm for `(?m)^\\s{2}(\\w[\\w-]*):\\s*\\n\\s+(?:runs-on|uses):`. This rule could not fire at ALL before: it needs two leading spaces, and no file starts with them. First job in the file."
+    },
+    {
+      "name": "publish",
+      "kind": "Operation",
+      "source_file": "ci/workflows/build.yml",
+      "must_exist": true,
+      "note": "Same rule, a LATER job — the vertical-position axis, which is the defect itself."
+    },
+    {
+      "name": "smoke",
+      "kind": "Operation",
+      "source_file": "ci/workflows/nightly.yml",
+      "must_exist": true,
+      "note": "Same rule through the OTHER half of its `(?:runs-on|uses)` alternation: a reusable-workflow call, which has no `runs-on:` at all. Without this row the `uses:` branch is graded by nothing."
+    },
+    {
+      "name": "pull_request",
+      "kind": "Config",
+      "source_file": "ci/workflows/build.yml",
+      "must_exist": true,
+      "note": "#6927 recall arm for `(?m)^on:\\s*\\n\\s+(\\w+):` (block-form trigger). Both `on:` rules mint this one and the duplicate folds; the single-event rule is graded separately by `workflow_dispatch`, which the block-form rule cannot match."
+    },
+    {
+      "name": "workflow_dispatch",
+      "kind": "Config",
+      "source_file": "ci/workflows/nightly.yml",
+      "must_exist": true,
+      "note": "#6927 recall arm for `(?m)^on:\\s+(\\w+)` on a genuine single-event `on:` line, which `^on:\\s*\\n` cannot reach."
+    },
+    {
+      "name": "REGISTRY",
+      "kind": "Config",
+      "source_file": "ci/workflows/build.yml",
+      "must_exist": true,
+      "note": "#6927 recall arm for `(?m)^env:\\s*\\n\\s+(\\w+):` — another rule that could never fire under start-of-text."
+    },
+    {
+      "name": "SMOKE_REGION",
+      "kind": "Config",
+      "source_file": "ci/workflows/nightly.yml",
+      "must_exist": true,
+      "note": "Same rule at the OTHER extreme of the vertical axis: the workflow-level `env:` block is the LAST construct in nightly.yml, as far from start-of-text as the file allows."
+    },
+    {
+      "name": "actions/checkout@v4",
+      "kind": "Dependency",
+      "source_file": "ci/workflows/build.yml",
+      "must_exist": true,
+      "note": "CONTROL, held constant. `uses:\\s+(\\S+)` carries no `^`, so it was green before the fix and must stay green. Without a control, 'the anchored rules came back' and 'rule loading broke entirely' look identical."
+    },
+    {
+      "name": "ubuntu-latest",
+      "kind": "Config",
+      "source_file": "ci/workflows/build.yml",
+      "must_exist": true,
+      "note": "Second CONTROL on a different rule (`runs-on:\\s+(\\S+)`), un-anchored and untouched."
+    },
+    {
+      "name": "Compile assets",
+      "kind": "Task",
+      "source_file": "ci/workflows/build.yml",
+      "must_exist": true,
+      "note": "CONTROL, and deliberately NOT evidence for `(?m)^\\s+-\\s+name:` -> Task. ansible_core.yaml's un-anchored `- name:` -> Task rule is in the same `yaml` bucket and mints this entity whether or not the GitHub Actions step rule fires, so this row was green before the fix too. The step rule's own two directions are graded at engine level, against a detector holding only this rule set (TestIssue6927_GitHubActions_*)."
+    }
+  ],
+  "forbidden_entities": [
+    {
+      "name": "storefront-chart",
+      "kind": "Service",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, FRAMEWORK-GATE direction, and the reason this change is not `(?m)` alone. `^name:` is a plain column-0 YAML key; the cicd bucket is aliased onto the `yaml` language, so under `(?m)` alone it types every helm Chart.yaml, pubspec.yaml and compose.yaml in a repo as a GitHub Actions Service — 34 matches in 34 non-workflow files across the measured corpus. deploy/helm/Chart.yaml names GitHub Actions nowhere; `requires_framework: true` is what holds this row. Deleting that key mints it."
+    },
+    {
+      "name": "MATRIX_KEY",
+      "kind": "Config",
+      "must_exist": false,
+      "note": "Second row for the same gate on a different rule and a different file shape: ops/legacy-ci.yml is a travis-style config whose column-0 `env:` block would otherwise be read as a workflow-level env block. One row could be held by an accident of one file; two of different shapes cannot."
+    },
+    {
+      "name": "Compile assets",
+      "kind": "Service",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, ANCHOR direction for `^name:`, and deliberately INSIDE ci/workflows/build.yml, which satisfies the framework gate. The Chart.yaml row above is held by the gate and so says nothing about the anchor; this one is held by the anchor alone, so the two fences are graded separately and their mutants are distinguishable. `^name:` -> `^\\s*name:` mints a Service for every step name in the workflow. Note the same string is an expected TASK: the kinds are what separate them."
+    },
+    {
+      "name": "Build and test",
+      "kind": "Service",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, ANCHOR direction for `^name:`, and the row that actually grades it. `^name:` -> `^\\s*name:` was ALIVE at BOTH levels on first scoring: a step's `- name:` opens with a dash, so `\\s*` cannot reach it and the `Compile assets` row above says nothing about that mutant. A JOB's `name:` — the display-name key, indented and dash-less — is what the widened anchor claims, and it is the shape a real workflow carries. Two anchor rows for one fence, because the first one was passing for the wrong reason."
+    },
+    {
+      "name": "BUNDLE_PATH",
+      "kind": "Config",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, ANCHOR direction for `^env:`. Column 0 is the whole of what distinguishes the WORKFLOW-level env block from a job-level one, and build.yml declares `env: BUNDLE_PATH` indented inside the `build` job. `^env:` -> `^\\s*env:` mints it."
+    },
+    {
+      "name": "matrix",
+      "kind": "Operation",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, INDENT direction for the job rule. `\\s{2}` means EXACTLY two, which is what keeps the rule off deeper keys; build.yml carries the idiomatic `strategy.matrix.runs-on` axis list, so `\\s{2}` -> `\\s+` reads `matrix:` as a job name and mints an Operation for it. This is the only forbidden row the job rule has, because across 402 non-workflow YAML files in the corpus the widened rule matched ZERO times — it names `runs-on:`/`uses:` itself and is self-gating, so it takes no requires_framework."
+    },
+    {
+      "name": "needs",
+      "kind": "Config",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, ANCHOR direction for BOTH `on:` rules — the two that are deliberately left ungated, so the column-0 anchor is the entire fence. `notification:` is a legal job name that ENDS in `on:`, so dropping `^` makes both rules read the job's next key and mint a Config called `needs`."
+    },
+    {
+      "name": "20",
+      "kind": "Config",
+      "must_exist": false,
+      "note": "Second row for the same anchor on a different shape: `node-version: 20` contains the substring `on: 20`, so a `^`-less `on:\\s+(\\w+)` mints a Config named `20`. A `- name:`-shaped row and a `<key>: <value>`-shaped row cannot both be held by one accident of spelling."
+    }
+  ],
+  "expected_relationships": [
+    {
+      "from_name": "Storefront CI",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "ci/workflows/build.yml",
+      "kind": "CONTAINS",
+      "to_name": "build",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "ci/workflows/build.yml",
+      "must_exist": true,
+      "note": "CONTROL, held constant. Workflow-contains-job comes from the structured extractor in internal/extractors/yaml, NOT from these regex rules, and is green before and after. It is asserted because #6490 requires every fixture to grade its language's edge extraction with something, and because it is the row that would catch a regression in the structured path while the rule path stays green."
+    },
+    {
+      "from_name": "Storefront CI",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "ci/workflows/build.yml",
+      "kind": "CONTAINS",
+      "to_name": "notification",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "ci/workflows/build.yml",
+      "must_exist": true,
+      "note": "Same edge for the job the REGEX rule cannot see: `notification:` is followed by `needs:` rather than `runs-on:`, and `(?m)^\\s{2}(\\w[\\w-]*):\\s*\\n\\s+(?:runs-on|uses):` only looks at the immediately-next line. Recorded as an edge rather than as prose so the gap between the two producers is observed rather than asserted."
+    },
+    {
+      "from_name": "build.yml",
+      "from_kind": "SCOPE.Document",
+      "from_file": "ci/workflows/build.yml",
+      "kind": "IMPORTS",
+      "to_name": "gha:actions/checkout",
+      "to_kind": "SCOPE.External",
+      "must_exist": true,
+      "note": "CONTROL on a second edge kind and a second producer path (the external-action synthesiser in internal/external), so one broken emitter cannot take the whole relationship assertion with it."
+    }
+  ]
+}

--- a/internal/quality/golden/github-actions-workflows-mini/expected.json
+++ b/internal/quality/golden/github-actions-workflows-mini/expected.json
@@ -126,6 +126,12 @@
       "note": "#6927 forbidden arm, INDENT direction for the job rule. `\\s{2}` means EXACTLY two, which is what keeps the rule off deeper keys; build.yml carries the idiomatic `strategy.matrix.runs-on` axis list, so `\\s{2}` -> `\\s+` reads `matrix:` as a job name and mints an Operation for it. This is the only forbidden row the job rule has, because across 402 non-workflow YAML files in the corpus the widened rule matched ZERO times — it names `runs-on:`/`uses:` itself and is self-gating, so it takes no requires_framework."
     },
     {
+      "name": "notification",
+      "kind": "Operation",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, ALTERNATION direction for the job rule, and the row that grades the reason it is ungated. PR #6945 review M3: widening `(?:runs-on|uses)` to `(?:runs-on|uses|needs)` was ALIVE at the engine suite AND here, and died only incidentally on the ratchet's generic entity-count ceiling — a guard that fires for any extra entity and would not fire at all for a same-count substitution. `notification:` is a job whose first key is `needs:`, so the shipped rule cannot see it; any rule that reads a key outside its own two-key vocabulary mints it. The structured extractor DOES see that job — the CONTAINS edge asserted below is the same job — which is what keeps this row about the regex rule's blast radius rather than about the workflow being parsed at all."
+    },
+    {
       "name": "needs",
       "kind": "Config",
       "must_exist": false,

--- a/internal/quality/golden/github-actions-workflows-mini/src/ci/workflows/build.yml
+++ b/internal/quality/golden/github-actions-workflows-mini/src/ci/workflows/build.yml
@@ -1,0 +1,48 @@
+# Storefront build pipeline.
+#
+# Deliberately NOT under .github/: internal/daemon/walk/walker.go's
+# hardcodedSkipDirs skips `.github` outright, so a workflow stored where GitHub
+# actually looks for it is never walked and these rules would grade nothing.
+# GitHub's own starter-workflows repo stores workflow YAML at ci/*.yml, which is
+# the layout copied here.
+name: Storefront CI
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+env:
+  REGISTRY: ghcr.io
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build and test
+    env:
+      BUNDLE_PATH: vendor/bundle
+    strategy:
+      matrix:
+        runs-on: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile assets
+        run: make assets
+      # - name: Deploy to staging
+      #   run: make deploy
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Upload bundle
+        run: make upload
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/upload-artifact@v4
+      - name: Push image
+        run: docker push "$REGISTRY/storefront"
+  notification:
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post build result
+        run: ./ci/notify.sh

--- a/internal/quality/golden/github-actions-workflows-mini/src/ci/workflows/nightly.yml
+++ b/internal/quality/golden/github-actions-workflows-mini/src/ci/workflows/nightly.yml
@@ -1,0 +1,8 @@
+# Nightly smoke run against the deployed storefront.
+name: Nightly Smoke
+on: workflow_dispatch
+jobs:
+  smoke:
+    uses: ./.github/workflows/build.yml
+env:
+  SMOKE_REGION: eu-west-1

--- a/internal/quality/golden/github-actions-workflows-mini/src/deploy/helm/Chart.yaml
+++ b/internal/quality/golden/github-actions-workflows-mini/src/deploy/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: storefront-chart
+description: Storefront deployment chart
+type: application
+version: 0.4.1
+appVersion: "1.16.0"

--- a/internal/quality/golden/github-actions-workflows-mini/src/ops/legacy-ci.yml
+++ b/internal/quality/golden/github-actions-workflows-mini/src/ops/legacy-ci.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 3.1
+env:
+  MATRIX_KEY: fast
+script:
+  - bundle exec rake

--- a/internal/quality/golden/github-actions-workflows-mini/src/ops/provision.yml
+++ b/internal/quality/golden/github-actions-workflows-mini/src/ops/provision.yml
@@ -1,0 +1,11 @@
+- hosts: web
+  become: true
+  tasks:
+    - name: Install nginx
+      apt:
+        name: nginx
+        state: present
+    - name: Restart nginx
+      service:
+        name: nginx
+        state: restarted

--- a/internal/quality/subtype_assertion_6488_test.go
+++ b/internal/quality/subtype_assertion_6488_test.go
@@ -288,8 +288,8 @@ func TestOnlyTheIntendedGoldenRowsAssertSubtype_6488(t *testing.T) {
 			}
 		}
 	}
-	if fixtures != 34 {
-		t.Fatalf("parsed %d fixtures, want 34 — every golden expected.json must "+
+	if fixtures != 35 {
+		t.Fatalf("parsed %d fixtures, want 35 — every golden expected.json must "+
 			"keep parsing across this additive schema change", fixtures)
 	}
 	// #6815 added the three file-carrier rows below. They are subtype-asserting

--- a/internal/quality/zero_relationships_6490_test.go
+++ b/internal/quality/zero_relationships_6490_test.go
@@ -177,8 +177,8 @@ func TestNoGoldenFixtureClaimsTheOptIn_6490(t *testing.T) {
 			optedOut = append(optedOut, e.Name())
 		}
 	}
-	if inspected != 34 {
-		t.Fatalf("inspected %d golden fixtures, want 34 — the corpus size changed, so "+
+	if inspected != 35 {
+		t.Fatalf("inspected %d golden fixtures, want 35 — the corpus size changed, so "+
 			"this test's coverage claim needs re-deriving", inspected)
 	}
 	if len(optedOut) != 0 {


### PR DESCRIPTION
The **GitHub Actions arm** of #6927 — 6 of the 14 remaining patterns, the largest block.
`docker_compose.yaml`, `ansible_core.yaml`, `play_framework.yaml` and `graphql_schema.yaml` are
untouched and stay separate arms.

`internal/engine/detector.go` compiles rule patterns with plain `regexp.Compile` at `:156,177`, so
`^` means start of **text**. In `rules/cicd/frameworks/github_actions.yaml` that left **three
patterns unable to fire at all** — `^\s{2}…` (job), `^\s+-\s+name:` (step) and `^env:\s*\n…` all
require something before the match, and start-of-text forbids it — and the other three firing only
on a file whose very first byte is `name:` or `on:`.

## The first question was not "add `(?m)`"

It was, per pattern: **is this actually specific to GitHub Actions, or has start-of-text been doing
the gating?** #6943 found exactly that in sqlalchemy. Answered here by measurement, not by reading —
every `.yml`/`.yaml` in a 59-repo corpus (`starter-workflows`, `argocd-example-apps`,
`prometheus-helm`, `awesome-compose`, `kafka`, `django`, `rails`, …): **671 files, 269 of them
GitHub Actions workflows/composite actions by location, 402 not.** Matches, files in brackets:

| pattern | kind | current (start-of-text) wf / other | `(?m)` ungated wf / other | `(?m)` + gate wf / other | verdict |
|---|---|---|---|---|---|
| `^name:\s+["']?([^"'\n]+)` | Service | 99 (99) / 24 (24) | 264 (264) / **34 (34)** | 264 (264) / 0 (0) | **gated** |
| `^\s{2}(\w[\w-]*):\s*\n\s+(?:runs-on\|uses):` | Operation | 0 / 0 | 152 (131) / **0 (0)** | — | ungated |
| `^\s+-\s+name:\s+["']?([^"'\n]+)` | Task | 0 / 0 | 1138 (232) / **194 (49)** | 1138 (232) / 0 (0) | **gated** |
| `^on:\s*\n\s+(\w+):` | Config | 1 (1) / 0 | 234 (234) / **0 (0)** | — | ungated |
| `^on:\s+(\w+)` | Config | 1 (1) / 0 | 235 (235) / **0 (0)** | — | ungated |
| `^env:\s*\n\s+(\w+):` | Config | 0 / 0 | 35 (35) / **3 (3)** | 35 (35) / 0 (0) | **gated** |

Three of the six are plain YAML — a column-0 `name:`, a `- name:` list item, a column-0 `env:`
block — and the cicd bucket is aliased onto the whole `yaml` language
(`detector.go` `dormantBucketAliases`), so `(?m)` alone would type every helm `Chart.yaml`,
`pubspec.yaml`, `compose.yaml`, ansible task and travis config in a repo as a workflow part. They
get `requires_framework: true` plus a `frameworks.detection.import_markers` block
(`runs-on:`, `uses: actions/`, `${{`, `.github/workflows/`) — the #6152 falcon/cherrypy remedy.
The marker set selects **265 of the 269** workflow files and **zero of the 402** others; the 4 it
declines are not workflows (`dependabot.yml`, `labeler.yml`, `auto_assign.yml`,
`.pre-commit-config.yaml`, which merely live in `.github/`). The gate costs no recall: 264→264 for
the name rule, 35→35 for the env rule.

The other three are self-gating and stay ungated **because that was measured, not assumed**: the
job rule names `runs-on:`/`uses:` itself, and `on:` at column 0 is GitHub Actions' trigger key —
zero matches across all 402 non-workflow files. Their anchors are graded by forbidden rows instead.

**`$`**: none of the six carries one, so `(?m)`'s second effect cannot reach them. Asserted, not
claimed — `TestIssue6927_GitHubActions_NoDollarInWidenedPatterns` fails if a `$` is ever added to a
`(?m)` pattern in this file, and pins the count at 6.

## Graded in both directions, at two levels

New golden fixture **`github-actions-workflows-mini`** (5 files: two workflows, a helm chart, an
ansible playbook, a travis config): **25.0% entity recall on the pre-fix binary (3/12), 100% after**
(12/12 entities, 3/3 relationships, 0 forbidden hits). The 3 found pre-fix are exactly the three
un-anchored controls.

New engine-level test file **`github_actions_multiline_anchor_6927_test.go`**, driving the real
embedded YAML through `LoadAllRules()` + `Detect()` against a detector holding **only** this rule
set. It exists because the fixture structurally cannot see two things:

* **The step rule's blast radius.** `ansible_core.yaml` carries an **un-anchored** `- name:` → Task
  rule in the same `yaml` bucket, which subsumes this one outright, so those 194 over-fired Tasks
  are already in the graph from the other rule file and the gate is invisible at graph level. The
  gate is still right: it stops this file depending on another rule file's accident for its own
  blast radius, and #6927's ansible arm is going to narrow that pattern.
* **Which rule produced an entity** — the fixture asserts what the graph contains.

### Axes varied vs held constant

| axis | varied | held constant |
|---|---|---|
| vertical position | nothing on line 1 (7-line comment header); second job far down; `env:` block is the LAST construct in `nightly.yml` | — |
| anchor (column 0 vs indented vs commented) | a JOB's `name:` and a STEP's `- name:` (dash-less vs dashed — these are different mutants), job-level `env:` indented, `strategy.matrix` deeper, a commented-out step | — |
| framework gate | 3 non-workflow files naming GitHub Actions nowhere | the 2 workflow files satisfy the gate, so their forbidden rows grade the anchor alone |
| alternation branch | `runs-on:` job **and** `uses:` reusable-workflow job | — |
| trigger form | block `on:` and single-line `on:` | — |
| entity name / spelling | idiomatic throughout | held constant deliberately — the name axis is graded by `TestZeroProducingKinds6776_NoSiteOverFires` and by the two different-shaped rows per fence |

Anchor rows and gate rows are kept in **separate files** on purpose (the #6943 R3 lesson): a row
held by the gate says nothing about the anchor, so each fence has rows only it can hold, and each
has two rows of different shapes so no single accident of spelling carries a fence.

### Forbidden rows, each proven capable of firing

| row | fence | mutant that mints it |
|---|---|---|
| `Service:storefront-chart` (Chart.yaml) | name-rule gate | delete `requires_framework` |
| `Config:MATRIX_KEY` (legacy-ci.yml) | env-rule gate | delete `requires_framework` |
| `Service:Build and test` (a JOB's indented `name:`, inside build.yml) | name-rule anchor | `^name:` → `^\s*name:` |
| `Service:Compile assets` (a STEP's `- name:`, inside build.yml) | name-rule anchor | `^name:` → `name:` |
| `Config:BUNDLE_PATH` (job-level `env:`) | env-rule anchor | `^env:` → `^\s*env:` |
| `Operation:matrix` (`strategy.matrix.runs-on`) | job-rule indent | `\s{2}` → `\s+` |
| `Config:needs` (job named `notification:`, which ENDS in `on:`) | both `on:` anchors | drop `^` |
| `Config:20` (`node-version: 20` contains `on: 20`) | single-event `on:` anchor | drop `^` |
| `Task:Install nginx` / `Restart nginx`, `Service:language`, `Task:Deploy to staging` (commented step) | step-rule gate + anchor | engine-level only — see above |

## Findings the widening surfaced

1. **`.github` is on the walker's hard-coded skip list** (`internal/daemon/walk/walker.go`
   `hardcodedSkipDirs`), so a workflow stored where GitHub actually looks for it is never walked —
   these rules and this file's `.github/workflows/*.yml` `file_conventions` globs cannot fire on a
   real repo at all. The fixture stores its workflows at `ci/workflows/`, the layout GitHub's own
   `starter-workflows` repo uses. Filed separately.
2. **The job rule only looks at the immediately-next line**, so a job whose first key is `needs:`
   (or `if:`, `name:`, `permissions:`) is missed. Pinned as an *edge* rather than as prose: the
   fixture's `notification` job is asserted through the structured extractor's
   `CONTAINS` edge, which sees it while the regex rule does not.
3. **The single-event `on:` rule also reads the block form** — `\s` matches a newline — which is why
   its corpus count (235) sits one *above* the block-form rule's (234) rather than complementing it.
   The old `# on: single event` comment denied this. Now pinned by
   `TestIssue6927_GitHubActions_SingleEventRuleAlsoReadsBlockForm` against the shipped pattern text,
   because at entity level the two rules mint the same Config and the duplicate folds away.


### Mutants — scored at BOTH levels

Eighteen mutants, each applied to a pristine copy with the anchor-text occurrence count asserted
**exactly 1** (a silently-unapplied edit reads as ALIVE and argues the opposite, #6926), with a
green positive control before the first and after the last.

| mutant | engine suite | fixture gate |
|---|---|---|
| `^name:` → `^\s*name:` | DEAD | DEAD |
| `^name:` → `name:` (drop anchor) | DEAD | DEAD |
| name rule: drop `(?m)` | DEAD | DEAD |
| name rule: drop `requires_framework` | DEAD | DEAD |
| job rule: `\s{2}` → `\s+` | DEAD | DEAD |
| job rule: drop `(?m)` | DEAD | DEAD |
| step rule: drop `(?m)` | DEAD | **ALIVE** |
| step rule: drop `^` | DEAD | **ALIVE** |
| step rule: drop `requires_framework` | DEAD | **ALIVE** |
| block `on:`: drop `^` | DEAD | DEAD |
| block `on:`: drop `(?m)` | DEAD | **ALIVE** |
| single `on:`: drop `^` | DEAD | DEAD |
| single `on:`: drop `(?m)` | DEAD | DEAD |
| `^env:` → `^\s*env:` | DEAD | DEAD |
| env rule: drop `(?m)` | DEAD | DEAD |
| env rule: drop `requires_framework` | DEAD | DEAD |
| replace the marker set with one that matches nothing | DEAD | DEAD |

**All 18 DEAD at engine level. Four are ALIVE at the fixture gate**, and all four for reasons this
PR documents rather than discovers: the three step-rule mutants are invisible in the graph because
`ansible_core.yaml` mints those Tasks anyway, and `block on:` losing `(?m)` is masked because the
*single-event* rule reads the block form too and still mints `pull_request`. That masking is
precisely why the single-event rule's real behaviour is now pinned.

**One mutant was ALIVE at BOTH levels on first scoring and is now DEAD.** `^name:` → `^\s*name:`
survived every row: a step's `- name:` opens with a **dash**, so `\s*` cannot reach it, and the
`Service:Compile assets` row was passing for the wrong reason. What the widened anchor actually
claims is a **job's** `name:` — the display-name key, indented and dash-less, which every real
workflow may carry. `build.yml` now declares one and the fixture forbids `Service:Build and test`.
Two anchor rows for that fence, because the first one was not grading it.

### Ratchet delta

`scripts/quality/run.sh --ratchet` → **OK, 35 gated fixtures held their baseline** (26 at 100%
must-have recall), exit 0, no `GREW` line. The three known python drifts of #6898
(`python-django-mini`, `python-fastapi-mini`, `python-rq-mini`) did not appear — and that is **not
python recovering**, which is worth stating because "no drift" invites exactly that inference. The
new baseline row was written **by hand** rather than by `--update-baseline`, so no re-record
happened; #6898's drift is a *downward* movement of the extracted totals, `ratchet.py` fails on
`got > want` only, and a fall is silent by design. With no re-record there was no write for a drift
to appear in — the mechanism was **not exercised**, not satisfied. The baseline diff is purely
additive (one object, six keys), so nothing else could be re-recorded as a side effect.

### Review round (#6945 review, `24b2310d8`)

Independent review scored five mutants of its own and found **three fences that read as covered and
were not**. All three are closed; no shipped rule text changed.

| gap | before | now |
|---|---|---|
| no SINGLE `import_marker` was graded — deleting only `runs-on:` cost a `run:`-only workflow its Service and every Task | ALIVE at engine, fixture **and** ratchet | **DEAD** — one minimal workflow per marker, each asserting it carries exactly one marker first |
| the `(?:runs-on\|uses)` alternation — the entire justification for leaving the job rule ungated | ALIVE at engine and fixture; died only *incidentally* on the ratchet's generic growth ceiling | **DEAD at both** — forbidden `Operation:notification` plus an exact-set assertion |
| `SingleEventRuleAlsoReadsBlockForm` selected its rule by pattern **text** | red on a behaviour-**preserving** rewrite; its "kill" of a real anchor weakening was selector loss | rules selected by **behaviour**; the weakening `^on:` → `^\s*on:` now DEAD on its own test, and the behaviour-preserving control is **GREEN** |

The control is the one that matters: `(\w+)` → `([\w]+)` changes nothing and used to turn the suite
red with the same message a real break produced. A test that fails when you rename something and
passes for the wrong reason when you break something reads as coverage and is not.

Two caveats are now recorded beside the marker list rather than left implicit: **`${{` is Azure
Pipelines' template syntax too** (and an `azure-pipelines.yml` carries a column-0 `name:` *and* a
`- name:` variables list, so both gated rules would over-fire on one), and a **composite `action.yml`
whose steps are all `run:`** carries none of the four markers. Zero of 402 is a measurement, not a
proof.

## Verification

* `go test ./internal/engine/ ./internal/quality/... ./cmd/grafel/ -count=1` — green.
* `scripts/quality/run.sh --ratchet` — green at 35 gated fixtures, delta enumerated above.
* Corpus-size guards re-derived **from disk**, not from the diff: 35 fixture directories, 35
  baseline entries, guards moved 34 → 35 in `zero_relationships_6490_test.go`,
  `subtype_assertion_6488_test.go` and `absent_relationships_6490_test.go`.

Refs #6927, #6917, #6902, #6152, #6943.
