### PR TITLE
feat(#6932) arm B part 1: project the inotify watch-descriptor cost and say it out loud — the probe, not the auto-switch

### DIFF
--- a/internal/cli/status_daemon_detail.go
+++ b/internal/cli/status_daemon_detail.go
@@ -54,6 +54,18 @@ func printDaemonDetail(w io.Writer, st proto.StatusReply) {
 		}
 		fmt.Fprintln(w)
 	}
+	// #6932 arm B: the inotify budget probe. Announced with the reason and the
+	// numbers rather than as a boolean, and NOT gated on anything above — the
+	// case worth seeing is precisely the one where the watcher looks healthy.
+	// The caveats print with the number, never instead of it: the pool is
+	// per-UID and host-level, so this is grafel's own demand against a ceiling
+	// other processes are also drawing on, and grafel cannot see their share.
+	if st.InotifyBudgetSummary != "" {
+		fmt.Fprintf(w, "  %s\n", st.InotifyBudgetSummary)
+		for _, n := range st.InotifyBudgetNotes {
+			fmt.Fprintf(w, "    note: %s\n", n)
+		}
+	}
 	if st.QueueLen > 0 || len(st.IndexInFlight) > 0 ||
 		len(st.PendingAlgo) > 0 || len(st.PendingLinks) > 0 {
 		fmt.Fprintf(w, "  scheduler: queue=%d in_flight=%d pending_algo=%d pending_links=%d\n",

--- a/internal/cli/status_inotify_6932_test.go
+++ b/internal/cli/status_inotify_6932_test.go
@@ -1,0 +1,52 @@
+package cli
+
+// status_inotify_6932_test.go — #6932 arm B, the print gate for the inotify
+// budget probe.
+//
+// A number on the wire that is never printed is the #6014 defect. The caveats
+// are printed WITH the number rather than summarised away, because the number
+// alone reads as headroom the daemon owns — and the pool is per-UID and shared
+// with every other process running as the same user.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+func TestPrintDaemonDetail_PrintsInotifyBudgetWithItsCaveats(t *testing.T) {
+	var buf bytes.Buffer
+	printDaemonDetail(&buf, proto.StatusReply{
+		// Zero watcher activity on purpose: the budget line must not be
+		// nested inside the `watcher:` block, whose gate is about events that
+		// arrived and says nothing about what the watch set costs.
+		InotifyBudgetSummary: "inotify budget: 9760 of 8192 watch descriptors (projected, 9760 dirs across 10 repos) — WOULD EXCEED",
+		InotifyBudgetNotes:   []string{"the inotify watch pool is per-UID and host-level", "demand is PROJECTED from a directory walk"},
+		InotifyBudgetExceeds: true,
+	})
+	out := buf.String()
+
+	for _, want := range []string{
+		"9760 of 8192 watch descriptors",
+		"WOULD EXCEED",
+		"per-UID and host-level",
+		"PROJECTED from a directory walk",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("`grafel status` output is missing %q — a budget the user cannot see is no "+
+				"improvement on a watcher nobody can see failing.\ngot:\n%s", want, out)
+		}
+	}
+}
+
+// A daemon whose reply carries no probe (an older daemon, or one with no
+// watcher) prints nothing rather than an empty line or a fabricated zero.
+func TestPrintDaemonDetail_NoInotifyLineWithoutAProbe(t *testing.T) {
+	var buf bytes.Buffer
+	printDaemonDetail(&buf, proto.StatusReply{WatcherRepos: 2, WatcherEvents: 400})
+	if out := buf.String(); strings.Contains(out, "inotify") {
+		t.Errorf("inotify budget line printed with no probe in the reply:\n%s", out)
+	}
+}

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -101,6 +101,22 @@ type StatusReply struct {
 	//
 	// A non-zero count is the only way this failure is visible at all: the
 	// watcher keeps running and keeps reporting healthy through an overflow.
+	// InotifyBudget* is the #6932 arm B probe: what this configuration costs
+	// the host's per-UID inotify watch pool, and what that pool allows.
+	// Reported rather than acted on — nothing switches mode on these numbers.
+	//
+	// InotifyBudgetSummary is the one-line announcement and
+	// InotifyBudgetNotes are the caveats that go with it. The caveats are
+	// carried across the wire rather than reconstructed by the client,
+	// because the most important one — the pool is per-UID and host-level, so
+	// grafel can see its own demand and NOT anyone else's — is a property of
+	// how the number was obtained, and the client has no way to know it.
+	InotifyBudgetSummary string   `json:"inotify_budget_summary,omitempty"`
+	InotifyBudgetNotes   []string `json:"inotify_budget_notes,omitempty"`
+	// InotifyBudgetExceeds is true only when grafel's OWN projected demand is
+	// larger than the host ceiling. False when no ceiling could be read: not
+	// knowing the limit is not evidence of exceeding it.
+	InotifyBudgetExceeds   bool               `json:"inotify_budget_exceeds,omitempty"`
 	WatcherOverflows       uint64             `json:"watcher_overflows,omitempty"`
 	WatcherOverflowRescans uint64             `json:"watcher_overflow_rescans,omitempty"`
 	WatcherLastOverflow    string             `json:"watcher_last_overflow,omitempty"`

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -101,6 +101,10 @@ type StatusReply struct {
 	//
 	// A non-zero count is the only way this failure is visible at all: the
 	// watcher keeps running and keeps reporting healthy through an overflow.
+	WatcherOverflows       uint64 `json:"watcher_overflows,omitempty"`
+	WatcherOverflowRescans uint64 `json:"watcher_overflow_rescans,omitempty"`
+	WatcherLastOverflow    string `json:"watcher_last_overflow,omitempty"`
+
 	// InotifyBudget* is the #6932 arm B probe: what this configuration costs
 	// the host's per-UID inotify watch pool, and what that pool allows.
 	// Reported rather than acted on — nothing switches mode on these numbers.
@@ -116,16 +120,13 @@ type StatusReply struct {
 	// InotifyBudgetExceeds is true only when grafel's OWN projected demand is
 	// larger than the host ceiling. False when no ceiling could be read: not
 	// knowing the limit is not evidence of exceeding it.
-	InotifyBudgetExceeds   bool               `json:"inotify_budget_exceeds,omitempty"`
-	WatcherOverflows       uint64             `json:"watcher_overflows,omitempty"`
-	WatcherOverflowRescans uint64             `json:"watcher_overflow_rescans,omitempty"`
-	WatcherLastOverflow    string             `json:"watcher_last_overflow,omitempty"`
-	QueueLen               int                `json:"queue_len,omitempty"`
-	IndexInFlight          []string           `json:"index_in_flight,omitempty"`
-	PendingAlgo            []string           `json:"pending_algo,omitempty"`
-	PendingLinks           []string           `json:"pending_links,omitempty"`
-	IndexedRepos           []IndexedRepoState `json:"indexed_repos,omitempty"`
-	RecentLog              []SchedLogEntry    `json:"recent_log,omitempty"`
+	InotifyBudgetExceeds bool               `json:"inotify_budget_exceeds,omitempty"`
+	QueueLen             int                `json:"queue_len,omitempty"`
+	IndexInFlight        []string           `json:"index_in_flight,omitempty"`
+	PendingAlgo          []string           `json:"pending_algo,omitempty"`
+	PendingLinks         []string           `json:"pending_links,omitempty"`
+	IndexedRepos         []IndexedRepoState `json:"indexed_repos,omitempty"`
+	RecentLog            []SchedLogEntry    `json:"recent_log,omitempty"`
 
 	// GroupAlgoRunning names the groups whose ANNOTATION (group-algo) pass is
 	// executing right now, and GroupAlgoInFlight counts them. The pass produces

--- a/internal/daemon/service_watcher_status.go
+++ b/internal/daemon/service_watcher_status.go
@@ -30,6 +30,10 @@ type watcherStatusSource interface {
 	FDBudgetStats() (int, int, int, []string)
 	// OverflowStats returns (overflows, rescans, coalesced, last) (#6921).
 	OverflowStats() (uint64, uint64, uint64, time.Time)
+	// InotifyBudgetReport returns (summary, notes, exceeds) for the probe
+	// that projects this configuration's cost against the host's per-UID
+	// inotify watch pool (#6932 arm B).
+	InotifyBudgetReport() (string, []string, bool)
 }
 
 // fillWatcherStatus copies the watcher's counters into the status reply.
@@ -56,4 +60,12 @@ func fillWatcherStatus(reply *proto.StatusReply, w watcherStatusSource) {
 	if !lastOverflow.IsZero() {
 		reply.WatcherLastOverflow = lastOverflow.UTC().Format(time.RFC3339)
 	}
+	// #6932 arm B: say what the watch set costs the host's per-UID inotify
+	// pool, and what that pool allows. The summary and its caveats travel
+	// together — the caveats are the part that keeps the number honest, and a
+	// client cannot reconstruct them.
+	summary, notes, exceeds := w.InotifyBudgetReport()
+	reply.InotifyBudgetSummary = summary
+	reply.InotifyBudgetNotes = notes
+	reply.InotifyBudgetExceeds = exceeds
 }

--- a/internal/daemon/service_watcher_status_6921_test.go
+++ b/internal/daemon/service_watcher_status_6921_test.go
@@ -33,6 +33,10 @@ func (s stubWatcherStatus) OverflowStats() (uint64, uint64, uint64, time.Time) {
 	return s.overflows, s.rescans, s.coalesced, s.last
 }
 
+func (stubWatcherStatus) InotifyBudgetReport() (string, []string, bool) {
+	return "", nil, false
+}
+
 func TestFillWatcherStatusReportsQueueOverflows6921(t *testing.T) {
 	last := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
 	var reply proto.StatusReply

--- a/internal/daemon/service_watcher_status_6932_test.go
+++ b/internal/daemon/service_watcher_status_6932_test.go
@@ -1,0 +1,96 @@
+package daemon
+
+// service_watcher_status_6932_test.go — #6932 arm B, the announcement on the
+// wire.
+//
+// The probe exists to be SEEN. A projection that reaches no surface is the same
+// defect class as the watcher failures #6921/#6923/#6928 belong to: something
+// the daemon knows and the operator cannot. Two levels, as in the #6921 file:
+// the mapping, driven by a stand-in, and the CALL, driven by a real watcher.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/watch"
+)
+
+// budgetStub is a watcherStatusSource whose budget report can be set to
+// anything, including the exceeded case, which cannot be provoked on a
+// developer machine with a real kernel limit.
+type budgetStub struct {
+	summary string
+	notes   []string
+	exceeds bool
+}
+
+func (budgetStub) Stats() (int, int, uint64, uint64, int)   { return 1, 4, 0, 0, 0 }
+func (budgetStub) FDBudgetStats() (int, int, int, []string) { return 0, 0, 0, nil }
+func (budgetStub) OverflowStats() (uint64, uint64, uint64, time.Time) {
+	return 0, 0, 0, time.Time{}
+}
+func (b budgetStub) InotifyBudgetReport() (string, []string, bool) {
+	return b.summary, b.notes, b.exceeds
+}
+
+func TestFillWatcherStatusReportsTheInotifyBudget6932(t *testing.T) {
+	var reply proto.StatusReply
+	fillWatcherStatus(&reply, budgetStub{
+		summary: "inotify budget: 9760 of 8192 watch descriptors — WOULD EXCEED",
+		notes:   []string{"the inotify watch pool is per-UID and host-level"},
+		exceeds: true,
+	})
+
+	if !strings.Contains(reply.InotifyBudgetSummary, "WOULD EXCEED") {
+		t.Errorf("InotifyBudgetSummary = %q — the projection never reaches the status reply",
+			reply.InotifyBudgetSummary)
+	}
+	if len(reply.InotifyBudgetNotes) != 1 {
+		t.Errorf("InotifyBudgetNotes = %v — the caveats were dropped, leaving the number to be read "+
+			"as headroom this process owns", reply.InotifyBudgetNotes)
+	}
+	if !reply.InotifyBudgetExceeds {
+		t.Error("InotifyBudgetExceeds = false for a report that exceeds")
+	}
+}
+
+// The negative half: a fitting budget must not set the flag, or a `grafel
+// status` reader learns to ignore it.
+func TestFillWatcherStatusDoesNotClaimExcessWhenItFits6932(t *testing.T) {
+	var reply proto.StatusReply
+	fillWatcherStatus(&reply, budgetStub{summary: "inotify budget: 100 of 8192 watch descriptors — fits"})
+	if reply.InotifyBudgetExceeds {
+		t.Error("InotifyBudgetExceeds = true for a budget that fits")
+	}
+	if len(reply.InotifyBudgetNotes) != 0 {
+		t.Errorf("notes invented from nowhere: %v", reply.InotifyBudgetNotes)
+	}
+}
+
+// The control one level up: a Service holding a REAL watcher publishes a real
+// summary. Without it, the mapping above could be a helper Status never calls.
+func TestStatusPublishesTheInotifyBudget6932(t *testing.T) {
+	w, err := watch.NewWatcher(time.Hour, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	t.Cleanup(w.Stop)
+	if _, err := w.AddRepo(t.TempDir()); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+
+	s := &Service{watcher: w, startedAt: time.Now()}
+	var reply proto.StatusReply
+	if err := s.Status(&proto.StatusArgs{}, &reply); err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !strings.Contains(reply.InotifyBudgetSummary, "inotify budget:") {
+		t.Fatalf("StatusReply.InotifyBudgetSummary = %q — the probe is computed and discarded "+
+			"before anyone sees it", reply.InotifyBudgetSummary)
+	}
+	if len(reply.InotifyBudgetNotes) == 0 {
+		t.Error("a real report reached the wire with no caveats attached")
+	}
+}

--- a/internal/daemon/watch/inotifybudget.go
+++ b/internal/daemon/watch/inotifybudget.go
@@ -1,0 +1,315 @@
+package watch
+
+// inotifybudget.go — the inotify budget PROBE (#6932 arm B, part 1).
+//
+// What this is, and what it deliberately is NOT.
+//
+// It is a projection: "how many inotify watch descriptors would this
+// configuration ask the kernel for, and how many does this host allow". It
+// changes no configuration and switches no mode. `auto` still resolves to
+// fsnotify, PollingEnabled() is untouched, and a repo subscribes exactly what
+// it subscribed before. The only new behaviour is that grafel can now say what
+// the watch set costs.
+//
+// It is NOT an auto-switch. An auto-switch needs a threshold, and every number
+// #6932 records is macOS/APFS with no concurrency measurement. This probe is
+// what produces the data such a threshold would need, on the target hosts.
+//
+// The honesty constraint that shapes the whole type:
+//
+//	fs.inotify.max_user_watches is PER-UID and HOST-LEVEL. It is not
+//	namespaced, so every container running as the same UID draws from one
+//	pool, and a container cannot raise it. This probe can see grafel's own
+//	demand. It cannot see what any other process has already taken out of
+//	the same pool. Headroom computed here is therefore an UPPER BOUND on
+//	what is actually available, never a promise — and the report says so in
+//	its own text rather than leaving the reader to assume otherwise.
+//
+// On non-Linux the answer is "not applicable on this platform", not 0.
+// defaultFDBudgetLimit() returns 0 off Darwin to mean "accounting disabled",
+// and a probe that reused that 0 as a limit would read as "no headroom at all"
+// on a platform where the question does not arise.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/walk"
+)
+
+// inotifyLimitEnv lets an operator supply the ceiling the probe should measure
+// against. Two uses: a what-if ("what would my container's 8192 mean for this
+// fleet?") from a machine that is not the container, and testability of the
+// arithmetic on a host with no /proc. A report built from it names it as the
+// source, so an env-supplied number never passes itself off as a kernel read.
+const inotifyLimitEnv = "GRAFEL_INOTIFY_MAX_USER_WATCHES"
+
+// InotifyBudget is one probe result.
+//
+// Dirs is the demand in DIRECTORIES; Projected is that demand converted to
+// watch descriptors by the inotify cost model (one wd per directory,
+// recursively, nothing per file). The two are kept apart because the directory
+// count is a measured property of the tree on any platform, while the
+// descriptor figure only means something where an inotify pool exists.
+type InotifyBudget struct {
+	// Platform is runtime.GOOS, so a report read out of a log or a bug
+	// attachment carries the host it describes.
+	Platform string
+	// PoolApplies is true only where a per-UID inotify watch pool governs
+	// the watch set — i.e. Linux, or any host where the operator supplied a
+	// ceiling explicitly via inotifyLimitEnv.
+	PoolApplies bool
+	// Limit is the per-UID ceiling, and 0 means "not known", never "zero
+	// watches allowed". Consult LimitKnown rather than testing this field.
+	Limit int
+	// LimitSource names where Limit came from: the sysctl path, or the env
+	// override. Empty when no limit was obtained.
+	LimitSource string
+	// LimitErr is the reason no limit could be read, if any.
+	LimitErr string
+
+	// Repos is how many registered repos the demand covers. Each tracked
+	// linked worktree registers as its own repo and subscribes its own tree,
+	// so the worktree multiplier is already inside this count rather than
+	// being applied to it as arithmetic.
+	Repos int
+	// Dirs is the number of directories a subscription would take a watch
+	// on, summed over Repos.
+	Dirs int
+	// Projected is Dirs converted to inotify watch descriptors.
+	Projected int
+	// Measured is true when Dirs is the LIVE subscribed directory set rather
+	// than a walk's projection of one. Reported because the two answer
+	// slightly different questions and a reader is entitled to know which
+	// one they are looking at.
+	Measured bool
+
+	// Notes carries the caveats in the report's own words. Every consumer
+	// prints them; none of them summarise them away.
+	Notes []string
+}
+
+// LimitKnown reports whether Limit is a real ceiling this report may be
+// compared against.
+func (b InotifyBudget) LimitKnown() bool { return b.PoolApplies && b.Limit > 0 }
+
+// WouldExceed reports whether the projected demand does not fit under the
+// host's per-UID ceiling — grafel's demand ALONE, before any other process on
+// the host is accounted for. With no known limit the answer is false, because
+// "we could not read the ceiling" is not evidence of exceeding it.
+func (b InotifyBudget) WouldExceed() bool {
+	return b.LimitKnown() && b.Projected > b.Limit
+}
+
+// Headroom returns how many watch descriptors remain under the ceiling once
+// grafel's own demand is met, and whether that number is meaningful at all.
+//
+// It is an UPPER BOUND. The pool is shared per-UID across every process on the
+// host, and this probe cannot see the other consumers, so the true headroom is
+// this number minus an unknown.
+func (b InotifyBudget) Headroom() (int, bool) {
+	if !b.LimitKnown() {
+		return 0, false
+	}
+	return b.Limit - b.Projected, true
+}
+
+// Summary is the one-line announcement, in the form `grafel status` prints it.
+// The caveats live in Notes and are printed with it, never instead of it.
+func (b InotifyBudget) Summary() string {
+	demand := "projected"
+	if b.Measured {
+		demand = "measured"
+	}
+	if !b.PoolApplies {
+		return fmt.Sprintf("inotify budget: not applicable on %s — %d dirs across %d repos (%s)",
+			b.Platform, b.Dirs, b.Repos, demand)
+	}
+	if !b.LimitKnown() {
+		return fmt.Sprintf("inotify budget: %d watch descriptors (%s, %d dirs across %d repos), host limit unknown",
+			b.Projected, demand, b.Dirs, b.Repos)
+	}
+	verdict := "fits"
+	if b.WouldExceed() {
+		verdict = "WOULD EXCEED"
+	}
+	return fmt.Sprintf("inotify budget: %d of %d watch descriptors (%s, %d dirs across %d repos) — %s",
+		b.Projected, b.Limit, demand, b.Dirs, b.Repos, verdict)
+}
+
+// inotifySharedPoolNote is the caveat that must survive every refactor: the
+// pool is shared and this probe is half-blind to it.
+const inotifySharedPoolNote = "the inotify watch pool is per-UID and host-level, NOT per-container: every process running as this UID draws from the same pool and a container cannot raise it. This probe sees only grafel's own demand — it cannot see what other processes have already taken, so any headroom shown is an upper bound, not a reservation."
+
+// ProjectInotifyBudget projects the watch-descriptor cost of subscribing repos,
+// WITHOUT subscribing anything.
+//
+// extraSkip is the per-Watcher exclude set, so a projection made for a live
+// Watcher asks the same question that Watcher's own subscription walk asks.
+func ProjectInotifyBudget(repos []string, extraSkip map[string]struct{}) InotifyBudget {
+	b := newInotifyBudget()
+	b.Repos = len(repos)
+	for _, r := range repos {
+		b.Dirs += projectWatchDirs(r, extraSkip)
+	}
+	b.Projected = inotifyCostModel.cost(b.Dirs, 0)
+	b.Notes = append(b.Notes, "demand is PROJECTED from a directory walk; nothing was subscribed to produce it.")
+	return b
+}
+
+// MeasuredInotifyBudget builds a report from a directory count that has already
+// been taken — the live subscribed set — rather than from a projection walk.
+func MeasuredInotifyBudget(repos, dirs int) InotifyBudget {
+	b := newInotifyBudget()
+	b.Repos = repos
+	b.Dirs = dirs
+	b.Measured = true
+	b.Projected = inotifyCostModel.cost(dirs, 0)
+	b.Notes = append(b.Notes, "demand is the LIVE subscribed directory set, counted from the watcher's own map.")
+	return b
+}
+
+// newInotifyBudget fills in everything that depends on the host rather than on
+// the watch set: the platform, the ceiling, and the caveats attached to both.
+func newInotifyBudget() InotifyBudget {
+	b := InotifyBudget{Platform: runtime.GOOS}
+	if n, ok := envInotifyLimit(); ok {
+		// An operator-supplied ceiling makes the comparison meaningful even
+		// where the kernel has no such pool — as a what-if. It is labelled as
+		// such so it cannot be mistaken for a reading of this host.
+		b.PoolApplies = true
+		b.Limit = n
+		b.LimitSource = inotifyLimitEnv
+		b.Notes = append(b.Notes, fmt.Sprintf("limit was supplied by %s, NOT read from this host's kernel.", inotifyLimitEnv))
+		if !inotifyPoolApplies {
+			b.Notes = append(b.Notes, fmt.Sprintf("%s has no inotify watch pool of its own; this is a what-if against a Linux ceiling.", runtime.GOOS))
+		}
+		b.Notes = append(b.Notes, inotifySharedPoolNote)
+		return b
+	}
+	if !inotifyPoolApplies {
+		b.Notes = append(b.Notes,
+			fmt.Sprintf("inotify is a Linux facility and there is no per-UID watch pool on %s, so no limit applies here. The directory count is still real: it is what a Linux host would be asked for. Set %s to compare it against a ceiling.", runtime.GOOS, inotifyLimitEnv))
+		return b
+	}
+	b.PoolApplies = true
+	n, src, err := readInotifyLimit()
+	b.LimitSource = src
+	if err != nil {
+		b.LimitErr = err.Error()
+		b.Notes = append(b.Notes, fmt.Sprintf("could not read %s (%v), so the ceiling is unknown and nothing here is compared against one.", src, err))
+	} else {
+		b.Limit = n
+	}
+	b.Notes = append(b.Notes, inotifySharedPoolNote)
+	return b
+}
+
+// envInotifyLimit returns (value, true) when the operator override is set to a
+// parseable non-negative integer.
+func envInotifyLimit() (int, bool) {
+	v := strings.TrimSpace(os.Getenv(inotifyLimitEnv))
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// projectWatchDirs counts the directories a subscription of repoPath would take
+// a watch on.
+//
+// It mirrors subscribeRepo's walk in the ONE respect that decides the count:
+// which directories survive. The per-directory verdict is not re-implemented
+// here — watchDirSkip is the single definition of it and both walks call it —
+// and the two remaining gates (the TCC protected-path guard and the watch-dir
+// cap) are the same helpers applied in the same order. The projection is
+// checked against a real subscription's count by
+// TestProjectInotifyBudget_MatchesWhatSubscriptionActuallyTakes; a projection
+// nobody compared to a measurement is arithmetic, not a probe.
+func projectWatchDirs(repoPath string, extraSkip map[string]struct{}) int {
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		return 0
+	}
+	if protected, _ := walk.IsProtectedPath(abs); protected {
+		return 0
+	}
+	dirCap := walk.WatchDirCap()
+	added := 0
+	_ = filepath.WalkDir(abs, func(p string, d os.DirEntry, err error) error {
+		if err != nil || !d.IsDir() {
+			return nil
+		}
+		if protected, _ := walk.IsProtectedPath(p); protected {
+			return filepath.SkipDir
+		}
+		if dirCap > 0 && added >= dirCap {
+			return filepath.SkipDir
+		}
+		if skip, _ := watchDirSkip(abs, p, extraSkip); skip != watchSkipNone {
+			return filepath.SkipDir
+		}
+		added++
+		return nil
+	})
+	return added
+}
+
+// inotifyProbeTTL is how long a budget report is reused before the walk is
+// repeated. A variable so tests can drive the refresh path without sleeping.
+var inotifyProbeTTL = 60 * time.Second
+
+// InotifyBudget reports what this Watcher's configuration would cost the host's
+// per-UID inotify watch pool (#6932 arm B). It subscribes nothing, unsubscribes
+// nothing, and switches no mode.
+//
+// Which question it answers depends on what is live:
+//
+//   - fsnotify mode: the demand is MEASURED. The subscribed directory set IS
+//     the demand, and the watcher already knows its size, so no walk happens.
+//   - poll mode (a change-detection delegate is installed): nothing is
+//     subscribed at all, so the demand is PROJECTED by walking the registered
+//     repos. That is the number worth having there — it is what poll mode is
+//     not spending.
+//
+// The result is cached for inotifyProbeTTL because the projection walk is not
+// free and /diagnostics is polled.
+func (w *Watcher) InotifyBudget() InotifyBudget {
+	w.inotifyProbeMu.Lock()
+	defer w.inotifyProbeMu.Unlock()
+	now := w.clk.Now()
+	if !w.inotifyProbeAt.IsZero() && now.Sub(w.inotifyProbeAt) < inotifyProbeTTL {
+		return w.inotifyProbeVal
+	}
+	var b InotifyBudget
+	if w.cfg.Delegate != nil {
+		b = ProjectInotifyBudget(w.Repos(), w.extraSkip)
+		b.Notes = append(b.Notes, "change_detection=poll: grafel holds ZERO inotify watch descriptors right now. The figure above is what fsnotify mode would ask this host for instead.")
+	} else {
+		repos, dirs, _, _, _ := w.Stats()
+		b = MeasuredInotifyBudget(repos, dirs)
+	}
+	w.inotifyProbeVal = b
+	w.inotifyProbeAt = now
+	return b
+}
+
+// InotifyBudgetReport is InotifyBudget flattened to primitives: the one-line
+// announcement, its caveats, and whether grafel's own demand exceeds the host
+// ceiling. It exists so the status and /diagnostics surfaces can report the
+// probe without importing this package's types — and so the caveats travel WITH
+// the summary rather than being reconstructed downstream by a caller that
+// cannot know how the number was obtained.
+func (w *Watcher) InotifyBudgetReport() (summary string, notes []string, exceeds bool) {
+	b := w.InotifyBudget()
+	return b.Summary(), b.Notes, b.WouldExceed()
+}

--- a/internal/daemon/watch/inotifybudget.go
+++ b/internal/daemon/watch/inotifybudget.go
@@ -37,6 +37,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/walk"
@@ -89,6 +90,28 @@ type InotifyBudget struct {
 	// one they are looking at.
 	Measured bool
 
+	// UnwatchedRepos and FailedDirs are the DEGRADED half of the demand, and
+	// they exist because a measured figure alone is a LOWER BOUND on demand,
+	// not the demand.
+	//
+	// The watcher's own directory map counts watches the kernel GRANTED. A
+	// repo the descriptor budget refused, or a directory whose fsnotify Add
+	// failed — on Linux, ENOSPC, which is exactly the inotify pool running
+	// out — leaves that map smaller, so the naive measured report gets
+	// CHEAPER the worse the failure is, and a repo receiving no events at all
+	// renders as "fits". That is the silent degradation this arm exists to
+	// expose (#6921, #6923, #6928) reproduced inside the instrument built to
+	// expose it, so the refused demand is counted back into Dirs and named
+	// here, and Summary says NOT WATCHED out loud.
+	UnwatchedRepos int
+	FailedDirs     int
+
+	// WhatIf records that Limit came from the operator rather than from this
+	// host's kernel. It is carried into the rendered line, not just into the
+	// notes: on a platform with no inotify pool at all a bare "N of 8192 —
+	// fits" is a Linux-shaped verdict about a host that has no such ceiling.
+	WhatIf bool
+
 	// Notes carries the caveats in the report's own words. Every consumer
 	// prints them; none of them summarise them away.
 	Notes []string
@@ -119,27 +142,64 @@ func (b InotifyBudget) Headroom() (int, bool) {
 	return b.Limit - b.Projected, true
 }
 
+// demandLabel says how the demand figure was obtained, in the rendered line
+// rather than only in a struct field. "measured" for a live subscription,
+// "projected" for a walk, and the honest hybrid when a refused repo's cost had
+// to be projected back into a measured report.
+func (b InotifyBudget) demandLabel() string {
+	if !b.Measured {
+		return "projected"
+	}
+	if b.UnwatchedRepos > 0 {
+		return fmt.Sprintf("measured, plus a projection of %d refused repo(s)", b.UnwatchedRepos)
+	}
+	return "measured"
+}
+
+// degradedClause is the NOT WATCHED announcement. Empty in the healthy case,
+// because a line that always prints trains the reader to ignore it.
+func (b InotifyBudget) degradedClause() string {
+	if b.UnwatchedRepos == 0 && b.FailedDirs == 0 {
+		return ""
+	}
+	return fmt.Sprintf("; NOT WATCHED: %d repo(s) refused, %d director(ies) the backend rejected — "+
+		"their cost IS included above and those trees receive no file events at all, so this is not an all-clear",
+		b.UnwatchedRepos, b.FailedDirs)
+}
+
 // Summary is the one-line announcement, in the form `grafel status` prints it.
 // The caveats live in Notes and are printed with it, never instead of it.
 func (b InotifyBudget) Summary() string {
-	demand := "projected"
-	if b.Measured {
-		demand = "measured"
-	}
+	shape := fmt.Sprintf("(%s, %d dirs across %d repos)", b.demandLabel(), b.Dirs, b.Repos)
+	tail := b.degradedClause()
+
 	if !b.PoolApplies {
-		return fmt.Sprintf("inotify budget: not applicable on %s — %d dirs across %d repos (%s)",
-			b.Platform, b.Dirs, b.Repos, demand)
+		return fmt.Sprintf("inotify budget: not applicable on %s — %d dirs across %d repos (%s)%s",
+			b.Platform, b.Dirs, b.Repos, b.demandLabel(), tail)
 	}
 	if !b.LimitKnown() {
-		return fmt.Sprintf("inotify budget: %d watch descriptors (%s, %d dirs across %d repos), host limit unknown",
-			b.Projected, demand, b.Dirs, b.Repos)
+		return fmt.Sprintf("inotify budget: %d watch descriptors %s, host limit unknown%s",
+			b.Projected, shape, tail)
 	}
-	verdict := "fits"
+
+	verdict := "fits (grafel's demand alone)"
+	if free, ok := b.Headroom(); ok && !b.WouldExceed() {
+		verdict = fmt.Sprintf("fits (grafel's demand alone), %d left under the ceiling — an UPPER BOUND, the pool is shared", free)
+	}
 	if b.WouldExceed() {
 		verdict = "WOULD EXCEED"
 	}
-	return fmt.Sprintf("inotify budget: %d of %d watch descriptors (%s, %d dirs across %d repos) — %s",
-		b.Projected, b.Limit, demand, b.Dirs, b.Repos, verdict)
+
+	// A ceiling this host does not have is rendered as the what-if it is. A
+	// bare "N of 8192 — fits" on a platform with no inotify pool is a
+	// Linux-shaped verdict about a machine that cannot produce one.
+	if b.WhatIf && !inotifyPoolApplies {
+		return fmt.Sprintf("inotify budget: not applicable on %s (no inotify watch pool on this platform) — "+
+			"WHAT-IF against the ceiling supplied in %s: %d of %d watch descriptors %s — %s%s",
+			b.Platform, inotifyLimitEnv, b.Projected, b.Limit, shape, verdict, tail)
+	}
+	return fmt.Sprintf("inotify budget: %d of %d watch descriptors %s — %s%s",
+		b.Projected, b.Limit, shape, verdict, tail)
 }
 
 // inotifySharedPoolNote is the caveat that must survive every refactor: the
@@ -170,7 +230,9 @@ func MeasuredInotifyBudget(repos, dirs int) InotifyBudget {
 	b.Dirs = dirs
 	b.Measured = true
 	b.Projected = inotifyCostModel.cost(dirs, 0)
-	b.Notes = append(b.Notes, "demand is the LIVE subscribed directory set, counted from the watcher's own map.")
+	b.Notes = append(b.Notes, "demand is the LIVE subscribed directory set — the watches the kernel GRANTED. "+
+		"A measured figure ALONE is a lower bound on demand, because a refused repo or a rejected directory makes "+
+		"it smaller rather than larger; anything refused is counted back in and called out as NOT WATCHED.")
 	return b
 }
 
@@ -183,6 +245,7 @@ func newInotifyBudget() InotifyBudget {
 		// where the kernel has no such pool — as a what-if. It is labelled as
 		// such so it cannot be mistaken for a reading of this host.
 		b.PoolApplies = true
+		b.WhatIf = true
 		b.Limit = n
 		b.LimitSource = inotifyLimitEnv
 		b.Notes = append(b.Notes, fmt.Sprintf("limit was supplied by %s, NOT read from this host's kernel.", inotifyLimitEnv))
@@ -297,6 +360,36 @@ func (w *Watcher) InotifyBudget() InotifyBudget {
 	} else {
 		repos, dirs, _, _, _ := w.Stats()
 		b = MeasuredInotifyBudget(repos, dirs)
+		// The demand is what was ATTEMPTED, not what survived. Two ways a
+		// watch is attempted and not granted, and both make the measured set
+		// SMALLER — which is why reporting the measured set alone announces
+		// "fits" exactly when the watcher has been refused:
+		//
+		//  1. A repo the descriptor budget refused outright. It is registered
+		//     with the daemon, receives no events, and is absent from
+		//     w.dirToRepo. Its cost is projected back in.
+		//  2. A directory whose fsnotify Add failed — on Linux, ENOSPC from a
+		//     max_user_watches pool that is already full. subscribeRepo logs
+		//     WARN and carries on, so the shortfall is exactly the number of
+		//     watches the kernel would not give us.
+		if _, _, _, refused := w.FDBudgetStats(); len(refused) > 0 {
+			p := ProjectInotifyBudget(refused, w.extraSkip)
+			b.Repos += p.Repos
+			b.Dirs += p.Dirs
+			b.UnwatchedRepos = len(refused)
+		}
+		if n := atomic.LoadUint64(&w.fsAddFailed); n > 0 {
+			b.FailedDirs = int(n)
+			b.Dirs += int(n)
+		}
+		b.Projected = inotifyCostModel.cost(b.Dirs, 0)
+		if b.UnwatchedRepos > 0 || b.FailedDirs > 0 {
+			b.Notes = append(b.Notes, fmt.Sprintf(
+				"DEGRADED: %d repo(s) were refused and %d director(ies) were rejected by the backend. "+
+					"Their cost is included in the demand above, but those trees are receiving no file "+
+					"events — a re-index will not be triggered by edits there.",
+				b.UnwatchedRepos, b.FailedDirs))
+		}
 	}
 	w.inotifyProbeVal = b
 	w.inotifyProbeAt = now

--- a/internal/daemon/watch/inotifybudget_6932_test.go
+++ b/internal/daemon/watch/inotifybudget_6932_test.go
@@ -1,0 +1,412 @@
+package watch
+
+// inotifybudget_6932_test.go — #6932 arm B part 1, the budget probe.
+//
+// The headline property is not arithmetic, it is AGREEMENT: what the probe
+// projects must equal what a real subscription actually takes. A projection
+// nobody compared to a measurement is arithmetic, so the comparison here is
+// against fsnotify's own WatchList — the library's record of what it handed the
+// kernel — and not against a counter grafel keeps about itself.
+//
+// The second property is honesty. The inotify pool is per-UID and host-level,
+// so the probe can see its own demand and NOT anyone else's, and off Linux the
+// pool does not exist at all. Both facts have to reach the reader, so both are
+// asserted on the report's own text.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// budgetRepo builds a tree whose directories are NOT all watchable: one
+// hard-coded skip (node_modules, with a child, so a whole subtree is pruned)
+// and one .gitignore'd directory. If the probe simply counted directories on
+// disk it would over-count here, which is what makes the agreement assertion
+// below non-vacuous.
+func budgetRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, d := range []string{
+		"src", "src/inner", "pkg",
+		"node_modules", "node_modules/deep",
+		"generated", "generated/nested",
+	} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("generated/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "x.go"), []byte("package src\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// dirsOnDisk counts every directory in the tree, watchable or not — the number
+// the probe must NOT report.
+func dirsOnDisk(t *testing.T, root string) int {
+	t.Helper()
+	n := 0
+	if err := filepath.WalkDir(root, func(_ string, d os.DirEntry, err error) error {
+		if err == nil && d.IsDir() {
+			n++
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+// The whole point of the probe: its projection is what a subscription really
+// costs. Measured at the backend, in fsnotify's own WatchList.
+func TestProjectInotifyBudget_MatchesWhatSubscriptionActuallyTakes(t *testing.T) {
+	repo := budgetRepo(t)
+
+	// Projected BEFORE anything subscribes — that is the probe's whole claim.
+	proj := ProjectInotifyBudget([]string{repo}, nil)
+
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+	added, err := w.AddRepo(repo)
+	if err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	actual := backendWatchList(w)
+
+	// Premises, so a pass cannot come from everything being zero or from a
+	// fixture with nothing to skip.
+	if actual == 0 {
+		t.Fatal("the subscription took 0 paths — the comparison would be vacuous")
+	}
+	if onDisk := dirsOnDisk(t, repo); onDisk <= actual {
+		t.Fatalf("fixture premise broken: %d dirs on disk but %d subscribed — nothing was skipped, "+
+			"so a probe that ignored every skip layer would still pass", onDisk, actual)
+	}
+	// Named, so a fixture that quietly stops exercising one of the two skip
+	// layers is a failure rather than a weaker test: the watched set is the
+	// root, src, src/inner and pkg — node_modules/** is a hard-coded skip and
+	// generated/** is refused by the .gitignore layer.
+	if onDisk := dirsOnDisk(t, repo); onDisk != 8 || actual != 4 {
+		t.Fatalf("fixture no longer exercises both skip layers: %d dirs on disk, %d subscribed, "+
+			"want 8 and 4 (node_modules/** hard-coded, generated/** gitignored)", onDisk, actual)
+	}
+
+	if proj.Dirs != actual {
+		t.Fatalf("probe projected %d watched dirs, the fsnotify backend actually took %d paths — "+
+			"a projection that disagrees with the subscription is not a probe", proj.Dirs, actual)
+	}
+	if proj.Dirs != added {
+		t.Fatalf("probe projected %d dirs, AddRepo reported %d", proj.Dirs, added)
+	}
+	if proj.Projected != proj.Dirs {
+		t.Fatalf("inotify spends one watch descriptor per directory: Projected=%d, Dirs=%d",
+			proj.Projected, proj.Dirs)
+	}
+	if proj.Measured {
+		t.Error("a projection walk reported itself as a measurement")
+	}
+}
+
+// Two repos: the demand is the sum, because each tracked worktree registers as
+// its own repo and subscribes its own tree. That multiplier is the reason one
+// lane can reach ~10,700 descriptors.
+func TestProjectInotifyBudget_SumsAcrossRepos(t *testing.T) {
+	a, b := budgetRepo(t), budgetRepo(t)
+	one := ProjectInotifyBudget([]string{a}, nil)
+	two := ProjectInotifyBudget([]string{a, b}, nil)
+	if one.Dirs == 0 {
+		t.Fatal("single-repo projection is 0 — vacuous")
+	}
+	if two.Dirs != 2*one.Dirs {
+		t.Fatalf("two identical repos projected %d dirs, want %d", two.Dirs, 2*one.Dirs)
+	}
+	if two.Repos != 2 {
+		t.Fatalf("Repos = %d, want 2", two.Repos)
+	}
+}
+
+// The per-instance exclude set must reach the projection: a Watcher configured
+// to skip a directory does not subscribe it, and the probe must not charge for
+// it either.
+func TestProjectInotifyBudget_HonoursInstanceExcludes(t *testing.T) {
+	repo := budgetRepo(t)
+	base := ProjectInotifyBudget([]string{repo}, nil)
+	excluded := ProjectInotifyBudget([]string{repo}, map[string]struct{}{"src": {}})
+	// src plus src/inner.
+	if excluded.Dirs != base.Dirs-2 {
+		t.Fatalf("excluding src projected %d dirs, want %d (base %d minus src and src/inner)",
+			excluded.Dirs, base.Dirs-2, base.Dirs)
+	}
+}
+
+// In fsnotify mode the demand is not projected at all — the subscribed set IS
+// the demand — and the report says which of the two it is looking at.
+func TestWatcherInotifyBudget_FsnotifyModeReportsTheLiveSubscription(t *testing.T) {
+	repo := budgetRepo(t)
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+
+	b := w.InotifyBudget()
+	if !b.Measured {
+		t.Error("fsnotify mode reported a projection where it holds a live subscription")
+	}
+	if got, want := b.Dirs, backendWatchList(w); got != want {
+		t.Fatalf("report says %d dirs, the backend holds %d paths", got, want)
+	}
+	if b.Repos != 1 {
+		t.Fatalf("Repos = %d, want 1", b.Repos)
+	}
+}
+
+// Poll mode is where the probe earns its keep: nothing is subscribed, so the
+// number worth printing is what fsnotify mode WOULD have asked this host for.
+// Graded against a real fsnotify subscription of the same tree.
+func TestWatcherInotifyBudget_PollModeProjectsWhatFsnotifyWouldCost(t *testing.T) {
+	repo := budgetRepo(t)
+
+	polling, err := NewWatcherConfig(Config{Debounce: time.Hour, Delegate: &recordingDelegate{}}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer polling.Stop()
+	if _, err := polling.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if n := backendWatchList(polling); n != 0 {
+		t.Fatalf("poll mode holds %d fsnotify paths; premise of this test is that it holds 0", n)
+	}
+	b := polling.InotifyBudget()
+
+	subscribing, err := NewWatcherConfig(Config{Debounce: time.Hour}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer subscribing.Stop()
+	if _, err := subscribing.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	actual := backendWatchList(subscribing)
+
+	if actual == 0 {
+		t.Fatal("the fsnotify control subscribed nothing — vacuous")
+	}
+	if b.Dirs != actual {
+		t.Fatalf("poll mode projects %d watch descriptors; fsnotify mode on the same tree takes %d",
+			b.Dirs, actual)
+	}
+	if b.Measured {
+		t.Error("poll mode reported its projection as a measurement of a subscription it does not hold")
+	}
+	if !notesMention(b.Notes, "ZERO inotify watch descriptors") {
+		t.Errorf("poll mode's report never says it holds no descriptors right now: %v", b.Notes)
+	}
+}
+
+func notesMention(notes []string, want string) bool {
+	for _, n := range notes {
+		if strings.Contains(n, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// "WOULD EXCEED" is a claim. It must be made when, and only when, grafel's own
+// demand is larger than the ceiling — including at the boundary, where equal
+// FITS.
+func TestInotifyBudget_WouldExceedOnlyWhenItWould(t *testing.T) {
+	for _, tc := range []struct {
+		limit  string
+		exceed bool
+	}{
+		{"101", false},
+		{"100", false}, // exactly the ceiling still fits
+		{"99", true},
+		{"1", true},
+	} {
+		t.Setenv(inotifyLimitEnv, tc.limit)
+		b := MeasuredInotifyBudget(1, 100)
+		if b.Projected != 100 {
+			t.Fatalf("limit=%s: Projected = %d, want 100", tc.limit, b.Projected)
+		}
+		if got := b.WouldExceed(); got != tc.exceed {
+			t.Errorf("limit=%s: WouldExceed() = %v, want %v (demand 100)", tc.limit, got, tc.exceed)
+		}
+		if got := strings.Contains(b.Summary(), "WOULD EXCEED"); got != tc.exceed {
+			t.Errorf("limit=%s: summary %q says WOULD EXCEED=%v, want %v", tc.limit, b.Summary(), got, tc.exceed)
+		}
+	}
+}
+
+// An unknown ceiling is not evidence of exceeding one. Whatever the demand, a
+// report with no limit must not accuse the host of anything.
+func TestInotifyBudget_UnknownLimitNeverClaimsExcess(t *testing.T) {
+	b := InotifyBudget{Platform: runtime.GOOS, PoolApplies: true, Dirs: 1 << 20, Projected: 1 << 20}
+	if b.LimitKnown() {
+		t.Fatal("a zero Limit was treated as a known ceiling")
+	}
+	if b.WouldExceed() {
+		t.Error("WouldExceed() is true with no limit read — not knowing the ceiling is not evidence of crossing it")
+	}
+	if _, ok := b.Headroom(); ok {
+		t.Error("Headroom() claims to be meaningful with no limit")
+	}
+	if strings.Contains(b.Summary(), "WOULD EXCEED") {
+		t.Errorf("summary accuses the host with no ceiling read: %q", b.Summary())
+	}
+	if !strings.Contains(b.Summary(), "limit unknown") {
+		t.Errorf("summary hides that the limit is unknown: %q", b.Summary())
+	}
+}
+
+// Off Linux there is no per-UID inotify pool at all, and the report must SAY
+// that rather than reporting a limit of 0 — which would read as "no headroom".
+// Both branches are asserted here rather than skipping one, so the Linux and
+// macOS/Windows legs each grade their own half.
+func TestInotifyBudget_PlatformAnswerIsHonest(t *testing.T) {
+	os.Unsetenv(inotifyLimitEnv)
+	b := MeasuredInotifyBudget(1, 50)
+
+	if b.Platform != runtime.GOOS {
+		t.Errorf("Platform = %q, want %q", b.Platform, runtime.GOOS)
+	}
+	if len(b.Notes) == 0 {
+		t.Fatal("a report with no caveats at all")
+	}
+
+	if inotifyPoolApplies {
+		if !b.PoolApplies {
+			t.Fatal("Linux reported that the inotify pool does not apply to it")
+		}
+		if b.LimitSource != inotifyMaxUserWatchesPath {
+			t.Errorf("LimitSource = %q, want the sysctl path %q", b.LimitSource, inotifyMaxUserWatchesPath)
+		}
+		if b.Limit == 0 && b.LimitErr == "" {
+			t.Error("no limit and no reason given — the report is silent about why it has no ceiling")
+		}
+		if b.LimitKnown() && !notesMention(b.Notes, "per-UID") {
+			t.Errorf("a report comparing demand against a shared pool omits the shared-pool caveat: %v", b.Notes)
+		}
+		return
+	}
+
+	if b.PoolApplies {
+		t.Fatalf("%s claims a per-UID inotify watch pool", runtime.GOOS)
+	}
+	if b.Limit != 0 || b.LimitKnown() {
+		t.Errorf("a platform with no pool reported a usable limit %d", b.Limit)
+	}
+	if b.WouldExceed() {
+		t.Error("a platform with no inotify pool claims to exceed it")
+	}
+	want := "not applicable on " + runtime.GOOS
+	if !strings.Contains(b.Summary(), want) {
+		t.Errorf("summary %q does not say %q — silently reporting 0 is the dishonest answer", b.Summary(), want)
+	}
+	if strings.Contains(b.Summary(), " of 0 ") {
+		t.Errorf("summary compares the demand against a fabricated ceiling of 0: %q", b.Summary())
+	}
+	if !notesMention(b.Notes, "Linux") {
+		t.Errorf("notes never explain that inotify is a Linux facility: %v", b.Notes)
+	}
+	// The directory count is still real, and still reported.
+	if b.Dirs != 50 {
+		t.Errorf("Dirs = %d, want 50 — the demand is a property of the tree, not of the platform", b.Dirs)
+	}
+}
+
+// The shared-pool caveat is the one sentence that keeps the number honest: the
+// pool is per-UID and host-level, and this probe cannot see the other
+// consumers. It must be present on every report that shows a comparison.
+func TestInotifyBudget_ComparisonAlwaysCarriesTheSharedPoolCaveat(t *testing.T) {
+	t.Setenv(inotifyLimitEnv, "8192")
+	repo := budgetRepo(t)
+	for name, b := range map[string]InotifyBudget{
+		"measured":  MeasuredInotifyBudget(1, 10),
+		"projected": ProjectInotifyBudget([]string{repo}, nil),
+	} {
+		if !b.LimitKnown() {
+			t.Fatalf("%s: premise broken, no limit to compare against", name)
+		}
+		for _, want := range []string{"per-UID", "host-level", "cannot see", "upper bound"} {
+			if !notesMention(b.Notes, want) {
+				t.Errorf("%s: notes omit %q — the reader would take the headroom as theirs: %v", name, want, b.Notes)
+			}
+		}
+	}
+}
+
+// A ceiling supplied by an operator is a what-if, not a reading of this host,
+// and the report must not let the two be confused.
+func TestInotifyBudget_EnvSuppliedLimitIsLabelledAsSuch(t *testing.T) {
+	t.Setenv(inotifyLimitEnv, "128")
+	b := MeasuredInotifyBudget(1, 200)
+	if b.Limit != 128 {
+		t.Fatalf("Limit = %d, want 128 from %s", b.Limit, inotifyLimitEnv)
+	}
+	if b.LimitSource != inotifyLimitEnv {
+		t.Errorf("LimitSource = %q, want %q", b.LimitSource, inotifyLimitEnv)
+	}
+	if !notesMention(b.Notes, inotifyLimitEnv) {
+		t.Errorf("an operator-supplied ceiling is not labelled as one: %v", b.Notes)
+	}
+	if !b.WouldExceed() {
+		t.Error("200 descriptors against a 128 ceiling does not report as exceeding")
+	}
+}
+
+// A malformed override is ignored rather than parsed into a fabricated ceiling.
+func TestInotifyBudget_MalformedEnvLimitIsIgnored(t *testing.T) {
+	for _, v := range []string{"", "  ", "abc", "-1", "12.5"} {
+		t.Setenv(inotifyLimitEnv, v)
+		if n, ok := envInotifyLimit(); ok {
+			t.Errorf("%s=%q parsed as %d", inotifyLimitEnv, v, n)
+		}
+	}
+}
+
+// The report is cached because the projection walk is not free and
+// /diagnostics is polled — so the staleness has to be BOUNDED, not permanent.
+func TestWatcherInotifyBudget_CacheIsBounded(t *testing.T) {
+	repoA, repoB := budgetRepo(t), budgetRepo(t)
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+	if _, err := w.AddRepo(repoA); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	first := w.InotifyBudget()
+	if _, err := w.AddRepo(repoB); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if second := w.InotifyBudget(); second.Dirs != first.Dirs {
+		t.Fatalf("the report was recomputed inside the TTL: %d then %d", first.Dirs, second.Dirs)
+	}
+	// Age the cache past the TTL: the next read must reflect the second repo.
+	w.inotifyProbeMu.Lock()
+	w.inotifyProbeAt = w.inotifyProbeAt.Add(-2 * inotifyProbeTTL)
+	w.inotifyProbeMu.Unlock()
+	third := w.InotifyBudget()
+	if third.Dirs != 2*first.Dirs {
+		t.Fatalf("after the TTL the report says %d dirs for two identical repos, want %d — "+
+			"the cache never expires, so the announcement is permanently stale", third.Dirs, 2*first.Dirs)
+	}
+}

--- a/internal/daemon/watch/inotifybudget_6932_test.go
+++ b/internal/daemon/watch/inotifybudget_6932_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -408,5 +409,226 @@ func TestWatcherInotifyBudget_CacheIsBounded(t *testing.T) {
 	if third.Dirs != 2*first.Dirs {
 		t.Fatalf("after the TTL the report says %d dirs for two identical repos, want %d — "+
 			"the cache never expires, so the announcement is permanently stale", third.Dirs, 2*first.Dirs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The demand is what was ATTEMPTED, not what survived (review blocker)
+// ---------------------------------------------------------------------------
+//
+// The measured figure comes from the watcher's directory map, which holds the
+// watches the kernel GRANTED. So every way a subscription fails makes the
+// report CHEAPER, and the announcement reads "fits" in exactly the case the
+// arm exists to catch: a repo that is registered and receiving nothing.
+
+// A repo the descriptor budget refused is registered, unwatched, and absent
+// from the measured set. Its cost must be projected back in, and the line must
+// say NOT WATCHED.
+func TestWatcherInotifyBudget_RefusedRepoIsInTheDemandAndAnnounced(t *testing.T) {
+	t.Setenv(inotifyLimitEnv, "8192")
+	repo := budgetRepo(t)
+	// A private ledger of 1 descriptor: the walk cannot get through the
+	// fixture, so AddRepo refuses the repo outright and unwinds.
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour, FDBudget: 1}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+
+	if _, err := w.AddRepo(repo); err == nil {
+		t.Fatal("premise broken: a 1-descriptor budget subscribed the whole fixture")
+	}
+	if n := backendWatchList(w); n != 0 {
+		t.Fatalf("premise broken: %d paths survived the refusal", n)
+	}
+
+	b := w.InotifyBudget()
+	if b.UnwatchedRepos != 1 {
+		t.Fatalf("UnwatchedRepos = %d, want 1 — the refused repo vanished from the report", b.UnwatchedRepos)
+	}
+	if b.Dirs != 4 {
+		t.Fatalf("demand = %d dirs, want 4 — a refused subscription made the budget report CHEAPER, "+
+			"which is the silent degradation this probe exists to expose", b.Dirs)
+	}
+	sum := b.Summary()
+	if !strings.Contains(sum, "NOT WATCHED") {
+		t.Errorf("a repo that receives no events at all is announced as healthy: %q", sum)
+	}
+	if !notesMention(b.Notes, "DEGRADED") {
+		t.Errorf("no note explains the degradation: %v", b.Notes)
+	}
+}
+
+// The Linux ENOSPC shape: the pool is full, fsnotify's Add fails, subscribeRepo
+// logs a WARN and carries on. Driven through the fsAdd seam so the property is
+// deterministic on any host.
+func TestWatcherInotifyBudget_BackendRejectedDirsAreInTheDemand(t *testing.T) {
+	t.Setenv(inotifyLimitEnv, "8192")
+	repo := budgetRepo(t)
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+
+	// ENOSPC is what a full max_user_watches returns.
+	w.mu.Lock()
+	w.fsAdd = func(string) error { return syscall.ENOSPC }
+	w.mu.Unlock()
+
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if _, dirs, _, _, _ := w.Stats(); dirs != 0 {
+		t.Fatalf("premise broken: %d dirs subscribed while every Add failed", dirs)
+	}
+
+	b := w.InotifyBudget()
+	if b.FailedDirs != 4 {
+		t.Fatalf("FailedDirs = %d, want 4 — watches the kernel refused are not counted, so the "+
+			"report gets cheaper the worse the failure is", b.FailedDirs)
+	}
+	if b.Dirs != 4 {
+		t.Fatalf("demand = %d dirs, want 4", b.Dirs)
+	}
+	sum := b.Summary()
+	if !strings.Contains(sum, "NOT WATCHED") {
+		t.Errorf("every directory was rejected and the line still reads healthy: %q", sum)
+	}
+	if strings.Contains(sum, "0 of ") {
+		t.Errorf("the demand collapsed to zero when the kernel refused it: %q", sum)
+	}
+}
+
+// The negative half: a healthy watcher must not print the NOT WATCHED clause,
+// or a reader learns to ignore it.
+func TestWatcherInotifyBudget_HealthyWatcherIsNotAnnouncedAsDegraded(t *testing.T) {
+	t.Setenv(inotifyLimitEnv, "8192")
+	repo := budgetRepo(t)
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	b := w.InotifyBudget()
+	if b.UnwatchedRepos != 0 || b.FailedDirs != 0 {
+		t.Fatalf("a healthy subscription reports %d refused repos and %d rejected dirs",
+			b.UnwatchedRepos, b.FailedDirs)
+	}
+	if sum := b.Summary(); strings.Contains(sum, "NOT WATCHED") {
+		t.Errorf("healthy watcher announced as degraded: %q", sum)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The RENDERED line is the claim (review M5, M6)
+// ---------------------------------------------------------------------------
+
+// M6: the measured/projected distinction is a claim the summary makes, so it is
+// asserted on the string, not on the struct field behind it. Poll mode printing
+// "(measured, 9760 dirs)" for a walk that subscribed nothing is the failure.
+func TestInotifyBudget_SummaryNamesHowTheDemandWasObtained(t *testing.T) {
+	t.Setenv(inotifyLimitEnv, "8192")
+	repo := budgetRepo(t)
+
+	polling, err := NewWatcherConfig(Config{Debounce: time.Hour, Delegate: &recordingDelegate{}}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer polling.Stop()
+	if _, err := polling.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	projected := polling.InotifyBudget().Summary()
+	if !strings.Contains(projected, "(projected,") {
+		t.Errorf("poll mode's line does not say the demand is projected: %q", projected)
+	}
+	if strings.Contains(projected, "(measured,") {
+		t.Errorf("poll mode prints a walk as a measurement of a subscription it does not hold: %q", projected)
+	}
+
+	subscribing, err := NewWatcherConfig(Config{Debounce: time.Hour}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer subscribing.Stop()
+	if _, err := subscribing.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	measured := subscribing.InotifyBudget().Summary()
+	if !strings.Contains(measured, "(measured,") {
+		t.Errorf("fsnotify mode's line does not say the demand is measured: %q", measured)
+	}
+	if strings.Contains(measured, "(projected,") {
+		t.Errorf("a live subscription is printed as a projection: %q", measured)
+	}
+}
+
+// M5: the env override on a platform with NO inotify pool. This combination was
+// ungraded, and on it the summary rendered a Linux-shaped "N of 8192 — fits"
+// verdict about a host that cannot produce such a ceiling. Both legs asserted,
+// so neither platform's CI run is vacuous.
+func TestInotifyBudget_WhatIfCeilingIsNeverPrintedAsAMeasuredOne(t *testing.T) {
+	t.Setenv(inotifyLimitEnv, "8192")
+	b := MeasuredInotifyBudget(1, 4)
+	sum := b.Summary()
+
+	if !b.WhatIf {
+		t.Fatal("an operator-supplied ceiling is not marked as a what-if")
+	}
+	if !strings.Contains(sum, "4 of 8192") {
+		t.Fatalf("premise broken, the comparison is missing: %q", sum)
+	}
+	if !notesMention(b.Notes, inotifyLimitEnv) {
+		t.Errorf("notes do not name the env var as the source: %v", b.Notes)
+	}
+
+	if inotifyPoolApplies {
+		// On Linux the what-if is a real ceiling shape for a real pool; it
+		// must still be labelled in the notes, which the assertion above
+		// covers, and must not be dressed up as this host's own number.
+		if !notesMention(b.Notes, "NOT read from this host's kernel") {
+			t.Errorf("an operator-supplied ceiling is not distinguished from a kernel read: %v", b.Notes)
+		}
+		return
+	}
+	for _, want := range []string{"not applicable on " + runtime.GOOS, "no inotify watch pool", "WHAT-IF", inotifyLimitEnv} {
+		if !strings.Contains(sum, want) {
+			t.Errorf("the printed line is missing %q — on %s it reads as a measured verdict about a "+
+				"pool this host does not have.\ngot: %q", want, runtime.GOOS, sum)
+		}
+	}
+	if !notesMention(b.Notes, "what-if against a Linux ceiling") {
+		t.Errorf("notes do not say this platform has no pool of its own: %v", b.Notes)
+	}
+}
+
+// M2: the projection honours the watch-dir cap, which truncates the
+// subscription. Unreachable at the 100,000 default, reachable — and now graded
+// — through GRAFEL_WATCH_DIR_CAP, which WatchDirCap reads per call.
+func TestProjectInotifyBudget_HonoursTheWatchDirCap(t *testing.T) {
+	t.Setenv("GRAFEL_WATCH_DIR_CAP", "2")
+	repo := budgetRepo(t)
+
+	proj := ProjectInotifyBudget([]string{repo}, nil)
+	w, err := NewWatcherConfig(Config{Debounce: time.Hour}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	actual := backendWatchList(w)
+
+	if actual != 2 {
+		t.Fatalf("premise broken: the cap of 2 let %d paths through", actual)
+	}
+	if proj.Dirs != actual {
+		t.Fatalf("under a dir cap of 2 the probe projects %d dirs and the subscription takes %d — "+
+			"the projection over-reports by the truncated tail", proj.Dirs, actual)
 	}
 }

--- a/internal/daemon/watch/inotifylimit_linux.go
+++ b/internal/daemon/watch/inotifylimit_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+
+package watch
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// inotifyPoolApplies records that this platform HAS a per-UID inotify watch
+// pool, so a projection of watch descriptors can be compared against a real
+// ceiling. Selected by build tag rather than a runtime.GOOS check so the
+// constant is available to the compiler and to build-tagged tests (#6218).
+const inotifyPoolApplies = true
+
+// inotifyMaxUserWatchesPath is the kernel's per-UID watch ceiling. It is NOT
+// namespaced: a container reads and shares the host's value, and cannot raise
+// it (the sysctl is read-only from an unprivileged user namespace). That is
+// exactly why the probe exists — grafel can see its own demand against this
+// number, and cannot see anyone else's.
+const inotifyMaxUserWatchesPath = "/proc/sys/fs/inotify/max_user_watches"
+
+// readInotifyLimit reports the per-UID watch ceiling and where it came from.
+func readInotifyLimit() (int, string, error) {
+	b, err := os.ReadFile(inotifyMaxUserWatchesPath)
+	if err != nil {
+		return 0, inotifyMaxUserWatchesPath, err
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil {
+		return 0, inotifyMaxUserWatchesPath, fmt.Errorf("unparseable value %q: %w", strings.TrimSpace(string(b)), err)
+	}
+	if n < 0 {
+		n = 0
+	}
+	return n, inotifyMaxUserWatchesPath, nil
+}

--- a/internal/daemon/watch/inotifylimit_linux.go
+++ b/internal/daemon/watch/inotifylimit_linux.go
@@ -20,7 +20,12 @@ const inotifyPoolApplies = true
 // it (the sysctl is read-only from an unprivileged user namespace). That is
 // exactly why the probe exists — grafel can see its own demand against this
 // number, and cannot see anyone else's.
-const inotifyMaxUserWatchesPath = "/proc/sys/fs/inotify/max_user_watches"
+//
+// A var, not a const, for exactly one reason: the Linux leg of CI can then
+// point it at a fixture and grade the unreadable and unparseable branches,
+// which no host with a working /proc can produce on demand. Never reassigned
+// in production.
+var inotifyMaxUserWatchesPath = "/proc/sys/fs/inotify/max_user_watches"
 
 // readInotifyLimit reports the per-UID watch ceiling and where it came from.
 func readInotifyLimit() (int, string, error) {

--- a/internal/daemon/watch/inotifylimit_linux_test.go
+++ b/internal/daemon/watch/inotifylimit_linux_test.go
@@ -1,0 +1,91 @@
+package watch
+
+// inotifylimit_linux_test.go — the Linux half of the probe, GRADED rather than
+// asserted.
+//
+// Everything else in this package's #6932 tests runs on every platform and
+// therefore grades arithmetic. The kernel read itself — the sysctl that makes
+// the whole comparison mean anything — only exists here, and its two failure
+// branches (unreadable, unparseable) cannot be produced on demand by a host
+// with a working /proc. Redirecting the path is the only way to reach them.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The real read, against the real kernel. This is the end-to-end leg: an
+// actual max_user_watches, an actual demand, an actual comparison.
+func TestReadInotifyLimit_ReadsTheRealSysctl(t *testing.T) {
+	n, src, err := readInotifyLimit()
+	if err != nil {
+		t.Skipf("no readable %s on this host: %v", src, err)
+	}
+	if src != inotifyMaxUserWatchesPath {
+		t.Errorf("LimitSource = %q, want %q", src, inotifyMaxUserWatchesPath)
+	}
+	if n <= 0 {
+		t.Fatalf("max_user_watches read as %d — a non-positive ceiling would disable every "+
+			"comparison the probe makes", n)
+	}
+
+	b := MeasuredInotifyBudget(1, 4)
+	if !b.LimitKnown() || b.Limit != n {
+		t.Fatalf("report Limit = %d (known=%v), kernel says %d", b.Limit, b.LimitKnown(), n)
+	}
+	if b.WouldExceed() {
+		t.Errorf("4 watch descriptors reported as exceeding a ceiling of %d", n)
+	}
+	if !strings.Contains(b.Summary(), "fits") {
+		t.Errorf("summary of a trivially-fitting demand: %q", b.Summary())
+	}
+}
+
+// An unparseable sysctl must produce "unknown ceiling, and here is why", never
+// a fabricated 0 that reads as "no headroom".
+func TestReadInotifyLimit_UnparseableValueIsReportedNotInvented(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "max_user_watches")
+	if err := os.WriteFile(f, []byte("not-a-number\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := inotifyMaxUserWatchesPath
+	inotifyMaxUserWatchesPath = f
+	defer func() { inotifyMaxUserWatchesPath = orig }()
+
+	os.Unsetenv(inotifyLimitEnv)
+	b := MeasuredInotifyBudget(1, 4)
+	if b.LimitKnown() {
+		t.Fatalf("an unparseable sysctl produced a usable ceiling of %d", b.Limit)
+	}
+	if b.LimitErr == "" {
+		t.Error("no reason recorded for the missing ceiling")
+	}
+	if b.WouldExceed() {
+		t.Error("WouldExceed() true with no readable ceiling")
+	}
+	if !strings.Contains(b.Summary(), "host limit unknown") {
+		t.Errorf("summary hides that the ceiling could not be read: %q", b.Summary())
+	}
+	if !notesMention(b.Notes, "could not read") {
+		t.Errorf("notes do not explain the failed read: %v", b.Notes)
+	}
+}
+
+// An absent sysctl is the container/exotic-kernel case: still Linux, still a
+// pool, but no number. Same contract as above.
+func TestReadInotifyLimit_MissingSysctlIsReportedNotInvented(t *testing.T) {
+	orig := inotifyMaxUserWatchesPath
+	inotifyMaxUserWatchesPath = filepath.Join(t.TempDir(), "definitely-absent")
+	defer func() { inotifyMaxUserWatchesPath = orig }()
+
+	os.Unsetenv(inotifyLimitEnv)
+	b := MeasuredInotifyBudget(1, 4)
+	if !b.PoolApplies {
+		t.Error("an unreadable sysctl was taken as proof that Linux has no inotify pool")
+	}
+	if b.LimitKnown() || b.LimitErr == "" {
+		t.Fatalf("Limit=%d known=%v err=%q, want unknown with a reason", b.Limit, b.LimitKnown(), b.LimitErr)
+	}
+}

--- a/internal/daemon/watch/inotifylimit_other.go
+++ b/internal/daemon/watch/inotifylimit_other.go
@@ -1,0 +1,24 @@
+//go:build !linux
+
+package watch
+
+import "errors"
+
+// inotifyPoolApplies records that this platform has NO per-UID inotify watch
+// pool. macOS spends process file descriptors through kqueue (see
+// fdbudget_darwin.go) and Windows holds one handle per watched tree; neither is
+// the resource #6932 is about. Build-tagged, not runtime.GOOS-gated (#6218).
+const inotifyPoolApplies = false
+
+// errInotifyNotApplicable is returned instead of a fabricated 0. A probe that
+// silently reported "limit 0" here would read as "no headroom at all" on a
+// platform where the question does not arise.
+var errInotifyNotApplicable = errors.New("watch: inotify watch pool is a Linux facility and does not exist on this platform")
+
+// inotifyMaxUserWatchesPath is named for the message only; nothing reads it
+// here.
+const inotifyMaxUserWatchesPath = "/proc/sys/fs/inotify/max_user_watches"
+
+func readInotifyLimit() (int, string, error) {
+	return 0, "", errInotifyNotApplicable
+}

--- a/internal/daemon/watch/skip.go
+++ b/internal/daemon/watch/skip.go
@@ -258,3 +258,62 @@ func ShouldSkipPathForRepo(repoPath, p string) bool {
 	}
 	return false
 }
+
+// ---------------------------------------------------------------------------
+// The per-directory verdict, in ONE place (#6932 arm B)
+// ---------------------------------------------------------------------------
+//
+// subscribeRepo decides, directory by directory, what the watch set is. The
+// inotify budget probe has to project the cost of exactly that set without
+// subscribing it. Two walks asking the question two ways is how a projection
+// drifts from the thing it claims to project, so the layers below are defined
+// once and both walks call them.
+//
+// What is NOT in here, and why: the TCC protected-path guard and the watch-dir
+// cap. The first applies to the repo root as well as to its subdirectories and
+// the second is stateful (it depends on how many directories the walk has
+// already taken), so both stay at their call sites, applied in the same order
+// by both walks. The equality of the two answers is not asserted by
+// construction — it is measured, by
+// TestProjectInotifyBudget_MatchesWhatSubscriptionActuallyTakes.
+
+// watchSkipKind names which layer refused a directory. The distinction exists
+// because the subscription walk logs the three cases differently.
+type watchSkipKind int
+
+const (
+	// watchSkipNone: the walk takes a watch on this directory.
+	watchSkipNone watchSkipKind = iota
+	// watchSkipExcluded: hard-coded SkipDirs / walk.IsHardcodedSkip, or the
+	// per-instance ExcludeDirs set.
+	watchSkipExcluded
+	// watchSkipIgnored: .gitignore plus the per-repo .grafel/watch.json.
+	watchSkipIgnored
+)
+
+// watchDirSkip applies the subscription walk's per-directory skip layers to one
+// directory p under repo root abs. The repo root itself is never skipped by
+// these layers, matching the walk it is extracted from.
+func watchDirSkip(abs, p string, extraSkip map[string]struct{}) (watchSkipKind, string) {
+	if p == abs {
+		return watchSkipNone, ""
+	}
+	base := filepath.Base(p)
+	// Layer 1 + 2: hard-coded + per-instance excludes.
+	if ShouldSkipDir(base) {
+		return watchSkipExcluded, "skip list"
+	}
+	if _, ok := extraSkip[base]; ok {
+		return watchSkipExcluded, "instance exclude"
+	}
+	// Layer 3: .gitignore + per-repo watch.json.
+	relPath, relErr := filepath.Rel(abs, p)
+	if relErr != nil {
+		return watchSkipNone, ""
+	}
+	relPath = filepath.ToSlash(relPath)
+	if skip, reason := ShouldSkipDirGitignore(abs, p, relPath); skip {
+		return watchSkipIgnored, reason
+	}
+	return watchSkipNone, ""
+}

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -217,6 +217,14 @@ type Watcher struct {
 	// deterministic instead of racing the CI scheduler. Production behaviour
 	// is identical to using time.Now/time.AfterFunc directly.
 	clk clock
+	// inotifyProbe caches the last inotify budget report (#6932 arm B). In
+	// poll mode the report costs a directory walk of every registered repo,
+	// and /diagnostics is polled, so a status surface must not re-walk the
+	// fleet on every request. Guarded by its own mutex, never w.mu: the walk
+	// runs outside the watcher's lock.
+	inotifyProbeMu  sync.Mutex
+	inotifyProbeAt  time.Time
+	inotifyProbeVal InotifyBudget
 	// quarantine is the adaptive trash detector (#5394). When non-nil, it
 	// observes per-directory churn at the event boundary and drops events
 	// under directories it has quarantined. nil disables the feature.
@@ -805,21 +813,16 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 			}
 			return prune(p)
 		}
-		if p != abs {
-			base := filepath.Base(p)
-			// Layer 1 + 2: hard-coded + per-instance excludes.
-			if w.shouldSkipDir(base) {
-				return prune(p)
-			}
-			// Layer 3: .gitignore + per-repo watch.json.
-			relPath, relErr := filepath.Rel(abs, p)
-			if relErr == nil {
-				relPath = filepath.ToSlash(relPath)
-				if skip, reason := ShouldSkipDirGitignore(abs, p, relPath); skip {
-					w.logger.Info("watcher: skip", "path", p, "reason", reason)
-					return prune(p)
-				}
-			}
+		// Layers 1-3, from the single definition the budget probe also calls
+		// (#6932 arm B): hard-coded skips, this Watcher's excludes, then the
+		// .gitignore / watch.json layer. watchDirSkip leaves the repo root
+		// alone, exactly as the `p != abs` guard it replaces did.
+		switch kind, reason := watchDirSkip(abs, p, w.extraSkip); kind {
+		case watchSkipExcluded:
+			return prune(p)
+		case watchSkipIgnored:
+			w.logger.Info("watcher: skip", "path", p, "reason", reason)
+			return prune(p)
 		}
 		n, entries := chargeDir(p, cost)
 		if !w.fdb.reserve(n) {

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -222,6 +222,11 @@ type Watcher struct {
 	// and /diagnostics is polled, so a status surface must not re-walk the
 	// fleet on every request. Guarded by its own mutex, never w.mu: the walk
 	// runs outside the watcher's lock.
+	// fsAddFailed counts directories the backend REFUSED to watch (fsnotify
+	// Add returned an error; ENOSPC on a full inotify pool is the case that
+	// matters). Atomic: written from the subscribe walk, read by the budget
+	// probe.
+	fsAddFailed     uint64
 	inotifyProbeMu  sync.Mutex
 	inotifyProbeAt  time.Time
 	inotifyProbeVal InotifyBudget
@@ -831,6 +836,12 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 		}
 		if err := w.fsAdd(p); err != nil {
 			w.fdb.release(n)
+			// Counted, not just logged (#6932 arm B). On Linux this is
+			// ENOSPC — the per-UID inotify pool is full — and the walk
+			// carries on, so without a counter the shortfall shows up ONLY
+			// as a smaller watch set, i.e. as a CHEAPER budget report. The
+			// probe adds it back so the demand is what was attempted.
+			atomic.AddUint64(&w.fsAddFailed, 1)
 			w.logger.Warn("watcher: add failed", "path", p, "err", err)
 			return nil
 		}

--- a/internal/dashboard/handlers_diagnostics.go
+++ b/internal/dashboard/handlers_diagnostics.go
@@ -88,6 +88,15 @@ type DaemonDiagnostics struct {
 	WatcherOverflows       uint64 `json:"watcher_overflows,omitempty"`
 	WatcherOverflowRescans uint64 `json:"watcher_overflow_rescans,omitempty"`
 	WatcherLastOverflow    string `json:"watcher_last_overflow,omitempty"`
+
+	// Inotify budget probe (#6932 arm B). Summary and notes are shipped
+	// together on purpose: the notes carry what the number cannot say for
+	// itself — the pool is per-UID and host-level, so this is grafel's own
+	// demand against a ceiling other processes also draw on, and grafel
+	// cannot see their share.
+	InotifyBudgetSummary string   `json:"inotify_budget_summary,omitempty"`
+	InotifyBudgetNotes   []string `json:"inotify_budget_notes,omitempty"`
+	InotifyBudgetExceeds bool     `json:"inotify_budget_exceeds,omitempty"`
 }
 
 // GroupDiagnostics covers one group's health.
@@ -359,6 +368,11 @@ func (s *Server) buildDaemonDiagnostics() DaemonDiagnostics {
 		if !lastOverflow.IsZero() {
 			d.WatcherLastOverflow = lastOverflow.UTC().Format(time.RFC3339)
 		}
+		// #6932 arm B: the inotify budget, reported here as well as in
+		// `grafel status` for the same reason the overflow counters are —
+		// exhausting the host's per-UID watch pool produces a watcher that
+		// looks healthy and delivers nothing.
+		d.InotifyBudgetSummary, d.InotifyBudgetNotes, d.InotifyBudgetExceeds = s.watcher.InotifyBudgetReport()
 	}
 
 	return d

--- a/internal/dashboard/inotify_budget_6932_test.go
+++ b/internal/dashboard/inotify_budget_6932_test.go
@@ -1,0 +1,50 @@
+package dashboard
+
+// inotify_budget_6932_test.go — #6932 arm B, the /diagnostics half of the
+// announcement. Graded at the CALL SITE (buildDaemonDiagnostics), so deleting
+// the fill fails here rather than leaving a struct field nobody populates.
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+type budgetWatcher struct {
+	summary string
+	notes   []string
+	exceeds bool
+}
+
+func (budgetWatcher) ForceRescan()                             {}
+func (budgetWatcher) Stats() (int, int, uint64, uint64, int)   { return 1, 4, 0, 0, 0 }
+func (budgetWatcher) FDBudgetStats() (int, int, int, []string) { return 0, 0, 0, nil }
+func (budgetWatcher) OverflowStats() (uint64, uint64, uint64, time.Time) {
+	return 0, 0, 0, time.Time{}
+}
+func (b budgetWatcher) InotifyBudgetReport() (string, []string, bool) {
+	return b.summary, b.notes, b.exceeds
+}
+
+func TestDaemonDiagnosticsReportsTheInotifyBudget6932(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	s := &Server{watcher: budgetWatcher{
+		summary: "inotify budget: 9760 of 8192 watch descriptors — WOULD EXCEED",
+		notes:   []string{"the inotify watch pool is per-UID and host-level"},
+		exceeds: true,
+	}}
+
+	d := s.buildDaemonDiagnostics()
+
+	if !strings.Contains(d.InotifyBudgetSummary, "WOULD EXCEED") {
+		t.Errorf("InotifyBudgetSummary = %q — /diagnostics does not report the probe at all",
+			d.InotifyBudgetSummary)
+	}
+	if len(d.InotifyBudgetNotes) != 1 {
+		t.Errorf("InotifyBudgetNotes = %v — the caveats that keep the number honest were dropped",
+			d.InotifyBudgetNotes)
+	}
+	if !d.InotifyBudgetExceeds {
+		t.Error("InotifyBudgetExceeds = false for a report that exceeds")
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -160,6 +160,11 @@ type watcherForceRescan interface {
 	// events were dropped and never redelivered; rescans is how many full
 	// reindexes recovered them.
 	OverflowStats() (uint64, uint64, uint64, time.Time)
+	// InotifyBudgetReport returns (summary, notes, exceeds) for the inotify
+	// budget probe (#6932 arm B): what this configuration costs the host's
+	// per-UID watch pool, the caveats that keep that number honest, and
+	// whether grafel's own demand alone exceeds the ceiling.
+	InotifyBudgetReport() (string, []string, bool)
 }
 
 // webhookDispatcherIface is the subset of notifications.Dispatcher used by the

--- a/internal/dashboard/watcher_overflow_6921_test.go
+++ b/internal/dashboard/watcher_overflow_6921_test.go
@@ -32,6 +32,10 @@ func (o overflowingWatcher) OverflowStats() (uint64, uint64, uint64, time.Time) 
 	return o.overflows, o.rescans, o.coalesced, o.last
 }
 
+func (overflowingWatcher) InotifyBudgetReport() (string, []string, bool) {
+	return "", nil, false
+}
+
 func TestDaemonDiagnosticsReportsQueueOverflows6921(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 	last := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
#6932 **arm B, part 1**: the inotify budget becomes observable. This is the probe and the announcement — **not** the auto-switch. `auto` still resolves to fsnotify, `PollingEnabled()` is untouched, and no configuration subscribes anything it did not subscribe before.

## Why the arm is split

An auto-switch needs a threshold, and every number #6932 records is macOS/APFS with **no concurrency measurement**. Guessing a threshold and calling it automatic would be worse than the flag arm A already ships. This half produces the data the threshold needs, on the owner's own containers. Part 2 — the switch rule — changes exactly one function, and this PR does not touch it.

## The projection is compared against reality — one predicate, twice, plus one independent pin

`ProjectInotifyBudget` walks a repo set and reports what subscribing it would cost, without subscribing it. Graded against **fsnotify's own `WatchList()`** — the library's record of what it handed the kernel, the instrument the #6935 review used — after a real subscription of the same tree:

| | dirs |
|---|---|
| dirs on disk in the fixture | 8 |
| probe's projection | **4** |
| `AddRepo`'s own return | **4** |
| fsnotify `WatchList()` after subscribing | **4** |

**These are not three independent confirmations, and the body previously implied they were.** The projection and `AddRepo` are *one predicate (`watchDirSkip`) evaluated twice*, and `WatchList()` is a backend echo of the second evaluation — a real check that `AddRepo`'s counter is not lying about what it handed fsnotify, but not an independent opinion about *which* directories should be watched. Widen the shared predicate and all four numbers move together.

The one leg outside the predicate is the **named pin** at `inotifybudget_6932_test.go:100`: `dirsOnDisk` is a bare `WalkDir` counter and the `8`/`4` are literals. It carries the test, and it is correct — root + `src` + `src/inner` + `pkg` are watched, `node_modules{,/deep}` is pruned by `SkipDirs`, and `generated{,/nested}` by the `generated/` gitignore rule (`generated` is *not* in `SkipDirs`, so the gitignore layer really is the thing firing). Mutant 4 below is the demonstration: it is the only assertion that catches a widened shared predicate.

`Watcher.InotifyBudget()` answers with a **measurement** in fsnotify mode (the subscribed set *is* the demand, no walk needed) and a **projection** in poll mode (nothing is subscribed, so the number worth having is what fsnotify would have asked this host for). The report says which of the two it is. It is cached for 60 s because the projection walk is not free and `/diagnostics` is polled; the staleness is bounded and that bound is tested.

## One definition of "which directories are watched"

`subscribeRepo` and the probe now call the same `watchDirSkip` for layers 1–3 (hard-coded skips, the per-Watcher excludes, then `.gitignore`/`watch.json`). Two walks asking that question two ways is how a projection drifts from the thing it projects. The TCC protected-path guard and the watch-dir cap stay at their call sites — the first also applies to the repo root, the second is stateful — applied in the same order by both walks, and their agreement is measured rather than assumed.

## Honesty, where it was easy to be dishonest

- **The pool is shared and the probe is half-blind to it.** `max_user_watches` is per-UID and host-level, not namespaced: every container running as the same UID draws from one pool and none of them can raise it. The report says, in its own text, that it sees grafel's own demand and **cannot** see what other processes have taken, and that any headroom shown is an **upper bound, not a reservation**. That caveat travels over the wire *with* the summary, because it is a property of how the number was obtained and no client can reconstruct it.
- **Off Linux the answer is "not applicable on `<goos>`", never a limit of 0.** `defaultFDBudgetLimit()` returns 0 to mean *accounting disabled*; reusing that 0 as a ceiling would read as *no headroom at all* on a platform where the question does not arise. The directory count is still reported there, because it is a property of the tree, and the summary never renders an `N of 0` comparison.
- **"WOULD EXCEED" is a claim**, so it is made only when grafel's own demand is *strictly* larger than a ceiling that was actually read. Equal fits. An unreadable ceiling is not evidence of crossing one.
- **`GRAFEL_INOTIFY_MAX_USER_WATCHES`** lets an operator ask the what-if from a machine that is not the container. A report built from it names the env var as its source, so it can never pass itself off as a kernel read.
- **#6940 is not implied away.** The poll-mode note says only what it can support — that zero descriptors are held right now. It makes no claim about the poller's candidate set agreeing with the indexer's file set.

## The announcement

`grafel status` and `/diagnostics`, with the numbers and the caveats rather than a boolean, on its own line and gated on nothing above it — the case worth seeing is precisely the one where the watcher looks healthy. IntelliJ's precedent is exactly this: report hitting the limit rather than quietly degrading. Silent degradation is the class #6921/#6923/#6928 all belong to.

```
  inotify budget: 9760 of 8192 watch descriptors (projected, 9760 dirs across 10 repos) — WOULD EXCEED
    note: the inotify watch pool is per-UID and host-level, NOT per-container: ... This probe sees only
          grafel's own demand — it cannot see what other processes have already taken, so any headroom
          shown is an upper bound, not a reservation.
    note: demand is PROJECTED from a directory walk; nothing was subscribed to produce it.
```

## Review round: the blocker, and the mutants it left alive

The reviewer's blocker was real and is fixed in `46c1e85d8`. In fsnotify mode the demand came from `w.Stats()` — the watches the kernel **granted** — so every failure made the report *cheaper*, and `GRAFEL_WATCH_FD_BUDGET=2` rendered `inotify budget: 0 of 8192 watch descriptors (measured, 0 dirs across 0 repos) — fits` for a repo that was not watched at all. The demand now counts what was **attempted**: a refused repo's tree is projected back in, a directory whose `fsnotify` `Add` failed (Linux `ENOSPC`) increments a counter and is added back, and `Summary()` carries a `NOT WATCHED` clause plus a `DEGRADED` note. The healthy case stays silent. The verdict word is now `fits (grafel's demand alone)`.

Also addressed: the rendered line is asserted as a *string* (the measured/projected distinction was only ever checked on the struct field, so poll mode could print `(measured, …)` for a walk); darwin + `GRAFEL_INOTIFY_MAX_USER_WATCHES` is graded and renders as an explicit what-if instead of a Linux-shaped verdict; the Linux sysctl read is graded on the ubuntu leg (real read end to end, plus the unparseable and absent branches) rather than only asserted; `Headroom()` has a production caller; `proto.go`'s doc-comment hijack of `WatcherOverflows` is fixed.

## Mutants — 12 applied, 12 DEAD

Each applied with an asserted exact occurrence count, scored with `-count=1` against a green baseline taken immediately before, and reverted with a second asserted count.

| # | mutant (all in the permissive direction) | verdict | killed by |
|---|---|---|---|
| 1 | `WouldExceed`: `>` → `>=` | **DEAD** | boundary case — 100 of 100 must *fit* |
| 2 | non-Linux sets `PoolApplies = true` | **DEAD** | `PlatformAnswerIsHonest` (darwin leg) |
| 3 | projection drops the skip layers entirely | **DEAD** | projected 8 vs 4 actually subscribed |
| 4 | shared verdict drops the `.gitignore` layer — **both walks widen together, so every equality check stays satisfied** | **DEAD** | the named fixture pin, the only assertion outside the predicate |
| 5 | the cached report never expires | **DEAD** | `CacheIsBounded` |
| 6 | the caveats are dropped on the wire | **DEAD** | stand-in *and* the real-watcher call-site control |
| 7 | `grafel status` prints the number without the caveats | **DEAD** | `PrintsInotifyBudgetWithItsCaveats` |
| 8 | refused repos are not counted back into the demand | **DEAD** | `RefusedRepoIsInTheDemandAndAnnounced` |
| 9 | backend-rejected dirs (`ENOSPC`) are not counted | **DEAD** | `BackendRejectedDirsAreInTheDemand` |
| 10 | `Summary()` always prints `measured` *(reviewer's M6, was ALIVE)* | **DEAD** | `SummaryNamesHowTheDemandWasObtained` |
| 11 | the what-if ceiling renders as a measured one *(reviewer's M5, was ALIVE)* | **DEAD** | `WhatIfCeilingIsNeverPrintedAsAMeasuredOne` |
| 12 | projection drops the `dirCap` gate *(reviewer's M2, was ALIVE-unreachable)* | **DEAD** | `HonoursTheWatchDirCap`, via `GRAFEL_WATCH_DIR_CAP` |

Mutants 8 and 9 are the blocker's pins: without them the report gets *cheaper* the worse the failure is.

## Verification

`go test -count=1` green on `./internal/daemon/watch/`, `./internal/daemon/`, `./internal/registry/`, `./internal/cli/`, `./internal/dashboard/`, and `./cmd/grafel/` (the graph digest pin). `go vet ./...` clean, `gofmt` clean.

**`ci:full` applied** — this is `GOOS`-conditional behaviour and the macOS leg does not otherwise run tests. Re-apply it after any push.

## Not established

**Every measurement here is macOS/APFS.** The Linux leg now *grades* the sysctl read end to end (`inotifylimit_linux_test.go`) rather than only asserting arithmetic, but it runs against CI's kernel with a trivial demand — nothing has been measured on overlayfs, in a container, or under concurrency, and the 976-dirs-per-worktree figure remains one repo on one machine. This PR exists so those numbers can start coming from the target.

The unrelated flake the reviewer saw once (`TestChurnReturnsTheLedgerToItsSubscriptionBaseline`, `fdbudget_6268_test.go`, untouched here) is pre-existing and worth its own issue.

Refs #6932, #6940, #6921, #6923, #6928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
