### PR TITLE
fix(#6927): docker's `^\s{2}(\w[\w-]*):\s*$` and ansible's two `$`-anchored module rules needed BOTH ends of the file at once — and `(?m)` alone would have over-fired 1867 times

### DIFF
--- a/internal/engine/docker_ansible_multiline_anchor_6927_test.go
+++ b/internal/engine/docker_ansible_multiline_anchor_6927_test.go
@@ -1,0 +1,795 @@
+package engine
+
+import (
+	"context"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+)
+
+// #6927 — the docker_compose + ansible_core arm, i.e. the two files the sweep
+// flagged as the `$`-side over-fire HAZARD and the previous three arms
+// deliberately deferred.
+//
+// detector.go compiles rule patterns with plain regexp.Compile at :156 and
+// :177, so `^` means start of TEXT — and, less obviously, `$` means end of
+// TEXT. Go's `$` is stricter than Perl's: it does not even allow a trailing
+// newline before it. Five patterns were affected:
+//
+//	docker_compose.yaml  ^\s{2}(\w[\w-]*):\s*$                  -> Service
+//	docker_compose.yaml  ^volumes:\s*\n\s{2}(\w[\w-]*):         -> Config
+//	docker_compose.yaml  ^networks:\s*\n\s{2}(\w[\w-]*):        -> Config
+//	ansible_core.yaml    \s+(\w+\.\w+\.\w+):\s*$                -> Module
+//	ansible_core.yaml    ^\s+(apt|yum|…|import_role):\s*$       -> Module
+//
+// The three `$`-bearing ones needed start-of-text and end-of-text at the same
+// time (or, for the FQCN rule which has no `^`, needed the module key to be the
+// last construct in the file), so they were near-dead: ZERO matches across 992
+// real YAML files.
+//
+// `(?m)` ALONE is what this issue predicted would over-fire, and the
+// measurement is why the service rule was REWRITTEN rather than merely
+// widened. Under `(?m)`, `^\s{2}(\w[\w-]*):\s*$` reads "every two-space key
+// alone on its line": 1867 matches in 611 of the 941 non-compose corpus files,
+// AND 40 junk Services inside real compose files, where no framework gate can
+// help.
+//
+// What is graded HERE rather than in the two golden fixtures
+// (internal/quality/golden/{docker-compose-services-mini,
+// ansible-playbook-modules-mini}), and why this file exists alongside them:
+//
+//  1. WHICH RULE produced an entity. The docker and ansible buckets are both
+//     aliased onto the whole `yaml` language (dormantBucketAliases), so at
+//     graph level several rule files see every YAML file and one file's output
+//     can stand in for another's. Every case below runs against a detector
+//     holding ONE rule set.
+//  2. Each import_marker on its own. A realistic fixture file carries several
+//     markers at once, so deleting one is invisible there — the failure #6945
+//     had to be told about by a reviewer.
+//  3. Rule SELECTION by behaviour rather than by pattern text. #6945 shipped a
+//     test that selected its rule with strings.Contains on the pattern and so
+//     went red on a behaviour-preserving rewrite; its apparent kill of a real
+//     anchor weakening was selector loss, not grading. Everything here selects
+//     by what a pattern DOES, and TestIssue6927_DockerAnsible_SelectorSurvivesA
+//     BehaviourPreservingRewrite is the control that must PASS.
+//
+// Graded in BOTH directions (#6902): a recall assertion is structurally blind
+// to over-firing.
+
+// rules6927 returns the loaded rule map reduced to a single framework by name.
+// The rules are the REAL embedded YAML — the defect IS the shipped pattern
+// text, so a hand-written copy would leave the shipped one unobserved — but
+// every sibling rule set is dropped, so nothing another rule file mints can be
+// mistaken for evidence about this one.
+func rules6927(t *testing.T, frameworkName, wantBucket string) map[string][]FrameworkRule {
+	t.Helper()
+	all, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	out := map[string][]FrameworkRule{}
+	for lang, frs := range all {
+		for _, fr := range frs {
+			if fr.Frameworks.Name == frameworkName {
+				out[lang] = append(out[lang], fr)
+			}
+		}
+	}
+	// The loader keys rule sets by their BUCKET directory (`docker`,
+	// `ansible`); compile() aliases the bucket onto the `yaml` language via
+	// dormantBucketAliases, which is why these tests hand Detect a Language of
+	// "yaml" while the map key stays the bucket name. If that stops being true
+	// the tests measure nothing, so it is asserted rather than assumed.
+	if len(out[wantBucket]) != 1 {
+		t.Fatalf("expected exactly one %q rule set in the %q bucket, got %d",
+			frameworkName, wantBucket, len(out[wantBucket]))
+	}
+	if targets := dormantBucketAliases[wantBucket]; !containsStr6927(targets, "yaml") {
+		t.Fatalf("bucket %q is no longer aliased onto yaml (%v); these tests hand Detect "+
+			"Language=yaml and would grade nothing", wantBucket, targets)
+	}
+	return out
+}
+
+func containsStr6927(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func detect6927(t *testing.T, rules map[string][]FrameworkRule, path, src string) *DetectResult {
+	t.Helper()
+	res, err := New(rules).Detect(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "yaml",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	return res
+}
+
+func has6927(res *DetectResult, kind, name string) bool {
+	for _, e := range res.Entities {
+		if string(e.Kind) == kind && e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func names6927(res *DetectResult, kind string) []string {
+	var out []string
+	for _, e := range res.Entities {
+		if string(e.Kind) == kind {
+			out = append(out, e.Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func composeRules6927(t *testing.T) map[string][]FrameworkRule {
+	t.Helper()
+	return rules6927(t, "Docker Compose", "docker")
+}
+
+func ansibleRules6927(t *testing.T) map[string][]FrameworkRule {
+	t.Helper()
+	return rules6927(t, "Ansible Core", "ansible")
+}
+
+// composeFixtureSrc is a minimal but complete compose file. It carries the
+// marker, three services and a top-level volumes/networks pair, and is reused
+// wherever a case needs "a real compose file" as its positive control.
+const composeFixtureSrc6927 = `services:
+  api:
+    image: ghcr.io/example/api:1
+    depends_on:
+      - db
+  db:
+    # a comment between the key and its first argument
+    image: postgres:16
+
+volumes:
+  db-data:
+  cache-data:
+
+secrets:
+  db-password:
+    file: ./secrets/db.txt
+
+networks:
+  backend:
+    driver: bridge
+`
+
+// ansibleTasksSrc6927 is a minimal role tasks file in block form, carrying
+// several markers on purpose — it is the "realistic input" control, and the
+// per-marker cases below are the ones that carry exactly one.
+const ansibleTasksSrc6927 = `- name: Install nginx
+  ansible.builtin.apt:
+    name: nginx
+    state: present
+
+- name: Render the config
+  template:
+    src: nginx.conf.j2
+    dest: /etc/nginx/nginx.conf
+`
+
+// TestIssue6927_DockerAnsible_WidenedPatternsCarryMultiline pins the fix itself
+// at the level the defect lives at: the compiled pattern text.
+//
+// Rules are selected by BEHAVIOUR — which compiled pattern reads which
+// construct out of a real file — and the `(?m)` flag is then read off the
+// pattern that was selected. Selecting by `strings.Contains(sp.Pattern, "^\\s{2}")`
+// would make this test a spelling assertion, which is exactly the #6945 defect.
+func TestIssue6927_DockerAnsible_WidenedPatternsCarryMultiline(t *testing.T) {
+	type probe struct {
+		framework, bucket string
+		// what the rule must read out of src, which is how it is identified
+		src, wantCapture   string
+		entityType         string
+		describe           string
+		mustNotCarryDollar bool
+	}
+	probes := []probe{
+		{
+			framework: "Docker Compose", bucket: "docker",
+			src:         "services:\n  api:\n    image: nginx\n",
+			wantCapture: "api", entityType: "Service",
+			describe: "the compose service rule",
+			// The `$` is GONE from this rule on purpose: `(?m)` would have
+			// turned it into end-of-line, i.e. "every two-space key alone on
+			// its line", which is not what a service is. `[ \t]*\n` carries
+			// the same "nothing else on this line" half without the
+			// end-of-text / end-of-line ambiguity.
+			mustNotCarryDollar: true,
+		},
+		{
+			framework: "Docker Compose", bucket: "docker",
+			src:         "volumes:\n  db-data:\n",
+			wantCapture: "db-data", entityType: "Config",
+			describe: "the compose named-volume rule",
+		},
+		{
+			framework: "Docker Compose", bucket: "docker",
+			src:         "networks:\n  backend:\n    driver: bridge\n",
+			wantCapture: "backend", entityType: "Config",
+			describe: "the compose named-network rule",
+		},
+		{
+			framework: "Ansible Core", bucket: "ansible",
+			src:         "- name: x\n  ansible.builtin.apt:\n    name: nginx\n",
+			wantCapture: "ansible.builtin.apt", entityType: "Module",
+			describe: "the ansible FQCN module rule",
+		},
+		{
+			framework: "Ansible Core", bucket: "ansible",
+			src:         "- name: x\n  template:\n    src: a.j2\n",
+			wantCapture: "template", entityType: "Module",
+			describe: "the ansible shorthand module rule",
+		},
+	}
+
+	for _, p := range probes {
+		fr := rules6927(t, p.framework, p.bucket)[p.bucket][0]
+		var selected []SourcePattern
+		for _, sp := range fr.SourcePatterns {
+			if sp.EntityType != p.entityType {
+				continue
+			}
+			re, err := regexp.Compile(sp.Pattern)
+			if err != nil {
+				t.Fatalf("%s: rule file carries an uncompilable pattern %q: %v", p.describe, sp.Pattern, err)
+			}
+			m := re.FindStringSubmatch(p.src)
+			if len(m) > sp.NameGroup && m[sp.NameGroup] == p.wantCapture {
+				selected = append(selected, sp)
+			}
+		}
+		if len(selected) != 1 {
+			t.Errorf("%s: expected exactly ONE pattern to read %q out of the probe, got %d. "+
+				"Either the rule is gone or two rules now overlap, and in both cases the "+
+				"assertions below would be about the wrong pattern", p.describe, p.wantCapture, len(selected))
+			continue
+		}
+		sp := selected[0]
+		if !strings.Contains(sp.Pattern, "(?m)") {
+			t.Errorf("%s lost its `(?m)`: %q. Without it `^` is start of TEXT and `$` is end "+
+				"of TEXT (Go allows no trailing newline before it), which is the whole of "+
+				"#6927 — this rule measured ZERO matches in 992 real YAML files that way",
+				p.describe, sp.Pattern)
+		}
+		if p.mustNotCarryDollar && strings.Contains(sp.Pattern, "$") {
+			t.Errorf("%s grew a `$` back: %q. Under `(?m)` that is end of LINE, i.e. `every "+
+				"two-space key alone on its line`, which mints a Service for every named "+
+				"volume, network and secret in a real compose file — 40 of them across the "+
+				"measured corpus", p.describe, sp.Pattern)
+		}
+	}
+}
+
+// TestIssue6927_DockerAnsible_GatesAreDeclaredAndLoaded pins the OTHER half of
+// the remedy. requires_framework is inert without import_markers — detector.go
+// logs that combination and frameworkPresent then returns false for every file,
+// so a gate that looks present in the YAML can be an off switch — and a gate
+// that quietly disappears is a silent 1867-match over-fire, not a failure.
+func TestIssue6927_DockerAnsible_GatesAreDeclaredAndLoaded(t *testing.T) {
+	for _, tc := range []struct {
+		framework, bucket string
+		wantGated         int
+		wantMarkers       int
+	}{
+		{"Docker Compose", "docker", 1, 1},
+		{"Ansible Core", "ansible", 2, 7},
+	} {
+		fr := rules6927(t, tc.framework, tc.bucket)[tc.bucket][0]
+		markers := fr.Frameworks.Detection.ImportMarkers
+		if len(markers) != tc.wantMarkers {
+			t.Errorf("%s declares %d import_markers, want %d: %v — every marker is graded "+
+				"individually below, so a new one would be ungraded and a lost one is a gate "+
+				"getting weaker in silence", tc.framework, len(markers), tc.wantMarkers, markers)
+		}
+		if len(markers) == 0 {
+			t.Errorf("%s declares no import_markers at all, so every requires_framework "+
+				"pattern in it can NEVER fire", tc.framework)
+		}
+		gated := 0
+		for _, sp := range fr.SourcePatterns {
+			if sp.RequiresFramework {
+				gated++
+			}
+		}
+		if gated != tc.wantGated {
+			t.Errorf("%s has %d requires_framework patterns, want %d", tc.framework, gated, tc.wantGated)
+		}
+	}
+}
+
+// TestIssue6927_Compose_ServiceRuleNeedsBothFences is the core of the docker
+// arm. The rewritten service rule has TWO independent fences — its shape (a
+// two-space key whose block opens with a compose service-level key, at a
+// deeper LITERAL-SPACE indent) and its framework gate — and this table holds
+// each of them on inputs where the other one says nothing.
+//
+// Every "must not mint" row here is a shape measured in the real corpus, not
+// an invention: the workflow `deploy:` / `environment:` pair is what GitHub's
+// own starter-workflows carries in eleven files.
+func TestIssue6927_Compose_ServiceRuleNeedsBothFences(t *testing.T) {
+	rules := composeRules6927(t)
+	marker := rules["docker"][0].Frameworks.Detection.ImportMarkers[0]
+
+	cases := []struct {
+		name       string
+		src        string
+		wantHeld   []string // Service names that must NOT be minted
+		wantMinted []string // Service names that must be
+		fence      string
+	}{
+		{
+			name:       "a real compose file yields exactly its services",
+			src:        composeFixtureSrc6927,
+			wantMinted: []string{"api", "db"},
+			// The volume, network and secret names are the 40-per-corpus
+			// over-fire the un-rewritten `(?m)` form produced.
+			wantHeld: []string{"db-data", "cache-data", "db-password", "backend"},
+			fence:    "shape",
+		},
+		{
+			name: "a workflow job whose first key is compose vocabulary, WITHOUT the marker",
+			src: `name: Release
+jobs:
+  deploy:
+    environment:
+      name: production
+    runs-on: ubuntu-latest
+`,
+			wantHeld: []string{"deploy"},
+			fence:    "gate",
+		},
+		{
+			name: "a workflow that DOES carry the marker is still declined by shape alone",
+			src: `name: Test
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+`,
+			// `unit:` is declined because `runs-on` is not compose vocabulary;
+			// `postgres:` because it is six-space indented, not two.
+			wantHeld: []string{"unit", "postgres"},
+			fence:    "shape",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Premise, asserted rather than eyeballed: a "gate" case that
+			// quietly grew the marker would grade nothing, and a "shape" case
+			// that lost it would pass for the wrong reason.
+			gated := strings.Contains(tc.src, marker)
+			if tc.fence == "gate" && gated {
+				t.Fatalf("this case is meant to be held by the GATE but carries the marker %q, "+
+					"so it is held by the shape instead", marker)
+			}
+			if tc.fence == "shape" && !gated {
+				t.Fatalf("this case is meant to be held by the SHAPE but does not carry the "+
+					"marker %q, so the gate declines it before the shape is ever consulted", marker)
+			}
+			res := detect6927(t, rules, "deploy/case.yaml", tc.src)
+			for _, want := range tc.wantMinted {
+				if !has6927(res, "Service", want) {
+					t.Errorf("Service %q missing; got %v", want, names6927(res, "Service"))
+				}
+			}
+			for _, bad := range tc.wantHeld {
+				if has6927(res, "Service", bad) {
+					t.Errorf("Service %q was minted and must not be — the %s fence is not holding. "+
+						"Got %v", bad, tc.fence, names6927(res, "Service"))
+				}
+			}
+		})
+	}
+}
+
+// TestIssue6927_Compose_ServiceRuleMintsAnExactSet grades the rule as a SET
+// rather than by membership, because membership is blind to the direction the
+// dangerous mutants move in: widening the indent, the indent CLASS or the
+// vocabulary all ADD names, and every `has(...)` assertion above stays green
+// while they do.
+func TestIssue6927_Compose_ServiceRuleMintsAnExactSet(t *testing.T) {
+	res := detect6927(t, composeRules6927(t), "deploy/compose.yaml", composeFixtureSrc6927)
+	got := names6927(res, "Service")
+	want := []string{"api", "db"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("compose Services = %v, want exactly %v.\n"+
+			"  extra `db-data`/`cache-data`  -> the `[ ]{3,}` indent CLASS or the `$`-form revert\n"+
+			"  extra `db-password`           -> the next-line VOCABULARY was widened\n"+
+			"  missing `db`                  -> the comment arm `(?:#[^\\n]*)?\\n` was dropped",
+			got, want)
+	}
+}
+
+// TestIssue6927_Compose_TheImportMarkerAdmitsAComposeFileAlone grades the
+// docker marker set marker by marker in the RECALL direction. The set has one
+// entry today, deliberately: on the measured corpus `depends_on:` and
+// `container_name:` are strictly redundant with it, and #6945 records that
+// shipping a marker no input can grade is the shape to avoid. If a later arm
+// adds one, this test fails until a case for it is added.
+func TestIssue6927_Compose_TheImportMarkerAdmitsAComposeFileAlone(t *testing.T) {
+	rules := composeRules6927(t)
+	markers := rules["docker"][0].Frameworks.Detection.ImportMarkers
+
+	cases := []struct{ marker, src, wantName string }{
+		{
+			marker: "services:",
+			src: `services:
+  api:
+    image: nginx
+`,
+			wantName: "api",
+		},
+	}
+	if len(cases) != len(markers) {
+		t.Fatalf("%d cases for %d markers (%v) — a new marker is ungraded", len(cases), len(markers), markers)
+	}
+	for _, tc := range cases {
+		var present []string
+		for _, m := range markers {
+			if strings.Contains(tc.src, m) {
+				present = append(present, m)
+			}
+		}
+		if len(present) != 1 || present[0] != tc.marker {
+			t.Errorf("case %q carries markers %v, want exactly [%q]", tc.marker, present, tc.marker)
+			continue
+		}
+		res := detect6927(t, rules, "deploy/compose.yaml", tc.src)
+		if !has6927(res, "Service", tc.wantName) {
+			t.Errorf("marker %q alone did not admit a compose file: Service %q missing. "+
+				"Deleting this marker turns the service rule off entirely", tc.marker, tc.wantName)
+		}
+	}
+}
+
+// TestIssue6927_Compose_VolumeAndNetworkRulesAreColumnZeroOnly grades the two
+// UNGATED compose rules. They take no requires_framework — measured ZERO
+// matches across 941 non-compose corpus files — so the column-0 `^` is their
+// entire fence, and it has to be graded against WEAKENING and not only against
+// removal (#6945's third review finding).
+func TestIssue6927_Compose_VolumeAndNetworkRulesAreColumnZeroOnly(t *testing.T) {
+	rules := composeRules6927(t)
+	// A helm values file: an empty `volumes:` / `networks:` key INDENTED under
+	// a parent, each followed by a two-space sibling. This is the shape a
+	// `^`-less or `^\s*`-weakened rule reads as a compose block.
+	src := `replicaCount: 2
+serverSide:
+  volumes:
+  extraArgs: {}
+  networks:
+  hostAliases: []
+`
+	res := detect6927(t, rules, "deploy/helm/values.yaml", src)
+	for _, bad := range []string{"extraArgs", "hostAliases"} {
+		if has6927(res, "Config", bad) {
+			t.Errorf("Config %q was minted from an INDENTED volumes:/networks: key — the "+
+				"column-0 anchor is the only fence these two rules have, and it is not "+
+				"holding. Got %v", bad, names6927(res, "Config"))
+		}
+	}
+	// Positive control on the same rules and the same file shape, so a failure
+	// above cannot be "the rules stopped loading".
+	ctl := detect6927(t, rules, "deploy/compose.yaml", composeFixtureSrc6927)
+	for _, want := range []string{"db-data", "backend"} {
+		if !has6927(ctl, "Config", want) {
+			t.Errorf("control: Config %q missing from a real compose file; got %v",
+				want, names6927(ctl, "Config"))
+		}
+	}
+}
+
+// TestIssue6927_Ansible_ShorthandModuleRuleNeedsItsGate is the ansible arm's
+// gate row. `copy`, `template`, `file`, `service`, `command` and `debug` are
+// ordinary English words and the ansible bucket sees every YAML file in every
+// repo, so ungated this rule matched 59 times in 43 non-ansible corpus files —
+// 41 of them `template:`, from argocd ApplicationSets, helm chart templates and
+// k8s PodTemplateSpecs.
+//
+// This is invisible in a golden fixture in one direction: the entities it mints
+// have plausible names and nothing else in the graph contradicts them.
+func TestIssue6927_Ansible_ShorthandModuleRuleNeedsItsGate(t *testing.T) {
+	rules := ansibleRules6927(t)
+	markers := rules["ansible"][0].Frameworks.Detection.ImportMarkers
+
+	// A k8s Deployment: block-form `template:` and `command:` at matching
+	// indentation, and no ansible marker anywhere.
+	k8s := `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          command:
+            - /usr/local/bin/api
+`
+	for _, m := range markers {
+		if strings.Contains(k8s, m) {
+			t.Fatalf("the k8s case carries the ansible marker %q, so it grades nothing", m)
+		}
+	}
+	res := detect6927(t, rules, "deploy/k8s/deployment.yaml", k8s)
+	for _, bad := range []string{"template", "command"} {
+		if has6927(res, "Module", bad) {
+			t.Errorf("Module %q minted from a Kubernetes manifest — requires_framework is not "+
+				"holding. Got %v", bad, names6927(res, "Module"))
+		}
+	}
+	// Control: the same rule on a real task file must still fire, so "the gate
+	// holds" and "the rule is dead" stay distinguishable.
+	ctl := detect6927(t, rules, "provisioning/tasks/main.yml", ansibleTasksSrc6927)
+	if !has6927(ctl, "Module", "template") {
+		t.Errorf("control: Module \"template\" missing from a real task file; got %v",
+			names6927(ctl, "Module"))
+	}
+}
+
+// TestIssue6927_Ansible_EachImportMarkerAdmitsATaskFileAlone grades the ansible
+// marker set marker by marker. A realistic task file carries three or four of
+// them at once — ansibleTasksSrc6927 carries `ansible.builtin.`, `state: present`
+// and `.j2` — so no single deletion is observable on a realistic input, which
+// is precisely the hole a reviewer had to find in #6945.
+//
+// Each case carries EXACTLY ONE marker, and that premise is asserted.
+func TestIssue6927_Ansible_EachImportMarkerAdmitsATaskFileAlone(t *testing.T) {
+	rules := ansibleRules6927(t)
+	markers := rules["ansible"][0].Frameworks.Detection.ImportMarkers
+
+	cases := []struct{ marker, src, wantName string }{
+		{
+			marker: "ansible.builtin.",
+			// The FQCN rule is gated too, so its own marker must admit it.
+			src: `- name: t
+  ansible.builtin.copy:
+    dest: /tmp/x
+`,
+			wantName: "ansible.builtin.copy",
+		},
+		{
+			marker: "become:",
+			src: `- name: t
+  become: true
+  service:
+    state: started
+`,
+			wantName: "service",
+		},
+		{
+			marker: "gather_facts",
+			src: `- hosts: all
+  gather_facts: false
+  tasks:
+    - name: t
+      debug:
+        var: x
+`,
+			wantName: "debug",
+		},
+		{
+			marker: "ansible_",
+			src: `- name: t
+  command:
+    cmd: echo {{ ansible_hostname }}
+`,
+			wantName: "command",
+		},
+		{
+			marker: "with_items:",
+			src: `- name: t
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - nginx
+`,
+			wantName: "apt",
+		},
+		{
+			marker: ".j2",
+			src: `- name: t
+  template:
+    src: nginx.conf.j2
+`,
+			wantName: "template",
+		},
+		{
+			marker: "state: present",
+			src: `- name: t
+  yum:
+    name: nginx
+    state: present
+`,
+			wantName: "yum",
+		},
+	}
+	if len(cases) != len(markers) {
+		t.Fatalf("%d cases for %d markers (%v) — a new marker would be ungraded",
+			len(cases), len(markers), markers)
+	}
+	for _, tc := range cases {
+		var present []string
+		for _, m := range markers {
+			if strings.Contains(tc.src, m) {
+				present = append(present, m)
+			}
+		}
+		if len(present) != 1 || present[0] != tc.marker {
+			t.Errorf("case %q carries markers %v, want exactly [%q] — it grades the marker SET, "+
+				"not this marker", tc.marker, present, tc.marker)
+			continue
+		}
+		res := detect6927(t, rules, "provisioning/tasks/main.yml", tc.src)
+		if !has6927(res, "Module", tc.wantName) {
+			t.Errorf("marker %q alone did not admit a task file: Module %q missing. Deleting "+
+				"this one marker silently drops every gated Module from a file that carries "+
+				"only it", tc.marker, tc.wantName)
+		}
+	}
+}
+
+// TestIssue6927_Ansible_ModuleRulesReadBlockFormOnly grades the `$` — which is
+// the whole point of this arm. Under `(?m)` it becomes end of LINE, and that is
+// exactly the block form: a module key with its arguments in the mapping below
+// it. The inline `key=value` form must stay invisible, and a commented-out
+// module must not be read as a live one.
+//
+// Both cases sit inside content that SATISFIES the framework gate, so they are
+// held by the anchors alone and are distinguishable from the gate rows above.
+func TestIssue6927_Ansible_ModuleRulesReadBlockFormOnly(t *testing.T) {
+	rules := ansibleRules6927(t)
+	markers := rules["ansible"][0].Frameworks.Detection.ImportMarkers
+	src := `- name: Install nginx
+  ansible.builtin.apt:
+    name: nginx
+    state: present
+
+- name: Drop the maintenance page
+  copy: src=maintenance.html dest=/var/www/maintenance.html
+
+# - systemd:
+#     name: nginx
+#     state: reloaded
+
+- name: Report the path
+  ansible.builtin.debug: msg=/etc/nginx/nginx.conf
+
+- name: Ensure the include
+  lineinfile:
+    path: /etc/nginx/nginx.conf
+
+- name: Tune worker counts
+  ansible.builtin.set_fact:
+    nginx.conf:
+      worker_processes: 4
+`
+	var present []string
+	for _, m := range markers {
+		if strings.Contains(src, m) {
+			present = append(present, m)
+		}
+	}
+	if len(present) == 0 {
+		t.Fatal("this case must SATISFY the gate — otherwise the gate declines it and the " +
+			"anchors are never consulted, so every assertion below passes for the wrong reason")
+	}
+
+	res := detect6927(t, rules, "provisioning/tasks/main.yml", src)
+	got := names6927(res, "Module")
+	want := []string{"ansible.builtin.apt", "ansible.builtin.set_fact"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("ansible Modules = %v, want exactly %v.\n"+
+			"  extra `copy`                  -> the shorthand rule lost its `\\s*$`; the inline form is not a block\n"+
+			"  extra `systemd`               -> the shorthand rule lost its `^`; that key is inside a COMMENT\n"+
+			"  extra `ansible.builtin.debug` -> the FQCN rule lost its `\\s*$` (its only anchor)\n"+
+			"  extra `lineinfile`            -> the shorthand alternation was replaced by a generic \\w+\n"+
+			"  extra `nginx.conf`            -> the FQCN rule's third dotted segment became optional",
+			got, want)
+	}
+}
+
+// TestIssue6927_DockerAnsible_SelectorSurvivesABehaviourPreservingRewrite is
+// the control that must PASS, and the reason every selector in this file is
+// behavioural.
+//
+// #6945 shipped a test that picked its rule with strings.Contains over the
+// pattern TEXT. It went red on a deliberately behaviour-preserving rewrite with
+// the same message it produced for a real anchor weakening — i.e. its apparent
+// kill was selector loss, not grading, and only a control expected to pass
+// could find that. This test performs such a rewrite on each widened pattern
+// (`\w` -> `[\w]`, which RE2 treats identically) and asserts that the same
+// construct is still read out of the same input. A selector that cannot tell a
+// rename from a break reads as coverage and is worse than none.
+func TestIssue6927_DockerAnsible_SelectorSurvivesABehaviourPreservingRewrite(t *testing.T) {
+	cases := []struct {
+		framework, bucket, entityType, src, wantCapture string
+	}{
+		{"Docker Compose", "docker", "Service", "services:\n  api:\n    image: nginx\n", "api"},
+		{"Docker Compose", "docker", "Config", "volumes:\n  db-data:\n", "db-data"},
+		{"Docker Compose", "docker", "Config", "networks:\n  backend:\n    driver: bridge\n", "backend"},
+		{"Ansible Core", "ansible", "Module", "- name: x\n  ansible.builtin.apt:\n    name: nginx\n", "ansible.builtin.apt"},
+		{"Ansible Core", "ansible", "Module", "- name: x\n  template:\n    src: a.j2\n", "template"},
+	}
+	for _, tc := range cases {
+		fr := rules6927(t, tc.framework, tc.bucket)[tc.bucket][0]
+		found := 0
+		for _, sp := range fr.SourcePatterns {
+			if sp.EntityType != tc.entityType {
+				continue
+			}
+			// The rewrite: `\w` -> its exact RE2 expansion. Byte-for-byte a
+			// different pattern, character-for-character the same language,
+			// and invasive enough that any substring selector over the text
+			// would miss.
+			rewritten := expandWordClass6927(sp.Pattern)
+			re, err := regexp.Compile(rewritten)
+			if err != nil {
+				t.Fatalf("behaviour-preserving rewrite of %q did not compile: %v", sp.Pattern, err)
+			}
+			m := re.FindStringSubmatch(tc.src)
+			if len(m) > sp.NameGroup && m[sp.NameGroup] == tc.wantCapture {
+				found++
+			}
+		}
+		if found != 1 {
+			t.Errorf("%s/%s: after a behaviour-preserving rewrite, %d patterns read %q out of "+
+				"the probe, want 1. This test is the control that must PASS; a failure here "+
+				"means the selection in this file is about pattern SPELLING, not behaviour",
+				tc.framework, tc.entityType, found, tc.wantCapture)
+		}
+	}
+}
+
+// expandWordClass6927 replaces every `\w` in an RE2 pattern with its exact
+// expansion, `[0-9A-Za-z_]`, tracking character-class depth so that a `\w`
+// INSIDE a class (`[\w-]`) expands to the bare set rather than to a nested
+// bracket. RE2 defines `\w` as exactly this set, so the rewrite is
+// behaviour-preserving by construction rather than by inspection.
+func expandWordClass6927(pattern string) string {
+	var b strings.Builder
+	inClass := false
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		if c == '\\' && i+1 < len(pattern) {
+			if pattern[i+1] == 'w' {
+				if inClass {
+					b.WriteString("0-9A-Za-z_")
+				} else {
+					b.WriteString("[0-9A-Za-z_]")
+				}
+			} else {
+				b.WriteByte(c)
+				b.WriteByte(pattern[i+1])
+			}
+			i++
+			continue
+		}
+		switch {
+		case c == '[' && !inClass:
+			inClass = true
+		case c == ']' && inClass:
+			inClass = false
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}

--- a/internal/engine/docker_ansible_multiline_anchor_6927_test.go
+++ b/internal/engine/docker_ansible_multiline_anchor_6927_test.go
@@ -676,11 +676,27 @@ func TestIssue6927_Ansible_ModuleRulesReadBlockFormOnly(t *testing.T) {
 - name: Ensure the include
   lineinfile:
     path: /etc/nginx/nginx.conf
+  loop:
+    - conf.d
 
 - name: Tune worker counts
   ansible.builtin.set_fact:
     nginx.conf:
       worker_processes: 4
+  when:
+    - ansible_os_family == "Debian"
+  tags:
+    - tuning
+  vars:
+    worker_auto: true
+  args:
+    chdir: /etc/nginx
+  environment:
+    LANG: C
+  block:
+    - name: nested
+      uri:
+        url: https://example.test
 `
 	var present []string
 	for _, m := range markers {
@@ -702,7 +718,11 @@ func TestIssue6927_Ansible_ModuleRulesReadBlockFormOnly(t *testing.T) {
 			"  extra `systemd`               -> the shorthand rule lost its `^`; that key is inside a COMMENT\n"+
 			"  extra `ansible.builtin.debug` -> the FQCN rule lost its `\\s*$` (its only anchor)\n"+
 			"  extra `lineinfile`            -> the shorthand alternation was replaced by a generic \\w+\n"+
-			"  extra `nginx.conf`            -> the FQCN rule's third dotted segment became optional",
+			"  extra `nginx.conf`            -> the FQCN rule's third dotted segment became optional\n"+
+			"  extra `when`/`tags`/`loop`/`vars`/`args`/`environment`/`block` -> a task\n"+
+			"    KEYWORD entered the alternation. This is an EXACT SET on purpose: a membership\n"+
+			"    check is blind to a same-count SUBSTITUTION (swap `debug` for `when`), which no\n"+
+			"    growth ceiling would catch either (PR #6949 review MI-1)",
 			got, want)
 	}
 }
@@ -992,6 +1012,78 @@ func TestIssue6927_Compose_HeadWhitespaceCannotCrossALine(t *testing.T) {
 					"must be `[ \\t]*\\r?\\n`: `\\s*` there crosses line boundaries, so the "+
 					"\"nothing else on this line\" claim stops being about one line",
 					got, tc.want, tc.sep)
+			}
+		})
+	}
+}
+
+// TestIssue6927_Ansible_TaskKeywordsAreNotModules grades what the shorthand
+// rule's alternation CONTAINS — its third axis, and the permissive one.
+//
+// PR #6949 review MI-1: inserting `when` into
+// `^\s+(apt|yum|…|debug|set_fact|…):\s*$` left BOTH `./internal/engine/` and
+// `./internal/quality/...` at exit 0. Every mutant scored to that point — 28
+// mine, 5 the review's, 12 re-scores — attacked the anchor, the `$`, an indent,
+// the gate or one marker. Nobody attacked the list's membership, which is the
+// only axis where the rule gets WIDER without any regex construct changing.
+//
+// Every keyword below is bare-colon-legal ansible: `when:` takes a list of
+// conditions, `tags:`/`loop:`/`with_items:` a list, `vars:`/`args:`/
+// `environment:` a mapping, `block:`/`rescue:`/`always:` a task list. So each
+// has exactly the shape the rule matches and is reachable in the sense that
+// matters. Scalar-only keywords (`register:`, `become:`, `until:`,
+// `delegate_to:`) are deliberately NOT here: a bare one is legal YAML but not
+// legal ansible, so a case built on one would be arguing rather than
+// demonstrating.
+//
+// No corpus frequency is claimed for any of them. Reachability is the property
+// under test; a count would be the corpus-measurement-as-property trap running
+// in the permissive direction, which was one of this PR's own blockers.
+//
+// Selected by behaviour, not by reading the alternation text: each case feeds a
+// minimal GATE-SATISFYING task file and asserts the keyword mints no Module,
+// with a positive control in the same file so "the rule declined it" and "the
+// rule is off" stay distinguishable.
+func TestIssue6927_Ansible_TaskKeywordsAreNotModules(t *testing.T) {
+	rules := ansibleRules6927(t)
+	markers := rules["ansible"][0].Frameworks.Detection.ImportMarkers
+
+	for _, tc := range []struct{ keyword, body string }{
+		{"when", "    - ansible_os_family == \"Debian\""},
+		{"tags", "    - runtime"},
+		{"loop", "    - conf.d"},
+		{"with_items", "    - nginx"},
+		{"vars", "    worker_auto: true"},
+		{"args", "    chdir: /etc/nginx"},
+		{"environment", "    LANG: C"},
+		{"block", "    - name: nested\n      uri:\n        url: https://example.test"},
+		{"rescue", "    - name: recover\n      uri:\n        url: https://example.test"},
+		{"always", "    - name: cleanup\n      uri:\n        url: https://example.test"},
+	} {
+		t.Run(tc.keyword, func(t *testing.T) {
+			// The positive control is a REAL shorthand module in the same
+			// file, and `state: present` under it is what satisfies the gate.
+			src := "- name: Install nginx\n  apt:\n    name: nginx\n    state: present\n  " +
+				tc.keyword + ":\n" + tc.body + "\n"
+			gated := false
+			for _, m := range markers {
+				if strings.Contains(src, m) {
+					gated = true
+					break
+				}
+			}
+			if !gated {
+				t.Fatal("this case must SATISFY the gate, or the gate declines it and the " +
+					"alternation is never consulted")
+			}
+			res := detect6927(t, rules, "provisioning/tasks/main.yml", src)
+			if !has6927(res, "Module", "apt") {
+				t.Fatalf("control: Module \"apt\" missing, so this case grades nothing; got %v",
+					names6927(res, "Module"))
+			}
+			if has6927(res, "Module", tc.keyword) {
+				t.Errorf("Module %q minted from a task KEYWORD — it is in the shorthand rule's "+
+					"alternation, which lists MODULES. Got %v", tc.keyword, names6927(res, "Module"))
 			}
 		})
 	}

--- a/internal/engine/docker_ansible_multiline_anchor_6927_test.go
+++ b/internal/engine/docker_ansible_multiline_anchor_6927_test.go
@@ -793,3 +793,206 @@ func expandWordClass6927(pattern string) string {
 	}
 	return b.String()
 }
+
+// TestIssue6927_Compose_ServiceRuleReadsCRLF grades the `\r?` in
+// `[ \t]*\r?\n`, which PR #6949's review found missing.
+//
+// The `\s*$` this rewrite replaced could match a CRLF file — `\s` eats the
+// `\r` — and the sibling `^volumes:\s*\n` / `^networks:\s*\n` rules still can,
+// so a bare `[ \t]*\n` here made the service rule the ONLY compose rule blind
+// to CRLF, and blind in a way no other rule in the same file shared.
+// Demonstrated end-to-end at the time: converting docker-compose-services-mini's
+// own compose.yaml to CRLF took it from 7/7 to 4/7, losing every Service and
+// both `depends_on` edges. This repo runs a Windows CI leg.
+//
+// The CRLF is written into the Go source rather than into a fixture file on
+// purpose: a checked-in CRLF file is at the mercy of git's autocrlf and of
+// every editor that touches it, so it would stop grading this silently.
+func TestIssue6927_Compose_ServiceRuleReadsCRLF(t *testing.T) {
+	rules := composeRules6927(t)
+	lf := composeFixtureSrc6927
+	crlf := strings.ReplaceAll(lf, "\n", "\r\n")
+	if !strings.Contains(crlf, "\r\n") || strings.Contains(lf, "\r") {
+		t.Fatal("the CRLF premise is not what it claims to be")
+	}
+	want := names6927(detect6927(t, rules, "deploy/compose.yaml", lf), "Service")
+	got := names6927(detect6927(t, rules, "deploy/compose.yaml", crlf), "Service")
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("CRLF compose file yields Services %v, LF yields %v — the service rule is "+
+			"blind to CRLF. `[ \\t]*` cannot match a `\\r`, so the head of the rule must be "+
+			"`[ \\t]*\\r?\\n` and the comment/blank arm `(?:[ \\t]*(?:#[^\\r\\n]*)?\\r?\\n)*`",
+			got, want)
+	}
+	if len(got) == 0 {
+		t.Error("both line endings yielded nothing, so this test is vacuous")
+	}
+}
+
+// TestIssue6927_Compose_ServiceRuleIndentCountsAreExact grades the two indent
+// COUNTS, which are separate assertions from the indent CLASS that
+// TestIssue6927_Compose_ServiceRuleNeedsBothFences and the fixture's
+// `cache-data` row cover. PR #6949's review scored both of these ALIVE at the
+// engine suite AND at the fixture gate.
+//
+// The fixture cannot shape an input for either: a real compose file has no
+// two-space key whose SIBLING is a service-level word, and no column-0 key
+// preceded by two blank lines whose child is one. These inputs are therefore
+// constructed, and that is said rather than implied.
+func TestIssue6927_Compose_ServiceRuleIndentCountsAreExact(t *testing.T) {
+	rules := composeRules6927(t)
+
+	t.Run("child indent is at least THREE, not two", func(t *testing.T) {
+		// `[ ]{3,}` -> `[ ]{2,}` would read a SIBLING of the key as its block
+		// body. Two-space siblings are exactly what a top-level `volumes:` or
+		// `secrets:` block is made of.
+		src := `services:
+  api:
+    image: nginx
+
+volumes:
+  cache-data:
+  ports:
+`
+		res := detect6927(t, rules, "deploy/compose.yaml", src)
+		if has6927(res, "Service", "cache-data") {
+			t.Errorf("Service \"cache-data\" minted from a SIBLING key two spaces in — the "+
+				"child-indent count must be `[ ]{3,}`, not `[ ]{2,}`. Got %v",
+				names6927(res, "Service"))
+		}
+		if !has6927(res, "Service", "api") {
+			t.Error("control: the real service was not minted, so this case grades nothing")
+		}
+	})
+
+	t.Run("leading indent is TWO LITERAL SPACES, not two whitespace characters", func(t *testing.T) {
+		// `^[ ]{2}` -> `^\s{2}`: under `(?m)` `^` matches at a blank line and
+		// `\s{2}` then consumes newlines, so a COLUMN-0 key preceded by two
+		// blank lines satisfies it. That is the same `\s`-matches-a-newline
+		// trap the rule's own comment names for the child indent, one position
+		// to the left (PR #6949 review F3).
+		src := "services:\n  api:\n    image: nginx\n\n\nextras:\n   image: busybox\n"
+		res := detect6927(t, rules, "deploy/compose.yaml", src)
+		if has6927(res, "Service", "extras") {
+			t.Errorf("Service \"extras\" minted from a COLUMN-0 key preceded by two blank "+
+				"lines — the leading indent must be `^[ ]{2}`, not `^\\s{2}`. Got %v",
+				names6927(res, "Service"))
+		}
+		if !has6927(res, "Service", "api") {
+			t.Error("control: the real service was not minted, so this case grades nothing")
+		}
+	})
+}
+
+// TestIssue6927_Compose_EnvironmentFirstServiceIsMissed pins the PRICE of the
+// vocabulary narrowing, so the trade is observed rather than asserted in prose
+// (#6949 review F2).
+//
+// `labels` and `environment` are, per the Compose Spec, the only service-level
+// keys a top-level `volumes`/`networks`/`secrets`/`configs` entry may also
+// carry, so excluding them makes the in-compose false-positive class empty by
+// the format's schema instead of merely zero on one corpus. The cost is that a
+// service whose FIRST non-comment key is one of those two is missed, because
+// the rule inspects only that one key: 2 of the corpus's 111 services.
+//
+// This test asserts the CURRENT, deliberately imperfect behaviour. If a later
+// arm teaches the rule to look past the first key, it goes red — and the right
+// response is to delete it and update the rule comment's 109/111, not to work
+// around it.
+func TestIssue6927_Compose_EnvironmentFirstServiceIsMissed(t *testing.T) {
+	rules := composeRules6927(t)
+	src := `services:
+  cache:
+    image: redis:7
+  db:
+    environment:
+      POSTGRES_DB: storefront
+    image: postgres:16
+  edge:
+    labels:
+      com.example.role: proxy
+    image: nginx
+`
+	res := detect6927(t, rules, "deploy/compose.yaml", src)
+	got := names6927(res, "Service")
+	if strings.Join(got, ",") != "cache" {
+		t.Errorf("compose Services = %v, want exactly [cache].\n"+
+			"  `db` or `edge` present -> `environment`/`labels` are back in the next-line "+
+			"vocabulary, which re-opens the spec-legal in-compose over-fire the `db-data` "+
+			"forbidden row grades; if that was intended, update the rule comment's 109/111 "+
+			"and delete this test.\n"+
+			"  `cache` missing -> the rule stopped working entirely.", got)
+	}
+}
+
+// TestIssue6927_Compose_TopLevelSectionEntriesAreNotServices grades the
+// vocabulary against the Compose Spec rather than against the corpus, which is
+// the substance of #6949 review F2: "ZERO in-compose false positives" was a
+// corpus measurement being read as a property of the format.
+//
+// Each case is a spec-legal top-level section entry carrying the key that
+// section is allowed to share with a service.
+func TestIssue6927_Compose_TopLevelSectionEntriesAreNotServices(t *testing.T) {
+	rules := composeRules6927(t)
+	head := "services:\n  api:\n    image: nginx\n\n"
+	for _, tc := range []struct{ name, section, entry, key string }{
+		{"named volume with labels", "volumes", "db-data", "labels"},
+		{"named network with labels", "networks", "backend", "labels"},
+		{"secret with environment", "secrets", "db-password", "environment"},
+		{"config with environment", "configs", "app-config", "environment"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := head + tc.section + ":\n  " + tc.entry + ":\n    " + tc.key + ":\n      x: y\n"
+			res := detect6927(t, rules, "deploy/compose.yaml", src)
+			if has6927(res, "Service", tc.entry) {
+				t.Errorf("Service %q minted from a spec-legal `%s:` entry whose first key is "+
+					"`%s:` — that key is back in the next-line vocabulary. Got %v",
+					tc.entry, tc.section, tc.key, names6927(res, "Service"))
+			}
+			if !has6927(res, "Service", "api") {
+				t.Error("control: the real service was not minted, so this case grades nothing")
+			}
+		})
+	}
+}
+
+// TestIssue6927_Compose_HeadWhitespaceCannotCrossALine grades the `[ \t]` in
+// the rule's head, `):[ \t]*\r?\n`. PR #6949's review scored `[ \t]*` -> `\s*`
+// ALIVE at both levels and observed, correctly, that nothing preferred either
+// spelling.
+//
+// `\s` in RE2 is `[\t\n\f\r ]`, so it crosses LINE BOUNDARIES. `[ \t]*` cannot,
+// and that is the whole difference: the head's job is to say "nothing else on
+// THIS line", and `\s*` silently turns it into "nothing but whitespace for some
+// number of lines" — duplicating the blank/comment arm that follows it and then
+// over-reaching it, because the arm deliberately only skips lines that are
+// blank or comments.
+//
+// The distinguishing input is a line that is whitespace to `\s` but is NOT
+// blank to the arm — a lone form feed. Found by enumerating 39690 generated
+// key/separator/body combinations rather than by picking one: 7812 of them
+// separate the two spellings, and every one has this shape (a form feed, or a
+// stray `\r` in a half-converted CRLF file). Both controls below are lines the
+// arm DOES skip, so a failure cannot be "the arm stopped working".
+func TestIssue6927_Compose_HeadWhitespaceCannotCrossALine(t *testing.T) {
+	rules := composeRules6927(t)
+	for _, tc := range []struct {
+		name, sep string
+		want      bool
+	}{
+		{"a form feed is whitespace to \\s but is not a blank line", "\n\f\n", false},
+		{"control: a genuinely blank line IS skipped, by the arm", "\n \n", true},
+		{"control: a comment line IS skipped, by the arm", "\n#c\n", true},
+		{"control: a stray CR in a half-converted file is not a line the arm skips", "\r\r\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "services:\n  api:" + tc.sep + "    image: nginx\n"
+			got := has6927(detect6927(t, rules, "deploy/compose.yaml", src), "Service", "api")
+			if got != tc.want {
+				t.Errorf("Service \"api\" minted = %v, want %v for separator %q. The rule's head "+
+					"must be `[ \\t]*\\r?\\n`: `\\s*` there crosses line boundaries, so the "+
+					"\"nothing else on this line\" claim stops being about one line",
+					got, tc.want, tc.sep)
+			}
+		})
+	}
+}

--- a/internal/engine/rules/ansible/frameworks/ansible_core.yaml
+++ b/internal/engine/rules/ansible/frameworks/ansible_core.yaml
@@ -10,6 +10,55 @@ frameworks:
       - ansible
       - ansible-inventory
       - ansible-doc
+    # Presence signals for the requires_framework gate on the shorthand-module
+    # rule below (#6927). Literal substrings, matched against whole file
+    # content by compiledRuleSet.frameworkPresent. Note `config_files:
+    # ansible.cfg` above is NOT this signal — Detect is handed one file's
+    # content and cannot see a sibling.
+    #
+    # Measured over 992 real .yml/.yaml files: 309 ansible-shaped (4 upstream
+    # ansible repos — ansible-examples, ansible-for-devops, geerlingguy's
+    # docker and nginx roles) and 683 not (59 upstream repos in
+    # archigraph-corpora). Each of these seven markers matches ZERO of the 683
+    # on its own; the union takes the shorthand-module rule from 59 matches in
+    # 43 non-ansible files to 0 in 0, while keeping 128 of its 156
+    # in-framework matches.
+    #
+    # The 28 in-framework matches the gate declines, named rather than
+    # rounded away, because 15 of them are the gate WORKING:
+    #
+    #   * 15 are one file — ansible-for-devops's kube-flannel-vagrant.yml, a
+    #     Kubernetes manifest that happens to live in an ansible repo. Its
+    #     `template:` keys are k8s pod templates, not ansible modules, and
+    #     declining them is correct.
+    #   * 13 in 11 files are real losses, and they have one shape: a tiny
+    #     `roles/*/handlers/main.yml` holding `- name: restart apache` and
+    #     `service:` with `state: restarted`, which carries none of these
+    #     seven. `notify:` and `handlers:` would recover them but each admits
+    #     two non-ansible files, so the trade was declined; a later arm with a
+    #     bigger corpus should re-measure it.
+    #
+    # Blind spots. Zero-of-683 is a measurement, not a proof:
+    #
+    #   * `state: present` is a module ARGUMENT idiom, not an ansible-only
+    #     token. Any YAML declaring desired state can write it.
+    #   * `ansible_` is measured on repos that predate collections, which is
+    #     also why `ansible.builtin.` — the canonical FQCN prefix and the most
+    #     obviously correct marker here — is load-bearing for only 6 corpus
+    #     files and costs nothing to drop on THIS corpus. It is kept because
+    #     the corpus is old, not because the corpus grades it. Deleting it
+    #     alone is DEAD at the engine suite (one minimal task file per marker)
+    #     AND at the fixture gate, where a role handlers/main.yml carries it as
+    #     its ONLY marker and loses its Module without it — which is the input
+    #     shape #6945 had to be told its fixture was missing.
+    import_markers:
+      - "ansible.builtin."
+      - "become:"
+      - "gather_facts"
+      - "ansible_"
+      - "with_items:"
+      - ".j2"
+      - "state: present"
   version_signal: ansible.version (in playbooks or ansible --version output)
   notes: >-
     Ansible Core is the open-source orchestration engine. Detected by ansible.cfg
@@ -63,16 +112,90 @@ source_patterns:
     entity_type: Component
     name_group: 1
     scope: file
-  # Ansible module usage (e.g., ansible.builtin.copy:)
-  - pattern: "\\s+(\\w+\\.\\w+\\.\\w+):\\s*$"
+  # Ansible module usage by fully-qualified collection name
+  # (e.g. ansible.builtin.copy:).
+  #
+  # `(?m)` (#6927). This pattern carries NO `^`, so start-of-text was never
+  # its problem — `$` was. detector.go:156 compiles with plain
+  # regexp.Compile, where Go's `$` means end of TEXT and, unlike Perl, does
+  # not even allow a trailing newline before it. So this rule could fire only
+  # on a file whose LAST construct is a bare module key with no arguments
+  # under it, which no real task file is. Measured: ZERO matches across 992
+  # real YAML files, in ansible repos and outside them alike.
+  #
+  # What `$` BECOMES is the point, and here it becomes exactly right. Under
+  # `(?m)` it is end-of-LINE, so the rule reads "an FQCN key with nothing
+  # after the colon" — which is precisely the block form, a module whose
+  # arguments are the indented mapping below it. The rule still means what its
+  # name says; it just stops requiring that the module be the last thing in
+  # the file. Measured after: 22 matches in 9 files.
+  #
+  # `requires_framework: true`, even though this pattern measured ZERO matches
+  # in all 683 non-ansible files ungated. The three-segment dotted shape looks
+  # like a framework signal — a collection FQCN — but it is not one: a dotted
+  # key alone on its line is written by traefik labels in map form
+  # (`traefik.http.routers:`), by java-style `com.example.app:` config keys
+  # and by k8s annotation maps. Zero-of-683 is a measurement, not a proof, and
+  # the gate costs literally nothing here — all 9 in-framework files and all
+  # 22 matches survive it, checked file by file rather than in aggregate. A
+  # fence that is free is not worth declining on the strength of one corpus.
+  #
+  # So this rule has TWO fences and they are graded separately: the `$`, by an
+  # INLINE `ansible.builtin.debug: msg=hi` inside a file that SATISFIES the
+  # gate (dropping `\s*$` mints a Module for it), and the gate, by a
+  # `traefik.http.routers:` map key in a compose file that names ansible
+  # nowhere.
+  #
+  # Blind spot, unchanged by this fix: the INLINE `key=value` module form is
+  # invisible to this rule, before and after. That is a pre-existing recall
+  # gap, not something `(?m)` widened, and it is the same gap the `$` row pins
+  # shut from the other side.
+  - pattern: "(?m)\\s+(\\w+\\.\\w+\\.\\w+):\\s*$"
     entity_type: Module
     name_group: 1
     scope: file
-  # Built-in module shorthand (e.g., copy:, template:, service:)
-  - pattern: "^\\s+(apt|yum|dnf|pip|copy|template|file|service|systemd|command|shell|debug|set_fact|include_tasks|include_role|import_tasks|import_role):\\s*$"
+    requires_framework: true
+  # Built-in module shorthand (e.g. copy:, template:, service:).
+  #
+  # `(?m)` (#6927). Under start-of-text this could never fire at all: it needs
+  # `^` AND `$` at once, i.e. a file whose entire content is one indented key.
+  # Measured: ZERO matches across 992 real YAML files.
+  #
+  # `$` becomes end-of-line, which is right for the same reason as the FQCN
+  # rule above — block form, arguments in the mapping below. `^` becomes
+  # start-of-line, which is what makes the rule readable at all: the key must
+  # OPEN its line.
+  #
+  # `requires_framework: true` (#6927), because unlike the FQCN rule this one
+  # has no framework signal in its regex — `copy`, `template`, `file`,
+  # `service`, `command` and `debug` are ordinary English words that ordinary
+  # YAML uses as keys, and dormantBucketAliases maps the `ansible` bucket onto
+  # the whole `yaml` language, so every file in every repo is offered to it.
+  # Measured ungated on the 683 non-ansible files: 59 matches in 43 files,
+  # dominated by `template:` (41) from argocd ApplicationSets, helm chart
+  # templates and k8s PodTemplateSpecs, plus `service:` (7) from helm values,
+  # `file:` (5), `command:` (3) and `debug:` (3). Under the marker gate: 0 of
+  # 683, with 128 of the 156 in-framework matches kept. Same shape and same
+  # remedy as #6152's falcon/cherrypy gate and #6945's `^\s+- name:` gate.
+  #
+  # The two fences are graded separately: the gate holds a k8s Deployment
+  # whose `template:` is at the right indentation and would otherwise match,
+  # and the ANCHOR is held inside a file that satisfies the gate — an inline
+  # `copy: src=a dest=b`, which `\s*$` must decline. Naming the killing
+  # mutant, as #6945's job rule does: dropping `\s*$` mints a Module called
+  # `copy` for that inline task, which is a forbidden row in
+  # ansible-playbook-modules-mini.
+  #
+  # Blind spot: the alternation is a hand-written list of 18 names, so a
+  # shorthand module outside it (`user:`, `lineinfile:`, `git:`, `uri:`) is
+  # not seen. That is unchanged by this fix, and it is why the list itself is
+  # pinned as an exact set rather than by membership — a rule that grows a
+  # generic `(\w+)` there would type every block-form key in every gated file.
+  - pattern: "(?m)^\\s+(apt|yum|dnf|pip|copy|template|file|service|systemd|command|shell|debug|set_fact|include_tasks|include_role|import_tasks|import_role):\\s*$"
     entity_type: Module
     name_group: 1
     scope: file
+    requires_framework: true
   # handlers: section trigger
   - pattern: "notify:\\s+[\"']?([^\"'\\n]+)"
     entity_type: Operation

--- a/internal/engine/rules/ansible/frameworks/ansible_core.yaml
+++ b/internal/engine/rules/ansible/frameworks/ansible_core.yaml
@@ -186,11 +186,29 @@ source_patterns:
   # `copy` for that inline task, which is a forbidden row in
   # ansible-playbook-modules-mini.
   #
-  # Blind spot: the alternation is a hand-written list of 18 names, so a
-  # shorthand module outside it (`user:`, `lineinfile:`, `git:`, `uri:`) is
-  # not seen. That is unchanged by this fix, and it is why the list itself is
-  # pinned as an exact set rather than by membership — a rule that grows a
-  # generic `(\w+)` there would type every block-form key in every gated file.
+  # The alternation has TWO independent name questions and they are graded
+  # separately, because the first one's fence says nothing about the second:
+  #
+  #   * a shorthand module OUTSIDE the list (`user:`, `lineinfile:`, `git:`,
+  #     `uri:`) is not seen. A hand-written list of 18 names is a recall blind
+  #     spot, unchanged by this fix, and `lineinfile` is a forbidden row that
+  #     dies when the list is replaced by a generic `(\w+)`.
+  #   * a task KEYWORD getting INTO the list is the permissive direction, and
+  #     it was ungraded until PR #6949's review: inserting `when` left both
+  #     ./internal/engine/ and ./internal/quality/... at exit 0. `when:`,
+  #     `tags:`, `loop:`, `vars:`, `args:`, `environment:`, `block:` and their
+  #     siblings all take a list or a mapping, so a bare one has exactly the
+  #     shape this rule matches — and `when:` and `notify:` already have rules
+  #     of their own further down this file. No corpus frequency is claimed
+  #     for any of them; reachability is the property, and a count would be
+  #     the corpus-measurement-as-property trap running the permissive way.
+  #
+  # Naming the killing mutant, as this issue now requires: inserting `when`
+  # into the alternation mints a Module called `when`, which is a forbidden row
+  # in ansible-playbook-modules-mini, and the same file's Modules are asserted
+  # as an EXACT SET at engine level — which a membership check cannot do,
+  # because it is blind to a same-count SUBSTITUTION (swap `debug` for `when`)
+  # that no growth ceiling would catch either.
   - pattern: "(?m)^\\s+(apt|yum|dnf|pip|copy|template|file|service|systemd|command|shell|debug|set_fact|include_tasks|include_role|import_tasks|import_role):\\s*$"
     entity_type: Module
     name_group: 1

--- a/internal/engine/rules/docker/frameworks/docker_compose.yaml
+++ b/internal/engine/rules/docker/frameworks/docker_compose.yaml
@@ -90,35 +90,77 @@ source_patterns:
   #     `db-data`, `db-password`, `pgdata`, `default`. A framework gate cannot
   #     fix that one — the file IS compose.
   #
+  # Measured after the rewrite: 109 matches in 47 files, ZERO in-compose false
+  # positives and 5 matches in 3 non-compose files ungated (0 gated).
+  #
   # So the rule now says what a service is structurally, the same shape as
   # github_actions.yaml's job rule (#6945): a two-space key whose block opens
-  # with a compose SERVICE-level key. `$` is gone entirely; `[ \t]*\n`
-  # carries the "nothing else on this line" half without `$`'s end-of-text /
-  # end-of-line ambiguity, and `[ ]{3,}` requires the next key to be deeper
-  # indented. Both matter: `\s+` there would match a NEWLINE, so
-  # `volumes:\n  db-data:\n\nsecrets:` would read the column-0 `secrets:`
-  # as the block body and mint `db-data` — which is exactly the mutant this
-  # comment names, and `db-data` is a forbidden row in
-  # docker-compose-services-mini. The `(?:#[^\n]*)?\n` arm lets a comment
-  # line sit between the service key and its first key, which 7 of the
-  # corpus's compose files do.
+  # with a compose SERVICE-level key. Every character class in it is
+  # load-bearing, and three of them were wrong in the first version of this
+  # rewrite (PR #6949 review):
   #
-  # Measured after the rewrite: 111 matches in 48 files, which is 111 of the
-  # 111 real services in the corpus's compose files with ZERO in-compose false
-  # positives — full recall of the raw `(?m)` form with none of its 40 junk
-  # Services — and 14 matches in 12 non-compose files.
+  #   * `$` is gone entirely. `[ \t]*\r?\n` carries the "nothing else on
+  #     this line" half without `$`'s end-of-text / end-of-line ambiguity.
+  #     `[ \t]` and not `\s`, because `\s` is `[\t\n\f\r ]` and so
+  #     crosses LINE boundaries: `\s*` there would quietly turn "nothing else
+  #     on this line" into "nothing but whitespace for some number of lines",
+  #     duplicating the blank/comment arm below and then over-reaching it.
+  #     Graded by TestIssue6927_Compose_HeadWhitespaceCannotCrossALine, whose
+  #     distinguishing input was found by enumerating 39690 generated
+  #     key/separator/body combinations rather than by picking one.
+  #   * `\r?` is NOT optional decoration. The `\s*$` this replaced could
+  #     match a CRLF file (`\s` eats the `\r`) and the sibling
+  #     `^volumes:\s*\n` rules still can, so a bare `[ \t]*\n` here made
+  #     this the ONLY compose rule blind to CRLF: converting
+  #     docker-compose-services-mini's own compose.yaml to CRLF took it from
+  #     7/7 to 4/7, losing every Service and both `depends_on` edges. Graded
+  #     by TestIssue6927_Compose_ServiceRuleReadsCRLF.
+  #   * `[ ]{3,}` — literal spaces, at least three — requires the next key to
+  #     be deeper indented. `\s+` there would match a NEWLINE, so
+  #     `volumes:\n  db-data:\n\nsecrets:` would read the column-0
+  #     `secrets:` as the block body and mint `db-data`. `{3,}` rather than
+  #     `{2,}` is what keeps it off a SIBLING of the key, which is a separate
+  #     count and is graded separately.
+  #   * `^[ ]{2}` — literal spaces again, and for the same reason one position
+  #     to the left. `^\s{2}` under `(?m)` matches at a blank line and then
+  #     eats newlines, so a column-0 key preceded by two blank lines, or a
+  #     one-space key preceded by one, satisfied it.
   #
-  # `requires_framework: true` closes those 14. They are GitHub Actions jobs
-  # whose first key is `environment:` (starter-workflows/pages/*.yml all
-  # declare `deploy:\n  environment:`), an ansible `docker_container:` task
-  # and a helm values block. The vocabulary is compose's, but it is not
-  # compose's ALONE, and `environment`/`labels`/`command`/`user` are exactly
-  # the words other YAML dialects reuse. Under the gate: 0 of 941.
+  # The `(?:#[^\r\n]*)?\r?\n` arm lets comment and blank lines sit between
+  # the service key and its first key, which 7 of the corpus's compose files do.
+  #
+  # The next-line vocabulary is compose's SERVICE-level key set MINUS `labels`
+  # and `environment`, and that subtraction is the point rather than an
+  # oversight. Per the Compose Spec, an entry under top-level `volumes:`,
+  # `networks:`, `secrets:` or `configs:` may carry `driver`, `driver_opts`,
+  # `external`, `name`, `file`, `content`, `attachable`, `internal`, `ipam`,
+  # `enable_ipv6` — and `labels` (volumes, networks) and `environment`
+  # (secrets, configs). Those last two are the ONLY overlap with the
+  # service-level set, so excluding them makes the in-compose false-positive
+  # class empty by the FORMAT's own schema rather than merely zero on one
+  # corpus. A spec-legal `labels:` under a named volume is carried by
+  # docker-compose-services-mini and is what `db-data` (forbidden Service)
+  # grades; adding `labels` back mints it.
+  #
+  # The price is stated rather than rounded away: a service whose FIRST
+  # non-comment key is `environment:` or `labels:` is now missed, because the
+  # rule only inspects that one key. Measured over the corpus's 50 compose
+  # files: 109 of 111 real services (98.2%), down from 111 with the wider
+  # vocabulary and up from 0 before the fix, with ZERO in-compose false
+  # positives either way on that corpus. The two missed are `db` (an
+  # `environment:`-first service) and `postgres` (`labels:`-first), and the
+  # gap is pinned by TestIssue6927_Compose_EnvironmentFirstServiceIsMissed so
+  # it is observed rather than asserted here.
+  #
+  # `requires_framework: true` closes what is left: 5 matches in 3 non-compose
+  # files ungated (an ansible `docker_container:` task, a helm values block, a
+  # workflow's `workflow_call`), 0 of 941 under the gate. The vocabulary is
+  # compose's, but it is not compose's ALONE.
   #
   # The two fences are independent and each has its own forbidden rows —
-  # deleting `requires_framework` mints a Service for the workflow job, and
-  # weakening the vocabulary or the indent mints one for a named volume.
-  - pattern: "(?m)^\\s{2}(\\w[\\w-]*):[ \\t]*\\n(?:[ \\t]*(?:#[^\\n]*)?\\n)*[ ]{3,}(?:image|build|container_name|command|entrypoint|ports|expose|environment|env_file|depends_on|volumes|volumes_from|networks|network_mode|restart|healthcheck|deploy|labels|profiles|extends|logging|working_dir|user|hostname|platform|privileged|tty|stdin_open|init|secrets|configs|cap_add|devices|dns|links|pull_policy|scale|shm_size|sysctls|tmpfs|ulimits):"
+  # deleting `requires_framework` mints a Service for a workflow job, and
+  # weakening the vocabulary or either indent mints one for a named volume.
+  - pattern: "(?m)^[ ]{2}(\\w[\\w-]*):[ \\t]*\\r?\\n(?:[ \\t]*(?:#[^\\r\\n]*)?\\r?\\n)*[ ]{3,}(?:image|build|container_name|command|entrypoint|ports|expose|env_file|depends_on|volumes|volumes_from|networks|network_mode|restart|healthcheck|deploy|profiles|extends|logging|working_dir|user|hostname|platform|privileged|tty|stdin_open|init|secrets|configs|cap_add|devices|dns|links|pull_policy|scale|shm_size|sysctls|tmpfs|ulimits):"
     entity_type: Service
     name_group: 1
     scope: file

--- a/internal/engine/rules/docker/frameworks/docker_compose.yaml
+++ b/internal/engine/rules/docker/frameworks/docker_compose.yaml
@@ -11,6 +11,40 @@ frameworks:
     content_patterns:
       - "services:"
       - "version:"
+    # Presence signal for the requires_framework gate on the service rule
+    # below (#6927). A literal substring, matched against whole file content
+    # by compiledRuleSet.frameworkPresent.
+    #
+    # Measured over 992 real .yml/.yaml files (59 upstream repos in
+    # archigraph-corpora plus 4 upstream ansible repos): 51 are compose-shaped
+    # (a column-0 `services:` block, or one of the four config_files names)
+    # and 941 are not. `services:` admits 50 of the 51 and 10 of the 941 —
+    # django's and phoenix's CI workflows, which declare service CONTAINERS
+    # under a job, and three prometheus helm values files. Those ten are
+    # admitted by the gate and then declined by the pattern, which is the
+    # point: the two fences are independent and each is separately
+    # load-bearing. The product is ZERO matches in all 941.
+    #
+    # One marker, not a set, and deliberately: on this corpus `depends_on:`
+    # and `container_name:` are strictly redundant — every compose file
+    # carrying either also carries `services:` — so shipping them would add
+    # two markers that no input can grade, which is the shape #6945 called
+    # out. If a later arm finds a compose file with no `services:` key it
+    # should add a marker AND the case that grades it.
+    #
+    # Blind spots, named rather than implied. Zero-of-941 is a measurement,
+    # not a proof:
+    #
+    #   * `services:` is not compose-only. A GitHub Actions job's service
+    #     containers, a Kubernetes `spec.template` naming services and a helm
+    #     values file all write it. Every such file in the corpus is held by
+    #     the PATTERN, not by this marker.
+    #   * a compose v1 file (services at the top level, no `services:` key)
+    #     carries no marker at all. It also cannot match the service rule,
+    #     whose `^\s{2}` requires an indented key, so nothing is lost — but
+    #     the file is invisible to this rule set either way.
+    import_markers:
+      - "services:"
   notes: >-
     Docker Compose extraction. Detects service definitions, networks, volumes,
     and inter-service dependencies from compose files.
@@ -34,11 +68,61 @@ file_conventions:
     name_from: filename
 
 source_patterns:
-  # Service definition (top-level key under services:)
-  - pattern: "^\\s{2}(\\w[\\w-]*):\\s*$"
+  # Service definition (a key under `services:`).
+  #
+  # REWRITTEN, not just given `(?m)` (#6927). The old pattern was
+  # `^\s{2}(\w[\w-]*):\s*$`, compiled by detector.go:156 with plain
+  # regexp.Compile — so `^` meant start of TEXT and `$` end of TEXT, both at
+  # once. It matched only a file whose ENTIRE content is one indented key.
+  # Measured across 992 real YAML files: ZERO matches, in compose files and
+  # everywhere else.
+  #
+  # `(?m)` alone is what #6927 predicted would over-fire, and the measurement
+  # is why this pattern was rewritten instead. `(?m)` turns `$` into
+  # end-of-LINE, so `^\s{2}(\w[\w-]*):\s*$` reads "every two-space-indented
+  # key alone on its line" — which is not what a service is. Same corpus:
+  #
+  #   * 1867 matches in 611 of the 941 NON-compose files — `push`,
+  #     `pull_request` and `schedule` from workflow triggers, `tasks`/`roles`
+  #     from ansible plays, `labels`/`selector` from k8s manifests.
+  #   * and 40 false Services INSIDE real compose files, because a named
+  #     volume, network or secret is also a two-space key alone on its line:
+  #     `db-data`, `db-password`, `pgdata`, `default`. A framework gate cannot
+  #     fix that one — the file IS compose.
+  #
+  # So the rule now says what a service is structurally, the same shape as
+  # github_actions.yaml's job rule (#6945): a two-space key whose block opens
+  # with a compose SERVICE-level key. `$` is gone entirely; `[ \t]*\n`
+  # carries the "nothing else on this line" half without `$`'s end-of-text /
+  # end-of-line ambiguity, and `[ ]{3,}` requires the next key to be deeper
+  # indented. Both matter: `\s+` there would match a NEWLINE, so
+  # `volumes:\n  db-data:\n\nsecrets:` would read the column-0 `secrets:`
+  # as the block body and mint `db-data` — which is exactly the mutant this
+  # comment names, and `db-data` is a forbidden row in
+  # docker-compose-services-mini. The `(?:#[^\n]*)?\n` arm lets a comment
+  # line sit between the service key and its first key, which 7 of the
+  # corpus's compose files do.
+  #
+  # Measured after the rewrite: 111 matches in 48 files, which is 111 of the
+  # 111 real services in the corpus's compose files with ZERO in-compose false
+  # positives — full recall of the raw `(?m)` form with none of its 40 junk
+  # Services — and 14 matches in 12 non-compose files.
+  #
+  # `requires_framework: true` closes those 14. They are GitHub Actions jobs
+  # whose first key is `environment:` (starter-workflows/pages/*.yml all
+  # declare `deploy:\n  environment:`), an ansible `docker_container:` task
+  # and a helm values block. The vocabulary is compose's, but it is not
+  # compose's ALONE, and `environment`/`labels`/`command`/`user` are exactly
+  # the words other YAML dialects reuse. Under the gate: 0 of 941.
+  #
+  # The two fences are independent and each has its own forbidden rows —
+  # deleting `requires_framework` mints a Service for the workflow job, and
+  # weakening the vocabulary or the indent mints one for a named volume.
+  - pattern: "(?m)^\\s{2}(\\w[\\w-]*):[ \\t]*\\n(?:[ \\t]*(?:#[^\\n]*)?\\n)*[ ]{3,}(?:image|build|container_name|command|entrypoint|ports|expose|environment|env_file|depends_on|volumes|volumes_from|networks|network_mode|restart|healthcheck|deploy|labels|profiles|extends|logging|working_dir|user|hostname|platform|privileged|tty|stdin_open|init|secrets|configs|cap_add|devices|dns|links|pull_policy|scale|shm_size|sysctls|tmpfs|ulimits):"
     entity_type: Service
     name_group: 1
     scope: file
+    requires_framework: true
   # image: directive
   - pattern: "image:\\s+(\\S+)"
     entity_type: Dependency
@@ -59,13 +143,41 @@ source_patterns:
     entity_type: Dependency
     name_group: 1
     scope: file
-  # volumes definition (named volume)
-  - pattern: "^volumes:\\s*\\n\\s{2}(\\w[\\w-]*):"
+  # volumes definition (named volume).
+  #
+  # `(?m)` (#6927): compiled with plain regexp.Compile, so `^` meant start of
+  # TEXT — this fired only on a file whose very first bytes are `volumes:`,
+  # and no compose file opens that way. Measured: 0 matches in 992 real YAML
+  # files before, 18 in 18 compose files after.
+  #
+  # Carries no `$`, so `(?m)`'s other half cannot reach it.
+  #
+  # NOT gated, and that is measured rather than assumed: a column-0 `volumes:`
+  # whose next line is a two-space key is compose's top-level named-volume
+  # block and nothing else writes it. k8s puts `volumes:` under `spec`, i.e.
+  # indented; helm values write it at column 0 but as a LIST. Across all 941
+  # non-compose files the widened pattern matched ZERO times, so the column-0
+  # anchor is the whole fence and it is graded by a forbidden row instead
+  # (`app-data`, declared under an INDENTED `volumes:` in a k8s manifest).
+  #
+  # Known recall limit, unchanged by this fix: `^volumes:\s*\n\s{2}(...)`
+  # names only the FIRST volume of the block, because the regex has no way to
+  # repeat the group. That is why the corpus count is 18 in 18 files rather
+  # than one per named volume.
+  - pattern: "(?m)^volumes:\\s*\\n\\s{2}(\\w[\\w-]*):"
     entity_type: Config
     name_group: 1
     scope: file
-  # networks definition (named network)
-  - pattern: "^networks:\\s*\\n\\s{2}(\\w[\\w-]*):"
+  # networks definition (named network).
+  #
+  # `(?m)` (#6927), for the same reason and with the same measurement shape as
+  # the volumes rule above: 0 matches in 992 files before, 9 in 9 compose
+  # files after, ZERO in all 941 non-compose files, no `$`.
+  #
+  # Also ungated, also column-0-anchored, and also graded by a forbidden row
+  # rather than by a gate (`pod-network`, under an indented `networks:`).
+  # Same first-entry-only recall limit as the volumes rule.
+  - pattern: "(?m)^networks:\\s*\\n\\s{2}(\\w[\\w-]*):"
     entity_type: Config
     name_group: 1
     scope: file

--- a/internal/quality/absent_relationships_6490_test.go
+++ b/internal/quality/absent_relationships_6490_test.go
@@ -229,8 +229,8 @@ func TestEveryGoldenFixtureDeclaresExpectedRelationships_6490(t *testing.T) {
 	// Checked only after `missing` is reported, because a fixture that failed
 	// the key check never reached the counter — this is the number of fixtures
 	// actually INSPECTED, not the number of files opened.
-	if fixtures != 35 {
-		t.Fatalf("inspected %d golden fixtures, want 35 — the corpus size changed, so this "+
+	if fixtures != 37 {
+		t.Fatalf("inspected %d golden fixtures, want 37 — the corpus size changed, so this "+
 			"test's coverage claim needs re-deriving rather than silently shrinking", fixtures)
 	}
 	// A FAILURE, not a t.Logf. It was a log while arm A only required the key

--- a/internal/quality/comment_only_marker_6949_test.go
+++ b/internal/quality/comment_only_marker_6949_test.go
@@ -1,0 +1,213 @@
+package quality
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/engine"
+)
+
+// A golden fixture's own COMMENT can satisfy a framework gate, and it makes
+// every forbidden row in that file silently unfireable.
+//
+// Found while writing #6927's docker/ansible arm (PR #6949). Four
+// gate-direction fixture files were first written with headers explaining what
+// they do NOT contain — "declares no `services:` key", "no `become:`, no
+// `gather_facts`, no `.j2`" — and `compiledRuleSet.frameworkPresent`
+// (detector.go:96) is `strings.Contains` over WHOLE FILE CONTENT, evaluated
+// once per (rule set, file) at :402, BEFORE the per-pattern
+// `requiresFramework` skip at :409. So each of those headers admitted its own
+// file to the very rule set it was written to be declined by, and all four
+// gate rows passed for the wrong reason. Nothing failed; the rows were simply
+// unreachable. It was caught only by dumping what Detect actually emitted per
+// file before writing expected.json.
+//
+// That is a whole class of silently-unfireable negative control, so it is a
+// test rather than a lesson. The scan is deliberately broader than the
+// incident: it does not care WHY the marker is on a comment line.
+//
+// Three limits, stated rather than implied:
+//
+//  1. It sees COMMENTS only. The same hazard exists for a string literal, a
+//     docstring or a heredoc naming a marker, and this test is blind to all
+//     three. `strings.Contains` does not care where the bytes are.
+//  2. commentPrefixes6949 is a hand-written extension map. A fixture in a
+//     language it does not list is skipped, which is a false NEGATIVE — the
+//     failure mode is silence, so the map is asserted to cover the corpus
+//     below rather than trusted.
+//  3. It reports a marker whose occurrences are ALL on comment lines. A file
+//     carrying the marker in real code as well is genuinely admitted, and this
+//     test has no opinion on it.
+func TestGoldenFixtureMarkersAreNotCommentOnly_6949(t *testing.T) {
+	rules, err := engine.LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	// One marker string may be declared by several rule sets; the hazard is a
+	// property of the STRING, so they are deduplicated and the owners kept for
+	// the failure message.
+	owners := map[string]map[string]bool{}
+	for _, frs := range rules {
+		for _, fr := range frs {
+			for _, m := range fr.Frameworks.Detection.ImportMarkers {
+				if m == "" {
+					continue
+				}
+				if owners[m] == nil {
+					owners[m] = map[string]bool{}
+				}
+				owners[m][fr.Frameworks.Name] = true
+			}
+		}
+	}
+	if len(owners) < 200 {
+		t.Fatalf("only %d distinct import_markers were loaded; this scan grades nothing at "+
+			"that size, so rule loading is what broke", len(owners))
+	}
+
+	root := filepath.Join("golden")
+	var files []string
+	if err := filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
+		if err != nil || fi.IsDir() {
+			return err
+		}
+		// Only fixture SOURCE is offered to the detector; expected.json is not.
+		if strings.Contains(filepath.ToSlash(p), "/src/") {
+			files = append(files, p)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk golden/: %v", err)
+	}
+	if len(files) < 100 {
+		t.Fatalf("found %d fixture source files, which is too few for this scan to be "+
+			"measuring the corpus", len(files))
+	}
+
+	var skipped []string
+	var hits []string
+	for _, p := range files {
+		prefixes, known := commentPrefixes6949[strings.ToLower(filepath.Ext(p))]
+		if !known {
+			// Extensionless and build-file names (Gemfile, Makefile, …) are
+			// keyed by basename instead.
+			prefixes, known = commentPrefixes6949[strings.ToLower(filepath.Base(p))]
+		}
+		if !known {
+			skipped = append(skipped, p)
+			continue
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		content := string(b)
+		// Split once; the marker loop is 1000+ iterations per file.
+		var codeLines, commentLines []string
+		for _, line := range strings.Split(content, "\n") {
+			trimmed := strings.TrimLeft(line, " \t")
+			isComment := false
+			for _, pre := range prefixes {
+				if strings.HasPrefix(trimmed, pre) {
+					isComment = true
+					break
+				}
+			}
+			if isComment {
+				commentLines = append(commentLines, line)
+			} else {
+				codeLines = append(codeLines, line)
+			}
+		}
+		code := strings.Join(codeLines, "\n")
+		comments := strings.Join(commentLines, "\n")
+		for m := range owners {
+			if !strings.Contains(comments, m) || strings.Contains(code, m) {
+				continue
+			}
+			var names []string
+			for n := range owners[m] {
+				names = append(names, n)
+			}
+			sort.Strings(names)
+			key := fmt.Sprintf("%s :: %q (declared by %s)", filepath.ToSlash(p), m,
+				strings.Join(names, ", "))
+			if allowedCommentOnlyMarkers6949[fmt.Sprintf("%s|%s", filepath.ToSlash(p), m)] {
+				continue
+			}
+			hits = append(hits, key)
+		}
+	}
+	sort.Strings(hits)
+	for _, h := range hits {
+		t.Errorf("a fixture's COMMENT carries a framework import_marker and its code does not:\n"+
+			"    %s\n"+
+			"  frameworkPresent is strings.Contains over whole file content, so this comment "+
+			"admits the file to that rule set. If the file is a negative control for that "+
+			"framework, every forbidden row it holds is unfireable — rewrite the comment so it "+
+			"does not spell the marker. If the admission is intended, add the pair to "+
+			"allowedCommentOnlyMarkers6949 with the reason.", h)
+	}
+	// A map that stopped covering the corpus turns this test into silence, so
+	// the coverage is asserted rather than assumed (limit 2 above).
+	if len(skipped) > 0 {
+		sort.Strings(skipped)
+		t.Errorf("%d fixture source files have an extension commentPrefixes6949 does not know, "+
+			"so they were NOT scanned (e.g. %s). Add the extension's comment prefixes; a "+
+			"silently unscanned language is the failure mode this test exists to prevent",
+			len(skipped), strings.Join(skipped[:min6949(3, len(skipped))], ", "))
+	}
+}
+
+func min6949(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// commentPrefixes6949 maps a fixture source extension to the line-comment
+// openers of that language. Block comments are NOT modelled: a marker inside
+// `/* ... */` reads as code here, which is a false negative in the same
+// direction as limit 1 above.
+var commentPrefixes6949 = map[string][]string{
+	".c": {"//"}, ".cc": {"//"}, ".clj": {";"}, ".cs": {"//"}, ".cpp": {"//"},
+	".dart": {"//"}, ".ex": {"#"}, ".exs": {"#"}, ".erl": {"%"}, ".fs": {"//"},
+	".go": {"//"}, ".graphql": {"#"}, ".groovy": {"//"}, ".h": {"//"},
+	".hrl": {"%"}, ".hs": {"--"}, ".html": {"<!--"}, ".java": {"//"},
+	".js": {"//"}, ".json": {}, ".jsx": {"//"}, ".kt": {"//"}, ".lisp": {";"},
+	".lua": {"--"}, ".md": {}, ".ml": {}, ".mli": {}, ".nim": {"#"},
+	".php": {"//", "#"}, ".pony": {"//"}, ".proto": {"//"}, ".py": {"#"},
+	".rb": {"#"}, ".rs": {"//"}, ".sbt": {"//"}, ".scala": {"//"},
+	".sol": {"//"}, ".sql": {"--"}, ".swift": {"//"}, ".toml": {"#"},
+	".ts": {"//"}, ".tsx": {"//"}, ".txt": {}, ".vb": {"'"}, ".xml": {"<!--"},
+	".yaml": {"#"}, ".yml": {"#"}, ".cfg": {"#"}, ".conf": {"#"},
+	".gradle": {"//"}, ".properties": {"#"}, ".sh": {"#"}, ".j2": {"#"},
+	".mod": {"//"}, ".sum": {}, ".lock": {"#"}, ".csproj": {"<!--"},
+	".gitignore": {"#"}, ".env": {"#"}, ".ini": {";", "#"}, ".css": {},
+	".scss": {"//"}, ".vue": {"//"}, ".svelte": {"//"}, ".tf": {"#", "//"},
+	".edn": {";"}, ".cljs": {";"}, ".pl": {"#"}, ".pm": {"#"}, ".r": {"#"},
+	".jl": {"#"}, ".zig": {"//"}, ".v": {"//"}, ".d": {"//"}, ".m": {"//"},
+	".mm": {"//"}, ".f90": {"!"}, ".pas": {"//"}, ".ada": {"--"},
+	".adb": {"--"}, ".ads": {"--"}, ".cob": {"*"}, ".asm": {";"},
+	".ru": {"#"},
+	// Keyed by basename, for sources with no extension.
+	"gemfile": {"#"}, "rakefile": {"#"}, "makefile": {"#"}, "dockerfile": {"#"},
+	"procfile": {"#"},
+}
+
+// allowedCommentOnlyMarkers6949 records "<repo-relative path>|<marker>" pairs
+// that are known and harmless. Each needs a reason, because an entry here is a
+// negative control someone decided not to have.
+var allowedCommentOnlyMarkers6949 = map[string]bool{
+	// `stub` is one of lua/frameworks/test_patterns.yaml's markers, and this is
+	// a C# file: Detect resolves rule sets by file.Language, so the lua set is
+	// never offered this file and the admission cannot happen. Cross-language,
+	// therefore inert — but recorded rather than filtered out by a rule, so
+	// that a same-language instance still fails.
+	"golden/csharp-aspnet-core-mini/src/Services/UserService.cs|stub": true,
+}

--- a/internal/quality/golden/ansible-playbook-modules-mini/expected.json
+++ b/internal/quality/golden/ansible-playbook-modules-mini/expected.json
@@ -1,15 +1,14 @@
 {
   "fixture_name": "ansible-playbook-modules-mini",
   "language": "ansible",
-  "description": "Ansible Core rule patterns (#6927, the `$`-side arm). Two module rules in rules/ansible/frameworks/ansible_core.yaml were compiled without `(?m)`. Both carry a `$`, and in Go `$` without `(?m)` is end of TEXT with no trailing-newline allowance, so the FQCN rule needed the file to END with a bare module key and the shorthand rule needed `^` AND `$` at once — a file whose entire content is one indented key. Measured across 992 real YAML files (59 upstream repos plus 4 upstream ansible repos): ZERO matches for either, inside ansible repos and outside them alike. Under `(?m)` the `$` becomes end of LINE, which is exactly the block form — a module key with its arguments in the mapping below it — so both rules finally mean what their names say. The shorthand rule is plain English (`copy`, `template`, `file`, `service`, `command`) and the ansible bucket is aliased onto the whole `yaml` language, so it needed a framework gate: 59 matches in 43 non-ansible files ungated, 0 gated. The FQCN rule measured zero over-fire but is gated too, because the gate costs nothing here and a dotted map key is not ansible-only. The fixture separates the ANCHOR/`$` axis (inline forms and a commented-out module, inside files that satisfy the gate) from the GATE axis (a k8s manifest and a traefik config that name ansible nowhere), and grades the shorthand rule's NAME axis separately from both."
-  ,
+  "description": "Ansible Core rule patterns (#6927, the `$`-side arm). Two module rules in rules/ansible/frameworks/ansible_core.yaml were compiled without `(?m)`. Both carry a `$`, and in Go `$` without `(?m)` is end of TEXT with no trailing-newline allowance, so the FQCN rule needed the file to END with a bare module key and the shorthand rule needed `^` AND `$` at once \u2014 a file whose entire content is one indented key. Measured across 992 real YAML files (59 upstream repos plus 4 upstream ansible repos): ZERO matches for either, inside ansible repos and outside them alike. Under `(?m)` the `$` becomes end of LINE, which is exactly the block form \u2014 a module key with its arguments in the mapping below it \u2014 so both rules finally mean what their names say. The shorthand rule is plain English (`copy`, `template`, `file`, `service`, `command`) and the ansible bucket is aliased onto the whole `yaml` language, so it needed a framework gate: 59 matches in 43 non-ansible files ungated, 0 gated. The FQCN rule measured zero over-fire but is gated too, because the gate costs nothing here and a dotted map key is not ansible-only. The fixture separates the ANCHOR/`$` axis (inline forms and a commented-out module, inside files that satisfy the gate) from the GATE axis (a k8s manifest and a traefik config that name ansible nowhere), and grades the shorthand rule's NAME axis separately from both \u2014 twice over, since the alternation has two independent name questions: whether a module OUTSIDE the list is minted (`lineinfile`) and whether a task KEYWORD inside it would be (`when`, `tags`, `loop`).",
   "expected_entities": [
     {
       "name": "ansible.builtin.apt",
       "kind": "Module",
       "source_file": "provisioning/roles/storefront/tasks/main.yml",
       "must_exist": true,
-      "note": "#6927 recall arm for `(?m)\\s+(\\w+\\.\\w+\\.\\w+):\\s*$`. First module in the file — under end-of-TEXT only a module that is the LAST construct in the file could ever match, so a first-in-file row is the shape the old pattern was furthest from reaching."
+      "note": "#6927 recall arm for `(?m)\\s+(\\w+\\.\\w+\\.\\w+):\\s*$`. First module in the file \u2014 under end-of-TEXT only a module that is the LAST construct in the file could ever match, so a first-in-file row is the shape the old pattern was furthest from reaching."
     },
     {
       "name": "community.docker.docker_container",
@@ -23,14 +22,14 @@
       "kind": "Module",
       "source_file": "provisioning/roles/storefront/handlers/main.yml",
       "must_exist": true,
-      "note": "Same rule in a SECOND file — a role handlers/main.yml — so one file's layout is not what carries the FQCN rule's rows."
+      "note": "Same rule in a SECOND file \u2014 a role handlers/main.yml \u2014 so one file's layout is not what carries the FQCN rule's rows."
     },
     {
       "name": "template",
       "kind": "Module",
       "source_file": "provisioning/roles/storefront/tasks/main.yml",
       "must_exist": true,
-      "note": "#6927 recall arm for the shorthand rule `(?m)^\\s+(apt|yum|...|import_role):\\s*$`, which could not fire AT ALL before: it needs `^` and `$` simultaneously. `template` is also the single most common over-fire word for this rule outside ansible — 41 of its 59 non-ansible corpus matches — which is why deploy/k8s/deployment.yaml carries a k8s `template:` in exactly the matching shape and is held by the gate."
+      "note": "#6927 recall arm for the shorthand rule `(?m)^\\s+(apt|yum|...|import_role):\\s*$`, which could not fire AT ALL before: it needs `^` and `$` simultaneously. `template` is also the single most common over-fire word for this rule outside ansible \u2014 41 of its 59 non-ansible corpus matches \u2014 which is why deploy/k8s/deployment.yaml carries a k8s `template:` in exactly the matching shape and is held by the gate."
     },
     {
       "name": "service",
@@ -59,19 +58,19 @@
       "name": "copy",
       "kind": "Module",
       "must_exist": false,
-      "note": "#6927 forbidden arm, `$` direction for the shorthand rule, INSIDE a file that satisfies the framework gate — so this row is held by the anchor alone and is distinguishable from the gate rows below. The task writes the deprecated inline form `copy: src=... dest=...`; `\\s*$` is what declines it. Named in the rule comment as its own killing mutant: dropping `\\s*$` mints a Module called `copy`."
+      "note": "#6927 forbidden arm, `$` direction for the shorthand rule, INSIDE a file that satisfies the framework gate \u2014 so this row is held by the anchor alone and is distinguishable from the gate rows below. The task writes the deprecated inline form `copy: src=... dest=...`; `\\s*$` is what declines it. Named in the rule comment as its own killing mutant: dropping `\\s*$` mints a Module called `copy`."
     },
     {
       "name": "systemd",
       "kind": "Module",
       "must_exist": false,
-      "note": "#6927 forbidden arm, `^` direction for the shorthand rule — a separate half of the same anchor, in the same gate-satisfying file. A commented-out module block (`# - systemd:`) puts the key on a line it does not OPEN; without `^` the rule's own `\\s+` reaches it through the comment marker and mints a Module for code that is switched off."
+      "note": "#6927 forbidden arm, `^` direction for the shorthand rule \u2014 a separate half of the same anchor, in the same gate-satisfying file. A commented-out module block (`# - systemd:`) puts the key on a line it does not OPEN; without `^` the rule's own `\\s+` reaches it through the comment marker and mints a Module for code that is switched off."
     },
     {
       "name": "lineinfile",
       "kind": "Module",
       "must_exist": false,
-      "note": "#6927 forbidden arm, NAME direction for the shorthand rule, again inside the gate-satisfying file, so the name axis is graded independently of both the anchor and the gate (#6943's lesson: a fixture that pins one axis does not pin its neighbour). The alternation is a hand-written list of 18 module names; `lineinfile` is a real ansible module that is deliberately NOT in it. Replacing the alternation with `(\\w+)` mints this row — and would type every block-form key in every gated file."
+      "note": "#6927 forbidden arm, NAME direction for the shorthand rule, again inside the gate-satisfying file, so the name axis is graded independently of both the anchor and the gate (#6943's lesson: a fixture that pins one axis does not pin its neighbour). The alternation is a hand-written list of 18 module names; `lineinfile` is a real ansible module that is deliberately NOT in it. Replacing the alternation with `(\\w+)` mints this row \u2014 and would type every block-form key in every gated file."
     },
     {
       "name": "ansible.builtin.debug",
@@ -89,13 +88,31 @@
       "name": "command",
       "kind": "Module",
       "must_exist": false,
-      "note": "#6927 forbidden arm, FRAMEWORK-GATE direction for the shorthand rule. deploy/k8s/deployment.yaml is a Kubernetes Deployment carrying a block-form `command:` (and a `template:`) at matching indentation and naming ansible nowhere; `requires_framework: true` is the only thing declining it. `command` rather than `template` because forbidden rows are matched by name and kind globally, and `template` is a must-have from the tasks file — a forbidden row that collides with an expected one is unfireable, which is the #6938 shape this issue asks each row to be checked against."
+      "note": "#6927 forbidden arm, FRAMEWORK-GATE direction for the shorthand rule. deploy/k8s/deployment.yaml is a Kubernetes Deployment carrying a block-form `command:` (and a `template:`) at matching indentation and naming ansible nowhere; `requires_framework: true` is the only thing declining it. `command` rather than `template` because forbidden rows are matched by name and kind globally, and `template` is a must-have from the tasks file \u2014 a forbidden row that collides with an expected one is unfireable, which is the #6938 shape this issue asks each row to be checked against."
     },
     {
       "name": "storefront.rate.limiter",
       "kind": "Module",
       "must_exist": false,
-      "note": "#6927 forbidden arm, FRAMEWORK-GATE direction for the FQCN rule — the rule whose over-fire measured ZERO across 683 non-ansible files, which is why it is gated on a named blind spot rather than on a count. A traefik file-provider config names its middlewares, dots are legal in a middleware name, and a dotted key in block form is indistinguishable from a collection FQCN by shape alone. This file is constructed, not sampled: the corpus contained no such key, which is exactly why zero-of-683 was treated as a measurement and not a proof."
+      "note": "#6927 forbidden arm, FRAMEWORK-GATE direction for the FQCN rule \u2014 the rule whose over-fire measured ZERO across 683 non-ansible files, which is why it is gated on a named blind spot rather than on a count. A traefik file-provider config names its middlewares, dots are legal in a middleware name, and a dotted key in block form is indistinguishable from a collection FQCN by shape alone. This file is constructed, not sampled: the corpus contained no such key, which is exactly why zero-of-683 was treated as a measurement and not a proof."
+    },
+    {
+      "name": "when",
+      "kind": "Module",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, ALTERNATION-MEMBERSHIP direction \u2014 the third axis of the shorthand rule, and the permissive one. PR #6949 review MI-1: inserting `when` into the alternation left BOTH `./internal/engine/` and `./internal/quality/...` at exit 0, because every mutant scored so far attacked the anchor, the `$`, the indent or the gate, and nothing attacked what the list CONTAINS. `when:` followed by a list of conditions is ordinary ansible and is bare-colon-legal, so it has exactly the shape the rule matches; it is a task KEYWORD, not a module, and it already has its own `when:\\s+(.+)` -> Config rule in this same file. Adding it to the alternation mints this row."
+    },
+    {
+      "name": "tags",
+      "kind": "Module",
+      "must_exist": false,
+      "note": "Second ALTERNATION-MEMBERSHIP row, on a keyword with no other rule of its own, so the fence is not resting on `when`'s Config rule making the collision visible some other way. `tags:` with a list under it is bare-colon-legal ansible."
+    },
+    {
+      "name": "loop",
+      "kind": "Module",
+      "must_exist": false,
+      "note": "Third ALTERNATION-MEMBERSHIP row, on a loop keyword rather than a conditional or a metadata one, so one syntactic family cannot be what carries the axis. All three are graded together as an EXACT SET at engine level (TestIssue6927_Ansible_ModuleRulesReadBlockFormOnly), which a membership check cannot do: an exact set also catches a same-count SUBSTITUTION \u2014 swapping `debug` for `when` \u2014 that no growth ceiling and no per-row check would see."
     }
   ],
   "expected_relationships": [
@@ -108,7 +125,7 @@
       "to_kind": "Operation",
       "to_file": "provisioning/roles/storefront/tasks/main.yml",
       "must_exist": true,
-      "note": "The notify-triggers-handler edge. Its rule is un-anchored and untouched here, so it is a CONTROL — but a load-bearing one: the notify sits on the FIRST task on purpose, because `name:\\s+([^\\n]+)[\\s\\S]*?notify:` takes the first `name:` in the file as its source endpoint regardless of which task the notify belongs to. Putting it anywhere else would have asserted an edge that is right by accident."
+      "note": "The notify-triggers-handler edge. Its rule is un-anchored and untouched here, so it is a CONTROL \u2014 but a load-bearing one: the notify sits on the FIRST task on purpose, because `name:\\s+([^\\n]+)[\\s\\S]*?notify:` takes the first `name:` in the file as its source endpoint regardless of which task the notify belongs to. Putting it anywhere else would have asserted an edge that is right by accident."
     },
     {
       "from_name": "deployment.yaml",
@@ -119,7 +136,7 @@
       "to_kind": "SCOPE.Service",
       "to_file": "deploy/k8s/deployment.yaml",
       "must_exist": true,
-      "note": "CONTROL on a second producer path — the structured YAML extractor in internal/extractors/yaml — and deliberately in the file the framework gate DECLINES, so it also witnesses that the gate suppresses the ansible rules for that file without suppressing the file itself."
+      "note": "CONTROL on a second producer path \u2014 the structured YAML extractor in internal/extractors/yaml \u2014 and deliberately in the file the framework gate DECLINES, so it also witnesses that the gate suppresses the ansible rules for that file without suppressing the file itself."
     }
   ]
 }

--- a/internal/quality/golden/ansible-playbook-modules-mini/expected.json
+++ b/internal/quality/golden/ansible-playbook-modules-mini/expected.json
@@ -1,0 +1,125 @@
+{
+  "fixture_name": "ansible-playbook-modules-mini",
+  "language": "ansible",
+  "description": "Ansible Core rule patterns (#6927, the `$`-side arm). Two module rules in rules/ansible/frameworks/ansible_core.yaml were compiled without `(?m)`. Both carry a `$`, and in Go `$` without `(?m)` is end of TEXT with no trailing-newline allowance, so the FQCN rule needed the file to END with a bare module key and the shorthand rule needed `^` AND `$` at once — a file whose entire content is one indented key. Measured across 992 real YAML files (59 upstream repos plus 4 upstream ansible repos): ZERO matches for either, inside ansible repos and outside them alike. Under `(?m)` the `$` becomes end of LINE, which is exactly the block form — a module key with its arguments in the mapping below it — so both rules finally mean what their names say. The shorthand rule is plain English (`copy`, `template`, `file`, `service`, `command`) and the ansible bucket is aliased onto the whole `yaml` language, so it needed a framework gate: 59 matches in 43 non-ansible files ungated, 0 gated. The FQCN rule measured zero over-fire but is gated too, because the gate costs nothing here and a dotted map key is not ansible-only. The fixture separates the ANCHOR/`$` axis (inline forms and a commented-out module, inside files that satisfy the gate) from the GATE axis (a k8s manifest and a traefik config that name ansible nowhere), and grades the shorthand rule's NAME axis separately from both."
+  ,
+  "expected_entities": [
+    {
+      "name": "ansible.builtin.apt",
+      "kind": "Module",
+      "source_file": "provisioning/roles/storefront/tasks/main.yml",
+      "must_exist": true,
+      "note": "#6927 recall arm for `(?m)\\s+(\\w+\\.\\w+\\.\\w+):\\s*$`. First module in the file — under end-of-TEXT only a module that is the LAST construct in the file could ever match, so a first-in-file row is the shape the old pattern was furthest from reaching."
+    },
+    {
+      "name": "community.docker.docker_container",
+      "kind": "Module",
+      "source_file": "provisioning/roles/storefront/tasks/main.yml",
+      "must_exist": true,
+      "note": "Same rule, LAST module in the file (the vertical axis) and a NON-builtin collection, so `ansible.builtin.` cannot be what the rule is really keying on."
+    },
+    {
+      "name": "ansible.builtin.service",
+      "kind": "Module",
+      "source_file": "provisioning/roles/storefront/handlers/main.yml",
+      "must_exist": true,
+      "note": "Same rule in a SECOND file — a role handlers/main.yml — so one file's layout is not what carries the FQCN rule's rows."
+    },
+    {
+      "name": "template",
+      "kind": "Module",
+      "source_file": "provisioning/roles/storefront/tasks/main.yml",
+      "must_exist": true,
+      "note": "#6927 recall arm for the shorthand rule `(?m)^\\s+(apt|yum|...|import_role):\\s*$`, which could not fire AT ALL before: it needs `^` and `$` simultaneously. `template` is also the single most common over-fire word for this rule outside ansible — 41 of its 59 non-ansible corpus matches — which is why deploy/k8s/deployment.yaml carries a k8s `template:` in exactly the matching shape and is held by the gate."
+    },
+    {
+      "name": "service",
+      "kind": "Module",
+      "source_file": "provisioning/roles/storefront/tasks/main.yml",
+      "must_exist": true,
+      "note": "Same rule, a different alternation entry and a later position in the file."
+    },
+    {
+      "name": "Install nginx",
+      "kind": "Task",
+      "source_file": "provisioning/roles/storefront/tasks/main.yml",
+      "must_exist": true,
+      "note": "CONTROL, held constant. `-\\s+name:\\s+[\\\"']?([^\\\"'\\n]+)` carries no anchor and no gate, so it was green before this change and must stay green."
+    },
+    {
+      "name": "restart nginx",
+      "kind": "Operation",
+      "source_file": "provisioning/roles/storefront/tasks/main.yml",
+      "must_exist": true,
+      "note": "Second CONTROL on a second un-anchored rule (`notify:\\s+[\\\"']?([^\\\"'\\n]+)`), untouched by this change and the source endpoint of the edge asserted below."
+    }
+  ],
+  "forbidden_entities": [
+    {
+      "name": "copy",
+      "kind": "Module",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, `$` direction for the shorthand rule, INSIDE a file that satisfies the framework gate — so this row is held by the anchor alone and is distinguishable from the gate rows below. The task writes the deprecated inline form `copy: src=... dest=...`; `\\s*$` is what declines it. Named in the rule comment as its own killing mutant: dropping `\\s*$` mints a Module called `copy`."
+    },
+    {
+      "name": "systemd",
+      "kind": "Module",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, `^` direction for the shorthand rule — a separate half of the same anchor, in the same gate-satisfying file. A commented-out module block (`# - systemd:`) puts the key on a line it does not OPEN; without `^` the rule's own `\\s+` reaches it through the comment marker and mints a Module for code that is switched off."
+    },
+    {
+      "name": "lineinfile",
+      "kind": "Module",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, NAME direction for the shorthand rule, again inside the gate-satisfying file, so the name axis is graded independently of both the anchor and the gate (#6943's lesson: a fixture that pins one axis does not pin its neighbour). The alternation is a hand-written list of 18 module names; `lineinfile` is a real ansible module that is deliberately NOT in it. Replacing the alternation with `(\\w+)` mints this row — and would type every block-form key in every gated file."
+    },
+    {
+      "name": "ansible.builtin.debug",
+      "kind": "Module",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, `$` direction for the FQCN rule, the second of the two rules this arm widens. `ansible.builtin.debug: msg=...` is the inline form; end-of-line is the whole of what declines it. That rule has no `^` at all, so `$` is its only anchor and this is the only row that grades it."
+    },
+    {
+      "name": "nginx.conf",
+      "kind": "Module",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, NAME direction for the FQCN rule. `\\w+\\.\\w+\\.\\w+` is exactly three dotted segments because that is what a collection FQCN is; a two-segment key is a variable name, and `set_fact` sets one called `nginx.conf` in block form. Loosening the third segment to `(?:\\.\\w+)?` mints it. Inside the gate-satisfying file, so this is about the shape and not the gate."
+    },
+    {
+      "name": "command",
+      "kind": "Module",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, FRAMEWORK-GATE direction for the shorthand rule. deploy/k8s/deployment.yaml is a Kubernetes Deployment carrying a block-form `command:` (and a `template:`) at matching indentation and naming ansible nowhere; `requires_framework: true` is the only thing declining it. `command` rather than `template` because forbidden rows are matched by name and kind globally, and `template` is a must-have from the tasks file — a forbidden row that collides with an expected one is unfireable, which is the #6938 shape this issue asks each row to be checked against."
+    },
+    {
+      "name": "storefront.rate.limiter",
+      "kind": "Module",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, FRAMEWORK-GATE direction for the FQCN rule — the rule whose over-fire measured ZERO across 683 non-ansible files, which is why it is gated on a named blind spot rather than on a count. A traefik file-provider config names its middlewares, dots are legal in a middleware name, and a dotted key in block form is indistinguishable from a collection FQCN by shape alone. This file is constructed, not sampled: the corpus contained no such key, which is exactly why zero-of-683 was treated as a measurement and not a proof."
+    }
+  ],
+  "expected_relationships": [
+    {
+      "from_name": "Install nginx",
+      "from_kind": "Task",
+      "from_file": "provisioning/roles/storefront/tasks/main.yml",
+      "kind": "CALLS",
+      "to_name": "restart nginx",
+      "to_kind": "Operation",
+      "to_file": "provisioning/roles/storefront/tasks/main.yml",
+      "must_exist": true,
+      "note": "The notify-triggers-handler edge. Its rule is un-anchored and untouched here, so it is a CONTROL — but a load-bearing one: the notify sits on the FIRST task on purpose, because `name:\\s+([^\\n]+)[\\s\\S]*?notify:` takes the first `name:` in the file as its source endpoint regardless of which task the notify belongs to. Putting it anywhere else would have asserted an edge that is right by accident."
+    },
+    {
+      "from_name": "deployment.yaml",
+      "from_kind": "SCOPE.Document",
+      "from_file": "deploy/k8s/deployment.yaml",
+      "kind": "CONTAINS",
+      "to_name": "storefront-api",
+      "to_kind": "SCOPE.Service",
+      "to_file": "deploy/k8s/deployment.yaml",
+      "must_exist": true,
+      "note": "CONTROL on a second producer path — the structured YAML extractor in internal/extractors/yaml — and deliberately in the file the framework gate DECLINES, so it also witnesses that the gate suppresses the ansible rules for that file without suppressing the file itself."
+    }
+  ]
+}

--- a/internal/quality/golden/ansible-playbook-modules-mini/src/deploy/k8s/deployment.yaml
+++ b/internal/quality/golden/ansible-playbook-modules-mini/src/deploy/k8s/deployment.yaml
@@ -1,0 +1,21 @@
+# A Kubernetes Deployment. It carries none of the ansible presence markers.
+#
+# The gate is a literal SUBSTRING match over whole file content, comments
+# included, so this header deliberately does not list which markers are absent
+# - writing them down is what would admit the file.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: storefront-api
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: storefront-api
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/storefront/api:1.4.0
+          command:
+            - /usr/local/bin/api

--- a/internal/quality/golden/ansible-playbook-modules-mini/src/deploy/traefik/dynamic.yml
+++ b/internal/quality/golden/ansible-playbook-modules-mini/src/deploy/traefik/dynamic.yml
@@ -1,0 +1,9 @@
+# Traefik file-provider dynamic configuration. Middleware names are
+# user-chosen, so a dotted one is legal - and it has exactly the shape the
+# ansible FQCN module rule keys on. It carries none of the ansible presence
+# markers, and as in deploy/k8s/deployment.yaml this header does not name them.
+http:
+  middlewares:
+    storefront.rate.limiter:
+      rateLimit:
+        average: 100

--- a/internal/quality/golden/ansible-playbook-modules-mini/src/provisioning/roles/storefront/handlers/main.yml
+++ b/internal/quality/golden/ansible-playbook-modules-mini/src/provisioning/roles/storefront/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart nginx
+  ansible.builtin.service:
+    name: nginx
+    state: restarted

--- a/internal/quality/golden/ansible-playbook-modules-mini/src/provisioning/roles/storefront/tasks/main.yml
+++ b/internal/quality/golden/ansible-playbook-modules-mini/src/provisioning/roles/storefront/tasks/main.yml
@@ -29,6 +29,9 @@
   lineinfile:
     path: /etc/nginx/nginx.conf
     line: include conf.d/*.conf
+  loop:
+    - conf.d
+    - sites-enabled
 
 - name: Tune worker counts
   ansible.builtin.set_fact:
@@ -39,6 +42,11 @@
   service:
     name: nginx
     state: started
+  when:
+    - ansible_os_family == "Debian"
+    - not skip_restart
+  tags:
+    - runtime
 
 - name: Publish the edge container
   community.docker.docker_container:

--- a/internal/quality/golden/ansible-playbook-modules-mini/src/provisioning/roles/storefront/tasks/main.yml
+++ b/internal/quality/golden/ansible-playbook-modules-mini/src/provisioning/roles/storefront/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# Role tasks for the storefront web tier.
+#
+# Every module below is written in BLOCK form (key alone on its line, arguments
+# in the mapping under it) except where a row deliberately grades the inline
+# form, which the rules must decline.
+- name: Install nginx
+  ansible.builtin.apt:
+    name: nginx
+    state: present
+  notify: restart nginx
+
+- name: Render the site config
+  template:
+    src: nginx.conf.j2
+    dest: /etc/nginx/nginx.conf
+
+- name: Drop the maintenance page
+  copy: src=maintenance.html dest=/var/www/maintenance.html
+
+# - systemd:
+#     name: nginx
+#     state: reloaded
+
+- name: Report the rendered path
+  ansible.builtin.debug: msg=/etc/nginx/nginx.conf
+
+- name: Ensure the vhost include
+  lineinfile:
+    path: /etc/nginx/nginx.conf
+    line: include conf.d/*.conf
+
+- name: Tune worker counts
+  ansible.builtin.set_fact:
+    nginx.conf:
+      worker_processes: 4
+
+- name: Keep nginx running
+  service:
+    name: nginx
+    state: started
+
+- name: Publish the edge container
+  community.docker.docker_container:
+    name: storefront-edge
+    image: ghcr.io/storefront/api:1.4.0

--- a/internal/quality/golden/ansible-playbook-modules-mini/src/provisioning/site.yml
+++ b/internal/quality/golden/ansible-playbook-modules-mini/src/provisioning/site.yml
@@ -1,0 +1,6 @@
+# Storefront provisioning playbook.
+- hosts: web
+  become: true
+  gather_facts: true
+  roles:
+    - storefront

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -18,8 +18,8 @@
       "entity_expected": 7,
       "relationship_found": 2,
       "relationship_expected": 2,
-      "entity_extracted_total": 34,
-      "relationship_extracted_total": 32
+      "entity_extracted_total": 35,
+      "relationship_extracted_total": 33
     },
     "clojure-protocols-mini": {
       "entity_found": 12,

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -13,6 +13,14 @@
       "entity_extracted_total": 83,
       "relationship_extracted_total": 239
     },
+    "ansible-playbook-modules-mini": {
+      "entity_found": 7,
+      "entity_expected": 7,
+      "relationship_found": 2,
+      "relationship_expected": 2,
+      "entity_extracted_total": 34,
+      "relationship_extracted_total": 32
+    },
     "clojure-protocols-mini": {
       "entity_found": 12,
       "entity_expected": 12,
@@ -45,6 +53,14 @@
       "entity_extracted_total": 23,
       "relationship_extracted_total": 45
     },
+    "docker-compose-services-mini": {
+      "entity_found": 7,
+      "entity_expected": 7,
+      "relationship_found": 2,
+      "relationship_expected": 2,
+      "entity_extracted_total": 48,
+      "relationship_extracted_total": 68
+    },
     "elixir-phoenix-mini": {
       "entity_found": 22,
       "entity_expected": 22,
@@ -74,7 +90,7 @@
       "entity_expected": 12,
       "relationship_found": 3,
       "relationship_expected": 3,
-      "entity_extracted_total": 55,
+      "entity_extracted_total": 57,
       "relationship_extracted_total": 72
     },
     "go-chi-mini": {

--- a/internal/quality/golden/docker-compose-services-mini/expected.json
+++ b/internal/quality/golden/docker-compose-services-mini/expected.json
@@ -1,0 +1,137 @@
+{
+  "fixture_name": "docker-compose-services-mini",
+  "language": "docker",
+  "description": "Docker Compose rule patterns (#6927, the `$`-side arm). Three `^`-anchored patterns in rules/docker/frameworks/docker_compose.yaml were compiled without `(?m)` (detector.go:156 uses plain regexp.Compile), so `^` meant start of TEXT — and the service rule carries a `$` too, which in Go means end of TEXT with no trailing-newline allowance. It therefore needed both at once and matched a file whose ENTIRE content is one indented key: ZERO matches across 992 real YAML files. `(?m)` ALONE is the case this issue predicted would over-fire, and it does: `^\\s{2}(\\w[\\w-]*):\\s*$` then reads 'every two-space key alone on its line' — 1867 matches in 611 of 941 non-compose files, PLUS 40 junk Services inside real compose files (named volumes, networks and secrets), which no framework gate can fix. So the service rule was REWRITTEN to name compose's own service-level vocabulary on the next line, and gated. The fixture varies two axes independently: the ANCHOR/shape axis (indent depth, the vocabulary, the indent CLASS, a column-0 sibling) inside files that satisfy the framework gate, and the GATE axis in files that declare no compose service block at all. ci/test.yml exists to separate them: it satisfies the gate and is declined by the shape alone."
+  ,
+  "expected_entities": [
+    {
+      "name": "api",
+      "kind": "Service",
+      "source_file": "deploy/compose.yaml",
+      "must_exist": true,
+      "note": "#6927 recall arm for the rewritten service rule. First service in the file. Under the shipped pre-fix pattern this could not fire at all — `^` was start of text AND `$` end of text."
+    },
+    {
+      "name": "db",
+      "kind": "Service",
+      "source_file": "deploy/compose.yaml",
+      "must_exist": true,
+      "note": "Same rule with a COMMENT line between the service key and its first key, which is the shape 7 of the corpus's 50 compose files have (`db:` followed by a note about the image). The `(?:#[^\\n]*)?\\n` arm is what reaches it; deleting that arm drops this row and nothing else."
+    },
+    {
+      "name": "worker",
+      "kind": "Service",
+      "source_file": "deploy/compose.yaml",
+      "must_exist": true,
+      "note": "Same rule, LAST service in the block — the vertical-position axis, which is the defect itself — and through a different vocabulary word (`build:`, not `image:`), so one alternation entry cannot be what carries every service row."
+    },
+    {
+      "name": "db-data",
+      "kind": "Config",
+      "source_file": "deploy/compose.yaml",
+      "must_exist": true,
+      "note": "#6927 recall arm for `(?m)^volumes:\\s*\\n\\s{2}(\\w[\\w-]*):`. Under start-of-text this fired only on a file whose first bytes are `volumes:`, and no compose file opens that way: 0 matches in 992 corpus files before, 18 in 18 after. Note the SAME name is a forbidden Service below — the kinds are what separate the two rules, and that is deliberate: the volume block is exactly what the widened service rule would have swallowed."
+    },
+    {
+      "name": "backend",
+      "kind": "Config",
+      "source_file": "deploy/compose.yaml",
+      "must_exist": true,
+      "note": "#6927 recall arm for `(?m)^networks:\\s*\\n\\s{2}(\\w[\\w-]*):`, the same defect and the same measurement shape: 0 before, 9 in 9 compose files after."
+    },
+    {
+      "name": "postgres:16",
+      "kind": "Dependency",
+      "source_file": "deploy/compose.yaml",
+      "must_exist": true,
+      "note": "CONTROL, held constant. `image:\\s+(\\S+)` carries no anchor and no gate, so it was green before this change and must stay green. Without a control, 'the anchored rules came back' and 'rule loading broke entirely' look identical."
+    },
+    {
+      "name": "8080:8080",
+      "kind": "Config",
+      "source_file": "deploy/compose.yaml",
+      "must_exist": true,
+      "note": "Second CONTROL on a second un-anchored rule (`ports:\\s*\\n\\s+-\\s+[\\\"']?(\\d+:\\d+)`), untouched by this change."
+    }
+  ],
+  "forbidden_entities": [
+    {
+      "name": "db-data",
+      "kind": "Service",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, and THE row this whole change exists for. Reverting the service rule to `(?m)^\\s{2}(\\w[\\w-]*):\\s*$` — i.e. applying `(?m)` and nothing else, which is what the issue proposed — mints a Service for every named volume, network and secret in a real compose file. Measured: 40 such junk Services across the corpus's 50 compose files (`db-data`, `db-password`, `pgdata`, `default`). The file IS compose, so `requires_framework` says nothing about this row; only the rewrite holds it. It is the only forbidden row here that dies to that mutant alone."
+    },
+    {
+      "name": "cache-data",
+      "kind": "Service",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, INDENT-CLASS direction. The next-line requirement is `[ ]{3,}` — literal spaces — not `\\s+`, because `\\s` matches a NEWLINE: `cache-data:` is the last entry of the volumes block and is followed by a blank line and then a column-0 `secrets:`, so under `\\s+` the rule reaches past the blank line, reads that top-level key as the service body and mints `cache-data`. `db-data` above does NOT die to this mutant (its next line is a two-space sibling that is not in the vocabulary), which is what keeps the two rows about different things."
+    },
+    {
+      "name": "options",
+      "kind": "Service",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, INDENT-COUNT direction. `^\\s{2}` means EXACTLY two leading spaces — a third character that is whitespace fails the `\\w`. `api.logging.options` is six-space indented and its first key is `labels:`, which IS in the vocabulary, so `\\s{2}` -> `\\s+` mints an Operation-shaped Service for it. Inside the compose file, i.e. held by the anchor and not by the gate."
+    },
+    {
+      "name": "db-password",
+      "kind": "Service",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, VOCABULARY direction. The next-line alternation is compose's service-level key set; `secrets:` entries take `file:`, which is deliberately NOT in it. Replacing `(?:image|build|...)` with `\\w+` — the obvious 'simplification' — mints `db-password`. Also inside the compose file, so the gate is not what holds it."
+    },
+    {
+      "name": "deploy",
+      "kind": "Service",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, FRAMEWORK-GATE direction, and the reason the rewrite alone is not enough. `environment:`, `labels:`, `command:` and `user:` are compose's vocabulary but not compose's alone: a GitHub Actions job whose first key is `environment:` has the exact shape, and GitHub's own starter-workflows carries `deploy:\\n  environment:` in eleven files. ci/release.yml declares no compose service block, so `requires_framework: true` declines it; deleting that key mints this row. Measured: 14 such matches in 12 non-compose files ungated, 0 gated."
+    },
+    {
+      "name": "unit",
+      "kind": "Service",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, VOCABULARY direction inside a file the GATE ADMITS. ci/test.yml carries a job's service-container block, so it satisfies the compose marker and the gate says nothing about it; only the vocabulary declines `unit:\\n  runs-on:`. Two fences, graded separately — this is the row that proves the second one is not riding on the first."
+    },
+    {
+      "name": "postgres",
+      "kind": "Service",
+      "must_exist": false,
+      "note": "Second INDENT-COUNT row, in a gate-ADMITTED non-compose file: ci/test.yml's service container is six-space indented under `services:` and its first key is `image:`. `\\s{2}` -> `\\s+` mints it. One row could be an accident of one file's layout; two of different shapes in different files cannot."
+    },
+    {
+      "name": "extraArgs",
+      "kind": "Config",
+      "must_exist": false,
+      "note": "#6927 forbidden arm, ANCHOR direction for the volumes rule — which takes no framework gate at all, so the column-0 `^` is its entire fence. A helm values file writes an empty `volumes:` key indented under `serverSide`, with a sibling on the next line; dropping `^` makes `volumes:\\s*\\n\\s{2}(\\w[\\w-]*):` read that sibling and mint a Config. Ungated is a measured call: across 941 non-compose corpus files the widened rule matched ZERO times."
+    },
+    {
+      "name": "hostAliases",
+      "kind": "Config",
+      "must_exist": false,
+      "note": "The same ANCHOR row for the networks rule, on the same file and the same shape, because the two rules are separate patterns and one row cannot grade both."
+    }
+  ],
+  "expected_relationships": [
+    {
+      "from_name": "api",
+      "from_kind": "Service",
+      "from_file": "deploy/compose.yaml",
+      "kind": "DEPENDS_ON",
+      "to_name": "db",
+      "to_kind": "Service",
+      "to_file": "deploy/compose.yaml",
+      "must_exist": true,
+      "note": "The compose `depends_on` edge. BOTH endpoints are Services minted by the rewritten rule, so this row goes red if either the recall or the naming of that rule moves — it is the one assertion here that is about the rule's output being usable rather than merely present."
+    },
+    {
+      "from_name": "compose.yaml",
+      "from_kind": "SCOPE.Document",
+      "from_file": "deploy/compose.yaml",
+      "kind": "CONTAINS",
+      "to_name": "api",
+      "to_kind": "Service",
+      "to_file": "deploy/compose.yaml",
+      "must_exist": true,
+      "note": "CONTROL on a second producer path: the Document endpoint comes from the structured YAML extractor in internal/extractors/yaml, which is untouched by this change, so one broken emitter cannot take the whole relationship assertion with it."
+    }
+  ]
+}

--- a/internal/quality/golden/docker-compose-services-mini/expected.json
+++ b/internal/quality/golden/docker-compose-services-mini/expected.json
@@ -1,15 +1,14 @@
 {
   "fixture_name": "docker-compose-services-mini",
   "language": "docker",
-  "description": "Docker Compose rule patterns (#6927, the `$`-side arm). Three `^`-anchored patterns in rules/docker/frameworks/docker_compose.yaml were compiled without `(?m)` (detector.go:156 uses plain regexp.Compile), so `^` meant start of TEXT — and the service rule carries a `$` too, which in Go means end of TEXT with no trailing-newline allowance. It therefore needed both at once and matched a file whose ENTIRE content is one indented key: ZERO matches across 992 real YAML files. `(?m)` ALONE is the case this issue predicted would over-fire, and it does: `^\\s{2}(\\w[\\w-]*):\\s*$` then reads 'every two-space key alone on its line' — 1867 matches in 611 of 941 non-compose files, PLUS 40 junk Services inside real compose files (named volumes, networks and secrets), which no framework gate can fix. So the service rule was REWRITTEN to name compose's own service-level vocabulary on the next line, and gated. The fixture varies two axes independently: the ANCHOR/shape axis (indent depth, the vocabulary, the indent CLASS, a column-0 sibling) inside files that satisfy the framework gate, and the GATE axis in files that declare no compose service block at all. ci/test.yml exists to separate them: it satisfies the gate and is declined by the shape alone."
-  ,
+  "description": "Docker Compose rule patterns (#6927, the `$`-side arm). Three `^`-anchored patterns in rules/docker/frameworks/docker_compose.yaml were compiled without `(?m)` (detector.go:156 uses plain regexp.Compile), so `^` meant start of TEXT \u2014 and the service rule carries a `$` too, which in Go means end of TEXT with no trailing-newline allowance. It therefore needed both at once and matched a file whose ENTIRE content is one indented key: ZERO matches across 992 real YAML files. `(?m)` ALONE is the case this issue predicted would over-fire, and it does: `^\\s{2}(\\w[\\w-]*):\\s*$` then reads 'every two-space key alone on its line' \u2014 1867 matches in 611 of 941 non-compose files, PLUS 40 junk Services inside real compose files (named volumes, networks and secrets), which no framework gate can fix. So the service rule was REWRITTEN to name compose's own service-level vocabulary on the next line, and gated. The vocabulary deliberately EXCLUDES `labels` and `environment`, which the Compose Spec says are the only service-level keys a top-level `volumes`/`networks`/`secrets`/`configs` entry may also carry \u2014 so the in-compose false-positive class is empty by the format's schema rather than merely zero on one corpus, at a measured cost of 2 of 111 corpus services whose first key is one of those two. The rule also requires `\\r?\\n` rather than `\\n`: `[ \\t]*\\n` cannot match a CRLF file, and this was the only compose rule with that blindness. The fixture varies two axes independently: the ANCHOR/shape axis (indent depth, the vocabulary, the indent CLASS, a column-0 sibling) inside files that satisfy the framework gate, and the GATE axis in files that declare no compose service block at all. ci/test.yml exists to separate them: it satisfies the gate and is declined by the shape alone.",
   "expected_entities": [
     {
       "name": "api",
       "kind": "Service",
       "source_file": "deploy/compose.yaml",
       "must_exist": true,
-      "note": "#6927 recall arm for the rewritten service rule. First service in the file. Under the shipped pre-fix pattern this could not fire at all — `^` was start of text AND `$` end of text."
+      "note": "#6927 recall arm for the rewritten service rule. First service in the file. Under the shipped pre-fix pattern this could not fire at all \u2014 `^` was start of text AND `$` end of text."
     },
     {
       "name": "db",
@@ -23,14 +22,14 @@
       "kind": "Service",
       "source_file": "deploy/compose.yaml",
       "must_exist": true,
-      "note": "Same rule, LAST service in the block — the vertical-position axis, which is the defect itself — and through a different vocabulary word (`build:`, not `image:`), so one alternation entry cannot be what carries every service row."
+      "note": "Same rule, LAST service in the block \u2014 the vertical-position axis, which is the defect itself \u2014 and through a different vocabulary word (`build:`, not `image:`), so one alternation entry cannot be what carries every service row."
     },
     {
       "name": "db-data",
       "kind": "Config",
       "source_file": "deploy/compose.yaml",
       "must_exist": true,
-      "note": "#6927 recall arm for `(?m)^volumes:\\s*\\n\\s{2}(\\w[\\w-]*):`. Under start-of-text this fired only on a file whose first bytes are `volumes:`, and no compose file opens that way: 0 matches in 992 corpus files before, 18 in 18 after. Note the SAME name is a forbidden Service below — the kinds are what separate the two rules, and that is deliberate: the volume block is exactly what the widened service rule would have swallowed."
+      "note": "#6927 recall arm for `(?m)^volumes:\\s*\\n\\s{2}(\\w[\\w-]*):`. Under start-of-text this fired only on a file whose first bytes are `volumes:`, and no compose file opens that way: 0 matches in 992 corpus files before, 18 in 18 after. Note the SAME name is a forbidden Service below \u2014 the kinds are what separate the two rules, and that is deliberate: the volume block is exactly what the widened service rule would have swallowed."
     },
     {
       "name": "backend",
@@ -59,49 +58,43 @@
       "name": "db-data",
       "kind": "Service",
       "must_exist": false,
-      "note": "#6927 forbidden arm, and THE row this whole change exists for. Reverting the service rule to `(?m)^\\s{2}(\\w[\\w-]*):\\s*$` — i.e. applying `(?m)` and nothing else, which is what the issue proposed — mints a Service for every named volume, network and secret in a real compose file. Measured: 40 such junk Services across the corpus's 50 compose files (`db-data`, `db-password`, `pgdata`, `default`). The file IS compose, so `requires_framework` says nothing about this row; only the rewrite holds it. It is the only forbidden row here that dies to that mutant alone."
+      "note": "#6927 forbidden arm, and THE row this whole change exists for. Reverting the service rule to `(?m)^\\s{2}(\\w[\\w-]*):\\s*$` \u2014 i.e. applying `(?m)` and nothing else, which is what the issue proposed \u2014 mints a Service for every named volume, network and secret in a real compose file: 40 such junk Services across the corpus's 50 compose files. The file IS compose, so `requires_framework` says nothing about this row; only the rewrite holds it.\nIt also grades the VOCABULARY as a SPEC question rather than a corpus one (PR #6949 review F2). `db-data` here carries a `labels:` block, which the Compose Spec explicitly allows on a named volume \u2014 and `labels` is a service-level key too. Per the spec the ONLY keys a top-level `volumes`/`networks`/`secrets`/`configs` entry shares with a service are `labels` and `environment`, so the rule's next-line vocabulary excludes both and this row goes red the moment either is added back. A measured zero over one corpus was not a property of the format; this is."
     },
     {
       "name": "cache-data",
       "kind": "Service",
       "must_exist": false,
-      "note": "#6927 forbidden arm, INDENT-CLASS direction. The next-line requirement is `[ ]{3,}` — literal spaces — not `\\s+`, because `\\s` matches a NEWLINE: `cache-data:` is the last entry of the volumes block and is followed by a blank line and then a column-0 `secrets:`, so under `\\s+` the rule reaches past the blank line, reads that top-level key as the service body and mints `cache-data`. `db-data` above does NOT die to this mutant (its next line is a two-space sibling that is not in the vocabulary), which is what keeps the two rows about different things."
-    },
-    {
-      "name": "options",
-      "kind": "Service",
-      "must_exist": false,
-      "note": "#6927 forbidden arm, INDENT-COUNT direction. `^\\s{2}` means EXACTLY two leading spaces — a third character that is whitespace fails the `\\w`. `api.logging.options` is six-space indented and its first key is `labels:`, which IS in the vocabulary, so `\\s{2}` -> `\\s+` mints an Operation-shaped Service for it. Inside the compose file, i.e. held by the anchor and not by the gate."
+      "note": "#6927 forbidden arm, INDENT-CLASS direction. The next-line requirement is `[ ]{3,}` \u2014 literal spaces \u2014 not `\\s+`, because `\\s` matches a NEWLINE: `cache-data:` is the last entry of the volumes block and is followed by a blank line and then a column-0 `secrets:`, so under `\\s+` the rule reaches past the blank line, reads that top-level key as the service body and mints `cache-data`. `db-data` above does NOT die to this mutant (its next line is a two-space sibling that is not in the vocabulary), which is what keeps the two rows about different things."
     },
     {
       "name": "db-password",
       "kind": "Service",
       "must_exist": false,
-      "note": "#6927 forbidden arm, VOCABULARY direction. The next-line alternation is compose's service-level key set; `secrets:` entries take `file:`, which is deliberately NOT in it. Replacing `(?:image|build|...)` with `\\w+` — the obvious 'simplification' — mints `db-password`. Also inside the compose file, so the gate is not what holds it."
+      "note": "#6927 forbidden arm, VOCABULARY direction. The next-line alternation is compose's service-level key set; `secrets:` entries take `file:`, which is deliberately NOT in it. Replacing `(?:image|build|...)` with `\\w+` \u2014 the obvious 'simplification' \u2014 mints `db-password`. Also inside the compose file, so the gate is not what holds it."
     },
     {
       "name": "deploy",
       "kind": "Service",
       "must_exist": false,
-      "note": "#6927 forbidden arm, FRAMEWORK-GATE direction, and the reason the rewrite alone is not enough. `environment:`, `labels:`, `command:` and `user:` are compose's vocabulary but not compose's alone: a GitHub Actions job whose first key is `environment:` has the exact shape, and GitHub's own starter-workflows carries `deploy:\\n  environment:` in eleven files. ci/release.yml declares no compose service block, so `requires_framework: true` declines it; deleting that key mints this row. Measured: 14 such matches in 12 non-compose files ungated, 0 gated."
+      "note": "#6927 forbidden arm, FRAMEWORK-GATE direction, and the reason the rewrite alone is not enough. The next-line vocabulary is compose's, but it is not compose's ALONE: `secrets:` is a compose service-level key and also real GitHub Actions reusable-workflow syntax, so ci/release.yml's `deploy:` job has exactly the shape this rule looks for. It declares no compose service block, so `requires_framework: true` declines it; deleting that key mints this row. Measured: 5 such matches in 3 non-compose corpus files ungated, 0 gated.\nThe job's first key was changed from `environment:` to `secrets:` in the PR #6949 review round, because narrowing the vocabulary (F2) removed `environment` and left this row unfireable \u2014 a forbidden row that no mutant can reach is the #6938 shape, so it was re-scored rather than assumed to still hold."
     },
     {
       "name": "unit",
       "kind": "Service",
       "must_exist": false,
-      "note": "#6927 forbidden arm, VOCABULARY direction inside a file the GATE ADMITS. ci/test.yml carries a job's service-container block, so it satisfies the compose marker and the gate says nothing about it; only the vocabulary declines `unit:\\n  runs-on:`. Two fences, graded separately — this is the row that proves the second one is not riding on the first."
+      "note": "#6927 forbidden arm, VOCABULARY direction inside a file the GATE ADMITS. ci/test.yml carries a job's service-container block, so it satisfies the compose marker and the gate says nothing about it; only the vocabulary declines `unit:\\n  runs-on:`. Two fences, graded separately \u2014 this is the row that proves the second one is not riding on the first."
     },
     {
       "name": "postgres",
       "kind": "Service",
       "must_exist": false,
-      "note": "Second INDENT-COUNT row, in a gate-ADMITTED non-compose file: ci/test.yml's service container is six-space indented under `services:` and its first key is `image:`. `\\s{2}` -> `\\s+` mints it. One row could be an accident of one file's layout; two of different shapes in different files cannot."
+      "note": "#6927 forbidden arm, INDENT-COUNT direction, in a gate-ADMITTED non-compose file. `^[ ]{2}` means EXACTLY two leading spaces; ci/test.yml's service container is six-space indented under a job's `services:` key and its first key is `image:`, so `[ ]{2}` -> `\\s+` mints it. The child-indent count (`[ ]{3,}` vs `[ ]{2,}`) and the leading-indent CHARACTER CLASS (`[ ]{2}` vs `\\s{2}`, which eats newlines under `(?m)`) are two further counts this fixture cannot shape an input for; both are graded in internal/engine/docker_ansible_multiline_anchor_6927_test.go."
     },
     {
       "name": "extraArgs",
       "kind": "Config",
       "must_exist": false,
-      "note": "#6927 forbidden arm, ANCHOR direction for the volumes rule — which takes no framework gate at all, so the column-0 `^` is its entire fence. A helm values file writes an empty `volumes:` key indented under `serverSide`, with a sibling on the next line; dropping `^` makes `volumes:\\s*\\n\\s{2}(\\w[\\w-]*):` read that sibling and mint a Config. Ungated is a measured call: across 941 non-compose corpus files the widened rule matched ZERO times."
+      "note": "#6927 forbidden arm, ANCHOR direction for the volumes rule \u2014 which takes no framework gate at all, so the column-0 `^` is its entire fence. A helm values file writes an empty `volumes:` key indented under `serverSide`, with a sibling on the next line; dropping `^` makes `volumes:\\s*\\n\\s{2}(\\w[\\w-]*):` read that sibling and mint a Config. Ungated is a measured call: across 941 non-compose corpus files the widened rule matched ZERO times."
     },
     {
       "name": "hostAliases",
@@ -120,7 +113,7 @@
       "to_kind": "Service",
       "to_file": "deploy/compose.yaml",
       "must_exist": true,
-      "note": "The compose `depends_on` edge. BOTH endpoints are Services minted by the rewritten rule, so this row goes red if either the recall or the naming of that rule moves — it is the one assertion here that is about the rule's output being usable rather than merely present."
+      "note": "The compose `depends_on` edge. BOTH endpoints are Services minted by the rewritten rule, so this row goes red if either the recall or the naming of that rule moves \u2014 it is the one assertion here that is about the rule's output being usable rather than merely present."
     },
     {
       "from_name": "compose.yaml",

--- a/internal/quality/golden/docker-compose-services-mini/src/ci/release.yml
+++ b/internal/quality/golden/docker-compose-services-mini/src/ci/release.yml
@@ -1,0 +1,18 @@
+# A GitHub Actions release workflow. Stored at ci/ rather than .github/ because
+# the walker skips .github outright (#6946).
+#
+# It declares no compose service block anywhere, so the compose service rule's
+# framework gate declines this file. The gate is a literal SUBSTRING match over
+# the whole file, comments included, so this header deliberately does not spell
+# the marker out - a comment saying "no such key here" would itself be the key.
+name: Release
+on:
+  push:
+    tags: ["v*"]
+jobs:
+  deploy:
+    environment:
+      name: production
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4

--- a/internal/quality/golden/docker-compose-services-mini/src/ci/release.yml
+++ b/internal/quality/golden/docker-compose-services-mini/src/ci/release.yml
@@ -5,14 +5,17 @@
 # framework gate declines this file. The gate is a literal SUBSTRING match over
 # the whole file, comments included, so this header deliberately does not spell
 # the marker out - a comment saying "no such key here" would itself be the key.
+#
+# The `deploy` job's first key is `secrets:` on purpose: that is real
+# reusable-workflow syntax AND a compose service-level key, so the rule's SHAPE
+# matches this job and only the gate declines it. Without such a job the gate
+# would have nothing to hold and the `deploy` forbidden row would be unfireable.
 name: Release
 on:
   push:
     tags: ["v*"]
 jobs:
   deploy:
-    environment:
-      name: production
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    secrets:
+      registry-token: ${{ secrets.RELEASE_TOKEN }}
+    uses: ./ci/workflows/publish.yml

--- a/internal/quality/golden/docker-compose-services-mini/src/ci/test.yml
+++ b/internal/quality/golden/docker-compose-services-mini/src/ci/test.yml
@@ -1,0 +1,16 @@
+# A GitHub Actions test workflow that DOES carry a job's service-container
+# block, so the compose framework gate ADMITS this file and only the service
+# rule's own shape declines it. That is the point: the two fences are
+# independent, and this file grades the second one alone.
+name: Test
+on: pull_request
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: make test

--- a/internal/quality/golden/docker-compose-services-mini/src/deploy/compose.yaml
+++ b/internal/quality/golden/docker-compose-services-mini/src/deploy/compose.yaml
@@ -1,0 +1,37 @@
+# Storefront runtime topology.
+#
+# Stored under deploy/ rather than at the repo root on purpose. The engine
+# resolves rule sets by file.Language (yaml), never by path, so the location is
+# not what admits this file to the compose rules - the top-level key below is.
+services:
+  api:
+    image: ghcr.io/storefront/api:1.4.0
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+    logging:
+      driver: json-file
+      options:
+        labels: "app,env"
+  db:
+    # postgres:16 ships both amd64 and arm64 images
+    image: postgres:16
+    environment:
+      POSTGRES_DB: storefront
+  worker:
+    build: ./worker
+    networks:
+      - backend
+
+volumes:
+  db-data:
+  cache-data:
+
+secrets:
+  db-password:
+    file: ./secrets/db.txt
+
+networks:
+  backend:
+    driver: bridge

--- a/internal/quality/golden/docker-compose-services-mini/src/deploy/compose.yaml
+++ b/internal/quality/golden/docker-compose-services-mini/src/deploy/compose.yaml
@@ -13,7 +13,7 @@ services:
     logging:
       driver: json-file
       options:
-        labels: "app,env"
+        max-size: "10m"
   db:
     # postgres:16 ships both amd64 and arm64 images
     image: postgres:16
@@ -26,6 +26,8 @@ services:
 
 volumes:
   db-data:
+    labels:
+      com.example.description: "primary database volume"
   cache-data:
 
 secrets:

--- a/internal/quality/golden/docker-compose-services-mini/src/deploy/helm/values.yaml
+++ b/internal/quality/golden/docker-compose-services-mini/src/deploy/helm/values.yaml
@@ -1,0 +1,9 @@
+# Helm values for the storefront chart. Declares no compose service block, so
+# the compose service rule's framework gate declines this file. As in
+# ci/release.yml, this header avoids spelling the marker out.
+replicaCount: 2
+serverSide:
+  volumes:
+  extraArgs: {}
+  networks:
+  hostAliases: []

--- a/internal/quality/subtype_assertion_6488_test.go
+++ b/internal/quality/subtype_assertion_6488_test.go
@@ -288,8 +288,8 @@ func TestOnlyTheIntendedGoldenRowsAssertSubtype_6488(t *testing.T) {
 			}
 		}
 	}
-	if fixtures != 35 {
-		t.Fatalf("parsed %d fixtures, want 35 — every golden expected.json must "+
+	if fixtures != 37 {
+		t.Fatalf("parsed %d fixtures, want 37 — every golden expected.json must "+
 			"keep parsing across this additive schema change", fixtures)
 	}
 	// #6815 added the three file-carrier rows below. They are subtype-asserting

--- a/internal/quality/zero_relationships_6490_test.go
+++ b/internal/quality/zero_relationships_6490_test.go
@@ -177,8 +177,8 @@ func TestNoGoldenFixtureClaimsTheOptIn_6490(t *testing.T) {
 			optedOut = append(optedOut, e.Name())
 		}
 	}
-	if inspected != 35 {
-		t.Fatalf("inspected %d golden fixtures, want 35 — the corpus size changed, so "+
+	if inspected != 37 {
+		t.Fatalf("inspected %d golden fixtures, want 37 — the corpus size changed, so "+
 			"this test's coverage claim needs re-deriving", inspected)
 	}
 	if len(optedOut) != 0 {


### PR DESCRIPTION
The docker + ansible arm of #6927 — the two files the previous three arms deliberately
deferred, because they hold the four `$`-bearing patterns and two of them were the measured
over-fire hazard. 5 of the 8 remaining patterns; `play_framework.yaml` and
`graphql_schema.yaml` are a separate arm.

## What `$` actually was, and what it becomes

`detector.go` compiles rule patterns with plain `regexp.Compile` at :156/:177, so `^` is start
of TEXT — and `$` is end of TEXT. Go's `$` is stricter than Perl's: it does not even allow a
trailing newline before it. Three of these five patterns carry a `$`, so they needed both ends
at once. **All five measured ZERO matches across 992 real YAML files** (671 from the 59
upstream repos in `archigraph-corpora`, plus 321 from four upstream ansible repos —
`ansible-examples`, `ansible-for-devops`, `geerlingguy/ansible-role-{docker,nginx}` — because
the existing corpus contains **no ansible at all**, which is itself a measurement).

The first question this arm was asked was not "add `(?m)`" but "is each pattern
framework-specific, or has start-of-text been gating it by accident?". Answered per pattern, by
measurement, before anything was widened:

| pattern | today | `(?m)` ungated, OUT of framework | decision |
|---|---|---|---|
| compose service `^\s{2}(\w[\w-]*):\s*$` | 0 | **1867 in 611 / 941 files** + **40 junk Services inside real compose files** | **REWRITTEN**, `$` removed, + `requires_framework` |
| compose `^volumes:\s*\n\s{2}(…):` | 0 | **0 / 941** | `(?m)`, ungated |
| compose `^networks:\s*\n\s{2}(…):` | 0 | **0 / 941** | `(?m)`, ungated |
| ansible FQCN `\s+(\w+\.\w+\.\w+):\s*$` | 0 | **0 / 683** | `(?m)` + `requires_framework` anyway (free; see below) |
| ansible shorthand `^\s+(apt\|…):\s*$` | 0 | **59 in 43 / 683 files** | `(?m)` + `requires_framework` |

`$` per pattern, reasoned explicitly:

* **compose service** — `$` is **deleted**. Under `(?m)` it would become end-of-line, and
  `^\s{2}(\w[\w-]*):\s*$` then reads *"every two-space key alone on its line"*, which is not
  what a service is. `[ \t]*\n` carries the same "nothing else on this line" half without the
  end-of-text/end-of-line ambiguity, and lets the rule additionally require the next line.
* **volumes / networks** — no `$`. Unaffected.
* **ansible FQCN and shorthand** — `$` becomes end-of-line, and that is exactly right: a module
  key with nothing after the colon *is* the block form, arguments in the mapping below. Both
  rules still mean what their names say; they simply stop requiring the module to be the last
  construct in the file. The inline `key=value` form stays invisible — a pre-existing recall
  gap, now pinned from the other side by forbidden rows.

## Why the compose service rule needed a rewrite and not a gate

`(?m)` alone is the change #6927 proposed, and the measurement is why it was not made.
`requires_framework` cannot help with 40 of its false positives, because **the file IS compose**:
a named volume, network or secret is also a two-space key alone on its line (`db-data`,
`db-password`, `pgdata`, `default`). So the rule now says what a service is structurally — the
same shape as #6945's job rule: a two-space key whose block opens with a compose *service-level*
key at a deeper **literal-space** indent.

Measured after: **109 matches in 47 files = 109 of the 111 real services** in the corpus's 50
compose files (98.2%, up from 0), **zero in-compose false positives**, 5 matches in 3 non-compose
files ungated, **0 under the gate**. The 2 missed are the price of the vocabulary narrowing below
and are pinned by a test, not asserted here.

Every character class in it is load-bearing, and the review round below found three of them wrong
in the first version. Two `\s`-related traps, both named in the rule comment and pinned:

* `\s+` for the next-line indent **matches a newline**, so `volumes:\n  db-data:\n\nsecrets:`
  reads the column-0 `secrets:` as the service body. Hence `[ ]{3,}`.
* 7 of the corpus's compose files put a comment between the service key and its first key
  (`db:` then a note about the image), so the rule carries an explicit comment arm.

And the same trap one position to the LEFT, which the review caught: `^\s{2}` under `(?m)` matches
at a blank line and then eats newlines, so a column-0 key preceded by two blank lines satisfied it.
It is now `^[ ]{2}`.

**The in-compose false-positive class is now empty by the Compose Spec's schema, not by a corpus
count.** Per the spec, the only service-level keys an entry under top-level `volumes:`,
`networks:`, `secrets:` or `configs:` may also carry are `labels` and `environment`, so the
next-line vocabulary excludes both. That is a deliberate precision-for-recall trade with a stated
price: a service whose FIRST non-comment key is one of those two is missed — 2 of the corpus's 111
— because the rule inspects only that one key.

## The marker sets, and their blind spots

**docker — one marker, `services:`.** It admits 50 of 51 compose-shaped corpus files and 10 of
941 others (django's and phoenix's CI workflows, which declare service *containers*; three
prometheus helm values files). Those ten are admitted by the gate and then **declined by the
pattern** — which is the point: the two fences are independent, and `ci/test.yml` in the fixture
is that exact shape. Product: **0 of 941**.

One marker rather than a set, deliberately: on this corpus `depends_on:` and `container_name:`
are strictly redundant with `services:`, so shipping them would add markers no input can grade —
the shape #6945 called out. Blind spots, stated rather than implied: `services:` is not
compose-only (a GHA job's service containers, a k8s `spec.template`, a helm values file all
write it — every such corpus file is held by the *pattern*); and a compose **v1** file has no
`services:` key at all, though it also cannot match the rule, whose `^\s{2}` requires an indented
key.

**ansible — seven markers**, each measured at **zero** of the 683 non-ansible files on its own:
`ansible.builtin.`, `become:`, `gather_facts`, `ansible_`, `with_items:`, `.j2`,
`state: present`. Product with the shorthand rule: 59/43 → **0/0**, keeping 128 of its 156
in-framework matches.

The 28 declined in-framework matches are named rather than rounded away, because **15 of them
are the gate working**: they are one file, `ansible-for-devops`'s `kube-flannel-vagrant.yml`, a
Kubernetes manifest that happens to live in an ansible repo, whose `template:` keys are pod
templates. The other 13 in 11 files are real losses with one shape — a tiny
`roles/*/handlers/main.yml` holding `service:` with `state: restarted`. `notify:` and `handlers:`
would recover them but each admits two non-ansible files, so the trade was declined and recorded.

Blind spots: `state: present` is a module-*argument* idiom, not an ansible-only token; and
`ansible_` / `ansible.builtin.` are measured on repos that predate collections, which is why
`ansible.builtin.` — the most obviously correct marker here — is load-bearing for only 6 corpus
files and costs nothing to drop *on this corpus*. It is kept because the corpus is old, not
because the corpus grades it — and deleting it alone is DEAD at both levels anyway, because the
fixture's role `handlers/main.yml` carries it as its only marker. Zero-of-683 is a measurement,
not a proof.

**The FQCN rule is gated even though it measured zero over-fire**, because the dotted-three-segment
shape only looks like a framework signal: a traefik middleware name, a java-style config key and a
k8s annotation map all have it. The gate was checked file by file rather than in aggregate and
costs **literally nothing** — all 9 in-framework files and all 22 matches survive it. A fence that
is free is not worth declining on the strength of one corpus.

## Graded in both directions, on two new golden fixtures

`docker-compose-services-mini` and `ansible-playbook-modules-mini`.

**Recall on the pre-fix binary (built from the base commit, same fixtures): 2/7 entities
(28.6%) each.** The 2 found are exactly the un-anchored controls. After: **7/7 entities, 2/2
relationships, 0 forbidden hits** on both. Docker relationships were **0/2** pre-fix, because
both endpoints of the `depends_on` edge are Services the dead rule never minted.

**Both axes pinned, listed explicitly** (#6943's lesson — a fixture that pins one does not pin
its neighbour):

*docker-compose-services-mini*

| row | axis VARIED | held constant |
|---|---|---|
| `db-data` / Service | the `$`-form revert, AND the spec-legal `labels:` on a named volume | inside compose, gate satisfied |
| `cache-data` / Service | indent **class** (`[ ]{3,}` vs `\s+`) | same file, same vocabulary |
| `db-password` / Service | next-line **vocabulary** | same file, indent correct |
| `deploy` / Service | the **gate** (file declares no service block) | shape matches: its first key is `secrets:` |
| `unit` / Service | **vocabulary**, in a file the gate ADMITS | gate satisfied |
| `postgres` / Service | leading-indent **count**, in a gate-admitted file | vocabulary in-set |
| `extraArgs`, `hostAliases` / Config | column-0 `^` of the two UNGATED rules | no gate involved |

*ansible-playbook-modules-mini*

| row | axis VARIED | held constant |
|---|---|---|
| `copy` / Module | the `$` (inline vs block) | gate satisfied, name in-set |
| `systemd` / Module | the `^` (commented-out module) | gate satisfied, name in-set |
| `lineinfile` / Module | the **name** alternation | gate satisfied, anchors intact |
| `ansible.builtin.debug` / Module | the `$` of the FQCN rule (its only anchor) | gate satisfied |
| `nginx.conf` / Module | the FQCN **name** shape (3 segments, not 2) | gate satisfied |
| `command` / Module | the **gate** (k8s Deployment) | shape would match |
| `storefront.rate.limiter` / Module | the **gate**, FQCN rule | shape would match |

The child-indent count (`[ ]{3,}` vs `[ ]{2,}`), the leading-indent class (`[ ]{2}` vs `\s{2}`),
the head's whitespace class (`[ \t]` vs `\s`), CRLF, and the spec-legal section-entry shapes are
graded at engine level, because a realistic compose file cannot be shaped into any of them.

Every forbidden row was checked to be **fireable** — each one is emitted by at least one scored
mutant below, so none is the #6938 shape (a row the producer can never spell). `command` rather
than `template` for the k8s gate row precisely because `template` is a must-have from the tasks
file and a forbidden row that collides with an expected one is unfireable by construction.

## Companion engine-level tests

`internal/engine/docker_ansible_multiline_anchor_6927_test.go`, for what a golden fixture
structurally cannot see: which RULE produced an entity (both buckets are aliased onto the whole
`yaml` language, so several rule files see every file and one file's output can stand in for
another's), and each import_marker on its own (a realistic fixture file carries three or four at
once, which is how #6945's single-marker hole survived).

**Rules are selected by BEHAVIOUR, never by pattern text**, and
`TestIssue6927_DockerAnsible_SelectorSurvivesABehaviourPreservingRewrite` is the **control that
must PASS**: it expands every `\w` to its exact RE2 set (`[0-9A-Za-z_]`, class-depth aware so a
`\w` inside `[\w-]` does not become a nested bracket) and asserts the same construct is still
read out of the same probe. That control caught a real defect while it was being written — the
first version rewrote `\w` to `[\w]`, which nests inside `[\w-]` and silently changes the
language; it failed, and the failure was the selector doing its job.

## Mutants

**28 mutants, all DEAD at the fast `./internal/engine/` suite.** Scored at both levels; the
fixture column is the golden gate (`grafel quality` on the two new fixtures plus
`github-actions-workflows-mini`, the one the ansible change touches). A green baseline was
verified immediately before scoring, every edit was proven to land by an exact occurrence count,
and the rule files were restored by `cp` from a shasum-checked backup after each one.

| mutant | engine | fixture | what fired |
|---|---|---|---|
| D1 compose service: revert to the `(?m)`-only form **this issue proposed** | DEAD | DEAD | `Service:db-data`, `cache-data`, `db-password`, `unit` |
| D2 `[ ]{3,}` -> `\s+` (indent CLASS; `\s` matches a newline) | DEAD | DEAD | `Service:cache-data` |
| D3 `^\s{2}` -> `^\s+` (indent COUNT) | DEAD | DEAD | `Service:options`, `Service:postgres` |
| D4 next-line vocabulary -> `\w+` | DEAD | DEAD | `Service:db-password` |
| D12 next-line vocabulary -> `[\w-]+` | DEAD | DEAD | `Service:db-password`, `Service:unit` |
| D5 compose service: drop `requires_framework` | DEAD | DEAD | `Service:deploy` |
| D6 compose service: drop the comment arm | DEAD | DEAD | recall 6/7 (`db` lost) |
| D7 volumes rule: drop `^` | DEAD | DEAD | `Config:extraArgs` |
| D8 networks rule: drop `^` | DEAD | DEAD | `Config:hostAliases` |
| D9 volumes rule: drop `(?m)` | DEAD | DEAD | recall 6/7 |
| D10 compose service: drop `(?m)` | DEAD | DEAD | recall 4/7 |
| D11 replace the docker marker with one nothing carries | DEAD | DEAD | recall 4/7 |
| A1 shorthand: drop `\s*$` (the `$` fence) | DEAD | DEAD | `Module:copy` |
| A2 shorthand: drop `^` | DEAD | DEAD | `Module:systemd` |
| A3 shorthand: alternation -> `(\w+)` | DEAD | DEAD | `Module:lineinfile` |
| A4 FQCN: drop `\s*$` (its only anchor) | DEAD | DEAD | `Module:ansible.builtin.debug` |
| A5 FQCN: third dotted segment optional | DEAD | DEAD | `Module:nginx.conf` |
| A6 shorthand: drop `requires_framework` | DEAD | DEAD | `Module:command` |
| A7 FQCN: drop `requires_framework` | DEAD | DEAD | `Module:storefront.rate.limiter` |
| A8 shorthand: drop `(?m)` | DEAD | DEAD | recall 5/7 |
| A9 FQCN: drop `(?m)` | DEAD | DEAD | recall 4/7 |
| delete only `ansible.builtin.` | DEAD | **DEAD** | recall 6/7 |
| delete only `become:` / `gather_facts` / `ansible_` / `with_items:` / `.j2` / `state: present` (6 mutants) | DEAD | **ALIVE** | — |

**Every one of the 16 forbidden rows is demonstrated capable of firing** by at least one mutant
above — the identities were read back out of the mutant graph, not inferred from a hit count, so
none of them is #6938's unfireable shape.

Two results worth stating rather than averaging away:

* **Six of the seven single-marker deletions are ALIVE at the fixture gate and DEAD only at the
  engine suite.** That is #6945's finding reproduced exactly: a realistic task file carries three
  or four markers at once, so no single deletion is observable on one. The engine test carries
  one minimal task file per marker and asserts *exactly one marker is present* before asserting
  the gated Module survives, so a case that grows a second marker fails loudly instead of
  quietly grading the set. The seventh (`ansible.builtin.`) is DEAD at both, because the
  fixture's role `handlers/main.yml` happens to carry it as its only marker.
* **D1 is the mutant that matters most**, and it is the change this issue originally proposed:
  `(?m)` and nothing else. It fires four forbidden rows across two files — the 40-per-corpus
  in-compose over-fire and a workflow job — and it is why this arm rewrote the pattern instead.

## Finding recorded, not absorbed

**A fixture's own comment can satisfy a substring marker.** Three of the four gate-direction
files were first written with headers saying "declares no `services:` key" and "no `become:`, no
`gather_facts`, no `.j2`" — and `frameworkPresent` is `strings.Contains` over whole file content,
comments included, so every one of those files was admitted and **all four gate rows were
silently unfireable**. Caught only by dumping what the detector actually emitted for each file
before writing `expected.json`, not by any assertion. The fixture headers now say why they do not
name the markers, and the engine tests assert the premise ("this case must NOT carry the marker" /
"this case must satisfy the gate") before asserting the consequence, so a case that drifts into
the other class fails loudly instead of passing for the wrong reason.

## Verification

* `./internal/engine/`, `./internal/quality/...`, `./cmd/grafel/` — green, `-count=1`. `go vet`
  clean, `gofmt -l` clean.
* Ratchet `scripts/quality/run.sh --runs 1 --ratchet`: **OK, 37 gated fixtures**. Delta
  enumerated: two new fixture entries, plus **exactly one** existing figure moved —
  `github-actions-workflows-mini`'s `entity_extracted_total` 55 → 57. Identified by diffing the
  graph of the pre-fix and post-fix binaries on that fixture: `Module:apt` and `Module:service`,
  added, nothing removed. They come from `ops/provision.yml`, which is a real ansible playbook
  the GA arm added as a non-workflow control and which carries `become:` and `state: present`;
  the shorthand module rule can finally read it. Recorded by hand rather than with
  `--update-baseline`, so no other fixture could re-record silently (#6898). **No python drift
  appeared, and as in #6945 that is not python recovering** — a hand-edit means the
  downward-drift mechanism was never exercised.
* Corpus-size guards re-derived **from disk**, not from the diff: 37 fixture directories, 37
  `expected.json`, 37 baseline entries; the three guards move 35 → 37.

Refs #6927, #6917, #6902, #6152, #6943, #6945.


---

## Review round (PR #6949 REQUEST-CHANGES)

All four rule-file changes are in the compose service pattern:

```
-(?m)^\s{2}(\w[\w-]*):[ \t]*\n(?:[ \t]*(?:#[^\n]*)?\n)*[ ]{3,}(?:…|environment|…|labels|…):
+(?m)^[ ]{2}(\w[\w-]*):[ \t]*\r?\n(?:[ \t]*(?:#[^\r\n]*)?\r?\n)*[ ]{3,}(?:…):
```

**F1 CRLF — fixed.** `[ \t]*\n` cannot match `\r\n`; the `\s*$` it replaced could and the
sibling `^volumes:\s*\n` rules still can, so the rewrite was the only compose rule with the
blindness. Now `\r?\n` in both the head and the comment/blank arm. Graded by
`TestIssue6927_Compose_ServiceRuleReadsCRLF`, which builds the CRLF input in Go source rather than
checking in a CRLF file — a checked-in one is at the mercy of autocrlf and would stop grading
silently. Both halves are separately scored (N1, N2).

**F2 "zero in-compose false positives" — the claim is withdrawn and the defect fixed.** The
reviewer is right that it was a corpus measurement being read as a property of the format. Rather
than restate it as "none on this corpus", the vocabulary now excludes `labels` and `environment`,
which per the Compose Spec are the **only** service-level keys a top-level
`volumes`/`networks`/`secrets`/`configs` entry may also carry — so the class is empty by the
schema. Graded four ways at engine level
(`TestIssue6927_Compose_TopLevelSectionEntriesAreNotServices`, one case per section) and at
fixture level: `db-data` now carries a spec-legal `labels:` block, and putting `labels` back in
the vocabulary fires that forbidden row (N3, DEAD at both levels). The price is stated, measured
(111 → 109 of 111 corpus services) and pinned by
`TestIssue6927_Compose_EnvironmentFirstServiceIsMissed`, which asserts the current imperfect
behaviour so a later improvement goes red rather than drifting.

**F3 `^\s{2}` — fixed** to `^[ ]{2}`, graded by
`TestIssue6927_Compose_ServiceRuleIndentCountsAreExact`.

**M1 / M2 / M3 — all three closed, and M3 was not equivalent.**

| review mutant | was | now |
|---|---|---|
| M1 `[ ]{3,}` → `[ ]{2,}` (child-indent COUNT) | ALIVE / ALIVE | **DEAD** at engine |
| M2 `^[ ]{2}` → `^\s{2}` (leading-indent CLASS) | ALIVE / ALIVE | **DEAD** at engine — and the shipped form is now the tight one |
| M3 `[ \t]*` → `\s*` (head whitespace CLASS) | ALIVE / ALIVE | **DEAD** at engine |

M3 was called "equivalent under the suite"; it is not equivalent at all. `\s` is `[\t\n\f\r ]`
and therefore crosses line boundaries, so `\s*` silently turns "nothing else on **this** line"
into "nothing but whitespace for some number of lines" — duplicating the blank/comment arm and
then over-reaching it, because that arm deliberately skips only blank and comment lines. The
distinguishing input was found by **enumerating** 39690 generated key/separator/body combinations
rather than by picking one: 7812 separate the two spellings, and the minimal case is a line
containing a lone form feed. `TestIssue6927_Compose_HeadWhitespaceCannotCrossALine` grades it with
two positive controls (a blank line and a comment line, both of which the arm *does* skip) so a
failure cannot be "the arm broke".

**A forbidden row was un-fired by the F2 fix, and re-scoring caught it.** Removing `environment`
from the vocabulary made `deploy` — the gate row — unreachable, because
`ci/release.yml`'s job opened with `environment:`. That is exactly the #6938 shape, produced by a
fix. Its first key is now `secrets:`, which is both real reusable-workflow syntax and a compose
service-level key, so the rule's shape matches the job and only the gate declines it; D5 fires
`Service:deploy` again at both levels. **All 12 docker mutants were re-scored against the new
pattern text rather than carried over** — the ansible half is untouched and its scores stand.

**The comment-satisfies-marker scan is now a test**, in this PR:
`internal/quality/comment_only_marker_6949_test.go`. It loads every rule set's `import_markers`,
splits each golden fixture source into code and comment lines by extension, and fails on any
marker whose occurrences are *all* in comments. Reproduces the reviewer's result exactly — one
hit, the cross-language lua `stub` in a C# file, recorded in an allow-list **with its reason**
rather than filtered out by a rule, so a same-language instance still fails. Two guards on the
guard: it fails if fewer than 200 markers or 100 fixture files are seen, and it fails on any
source file whose extension the comment map does not know (that guard fired immediately on
`Gemfile` and `config.ru`). Verified fireable by appending `# it has no services: key` to
`ci/release.yml` — it reported exactly the incident — then restored and re-verified by shasum.
Its limits are in the doc comment: comments only (a string literal naming a marker does the same
thing and is invisible to it), no block comments, and a hand-written extension map.

Re-verified after all of the above: `./internal/engine/`, `./internal/quality/...`,
`./cmd/grafel/` green with `-count=1`, `go vet` and `gofmt -l` clean, ratchet **OK at 37 gated
fixtures** with **no baseline change** (both new fixtures still 7/7, 2/2, 0 forbidden, totals
48/68 and 34/32; the GitHub-Actions 55 → 57 already recorded).


---

## MI-1 round: the ansible shorthand alternation's MEMBERSHIP

Fixed in `b29f9eac5`. The coordinator's mutant was right and the gap was real: three axes of that
rule were graded — the `^`, the `$`, the framework gate — plus its recall direction (a module
*outside* the list, `lineinfile`). Nobody attacked what the list **contains**, which is the only
axis where the rule gets wider without any regex construct changing.

`when:` with a list of conditions under it is ordinary ansible and bare-colon-legal, so it has
exactly the shape the rule matches — and it already has its own `when:\s+(.+)` → Config rule
further down the same file. Same for `tags:`, `loop:`, `with_items:`, `vars:`, `args:`,
`environment:`, `block:`/`rescue:`/`always:`. **No corpus frequency is claimed for any of them**;
reachability is the property, and a count here would be the corpus-measurement-as-property trap
running in the permissive direction.

* **Three fixture forbidden rows** — `when`, `tags`, `loop` — one per syntactic family
  (conditional / metadata / loop) so they cannot all rest on one accident, each carried by a bare
  colon block in a task file that already satisfies the gate, so they are held by the alternation
  and not by the gate or the anchors.
* **An exact-set assertion** over the minted Module names at engine level, which membership cannot
  do: it also catches a **same-count substitution** (`debug` → `when`) that no growth ceiling would
  see.
* **A ten-case behavioural table**, one keyword per case with a real module as positive control in
  the same file. Scalar-only keywords (`register`, `become`, `until`, `delegate_to`) are
  deliberately excluded — a bare one is legal YAML but not legal ansible, so a case built on one
  would argue rather than demonstrate.

| mutant | engine | fixture | fired |
|---|---|---|---|
| insert `when` / `tags` / `loop` (3) | DEAD | **DEAD** | `Module:when` / `tags` / `loop` |
| same-count substitution `debug` → `when` | DEAD | **DEAD** | `Module:when` |
| insert `vars` / `args` / `environment` / `block` (4) | DEAD | ALIVE | — |
| alternation → generic `(\w+)` (re-scored) | DEAD | DEAD | 4 rows, was 1 |

The four ALIVE-at-fixture rows are the expected shape: the fixture carries a bare colon for three
keywords, not for ten.

Baseline: `ansible-playbook-modules-mini` `entity_extracted_total` 34 → 35 and
`relationship_extracted_total` 32 → 33, recorded by hand. The one new entity is **identified, not
assumed**: `Config:- ansible_os_family == "Debian"`, minted by this file's own pre-existing
`when:` rule from the bare `when:` block the fixture gained. Recall, forbidden hits and every
other fixture unchanged; ratchet **OK at 37 gated fixtures**.
