### PR TITLE
fix(#6946): `.github` was on the walker's pre-ignore skip list, so every GitHub Actions rule was dead on a real repo — measured the blast radius, then un-skipped

### DIFF
--- a/cmd/grafel/ci_dirs_stale_parity_6946_test.go
+++ b/cmd/grafel/ci_dirs_stale_parity_6946_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+// TestShouldSkipDirForStale_CIDirs_6946 pins the THIRD hand-maintained copy of
+// the watcher skip list (shouldSkipDirForStale, whose doc comment says "keep in
+// sync with internal/daemon/watch.ShouldSkipDir"). A copy that drifts here
+// makes the daemon's stale-detection walk blind to a change under .github, so
+// a workflow edit never marks the graph dirty even though the walker indexes
+// it. See TestShouldSkipDir_CIDirsMatchWalker_6946 for the second copy.
+func TestShouldSkipDirForStale_CIDirs_6946(t *testing.T) {
+	for _, base := range []string{".github", ".gitlab", ".circleci"} {
+		if shouldSkipDirForStale(base) {
+			t.Errorf("shouldSkipDirForStale(%q) = true, want false (#6946) — the walker indexes "+
+				"this directory, so stale detection must see writes into it", base)
+		}
+	}
+	for _, base := range []string{".git", "node_modules", ".idea"} {
+		if !shouldSkipDirForStale(base) {
+			t.Errorf("shouldSkipDirForStale(%q) = false, want true — the #6946 un-skip reached "+
+				"further than the three CI dirs", base)
+		}
+	}
+}

--- a/internal/daemon/walk/ci_dirs_6946_test.go
+++ b/internal/daemon/walk/ci_dirs_6946_test.go
@@ -1,0 +1,121 @@
+package walk
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWalkRepo_CIDirsAreWalked_6946 grades BOTH directions of the #6946
+// change: the CI-definition dirs that came off hardcodedSkipDirs must now be
+// walked, and the tool-agent dirs that stayed on it must still be skipped.
+//
+// The skip mattered because hardcodedSkip runs BEFORE the ignore stack
+// (walker.go), so a `.github` on the list is not a default a repo can undo —
+// it is an unconditional erasure. Every GitHub Actions rule in
+// internal/engine/rules/cicd/frameworks/github_actions.yaml was therefore
+// unreachable on any repo that stores its workflows where GitHub requires
+// them. See TestGitHubActionsFileConventionsAreReachable_6946 in
+// internal/engine for the other half of that claim.
+func TestWalkRepo_CIDirsAreWalked_6946(t *testing.T) {
+	root := t.TempDir()
+
+	// Must be walked (#6946).
+	wantWalked := []string{
+		".github/workflows/ci.yml",
+		".github/workflows/release.yaml",
+		".github/actions/setup/action.yml",
+		".github/dependabot.yml",
+		".gitlab/ci-templates/build.yml",
+		".circleci/config.yml",
+		"src/main.go",
+	}
+	// Must still be skipped: tool-agent config that is not source, and the
+	// build/VCS dirs. If one of these ever leaks the un-skip was too wide.
+	wantSkipped := []string{
+		".claude/settings.json",
+		".cursor/rules/foo.json",
+		".windsurf/skills/coding.md",
+		".husky/pre-commit",
+		".devcontainer/devcontainer.json",
+		"node_modules/pkg/index.js",
+	}
+	for _, p := range append(append([]string{}, wantWalked...), wantSkipped...) {
+		mkfile(t, root, p, "x")
+	}
+
+	files, _, err := WalkRepo(root, nil)
+	if err != nil {
+		t.Fatalf("WalkRepo: %v", err)
+	}
+	got := make(map[string]bool, len(files))
+	for _, f := range files {
+		got[f] = true
+	}
+
+	for _, want := range wantWalked {
+		if !got[want] {
+			t.Errorf("#6946: %q was not walked; files=%v", want, files)
+		}
+	}
+	for _, notWant := range wantSkipped {
+		if got[notWant] {
+			t.Errorf("%q leaked into the walk results — the #6946 un-skip is too wide", notWant)
+		}
+	}
+
+	// The exported predicate the watcher and the RSS scanner consult must
+	// agree with the walker, or a repo would be walked and then never
+	// re-indexed on change (the walker/watcher divergence class of #6934).
+	for _, base := range []string{".github", ".gitlab", ".circleci"} {
+		if IsHardcodedSkip(base) {
+			t.Errorf("IsHardcodedSkip(%q) = true, want false (#6946) — the watcher would still "+
+				"drop the event for a directory the walker now indexes", base)
+		}
+	}
+	for _, base := range []string{".claude", ".cursor", ".windsurf", ".husky", ".devcontainer", "node_modules"} {
+		if !IsHardcodedSkip(base) {
+			t.Errorf("IsHardcodedSkip(%q) = false, want true — the #6946 un-skip removed more "+
+				"than the three CI dirs", base)
+		}
+	}
+}
+
+// TestWalkRepo_CIDirsStillHonourIgnoreStack_6946 pins the reason the skip was
+// wrong rather than merely unhelpful: the hard-coded layer runs before the
+// ignore stack and so cannot be overridden, while an un-skipped directory is
+// governed by the repo's own .gitignore/.grafelignore like anything else.
+//
+// Without this a "fix" that hard-coded `.github` as always-walked would pass
+// the test above and still take the choice away from the user.
+func TestWalkRepo_CIDirsStillHonourIgnoreStack_6946(t *testing.T) {
+	root := t.TempDir()
+	mkfile(t, root, ".github/workflows/ci.yml", "name: ci")
+	mkfile(t, root, ".circleci/config.yml", "version: 2.1")
+	mkfile(t, root, "src/main.go", "package main")
+	writeIgnoreFile(t, root, ".grafelignore", ".github/\n")
+
+	files, _, err := WalkRepo(root, nil)
+	if err != nil {
+		t.Fatalf("WalkRepo: %v", err)
+	}
+	for _, f := range files {
+		if strings.HasPrefix(f, ".github/") {
+			t.Errorf("%q was walked despite a .grafelignore entry — an un-skipped dir must "+
+				"remain governed by the ignore stack (#6946)", f)
+		}
+	}
+	got := make(map[string]bool, len(files))
+	for _, f := range files {
+		got[f] = true
+	}
+	// Negative control: the ignore file named only .github, so .circleci must
+	// still be walked. Without this row a walker that skipped every CI dir
+	// again would pass.
+	if !got[".circleci/config.yml"] {
+		t.Errorf(".circleci/config.yml was not walked; the .grafelignore named .github only; files=%v", files)
+	}
+	if !got["src/main.go"] {
+		t.Errorf("src/main.go was not walked; files=%v", files)
+	}
+
+}

--- a/internal/daemon/walk/gitignore_test.go
+++ b/internal/daemon/walk/gitignore_test.go
@@ -548,15 +548,18 @@ func TestWalkRepo_SkipsLinguistGeneratedDir(t *testing.T) {
 }
 
 // TestWalkRepo_SkipsToolAgentDirs verifies issue #1629: AI / pair-programmer
-// and CI metadata dirs are filtered at the walker so they never appear in
-// the index. These dirs hold .md / .json config — not source — and were
-// previously inflating per-module file counts (e.g. .windsurf/skills/*.md).
+// dirs are filtered at the walker so they never appear in the index. These
+// dirs hold .md / .json config — not source — and were previously inflating
+// per-module file counts (e.g. .windsurf/skills/*.md).
+//
+// #6946 removed the CI dirs (.github / .gitlab / .circleci) from this claim:
+// a pipeline definition IS source-graph content. See
+// TestWalkRepo_CIDirsAreWalked_6946.
 func TestWalkRepo_SkipsToolAgentDirs(t *testing.T) {
 	root := t.TempDir()
 	mkfile(t, root, ".windsurf/skills/coding.md", "skill")
 	mkfile(t, root, ".cursor/rules/foo.json", "{}")
 	mkfile(t, root, ".claude/settings.json", "{}")
-	mkfile(t, root, ".github/workflows/ci.yml", "name: ci")
 	mkfile(t, root, "src/main.go", "package main")
 
 	files, skipped, err := WalkRepo(root, nil)
@@ -568,14 +571,14 @@ func TestWalkRepo_SkipsToolAgentDirs(t *testing.T) {
 	for _, s := range skipped {
 		skippedNames[filepath.Base(s.AbsPath)] = true
 	}
-	for _, want := range []string{".windsurf", ".cursor", ".claude", ".github"} {
+	for _, want := range []string{".windsurf", ".cursor", ".claude"} {
 		if !skippedNames[want] {
 			t.Errorf("expected %q to be skipped (issue #1629); skipped=%v", want, skipped)
 		}
 	}
 
 	for _, f := range files {
-		for _, prefix := range []string{".windsurf/", ".cursor/", ".claude/", ".github/"} {
+		for _, prefix := range []string{".windsurf/", ".cursor/", ".claude/"} {
 			if strings.HasPrefix(f, prefix) {
 				t.Errorf("tool-agent file leaked into walk results: %q", f)
 			}
@@ -758,7 +761,7 @@ func TestDefaultWalkerHelpers(t *testing.T) {
 // watcher and scheduler (which use IsHardcodedSkip to short-circuit).
 func TestIsHardcodedSkip_NewEntries(t *testing.T) {
 	for _, name := range []string{
-		".windsurf", ".cursor", ".claude", ".github",
+		".windsurf", ".cursor", ".claude",
 		"assets", "images", "fonts", "media", "docs",
 		".cache", "bin", "obj", ".terraform", ".ruff_cache",
 	} {

--- a/internal/daemon/walk/walker.go
+++ b/internal/daemon/walk/walker.go
@@ -543,10 +543,22 @@ var hardcodedSkipDirs = map[string]struct{}{
 
 	// Tool / agent dirs (issue #1629) — checked-in tool-config noise that
 	// is not source and should never enter the graph. Cover the popular
-	// AI / pair-programming and CI metadata dirs.
-	".github":          {},
-	".gitlab":          {},
-	".circleci":        {},
+	// AI / pair-programming dirs.
+	//
+	// #6946: ".github", ".gitlab" and ".circleci" were on this list and are
+	// NOT any more. They are not tool-config noise: they are where CI
+	// pipeline definitions live, and a pipeline is architecture the graph
+	// claims to model (the GitHub Actions rule set scopes a workflow as a
+	// Service and a job as an Operation). Because this check runs BEFORE the
+	// ignore stack, the skip made every GitHub Actions rule — and the three
+	// `.github/...` file_conventions globs in
+	// internal/engine/rules/cicd/frameworks/github_actions.yaml —
+	// unreachable on any repo that stores its workflows where GitHub
+	// requires them. Measured blast radius of the un-skip over 58 corpus
+	// repos + this one: +189 walked files (+0.60%), +0.5% entities on the
+	// largest repo measured (django), whose .github is 0.16% of its source
+	// bytes. The corpus holds no .gitlab dir, so that one is graded by the
+	// synthetic walker test only.
 	".husky":           {},
 	".devcontainer":    {},
 	".claude":          {},

--- a/internal/daemon/watch/ci_dirs_parity_6946_test.go
+++ b/internal/daemon/watch/ci_dirs_parity_6946_test.go
@@ -1,0 +1,37 @@
+package watch
+
+import "testing"
+
+// TestShouldSkipDir_CIDirsMatchWalker_6946 pins the walker/watcher parity that
+// #6946 relies on and that nothing else grades.
+//
+// SkipDirs above is a genuine SECOND hand-maintained copy of the skip names
+// (it duplicates .git, .claude, node_modules, .idea, ...), consulted BEFORE
+// the delegation to walk.IsHardcodedSkip. Adding the three CI dirs to it
+// reproduces #6934 exactly — the walker indexes the directory and the watcher
+// never re-indexes it on change — and stays green across walk, watch, sched
+// and engine. The property held only by luck until this test.
+//
+// A third copy lives in cmd/grafel/daemon_tier.go (shouldSkipDirForStale,
+// "keep in sync with internal/daemon/watch.ShouldSkipDir"); it is covered by
+// TestShouldSkipDirForStale_CIDirs_6946 in that package.
+func TestShouldSkipDir_CIDirsMatchWalker_6946(t *testing.T) {
+	for _, base := range []string{".github", ".gitlab", ".circleci"} {
+		if ShouldSkipDir(base) {
+			t.Errorf("ShouldSkipDir(%q) = true, want false (#6946) — the walker indexes this "+
+				"directory, so a watcher that drops its events leaves it stale forever", base)
+		}
+		if ShouldSkipPath(base + "/workflows/ci.yml") {
+			t.Errorf("ShouldSkipPath(%q/workflows/ci.yml) = true, want false (#6946)", base)
+		}
+	}
+	// Negative controls: the tool-agent dirs that stayed on the list must
+	// still be dropped, or this test would pass against a watcher that
+	// skips nothing at all.
+	for _, base := range []string{".claude", "node_modules", ".idea"} {
+		if !ShouldSkipDir(base) {
+			t.Errorf("ShouldSkipDir(%q) = false, want true — the #6946 un-skip reached further "+
+				"than the three CI dirs", base)
+		}
+	}
+}

--- a/internal/engine/github_actions_reachable_6946_test.go
+++ b/internal/engine/github_actions_reachable_6946_test.go
@@ -1,0 +1,131 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cajasmota/grafel/internal/daemon/walk"
+)
+
+// TestGitHubActionsFileConventionsAreReachable_6946 joins the two halves of
+// #6946 in one assertion: the globs the GitHub Actions rule set declares, and
+// the repo-relative paths the walker actually emits for a repo laid out the
+// way GitHub requires.
+//
+// Neither half alone catches the bug. matchesFile(".github/workflows/*.yml",
+// ".github/workflows/ci.yml") was always true; the walker simply never
+// produced that path, because ".github" sat on hardcodedSkipDirs and the
+// hard-coded layer runs BEFORE the ignore stack. So every source_pattern in
+// github_actions.yaml was dead on a real repo while every unit test around it
+// stayed green.
+//
+// This test fails if `.github` goes back on the skip list, and it fails if the
+// globs are rewritten to a shape the walker does not emit — which is the
+// "make the rules match somewhere else" non-fix.
+func TestGitHubActionsFileConventionsAreReachable_6946(t *testing.T) {
+	rulePath := filepath.Join("rules", "cicd", "frameworks", "github_actions.yaml")
+	raw, err := os.ReadFile(rulePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", rulePath, err)
+	}
+	var rule FrameworkRule
+	if err := yaml.Unmarshal(raw, &rule); err != nil {
+		t.Fatalf("unmarshal %s: %v", rulePath, err)
+	}
+	if len(rule.FileConventions) == 0 {
+		t.Fatalf("%s declares no file_conventions — this test grades their reachability "+
+			"and has nothing to grade", rulePath)
+	}
+
+	// A repo laid out the way GitHub requires. One file per declared glob,
+	// plus decoys: ordinary YAML that GitHub Actions never reads, at paths a
+	// real repo has. They are the specificity half — see the forbidden loop
+	// below.
+	root := t.TempDir()
+	inLayout := []string{
+		".github/workflows/ci.yml",
+		".github/workflows/release.yaml",
+		".github/actions/setup/action.yml",
+	}
+	decoys := []string{
+		"config/app.yml",
+		"deploy/values.yaml",
+		"src/actions/setup/action.yml",
+	}
+	for _, rel := range append(append([]string{}, inLayout...), decoys...) {
+		abs := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(abs, []byte("name: ci\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	walked, _, err := walk.WalkRepo(root, nil)
+	if err != nil {
+		t.Fatalf("WalkRepo: %v", err)
+	}
+
+	// EVERY declared glob is graded, not only the .github/-prefixed ones.
+	// Grading the prefixed subset would leave the option-3 non-fix — rewrite
+	// the glob to some path the walker already emits, so the rule "fires"
+	// while still never seeing a real workflow — silently passing.
+	graded, dotGitHub := 0, 0
+	for _, fc := range rule.FileConventions {
+		if fc.Glob == "" {
+			continue
+		}
+		graded++
+		if strings.HasPrefix(fc.Glob, ".github/") {
+			dotGitHub++
+		}
+		cfc := compiledFileConvention{glob: fc.Glob, entityType: fc.EntityType, nameFrom: fc.NameFrom}
+		matched := false
+		for _, f := range walked {
+			if cfc.matchesFile(f) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Errorf("#6946: file_convention glob %q matches none of the paths the walker emits "+
+				"for a standard GitHub layout (walked=%v) — the rule is unreachable on a real "+
+				"repo. If the glob is legitimately new, add a file for it to the layout above.",
+				fc.Glob, walked)
+		}
+	}
+	if graded == 0 {
+		t.Fatalf("%s declares file_conventions but none carries a glob — the reachability "+
+			"claim this test pins was deleted rather than fixed", rulePath)
+	}
+	// Specificity, the other axis. Reachability alone is satisfied by a glob
+	// that matches EVERYTHING: matchesFile falls back to a BASENAME match
+	// when a glob carries no "/", so rewriting ".github/workflows/*.yml" to
+	// "*.yml" makes every .yml in the repo a GitHub Actions Config — the
+	// option-3 non-fix in a spelling that keeps the rules "firing". Grade it
+	// by requiring each glob to reject YAML GitHub never reads.
+	for _, fc := range rule.FileConventions {
+		if fc.Glob == "" {
+			continue
+		}
+		cfc := compiledFileConvention{glob: fc.Glob, entityType: fc.EntityType, nameFrom: fc.NameFrom}
+		for _, decoy := range decoys {
+			if cfc.matchesFile(decoy) {
+				t.Errorf("#6946: file_convention glob %q also matches %q, which GitHub Actions "+
+					"never reads. A glob that matches workflow files by accident is not a rule "+
+					"that found them.", fc.Glob, decoy)
+			}
+		}
+	}
+
+	if dotGitHub == 0 {
+		t.Errorf("%s no longer declares a single .github/ glob. GitHub reads workflows only "+
+			"from .github/workflows; a rule set that matches them anywhere else fires on the "+
+			"wrong files and still never sees the real ones (#6946)", rulePath)
+	}
+}


### PR DESCRIPTION
`hardcodedSkip` runs at walker.go:214, BEFORE the ignore stack, so `.github` on
`hardcodedSkipDirs` is not a default a repo can undo — it is an unconditional
erasure. Every `source_pattern` in
internal/engine/rules/cicd/frameworks/github_actions.yaml, and its three
`.github/...` file_conventions globs, were unreachable on any repo that stores
its workflows where GitHub requires them. Same for `.gitlab` and `.circleci`.

Measured first, because un-skipping changes what EVERY repo indexes, and the
primary consumer is concurrent MCP agents on a 16GB machine.

## Blast radius

58 corpus repos in ~/Projects/archigraph-corpora + this repo. Walk-level from a
`walk.WalkRepo` harness; entity-level end-to-end with `grafel quality` on
rsync'd copies, base binary vs un-skipped binary, isolated HOME/GRAFEL_HOME.

  walked files      31279 -> 31468   (+189, +0.60%)
  repos affected    30 of 59; 29 have no CI dir on disk at all (several are
                    sparse checkouts, where Layer 5 would drop the tree anyway)
  content           189 files / 277KB: 121 .yml, 21 .yaml, 38 .md,
                    5 extensionless, 2 .tpl, 1 .sh, 1 .json

`.gitlab` was measured on NOTHING. The corpus contains zero `.gitlab/`
directories, so these numbers cover `.github` plus three `.circleci` files. The
`.gitlab` un-skip is graded only by the synthetic walker test. It is the same
argument — a pipeline definition is architecture — but it is an argument, not a
measurement, and should not be read as covered by the figures above.

  entities, base -> un-skipped:
    django             87897 -> 88313  (+0.47%),  rels +690 (+0.08%)
    apollo-server      11551 -> 11617  (+0.57%)
    gin                 3967 ->  4091  (+3.1%)
    starter-workflows   3745 ->  3861  (+3.1%)
    flask               3261 ->  3354  (+2.9%)
    click               2421 ->  2513  (+3.8%)
    terraform-aws-vpc   2091 ->  2185  (+4.5%)
    requests            1723 ->  1894  (+9.9%)
    express             1663 ->  1798  (+8.1%)
    spring-petclinic     934 ->   991  (+6.1%)
    dart-samples         736 ->   897  (+21.9%, one 56KB workflow)
    tide                 307 ->   371  (+20.8%)

### Cost

The load-bearing figure is structural, not a timing run: django's `.github` is
43,365 bytes against 27.7MB of .py/.html/.txt/.js source — 0.16% of the source
bytes fed to the extractors. Cost here is linear in bytes walked, so the
expected peak-RSS delta is below the floor of any single measurement by
construction.

The observed peak RSS on django (`/usr/bin/time -l`, n=1) was 2058MB base ->
2047MB un-skipped. That is consistent with no cost and rules out a large
regression; it cannot establish "free". macOS max-RSS counts MADV_FREE pages,
so it is an upper bound rather than a footprint, and n=1 carries no variance
estimate. Read it as a ceiling, and the 0.16% as the reason.

### Outliers

"No outlier" holds for directory SIZE: largest `.github` is django's at 24
files / 43KB, largest single file is `dart-samples/.github/workflows/dart.yml`
at 56KB. It does NOT hold for entity YIELD, and the outlier is at the small end,
not the large one: dart-samples +21.9% and tide +20.8%, the former from that one
56KB workflow. A single oversized workflow moves a small repo's entity mix by a
fifth — and #6932's RSS-constrained container case is a small-repo case.

The untested mega-repo end (a kubernetes-scale `.github` of ~100 workflows) is
acceptable rather than merely unmeasured: cost is linear in bytes and a big
repo's source tree grows faster than its CI config, so the ratio only improves.

### Signal ratio, both denominators

By ENTITY yield, 83% of requests' +170 and 69% of tide's +64 come from
`.github/workflows/*`, as Service / Task / SCOPE.Operation / SCOPE.ScheduledJob.
By FILE count the split is much worse: only 90 of the 164 corpus `.github`
files (55%) live under `workflows/` or `actions/`; 74 are issue/PR templates,
FUNDING.yml and markdown. Notably the un-skip re-admits this repo's own
`.github/copilot-instructions.md` — a file `internal/install/rulesfiles`
GENERATES as tool config, i.e. exactly the #1629 class the skip list exists for.
Trimming that tail needs no new mechanism (a basename entry for
`ISSUE_TEMPLATE` plus a loose-`.md` rule removes 29% of the addition in two
lines); filed as #6954 rather than done here.

## Why option 1 and not the alternatives

  - Option 2 (walk only `.github/workflows` + `.github/actions`) is feasible —
    every call site already holds the full path — but costs one new
    `IsHardcodedSkipPath(rel)`, a change at each of four sites in walk, watch
    (x2) and sched, plus a genuine file-level rule, since `hardcodedSkip` only
    returns SkipDir for directories. #6954's two basename rules capture most of
    the benefit for none of that, and should be tried first.
  - Option 3 (leave the skip, retarget the globs) makes the rules fire on files
    stored in the WRONG place while still never seeing the real ones. It is now
    graded (M3 below) rather than merely rejected in prose.

## Grading, both directions

  - internal/daemon/walk/ci_dirs_6946_test.go — the three CI dirs are walked;
    the tool-agent dirs and node_modules must still be skipped; IsHardcodedSkip
    agrees with the walker in both directions. A second test pins that an
    un-skipped dir is still governed by .grafelignore, with .circleci as the
    negative control.
  - internal/daemon/watch/ci_dirs_parity_6946_test.go — ShouldSkipDir /
    ShouldSkipPath must not drop these three. `watch.SkipDirs` is a genuine
    SECOND hand-maintained copy of the skip names, consulted BEFORE the
    delegation to walk.IsHardcodedSkip; until this test the walker/watcher
    parity this PR asserts held only by luck.
  - cmd/grafel/ci_dirs_stale_parity_6946_test.go — the THIRD copy,
    shouldSkipDirForStale ("keep in sync with watch.ShouldSkipDir"), same rows.
  - internal/engine/github_actions_reachable_6946_test.go — grades both axes:
    every declared file_conventions glob must match a path walk.WalkRepo
    actually emits for a standard GitHub layout (reachability), and must NOT
    match ordinary YAML at paths GitHub never reads (specificity). Neither
    axis alone catches anything: matchesFile was always true for the real
    globs, and a glob of `*.yml` reaches everything.

## Mutants

Each edit's occurrence count asserted; baseline verified green immediately
before each score; restored by cp + shasum.

  M1  re-add the three dirs to hardcodedSkipDirs                      -> DEAD
  M2  glob -> "workflows/*.yml"                                       -> DEAD
  M3  globs -> "*.yml" / "*.yaml"; matchesFile falls back to a BASENAME
      match for slash-free globs, so every .yml in the repo becomes a
      GHA Config — option 3 in a spelling neither the issue nor I named
      -> ALIVE against the first version of the engine test (green on
      walk, engine, quality, extractors and cmd/grafel). Added the decoy
      rows; re-scored DEAD.
  M6  add the three names to watch.SkipDirs — reproduces #6934 exactly:
      walker indexes the dir, watcher never re-indexes it on change
      -> ALIVE against everything in the first push (green on walk,
      watch, sched, engine). Added the parity tests; re-scored DEAD.

M1/M2 were scored by me, M3/M6 by the adversarial review of #6951.

## Verification

go test -count=1 green on internal/daemon/walk, internal/daemon/watch,
internal/daemon/sched, internal/engine, internal/quality, internal/extractors
and ./cmd/grafel (the graph digest pin did NOT move). gofmt and go vet clean.

The extraction ratchet did not move either — and that is a finding, not a
reassurance: no fixture under internal/quality/golden contains a .github,
.gitlab or .circleci dir, and cmd/grafel's fixtures are all t.TempDir()
synthesis, so both the ratchet and the digest pin are blind to this change by
construction. Filed as #6955; the end-to-end cicd golden fixture belongs there.

Closes #6946
Refs #6954, #6955


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
