### PR TITLE
fix(#6952): `conf/routes` has no extension, so four Play/Revel routes producers were unreachable — two table entries, not a new mechanism

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -715,7 +715,29 @@ var basenameLanguageMap = map[string]string{
 	// handed (detectScalaFramework returns "play" on a column-0 HTTP verb line),
 	// so a non-Play file that happens to be named `routes` yields no route
 	// entities rather than wrong ones. Reaching the Java and Revel producers is
-	// a second change to those gates, filed separately.
+	// a second change to those gates, filed separately (#6957).
+	//
+	// WHAT THE LANGUAGE GATES DO NOT COVER, AND WHY IT IS STILL FINE. Those
+	// gates scope the routes token away from OTHER languages. They do nothing
+	// same-language: `file.Language == "scala"` is now true for every routes
+	// file, so ALL of internal/custom/scala's gated passes receive a routes DSL
+	// as if it were Scala source — anorm looking for SQL, caliban for GraphQL
+	// schemas, akka for actors, di for injection. Measured rather than argued:
+	// on lichess-org/lila's five real routes files (923 column-0 verb lines),
+	// this classification yields 1741 entities of which 1738 come from a routes
+	// file and every one is a Route, a SCOPE.Operation or a per-file carrier.
+	// Those passes produce ZERO spurious entities on real routes content. A
+	// future Scala custom pass should know routes files are in its input.
+	//
+	// THE COST OF A WRONG GUESS IS SMALL BUT NOT ZERO, so do not read the
+	// measured-zero over-fire as "harmless if it ever fires".
+	// detectScalaFramework's default arm returns "scala", not nothing, so a
+	// misclassified file still mints one SCOPE.Component carrier and its
+	// CONTAINS edge, and reGenericAuth (`\b(?:JWT|BearerToken|ApiKey|
+	// Authorization)\b`) fires for that arm — a stray `routes` file containing
+	// the word Authorization would mint a SCOPE.Security auth_check. "Yields no
+	// route entities rather than wrong ones" is true about ROUTES; it is not
+	// true about entities in general.
 	"routes": "scala",
 }
 

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -616,6 +616,16 @@ var extensionLanguageMap = map[string]string{
 	// unexamined accept.
 	".dockerfile":    "dockerfile",
 	".containerfile": "dockerfile",
+	// Play / Revel routes DSL (#6952). Play splits a router across
+	// `conf/routes` plus per-module `conf/<name>.routes` includes
+	// (`-> /admin admin.Routes`); 60 of the 139 routes files measured across
+	// the Play upstreams use this suffix form, so routing the bare basename
+	// alone would reach fewer than half of them. Routed to "scala" — the
+	// language of the only registered producer that gates on a routes DSL
+	// (internal/custom/scala's `play` framework arm, selected by a content
+	// sniff for a column-0 HTTP verb) — see the basenameLanguageMap entry
+	// below for why "scala" and not a routes-specific token.
+	".routes": "scala",
 	// Markdown / Documentation
 	".md":       "markdown",
 	".mdx":      "markdown",
@@ -674,6 +684,39 @@ var basenameLanguageMap = map[string]string{
 	// reaches the _cross_manifest extractor (which exact-name-matches it and
 	// parses the resolved dependency tree as kind=locked deps).
 	"luarocks.lock": "lua",
+	// Play / Revel routes file (#6952). `conf/routes` carries no extension, so
+	// before this entry detectLanguage returned "" and the classifier answered
+	// Skip{unsupported_extension} — which made FOUR producers unreachable in
+	// production: the two rules in engine/rules/scala/frameworks/play_framework.yaml,
+	// internal/custom/scala's `rePlayRoute`, internal/custom/java/play_routes.go
+	// and internal/custom/golang's Revel arm. Every one of them had passing unit
+	// tests, because those tests construct the file record directly.
+	//
+	// WHY THE BARE BASENAME AND NOT A `conf/` PATH ANCHOR. `conf/routes` is the
+	// narrower rule and it is the one the Play docs describe, but it is not the
+	// one the corpus supports: of 139 routes files measured across
+	// playframework/playframework, playframework/play-samples, lichess-org/lila,
+	// revel/examples and the 60-repo corpus, only 70 sit at `conf/routes`. Nine
+	// more are Play's own `src/main/resources/routes` (the maven-layout and
+	// sbt-plugin form), and 60 are `*.routes` module includes that a `conf/`
+	// anchor also misses. The over-fire the anchor would buy protection against
+	// was measured at ZERO: every one of the 139 is a genuine routes DSL, and
+	// the corpus contains exactly one file named `routes` outside the Play
+	// upstreams (play-scala-starter's, which is one).
+	//
+	// WHY "scala" AND NOT A ROUTES-SPECIFIC LANGUAGE TOKEN. All three custom
+	// producers hard-gate on their own base language — `file.Language != "scala"`
+	// (custom/scala/frameworks.go), `ctx.Language != "java"`
+	// (custom/java/play_routes.go), `language != "go"` (custom/golang/revel.go)
+	// — so ONE token cannot reach all three; a routes-specific token reaches
+	// none of them without also widening all three gates and teaching the scala
+	// rule-pack loader a second language. "scala" is chosen because it is the
+	// only one of the three whose producer already content-sniffs the file it is
+	// handed (detectScalaFramework returns "play" on a column-0 HTTP verb line),
+	// so a non-Play file that happens to be named `routes` yields no route
+	// entities rather than wrong ones. Reaching the Java and Revel producers is
+	// a second change to those gates, filed separately.
+	"routes": "scala",
 }
 
 // detectLanguage returns the language token for the given normalised path, or

--- a/internal/classifier/conf_routes_6952_test.go
+++ b/internal/classifier/conf_routes_6952_test.go
@@ -114,7 +114,18 @@ func TestRoutesNameDoesNotOverFire6952(t *testing.T) {
 	c := New(nil)
 
 	// Rows that must keep the language the EXTENSION router already gave them.
-	// These are the ones a `Contains`-style rule would steal.
+	//
+	// WHAT ACTUALLY PROTECTS THESE, corrected after review. It is tempting to
+	// say "extensionLanguageMap is consulted before basenameLanguageMap, so
+	// routes.rb is ruby before the routes entry is ever reached". That ordering
+	// is INERT: swapping the two lookups is equivalent under the current tables
+	// (probed on nginx.conf, luarocks.lock, .justfile, conf/routes and
+	// config/routes.rb — identical output both ways, because `.conf` and
+	// `.lock` are not in extensionLanguageMap and `.justfile` is in both with
+	// the same value). The thing that actually holds is that
+	// basenameLanguageMap is keyed on the FULL basename, exactly: `routes.rb`
+	// is simply not the string `routes`. A reader tightening the rule should
+	// preserve exact-full-basename keying, not the lookup order.
 	keepsLanguage := []struct{ path, lang, corpus string }{
 		{"config/routes.rb", "ruby", "rails-realworld/config/routes.rb"},
 		{"config/routes.yaml", "yaml", "symfony-demo/config/routes.yaml"},
@@ -157,6 +168,57 @@ func TestRoutesNameDoesNotOverFire6952(t *testing.T) {
 			if !got.Skip || got.Language != "" {
 				t.Errorf("Classify(%q) = {lang=%q skip=%v}, want an unclassified skip — %s",
 					tc.path, got.Language, got.Skip, tc.why)
+			}
+		})
+	}
+
+	// THE `.routes` EXTENSION HALF, graded on its own. Every row above keys on
+	// the BASENAME entry; before review this direction had zero forbidden rows,
+	// and adding `".route": "scala"` (singular) to extensionLanguageMap was
+	// ALIVE against the whole suite and the golden fixture. Two populations were
+	// measured (79 basename / 60 suffix) and only one was graded.
+	extensionHalfStaysSkipped := []struct{ path, why string }{
+		{"conf/admin.route", "SINGULAR. Zero instances in 139 measured files; Play's include suffix is plural, and a `.route` entry is invisible to every basename row"},
+		{"conf/admin.routez", "a one-character-off suffix — the lookup is exact, not a prefix or fuzzy match"},
+		{"conf/admin.routes.bak", "filepath.Ext takes the LAST segment, so this is `.bak` and must stay skipped even though `.routes` appears in the name"},
+		{"conf/admin.routes~", "the editor backup marker; `.routes~` is not `.routes`"},
+	}
+	for _, tc := range extensionHalfStaysSkipped {
+		t.Run("ext/"+tc.path, func(t *testing.T) {
+			if got := c.Classify(context.Background(), tc.path); !got.Skip || got.Language != "" {
+				t.Errorf("Classify(%q) = {lang=%q skip=%v}, want an unclassified skip — %s",
+					tc.path, got.Language, got.Skip, tc.why)
+			}
+		})
+	}
+
+	// A `routes/` DIRECTORY must not pull its contents in. The two rows in
+	// keepsLanguage that advertise this (express-realworld, nextjs) CANNOT
+	// grade it — review's N2 proved it: they carry extensions, so the extension
+	// lookup answers first and a `strings.Contains(norm, "/routes/")` widening
+	// at the natural edit site never reaches them. Killing that shape needs an
+	// EXTENSIONLESS file under a routes/ directory, which is what these are.
+	// The corpus has six `routes` directories (symfony-demo, nextjs x2,
+	// rails-actionpack, express-realworld, awesome-compose) and zero
+	// extensionless files in any of them, so these rows are synthetic by
+	// necessity — the widening is not production-reachable on the measured
+	// corpus, but it is the cheapest wrong turn a future editor can take.
+	routesDirStaysSkipped := []string{
+		"routes/health",
+		"app/routes/index",
+		"src/routes/admin/handler",
+		// NOT a row: a bare `routes/` with a trailing slash. path.Base strips it
+		// and the file classifies — but the classifier is only ever handed FILE
+		// paths (the walker decides directories, and does so before this), so a
+		// row for it would assert a contract that does not exist. Recorded
+		// rather than silently omitted: it was tried and rejected, not missed.
+	}
+	for _, p := range routesDirStaysSkipped {
+		t.Run("dir/"+p, func(t *testing.T) {
+			if got := c.Classify(context.Background(), p); !got.Skip || got.Language != "" {
+				t.Errorf("Classify(%q) = {lang=%q skip=%v}, want an unclassified skip — a "+
+					"segment match on `routes/` would fire here; the rule is a basename "+
+					"lookup and must not read the parent directory", p, got.Language, got.Skip)
 			}
 		})
 	}

--- a/internal/classifier/conf_routes_6952_test.go
+++ b/internal/classifier/conf_routes_6952_test.go
@@ -1,0 +1,198 @@
+// Package classifier — conf_routes_6952_test.go
+//
+// Issue #6952. Play Framework's router file carries NO EXTENSION, so
+// detectLanguage returned "" for it and both classifyInner and
+// classifyWithSizeInner answered Skip{unsupported_extension}. Four producers
+// were keyed on a file that never arrived — the two rules in
+// internal/engine/rules/scala/frameworks/play_framework.yaml, internal/custom/
+// scala's rePlayRoute, internal/custom/java/play_routes.go, and internal/custom/
+// golang's Revel arm — and every one of them had passing unit tests, because
+// those tests construct the file record directly and never go through here.
+//
+// THERE WAS NO MISSING MECHANISM. basenameLanguageMap has routed extensionless
+// well-known files since Dockerfile / Containerfile / Justfile / Caddyfile, and
+// extensionLanguageMap routes an unknown-to-the-OS extension like `.routes`
+// exactly as it routes `.tf` or `.hcl`. The bug was two absent table entries,
+// not an absent hook, which is why Dockerfile / Makefile / Gemfile / Procfile
+// need no new machinery either.
+//
+// WHY THE BARE BASENAME AND NOT A `conf/` PATH ANCHOR. detectLanguage CAN
+// express a path rule — the Debezium `.json` block's dirAnchor does — so the
+// narrower `conf/routes` rule was available and was rejected on measurement,
+// not on taste. Across playframework/playframework, playframework/play-samples,
+// lichess-org/lila, revel/examples and the 60-repo corpus at
+// ~/Projects/archigraph-corpora, 139 routes files:
+//
+//	basename `routes`      79 files   (70 at conf/routes, 9 at src/main/resources/routes)
+//	suffix   `*.routes`    60 files   (conf/<module>.routes sub-router includes)
+//	path     `conf/routes` 70 files   — HALF the population
+//
+// and the over-fire the path anchor buys protection against measured ZERO:
+// every one of the 139 is a genuine routes DSL, and the whole 60-repo corpus
+// contains exactly ONE file named `routes` (play-scala-starter's, which is a
+// Play routes file). The generic-name risk is real in the abstract and was not
+// observed once; the forbidden rows below are what hold it, together with the
+// fact that the consumer content-sniffs (detectScalaFramework only answers
+// "play" for a column-0 HTTP verb line).
+//
+// WHY "scala". All three custom producers hard-gate on their own base language
+// (`file.Language != "scala"`, `ctx.Language != "java"`, `language != "go"`),
+// so no single token reaches more than one of them and a routes-specific token
+// reaches NONE. "scala" is the only one of the three whose producer already
+// content-sniffs what it is handed. Reaching the Java and Revel producers needs
+// those gates widened and is filed separately.
+package classifier
+
+import (
+	"context"
+	"testing"
+)
+
+// TestConfRoutesIsClassified6952 grades the REACHABILITY direction: the paths
+// that carry a Play/Revel routes DSL must arrive at a language with a producer.
+//
+// The `.scala` row is a POSITIVE CONTROL, carried from the issue: without it a
+// blanket regression in the classifier (an early skip, a broken normalisePath)
+// would look identical to the bug this file pins, and the fix would read as
+// necessary when it was not.
+func TestConfRoutesIsClassified6952(t *testing.T) {
+	c := New(nil)
+	cases := []struct {
+		path string
+		why  string
+	}{
+		{"conf/routes", "the canonical Play/Revel location; 70 of 139 measured files"},
+		{"modules/admin/conf/routes", "a Play sub-project's own conf/ — path depth must not matter"},
+		{"src/main/resources/routes", "Play's maven-layout / sbt-plugin location; 9 measured files, and every one of them is invisible to a `conf/` path anchor"},
+		{"routes", "repo root, e.g. a sub-project indexed with its own directory as root"},
+		{"conf/admin.routes", "`-> /admin admin.Routes` sub-router include; 60 measured files"},
+		{"a.routes", "the include form at the tree root (playframework's routes-compiler-incremental-compilation fixtures)"},
+		{"documentation/manual/working/scalaGuide/main/http/code/scalaguide.http.routing.routes", "a multi-dot include name — filepath.Ext takes only the LAST segment, so this must route on `.routes` and not on `.http`"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			got := c.Classify(context.Background(), tc.path)
+			if got.Skip {
+				t.Fatalf("Classify(%q) = Skip{%s} — %s", tc.path, got.SkipReason, tc.why)
+			}
+			if got.Language != "scala" {
+				t.Fatalf("Classify(%q).Language = %q, want %q — internal/custom/scala's "+
+					"framework extractor gates on `file.Language != \"scala\"`, so any "+
+					"other token leaves the Play producer as unreachable as an outright "+
+					"skip does", tc.path, got.Language, "scala")
+			}
+			// ClassifyWithSize is a SECOND copy of the decision (classifier.go
+			// :190) and is the one the extraction pipeline actually calls
+			// (cmd/grafel/index.go:3973). A fix applied to only one of them
+			// would be green on Classify and dead in production.
+			ws := c.ClassifyWithSize(context.Background(), tc.path, 4096)
+			if ws.Skip || ws.Language != "scala" {
+				t.Fatalf("ClassifyWithSize(%q, 4096) = {lang=%q skip=%v reason=%s}, want "+
+					"{scala,false} — the two entry points disagree", tc.path, ws.Language, ws.Skip, ws.SkipReason)
+			}
+		})
+	}
+
+	// Positive control (#6952 as filed): a co-located ordinary Scala file was
+	// ALWAYS classified. The skip was a fact about the filename, not about the
+	// path or the repo layout.
+	if got := c.Classify(context.Background(), "app/controllers/HomeController.scala"); got.Skip || got.Language != "scala" {
+		t.Fatalf("premise: Classify(HomeController.scala) = {lang=%q skip=%v} — the control "+
+			"is broken, so nothing above grades the routes rules", got.Language, got.Skip)
+	}
+}
+
+// TestRoutesNameDoesNotOverFire6952 grades the OTHER direction, which is where
+// the whole risk of this change lives: `routes` is a plausible basename for
+// something that is not a Play router.
+//
+// Every row is a name that EXISTS in the measured corpus (the file it names is
+// noted) except where marked synthetic, and every row would flip if the rule
+// were spelled one notch wider — a `strings.Contains(base, "routes")`, a
+// `routes.` prefix arm, or a case-insensitive lookup.
+func TestRoutesNameDoesNotOverFire6952(t *testing.T) {
+	c := New(nil)
+
+	// Rows that must keep the language the EXTENSION router already gave them.
+	// These are the ones a `Contains`-style rule would steal.
+	keepsLanguage := []struct{ path, lang, corpus string }{
+		{"config/routes.rb", "ruby", "rails-realworld/config/routes.rb"},
+		{"config/routes.yaml", "yaml", "symfony-demo/config/routes.yaml"},
+		{"src/routes.rs", "rust", "actix-examples/databases/mysql/src/routes.rs"},
+		{"app/Http/routes.php", "php", "laravel-quickstart/app/Http/routes.php"},
+		{"src/app/routes/routes.ts", "typescript", "express-realworld — note the DIRECTORY named routes: a segment match would fire on the path, a basename match cannot"},
+		{"Sources/App/routes.swift", "swift", "vapor-api-template/Sources/App/routes.swift"},
+		{"_examples/rest/routes.md", "markdown", "chi/_examples/rest/routes.md"},
+		{"packages/next/src/export/routes/index.ts", "typescript", "nextjs — a file INSIDE a routes/ directory"},
+	}
+	for _, tc := range keepsLanguage {
+		t.Run("keeps/"+tc.path, func(t *testing.T) {
+			got := c.Classify(context.Background(), tc.path)
+			if got.Language != tc.lang {
+				t.Errorf("Classify(%q).Language = %q, want %q — %s", tc.path, got.Language, tc.lang, tc.corpus)
+			}
+		})
+	}
+
+	// Rows that must stay UNCLASSIFIED. `routes.<unknown>` is the widening
+	// internal/custom/java's isPlayRoutesFile already makes (`routes.` prefix);
+	// it was measured on exactly one file in the whole corpus — playframework's
+	// deliberately-broken `routes.bad` — and would admit every editor and deploy
+	// backup in exchange. scala-play-mini's conf/routes.bak forbidden_entities
+	// row is the end-to-end half of this.
+	staysSkipped := []struct{ path, why string }{
+		{"conf/routes.bak", "an editor/deploy backup: valid routes DSL, no longer served"},
+		{"conf/routes.orig", "a merge artefact, same shape"},
+		{"routes.bad", "playframework/dev-mode/.../dev-mode-compile-and-config-error-source/routes.bad — the only `routes.*` in 139 measured files, and it is deliberately broken"},
+		{"conf/routes.txt", "synthetic: the general `routes.<unknown ext>` case"},
+		{"conf/Routes", "case-SENSITIVE, matching every other basenameLanguageMap entry (bare `dockerfile` does not route either)"},
+		{"conf/ROUTES", "same"},
+		{"conf/route", "singular — a `routes` prefix rule would not catch it, a fuzzy one might"},
+		{"conf/myroutes", "a suffix-of-basename match would fire here; the lookup is exact"},
+		{"conf/routesx", "a prefix-of-basename match would fire here"},
+	}
+	for _, tc := range staysSkipped {
+		t.Run("skips/"+tc.path, func(t *testing.T) {
+			got := c.Classify(context.Background(), tc.path)
+			if !got.Skip || got.Language != "" {
+				t.Errorf("Classify(%q) = {lang=%q skip=%v}, want an unclassified skip — %s",
+					tc.path, got.Language, got.Skip, tc.why)
+			}
+		})
+	}
+
+	// The universal path skips still win. A vendored Play sample must not be
+	// re-admitted through the new entries: they run AFTER universalPathSkip.
+	for _, p := range []string{"vendor/play-sample/conf/routes", "node_modules/x/conf/admin.routes", "testdata/conf/routes"} {
+		if got := c.Classify(context.Background(), p); !got.Skip {
+			t.Errorf("Classify(%q) = {lang=%q skip=false} — the dependency-directory skip must "+
+				"still win over the routes rules", p, got.Language)
+		}
+	}
+}
+
+// TestRoutesExtensionIsRoutedByTheRouter6952 pins the CONSEQUENCE of choosing
+// extensionLanguageMap for the `*.routes` half rather than a bespoke suffix
+// branch: `.routes` becomes an extension the ROUTER claims, so it stops being
+// reported as unsupported and LanguageForExtension answers for it.
+//
+// This is asserted rather than left implicit because it is the observable
+// difference between the two spellings, and because a reader tightening the
+// rule into a private suffix check would silently reopen the unsupported-
+// extension report row without any other test noticing.
+func TestRoutesExtensionIsRoutedByTheRouter6952(t *testing.T) {
+	if got := LanguageForExtension(".routes"); got != "scala" {
+		t.Errorf("LanguageForExtension(%q) = %q, want %q", ".routes", got, "scala")
+	}
+	if !SupportedExtension(".ROUTES") {
+		t.Error("SupportedExtension(\".ROUTES\") = false — extension routing is case-INsensitive " +
+			"(the lookup lowercases), unlike the basename entry; a change that made the two agree " +
+			"in the wrong direction would break `conf/module.ROUTES`")
+	}
+	// The basename half is case-SENSITIVE and stays that way; the two halves of
+	// this fix genuinely differ, and pinning both stops a reader "harmonising"
+	// them without deciding which way.
+	if got := detectLanguage("conf/Routes"); got != "" {
+		t.Errorf("detectLanguage(%q) = %q, want \"\" — the basename entry is case-sensitive", "conf/Routes", got)
+	}
+}

--- a/internal/daemon/watch/routes_event_parity_6952_test.go
+++ b/internal/daemon/watch/routes_event_parity_6952_test.go
@@ -6,12 +6,23 @@
 // reading a file the watcher still drops, so the graph is correct exactly once
 // — at the initial index — and never updates again.
 //
-// The classifier is consulted at ONE boundary (cmd/grafel/index.go:3973,
-// internal/daemon/extract/{coordinator,subproc}.go), and the watcher does not
-// consult it at all: ShouldSkipPath is a DENYLIST over SkipDirs / SkipExts /
-// SkipBaseGlobs. So #6952 needed no watcher change, and these rows are what
-// makes that a checked fact rather than a claim — they fail the moment anyone
-// adds `conf` to SkipDirs or `.routes` to SkipExts.
+// The classifier has FOUR consumers, enumerated after review corrected an
+// earlier claim of one: cmd/grafel/index.go:3973,
+// internal/daemon/extract/coordinator.go:662, internal/daemon/extract/
+// subproc.go:105, and internal/extractors/incremental.go:885/1002. All four
+// call the same classifier, so none of them can disagree about a routes file —
+// but "there is one consumer" was wrong as written, and the fourth is the
+// UPDATE path, which is precisely where the #6934 class lives.
+//
+// The watcher consults none of them: ShouldSkipPath is a DENYLIST over SkipDirs
+// / SkipExts / SkipBaseGlobs. So #6952 needed no watcher change, and these rows
+// are what makes that a checked fact rather than a claim — they fail the moment
+// anyone adds `conf` to SkipDirs or `.routes` to SkipExts.
+//
+// THIS FILE GRADES THE EVENT, NOT THE RE-EXTRACT. A change event that survives
+// here and then hits a `continue` in incremental.go's re-extract loop is the
+// same user-visible failure. That second half is graded separately, in
+// internal/extractors/routes_incremental_reextract_6952_test.go.
 //
 // The `.bak` rows are the deliberate negative control, and they are the reason
 // this test is not vacuous: `.bak` IS on SkipExts, so the watcher already drops

--- a/internal/daemon/watch/routes_event_parity_6952_test.go
+++ b/internal/daemon/watch/routes_event_parity_6952_test.go
@@ -1,0 +1,52 @@
+// Package watch — routes_event_parity_6952_test.go
+//
+// Issue #6952 routed Play/Revel routes files (`conf/routes`, `conf/*.routes`)
+// in internal/classifier. That is a PRODUCER-side change, and #6934 is the
+// standing lesson about what a producer-only change costs: the indexer starts
+// reading a file the watcher still drops, so the graph is correct exactly once
+// — at the initial index — and never updates again.
+//
+// The classifier is consulted at ONE boundary (cmd/grafel/index.go:3973,
+// internal/daemon/extract/{coordinator,subproc}.go), and the watcher does not
+// consult it at all: ShouldSkipPath is a DENYLIST over SkipDirs / SkipExts /
+// SkipBaseGlobs. So #6952 needed no watcher change, and these rows are what
+// makes that a checked fact rather than a claim — they fail the moment anyone
+// adds `conf` to SkipDirs or `.routes` to SkipExts.
+//
+// The `.bak` rows are the deliberate negative control, and they are the reason
+// this test is not vacuous: `.bak` IS on SkipExts, so the watcher already drops
+// exactly the file the classifier also declines to route (conf/routes.bak). A
+// test that only asserted "nothing is skipped" would pass against a SkipExts of
+// any size.
+package watch
+
+import "testing"
+
+func TestRoutesFileEventsSurviveTheWatcherBoundary6952(t *testing.T) {
+	mustWatch := []struct{ path, why string }{
+		{"conf/routes", "the canonical Play/Revel router"},
+		{"modules/admin/conf/routes", "a sub-project's own conf/"},
+		{"src/main/resources/routes", "Play's maven-layout location"},
+		{"conf/admin.routes", "a `-> /admin admin.Routes` sub-router include"},
+		{"documentation/code/scalaguide.http.routing.routes", "a multi-dot include name — SkipBaseGlobs matches ANYWHERE in the basename, so a multi-dot name is exactly the shape those globs can catch by accident"},
+	}
+	for _, tc := range mustWatch {
+		if ShouldSkipPath(tc.path) {
+			t.Errorf("ShouldSkipPath(%q) = true — %s. The classifier routes this file (#6952); "+
+				"dropping it here reproduces #6934: indexed once at walk time, never re-indexed "+
+				"on change", tc.path, tc.why)
+		}
+	}
+
+	// Negative control: the watcher must still drop what it always dropped.
+	for _, p := range []string{"conf/routes.bak", "conf/routes.tmp", "conf/routes.swp"} {
+		if !ShouldSkipPath(p) {
+			t.Errorf("premise: ShouldSkipPath(%q) = false — SkipExts no longer holds this "+
+				"suffix, so the rows above assert nothing", p)
+		}
+	}
+	// And `conf` must not have become a skipped directory basename.
+	if ShouldSkipDir("conf") {
+		t.Error("ShouldSkipDir(\"conf\") = true — every Play routes file lives there")
+	}
+}

--- a/internal/engine/play_graphql_multiline_anchor_6927_test.go
+++ b/internal/engine/play_graphql_multiline_anchor_6927_test.go
@@ -432,40 +432,59 @@ func TestIssue6927_Play_RouteRuleIsNotFrameworkGated(t *testing.T) {
 // Reachability — the finding this arm could not fix
 // ---------------------------------------------------------------------------
 
-// TestIssue6927_Play_ConfRoutesIsNotClassified pins a DEFECT, deliberately, the
-// way #6949's TestIssue6927_Compose_EnvironmentFirstServiceIsMissed does.
+// TestIssue6927_Play_ConfRoutesIsClassified_6952 is the INVERSE of the tripwire
+// this used to be. Until #6952 it was TestIssue6927_Play_ConfRoutesIsNot-
+// Classified, pinning the defect deliberately the way #6949's
+// TestIssue6927_Compose_EnvironmentFirstServiceIsMissed does: `conf/routes`
+// carried no extension and no entry in classifier.go's basename tables, so
+// classifyInner returned Skip{unsupported_extension} and every assertion above
+// described what the rule WOULD do, driven through Detect directly.
 //
-// `conf/routes` carries no extension and no entry in classifier.go's
-// exactBasenameLanguageMap or basenameLanguageMap, so classifyInner returns
-// Skip{unsupported_extension} and the file never reaches the extraction
-// pipeline at all. Every assertion above therefore describes what the rule
-// WOULD do, driven through Detect directly — it is not reached in production
-// today. Same shape as #6946's `.github` finding for the GitHub Actions rules.
+// #6952 added basenameLanguageMap["routes"] and extensionLanguageMap[".routes"],
+// which turned this test red — the point of writing it that way. Its own
+// instruction was to read the two consequences recorded on the Route rule in
+// play_framework.yaml before deleting it, so they are recorded HERE, measured,
+// rather than deleted with it:
 //
-// When this is fixed the test goes red, which is the point: whoever fixes it
-// must read the two consequences recorded in the rule comment — that
-// internal/custom/scala/frameworks.go's rePlayRoute becomes a second producer
-// of the same route, and that the ROUTES_TO edge is what this rule uniquely
-// adds.
-func TestIssue6927_Play_ConfRoutesIsNotClassified(t *testing.T) {
+//  1. A SECOND PRODUCER OF THE SAME ROUTE IS NOW LIVE, and it is no longer a
+//     rounding error. On lichess-org/lila's five real routes files, this rule
+//     mints 833 `Route` entities against internal/custom/scala's 900
+//     `SCOPE.Operation` from the same lines — ~93% overlap, not the ~0.4% that
+//     held before #6953's `(?m)` fix landed (4 vs 900). The custom extractor's
+//     entity carries http_method, http_path and controller; this rule's carries
+//     the path alone.
+//  2. THE `ROUTES_TO` EDGE IS WHAT THIS RULE UNIQUELY ADDS, and on the same
+//     five files 905 of its 907 ROUTES_TO edges have an UNRESOLVED to-side —
+//     dangling `Operation:controllers.X.y` bare names that never bind to the
+//     controller method. So the rule's sole advantage over the custom extractor
+//     is, today, almost entirely unlanded.
+//
+// Both figures are why the ownership merge is filed as #6959 rather than
+// asserted here: this test grades reachability, not the resolution.
+func TestIssue6927_Play_ConfRoutesIsClassified_6952(t *testing.T) {
 	c := classifier.New(nil)
 	for _, p := range []string{"conf/routes", "modules/admin/conf/routes"} {
 		got := c.Classify(context.Background(), p)
-		if !got.Skip {
-			t.Errorf("%s now classifies as %q — the Play routes rules have become REACHABLE. "+
-				"Read the comment on the Route rule in "+
-				"internal/engine/rules/scala/frameworks/play_framework.yaml before deleting "+
-				"this test: a second producer of the same route entity is waiting behind it",
-				p, got.Language)
+		if got.Skip || got.Language != "scala" {
+			t.Errorf("%s classified as {lang=%q skip=%v reason=%s}, want scala/not-skipped — "+
+				"the Play routes rules are UNREACHABLE again, and every assertion above this "+
+				"line describes a rule that production never runs (#6952)",
+				p, got.Language, got.Skip, got.SkipReason)
 		}
 	}
-	// Positive control: the pipeline does classify Play's Scala sources, so the
-	// skip above is a fact about this filename and not about the classifier
-	// being broken or the paths being malformed.
+	// Positive control, carried over unchanged: the pipeline classifies Play's
+	// Scala sources, so the rows above are a fact about the routes filename and
+	// not about the classifier being broken or the paths being malformed.
 	if got := c.Classify(context.Background(), "app/controllers/HomeController.scala"); got.Skip ||
 		got.Language != "scala" {
-		t.Fatalf("a Play controller classified as %+v — the control failed, so the skip "+
-			"assertions above measure nothing", got)
+		t.Fatalf("a Play controller classified as %+v — the control failed, so the assertions "+
+			"above measure nothing", got)
+	}
+	// Negative control: the routes rules must not have become reachable by the
+	// classifier having stopped skipping ANYTHING.
+	if got := c.Classify(context.Background(), "conf/routes.bak"); !got.Skip {
+		t.Errorf("conf/routes.bak classified as %q — the rows above would pass under a "+
+			"classifier that skips nothing, so this is what makes them mean something", got.Language)
 	}
 }
 

--- a/internal/engine/rules/scala/frameworks/play_framework.yaml
+++ b/internal/engine/rules/scala/frameworks/play_framework.yaml
@@ -152,20 +152,32 @@ source_patterns:
   # a later change to the capture is known to be ungraded rather than assumed
   # to be covered by the rows above.
   #
-  # UNREACHABLE IN PRODUCTION TODAY, and this fix does not change that.
-  # `conf/routes` has no extension and no entry in classifier.go's
-  # basenameLanguageMap, so classifyInner returns
-  # Skip{unsupported_extension} and the file never reaches the extraction
-  # pipeline at all — the same shape as #6946's `.github` finding for the
-  # GitHub Actions rules. TestIssue6927_Play_ConfRoutesIsNotClassified pins
-  # that, so the day it is fixed this comment is read rather than trusted.
-  # Two things wait behind it, both recorded on the reachability issue:
-  # internal/custom/scala/frameworks.go already carries its own `rePlayRoute`
-  # (with `(?m)`) emitting a RICHER `SCOPE.Operation` "GET:/path" carrying
-  # method, path and controller, so this rule would become a second producer
-  # of the same fact — the shape #6370 removed the `implements` rule for; and
-  # what this rule adds that the extractor does not is the ROUTES_TO edge
-  # below, which is the reason it is fixed here rather than deleted.
+  # REACHABLE SINCE #6952, which is the day this comment was written to be
+  # read. `conf/routes` had no extension and no entry in classifier.go's
+  # basenameLanguageMap, so classifyInner returned Skip{unsupported_extension}
+  # and the file never reached the extraction pipeline at all — the same shape
+  # as #6946's `.github` finding for the GitHub Actions rules. #6952 added
+  # basenameLanguageMap["routes"] and extensionLanguageMap[".routes"], and
+  # TestIssue6927_Play_ConfRoutesIsClassified_6952 (the inverted tripwire) now
+  # pins the reachability instead.
+  #
+  # BOTH THINGS THAT WERE WAITING BEHIND IT HAVE ARRIVED, measured on
+  # lichess-org/lila's five real routes files:
+  #
+  #   * SECOND PRODUCER. internal/custom/scala/frameworks.go's `rePlayRoute`
+  #     emits a RICHER `SCOPE.Operation` "GET:/path" carrying method, path and
+  #     controller. This rule mints 833 `Route` against its 900 — ~93% overlap,
+  #     the shape #6370 removed the `implements` rule for. Before #6953 gave
+  #     this pattern its `(?m)` the same measurement was 4 vs 900, which is why
+  #     the collision was originally judged negligible; it is not any more.
+  #   * ROUTES_TO IS WHAT THIS RULE UNIQUELY ADDS, and it is largely unlanded:
+  #     905 of the 907 edges emitted from those files have an UNRESOLVED
+  #     to-side (dangling `Operation:controllers.X.y` bare names). The reason
+  #     this rule was fixed rather than deleted is therefore weaker than it
+  #     looked, and is not a reason to keep it as-is.
+  #
+  # The ownership merge — which producer owns the Route entity, and where
+  # ROUTES_TO lives — is #6959. Do not resolve it by widening this rule.
   - pattern: "(?m)^(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\\s+(\\S+)\\s+controllers\\.(\\w+\\.\\w+)"
     entity_type: Route
     name_group: 1

--- a/internal/extractors/routes_incremental_reextract_6952_test.go
+++ b/internal/extractors/routes_incremental_reextract_6952_test.go
@@ -1,0 +1,87 @@
+// Package extractors — routes_incremental_reextract_6952_test.go
+//
+// Issue #6952 routed Play/Revel routes files in internal/classifier. The PR
+// body originally claimed the classifier was consulted at ONE boundary. THAT
+// WAS FALSE, and the review caught it: there is a fourth site, here in
+// incremental.go — `classifier.New(nil)` at the top of Step 6 and
+// `cls.ClassifyWithSize(ctx, rel, …)` in the re-extract loop. It is the UPDATE
+// path: the walker decides what is indexed once, and this decides what is
+// re-indexed every time a watched file changes.
+//
+// internal/daemon/watch/routes_event_parity_6952_test.go proves the change
+// EVENT is not dropped. Nothing proved the RE-EXTRACT lands, and the two are
+// different failures: an event that arrives and then hits a `continue` here is
+// #6934 wearing a different hat — indexed once at walk time, never refreshed.
+//
+// The loop has exactly two ways to drop a changed file, and this test is those
+// two conditions, in order:
+//
+//	cr := cls.ClassifyWithSize(ctx, rel, int64(len(content)))
+//	if cr.Skip || cr.Language == "" { … continue }   // (1)
+//	ext, ok := Get(cr.Language)
+//	if !ok { … continue }                            // (2)
+//
+// (2) is the one the classifier change cannot satisfy on its own and is the
+// reason #6952 routes to "scala" rather than to a routes-specific token: a
+// token with no registry entry passes (1) and dies at (2), silently, with the
+// file's entities already evicted by Step 5.
+//
+// WHAT THIS TEST DOES NOT CLAIM. `incremental.go` never calls
+// RunCustomExtractors — no incremental re-extraction has ever dispatched ANY of
+// the ~340 custom/framework extractors, so the Play routes producer itself does
+// not run on this path. That is pre-existing, universal to every custom
+// extractor, and the same shape as cmd/grafel's default-off
+// GRAFEL_INPROC_CUSTOM_EXTRACTORS gate; it is not something #6952 introduced or
+// can fix from the classifier. What is asserted here is the part #6952 owns:
+// the routes file reaches the re-extract loop's extractor dispatch instead of
+// being dropped by it.
+package extractors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/classifier"
+)
+
+func TestRoutesFilesSurviveTheIncrementalReExtractGates6952(t *testing.T) {
+	cls := classifier.New(nil)
+	ctx := context.Background()
+
+	for _, rel := range []string{
+		"conf/routes",
+		"conf/admin.routes",
+		"main/resources/routes",
+	} {
+		// Gate (1) — incremental.go's classify step. Spelled with
+		// ClassifyWithSize and a real byte count because that is the call the
+		// loop makes; Classify is a different function and #6952's first cut
+		// could have fixed only one of them.
+		cr := cls.ClassifyWithSize(ctx, rel, 512)
+		if cr.Skip || cr.Language == "" {
+			t.Fatalf("incremental gate 1: ClassifyWithSize(%q) = {lang=%q skip=%v reason=%s} — "+
+				"the re-extract loop `continue`s here, so an edit to this file would evict its "+
+				"entities in Step 5 and re-add nothing", rel, cr.Language, cr.Skip, cr.SkipReason)
+		}
+
+		// Gate (2) — the registry lookup. This is what makes "route it to a
+		// language that HAS an extractor" a requirement rather than a
+		// preference.
+		if _, ok := Get(cr.Language); !ok {
+			t.Fatalf("incremental gate 2: Get(%q) = !ok for %q — the classifier names a language "+
+				"no extractor is registered for, so the re-extract loop drops the file after "+
+				"Step 5 has already evicted it", cr.Language, rel)
+		}
+	}
+
+	// Negative control. Without it every assertion above is satisfiable by a
+	// Get() that returns ok for everything and a classifier that never skips.
+	if cr := cls.ClassifyWithSize(ctx, "conf/routes.bak", 512); !cr.Skip {
+		t.Errorf("premise: ClassifyWithSize(conf/routes.bak) = {lang=%q skip=false} — a backup "+
+			"must still be dropped at gate 1, or gate 1 is not gating", cr.Language)
+	}
+	if _, ok := Get("no_such_language_6952"); ok {
+		t.Error("premise: Get(\"no_such_language_6952\") = ok — the registry answers for an " +
+			"unregistered key, so the gate-2 assertions above are vacuous")
+	}
+}

--- a/internal/quality/comment_only_marker_6949_test.go
+++ b/internal/quality/comment_only_marker_6949_test.go
@@ -195,9 +195,21 @@ var commentPrefixes6949 = map[string][]string{
 	".mm": {"//"}, ".f90": {"!"}, ".pas": {"//"}, ".ada": {"--"},
 	".adb": {"--"}, ".ads": {"--"}, ".cob": {"*"}, ".asm": {";"},
 	".ru": {"#"},
+	// Play / Revel routes DSL (#6952). `conf/routes` is extensionless and
+	// `conf/<module>.routes` carries the `.routes` suffix; both comment with
+	// `#`, and a commented-out route is the most ordinary line in one — which
+	// is exactly the hazard this scan exists for. Listed in BOTH tables because
+	// the two spellings are routed by two different classifier entries.
+	".routes": {"#"},
 	// Keyed by basename, for sources with no extension.
 	"gemfile": {"#"}, "rakefile": {"#"}, "makefile": {"#"}, "dockerfile": {"#"},
 	"procfile": {"#"},
+	"routes":   {"#"},
+	// scala-play-mini's negative fixture: a backup of a routes file, byte-for-
+	// byte the same DSL. Keyed by basename rather than by a `.bak` EXTENSION
+	// entry, because `.bak` names no language and a global entry for it would
+	// claim every backup in the corpus comments the same way.
+	"routes.bak": {"#"},
 }
 
 // allowedCommentOnlyMarkers6949 records "<repo-relative path>|<marker>" pairs

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -254,12 +254,12 @@
       "relationship_extracted_total": 63
     },
     "scala-play-mini": {
-      "entity_found": 23,
-      "entity_expected": 23,
+      "entity_found": 29,
+      "entity_expected": 29,
       "relationship_found": 5,
       "relationship_expected": 10,
-      "entity_extracted_total": 81,
-      "relationship_extracted_total": 201
+      "entity_extracted_total": 90,
+      "relationship_extracted_total": 210
     },
     "solidity-mini": {
       "entity_found": 40,

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -254,12 +254,12 @@
       "relationship_extracted_total": 63
     },
     "scala-play-mini": {
-      "entity_found": 29,
-      "entity_expected": 29,
+      "entity_found": 30,
+      "entity_expected": 30,
       "relationship_found": 5,
       "relationship_expected": 10,
-      "entity_extracted_total": 90,
-      "relationship_extracted_total": 210
+      "entity_extracted_total": 97,
+      "relationship_extracted_total": 224
     },
     "solidity-mini": {
       "entity_found": 40,

--- a/internal/quality/golden/scala-play-mini/expected.json
+++ b/internal/quality/golden/scala-play-mini/expected.json
@@ -21,6 +21,16 @@
 
     { "name": "UserService", "kind": "SCOPE.Component", "source_file": "UserService.scala", "must_exist": true, "note": "trait UserService" },
     { "name": "UserServiceImpl", "kind": "SCOPE.Component", "source_file": "UserService.scala", "must_exist": true },
+
+    { "name": "GET:/health", "kind": "SCOPE.Operation", "source_file": "conf/routes", "must_exist": true,
+      "note": "#6952 — conf/routes is EXTENSIONLESS. Until the classifier's `routes` basename entry it was Skip{unsupported_extension}, so internal/custom/scala's rePlayRoute (provenance PLAY_ROUTES_FILE) never saw a single production routes file. These six rows are the reachability grade: they fail if the classifier stops routing the file, and they fail if it routes it to a language whose producers do not read a routes DSL." },
+    { "name": "GET:/users", "kind": "SCOPE.Operation", "source_file": "conf/routes", "must_exist": true },
+    { "name": "GET:/users/{id}", "kind": "SCOPE.Operation", "source_file": "conf/routes", "must_exist": true,
+      "note": "Play's :id colon parameter, canonicalised to {id} by canonicalScalaColonPath." },
+    { "name": "POST:/users", "kind": "SCOPE.Operation", "source_file": "conf/routes", "must_exist": true },
+    { "name": "DELETE:/users/{id}", "kind": "SCOPE.Operation", "source_file": "conf/routes", "must_exist": true },
+    { "name": "GET:/admin/users", "kind": "SCOPE.Operation", "source_file": "conf/admin.routes", "must_exist": true,
+      "note": "Routed by a DIFFERENT rule from the five rows above: `.routes` in extensionLanguageMap, not `routes` in basenameLanguageMap. 60 of the 139 routes files measured across the Play upstreams are this sub-router include form, so deleting either entry alone must fail." },
     { "name": "findAll", "kind": "SCOPE.Operation", "source_file": "UserService.scala", "must_exist": true },
     { "name": "findById", "kind": "SCOPE.Operation", "source_file": "UserService.scala", "must_exist": true },
     { "name": "create", "kind": "SCOPE.Operation", "source_file": "UserService.scala", "must_exist": true },
@@ -62,6 +72,10 @@
     { "from_name": "UserController", "from_kind": "SCOPE.Component", "from_file": "UserController.scala",
       "kind": "CONTAINS", "to_name": "deleteUser", "to_kind": "SCOPE.Operation", "to_file": "UserController.scala",
       "must_exist": true }
+  ],
+  "forbidden_entities": [
+    { "name": "GET:/backup-only", "kind": "SCOPE.Operation", "source_file": "conf/routes.bak",
+      "note": "#6952 — src/conf/routes.bak is a byte-for-byte valid Play routes DSL, so every downstream content sniff accepts it; the only thing keeping it out of the graph is that the classifier routes `routes` and `*.routes` and NOT `routes.<anything>`. internal/custom/java's isPlayRoutesFile DOES accept the `routes.` prefix, so this is a widening a reader would reasonably make: it was measured on exactly one file in the whole corpus (playframework's deliberately-broken routes.bad) and would admit every routes.bak / routes.orig / routes.txt in exchange. FIREABLE: add \"routes.bak\": \"scala\" to basenameLanguageMap, or a `strings.HasPrefix(base, \"routes.\")` arm to detectLanguage, and this row hits." }
   ],
   "forbidden_relationships": []
 }

--- a/internal/quality/golden/scala-play-mini/expected.json
+++ b/internal/quality/golden/scala-play-mini/expected.json
@@ -31,6 +31,8 @@
     { "name": "DELETE:/users/{id}", "kind": "SCOPE.Operation", "source_file": "conf/routes", "must_exist": true },
     { "name": "GET:/admin/users", "kind": "SCOPE.Operation", "source_file": "conf/admin.routes", "must_exist": true,
       "note": "Routed by a DIFFERENT rule from the five rows above: `.routes` in extensionLanguageMap, not `routes` in basenameLanguageMap. 60 of the 139 routes files measured across the Play upstreams are this sub-router include form, so deleting either entry alone must fail." },
+    { "name": "GET:/legacy/health", "kind": "SCOPE.Operation", "source_file": "main/resources/routes", "must_exist": true,
+      "note": "Play's MAVEN-LAYOUT router location — 9 of the 139 measured routes files live at src/main/resources/routes and NONE is under a `conf/` directory. This row is what stops the fixture from being satisfiable by a `conf/` directory anchor: the review's M6' mutant (both entries gated on `conf/`) scored a byte-identical 29/29 against the fixture without it, and died only on the unit test." },
     { "name": "findAll", "kind": "SCOPE.Operation", "source_file": "UserService.scala", "must_exist": true },
     { "name": "findById", "kind": "SCOPE.Operation", "source_file": "UserService.scala", "must_exist": true },
     { "name": "create", "kind": "SCOPE.Operation", "source_file": "UserService.scala", "must_exist": true },

--- a/internal/quality/golden/scala-play-mini/src/conf/admin.routes
+++ b/internal/quality/golden/scala-play-mini/src/conf/admin.routes
@@ -1,0 +1,4 @@
+# Play sub-router include, reached via `-> /admin admin.Routes` in conf/routes.
+# Graded separately from conf/routes because it is routed by a DIFFERENT rule:
+# the `.routes` entry in extensionLanguageMap, not the `routes` basename entry.
+GET     /admin/users                controllers.UserController.listUsers

--- a/internal/quality/golden/scala-play-mini/src/conf/routes
+++ b/internal/quality/golden/scala-play-mini/src/conf/routes
@@ -1,0 +1,12 @@
+# Play routes file (#6952). Extensionless by convention — before the
+# classifier's `routes` basename entry this file was never handed to any
+# extractor, so every producer keyed on it was unreachable in production.
+GET     /health                     controllers.UserController.health
+GET     /users                      controllers.UserController.listUsers
+GET     /users/:id                  controllers.UserController.getUser(id: Int)
+POST    /users                      controllers.UserController.createUser
+DELETE  /users/:id                  controllers.UserController.deleteUser(id: Int)
+
+# Sub-router include — the `conf/<name>.routes` form. 60 of the 139 routes
+# files measured across the Play upstreams use it.
+->      /admin                      admin.Routes

--- a/internal/quality/golden/scala-play-mini/src/conf/routes.bak
+++ b/internal/quality/golden/scala-play-mini/src/conf/routes.bak
@@ -1,0 +1,7 @@
+# An editor/deploy backup of a routes file. Byte-for-byte a valid Play routes
+# DSL, so it clears every content sniff downstream — the ONLY thing keeping it
+# out of the graph is that the classifier does not route `routes.<anything>`.
+# Its route is a forbidden_entities row: widening the rule to a `routes.` PREFIX
+# (which internal/custom/java's isPlayRoutesFile already does) mints a duplicate
+# of every route in conf/routes from a file nobody serves.
+GET     /backup-only                controllers.UserController.health

--- a/internal/quality/golden/scala-play-mini/src/main/resources/routes
+++ b/internal/quality/golden/scala-play-mini/src/main/resources/routes
@@ -1,0 +1,14 @@
+# Play's MAVEN-LAYOUT router location, `src/main/resources/routes`. Play's own
+# sbt-plugin tests use it (basic-service-with-routes-file, http-backend-netty,
+# maven-layout-twirl-reload, java-test-helpers, shutdown-*): 9 of the 139 routes
+# files measured for #6952 live here and NONE of them is under a `conf/`
+# directory. Without this file the fixture cannot distinguish the shipped
+# basename rule from a `conf/` directory anchor — the M6/M6' mutant scored 29/29
+# against the fixture and died only on the unit test.
+#
+# NOTE ON THE PATH. The fixture root IS the indexer's repo root, so this file's
+# repo-relative path is `main/resources/routes`, not `src/main/resources/routes`
+# — golden fixtures put their tree directly under `src/`. The rule under test is
+# the bare basename, which does not read the parent, so the shortened path
+# exercises exactly the same lookup; what matters is that no ancestor is `conf`.
+GET     /legacy/health              controllers.UserController.health


### PR DESCRIPTION
Play's router file carries no extension, so `detectLanguage` returned `""` and both
`classifyInner` and `classifyWithSizeInner` answered `Skip{unsupported_extension}`. Four producers
were keyed on a file that never arrived — the two rules in
`engine/rules/scala/frameworks/play_framework.yaml`, `internal/custom/scala`'s `rePlayRoute`,
`internal/custom/java/play_routes.go` and `internal/custom/golang`'s Revel arm. All four have
passing unit tests, because those tests construct the file record directly.

> **Round 2.** Rebased onto `origin/main` (12 commits, including `59de3205d`, #6953's `(?m)` fix).
> Every figure below is re-derived from a run on the rebased tree, not carried across. The rebase
> changed an argument, not just numbers — see "What the rebase changed".

## Part 1 — the mechanism, read rather than assumed

**There was no missing hook.** `basenameLanguageMap` has routed extensionless well-known files
since `Dockerfile` / `Containerfile` / `Justfile` / `.justfile` / `Caddyfile` / `luarocks.lock`, and
`extensionLanguageMap` routes an unknown-to-the-OS extension like `.routes` exactly as it routes
`.tf`. The bug was **two absent table entries**, not an absent mechanism — so `Dockerfile`,
`Makefile`, `Gemfile`, `Procfile`, `CODEOWNERS` need no new machinery either; they need a measured
entry each. There is nothing here to generalise.

**Basename or path?** Both are expressible — `detectLanguage` receives the full normalised path and
already keys on it in four places (three compound suffixes and the Debezium `dirAnchor`). So the
narrow `conf/routes` anchor was available and was rejected on measurement.

```go
basenameLanguageMap["routes"]   = "scala"   // conf/routes, src/main/resources/routes
extensionLanguageMap[".routes"] = "scala"   // conf/admin.routes sub-router includes
```

## Part 2 — measured

Corpus `~/Projects/archigraph-corpora` (60 repos) plus cloned `playframework/playframework`,
`playframework/play-samples`, `lichess-org/lila`, `revel/examples`. Measured in this branch's own
worktree; the repo root was never walked.

| rule | files | what it misses |
|---|---|---|
| path suffix `conf/routes` | **70** | 9 at `src/main/resources/routes` + 60 `*.routes` includes |
| basename `routes` | **79** | the 60 `*.routes` includes |
| suffix `*.routes` | **60** | — |
| **both entries (this PR)** | **139** | — |

The `conf/` anchor reaches **half** the population, and what it misses is structural, not an
artefact of which repos were cloned: it cannot express `src/main/resources/routes` (Play's
maven-layout / sbt-plugin location) or any `*.routes` include at all.

**Over-fire: ZERO**, and the review widened the population it holds over — the ansible/infra corpus,
every other corpus tree on the machine, `*.route` anywhere, and extensionless files under any
`routes/` directory all measure zero. All 139 are genuine routes DSLs (the four `conf/routes` with
no column-0 verb are Play `->` aggregators, still routers). This repo's own blast radius is **zero
files**: `git ls-files` matches two routes files, both under `testdata/`, dropped by
`universalPathSkip`.

It is a **corpus-relative zero** and is named as one in the code comment. The shape that would break
it — a `files/etc/network/routes` static-route table in an ansible role, a `bin/routes` wrapper —
has no instance here and would be called `"scala"`.

**End to end, lila's five real routes files (923 column-0 verb lines), base vs branch:**

```
  base    0 entities / 0 relationships
  branch  1741 / 2647

  SCOPE.Operation  900   custom/scala, provenance PLAY_ROUTES_FILE
  Route            833   play_framework.yaml
  SCOPE.Component    5   one per-file carrier
  Module/External    3
```

**1738 of 1741 entities come from a routes file**, and every one is a `Route`, a `SCOPE.Operation`
or a carrier. The three that are not are Module/External aggregates. This is not a file-count
artefact: the fixture contains *nothing but* routes files, and the base binary extracts zero.

## What the rebase changed — and it is not just numbers

The first push priced #6959's duplicate-producer collision at "~0.4%, 4 `Route` vs 900, and 0
`ROUTES_TO` edges", and deferred it on that basis. `59de3205d` gives `play_framework.yaml` its
`(?m)`, and it is on `origin/main`. On the merge target:

- **833 `Route` against 900 `SCOPE.Operation` — ~93% duplication, not ~0.4%.**
- `ROUTES_TO` now fires: **907 edges, of which 905 have an unresolved to-side** (dangling
  `Operation:controllers.X.y` bare names that never bind, even in `scala-play-mini` where the
  target `SCOPE.Operation` exists in the same fixture).

So the rule pack's sole advantage over the custom extractor — the edge — is today almost entirely
unlanded, while its entity is a near-complete duplicate. **#6959 has been re-priced against these
numbers rather than left standing on the void ones**, and the same two figures are now recorded on
the rule itself in `play_framework.yaml` and on the inverted tripwire.

## Part 3 — why `"scala"`, and what that does and does not scope

All three custom producers hard-gate on their own base language
(`file.Language != "scala"`, `ctx.Language != "java"`, `language != "go"`). One file has one
language token, so **no single token reaches more than one of them**, and a routes-specific token
reaches **none**. `"scala"` is chosen because it is the only one whose producer already
content-sniffs what it is handed (`detectScalaFramework` answers `"play"` on a column-0 verb line).

**Those gates scope cross-language leakage only.** Same-language they do nothing:
`file.Language == "scala"` is now true for every routes file, so **all of `internal/custom/scala`'s
gated passes receive routes DSL as input** — anorm looking for SQL, caliban for GraphQL, akka for
actors, di for injection. The lila run is the evidence they produce nothing on it (1738/1741 from
routes files, zero spurious kinds), and that is now stated in the code so the next person adding a
Scala pass knows routes files are in its input.

**The cost of a wrong guess is small but not zero**, also now stated: `detectScalaFramework`'s
default arm returns `"scala"` rather than nothing, so a misclassified file still mints a
`SCOPE.Component` carrier and its `CONTAINS`, and `reGenericAuth` can mint a `SCOPE.Security`
`auth_check` from the word `Authorization`. "Yields no route entities rather than wrong ones" is
true about *routes*, not about entities.

Java and Revel producers stay unreachable → **#6957**.

## Grading — both directions

`internal/classifier/conf_routes_6952_test.go`

- **Reachability**: 7 paths must classify `scala` through **both** `Classify` and
  `ClassifyWithSize`. Carries the issue's `.scala` positive control.
- **Over-fire, basename half**: 8 rows that must keep their extension's language (every one an
  actual corpus path), 9 that must stay unclassified, 3 proving `universalPathSkip` still wins.
- **Over-fire, extension half** *(new in round 2 — this direction had zero rows and N1 was alive)*:
  `.route` singular, `.routez`, `.routes.bak`, `.routes~`.
- **`routes/` as a directory** *(new in round 2 — N2 proved the two rows advertised for this could
  not fire, since they carry extensions and extension lookup answers first)*: three EXTENSIONLESS
  files under a `routes/` directory. Synthetic by necessity — the corpus has six `routes`
  directories and zero extensionless files in any of them.
- The case asymmetry is pinned in both directions; the two halves genuinely differ.
- A row that was **tried and rejected** is recorded rather than omitted: bare `routes/` with a
  trailing slash classifies (`path.Base` strips it), but the classifier is only ever handed file
  paths, so a row for it would assert a contract that does not exist.

`internal/quality/golden/scala-play-mini/` — four files under `src/`: `conf/routes`,
`conf/admin.routes` (the *other* rule), **`main/resources/routes`** *(new in round 2 — the
maven-layout shape, 9 of the 139)*, and `conf/routes.bak` as the forbidden row. Base binary scores
**23/30**; branch **30/30**.

`internal/extractors/routes_incremental_reextract_6952_test.go` *(new in round 2)* — see below.

`internal/daemon/watch/routes_event_parity_6952_test.go` — the change event is not dropped; `.bak` /
`.tmp` / `.swp` are the negative control and `.bak` genuinely is on `SkipExts`.

## Corrected claim: FOUR consumers, not one

The first push said the classifier is consulted at one boundary. **That was false.** The consumers
are `cmd/grafel/index.go:3973`, `daemon/extract/coordinator.go:662`, `daemon/extract/subproc.go:105`
and **`internal/extractors/incremental.go:885/1002`** — the fourth being the UPDATE path, which is
exactly where the #6934 class lives. All four call the same classifier, so none can disagree, but
the enumeration was wrong and the watcher test only graded the *event*.

The re-extract is now graded too, on both conditions that can drop a changed routes file: the
classify step (`cr.Skip || cr.Language == ""`) and the registry lookup (`Get(cr.Language)`). The
second is why `"scala"` rather than a routes-specific token is a requirement and not a preference —
an unregistered token passes gate 1 and dies at gate 2, silently, after Step 5 has already evicted
the file's entities.

Stated and not claimed: `incremental.go` never calls `RunCustomExtractors`, so **no** incremental
re-extraction dispatches **any** of the ~340 custom extractors. That is pre-existing, universal, and
the same shape as the default-off `GRAFEL_INPROC_CUSTOM_EXTRACTORS` gate — not something #6952
introduced or can fix from the classifier.

## Rebase fallout, fixed rather than worked around

- **`TestIssue6927_Play_ConfRoutesIsNotClassified`** is a tripwire that pins the defect and goes red
  on the fix *by design*, instructing whoever fixes it to read the two consequences on the Route
  rule. Inverted to `..._IsClassified_6952`, carrying both consequences with the post-rebase
  numbers, plus a `routes.bak` negative control so the new rows are not satisfiable by a classifier
  that skips nothing. The rule's own comment is updated the same way.
- **`TestGoldenFixtureMarkersAreNotCommentOnly_6949`** fails when a fixture file has an extension its
  comment-prefix map does not know — a false-negative guard working exactly as designed. Three
  entries added (`.routes`, `routes`, `routes.bak`, all `#`). `routes.bak` is keyed by basename
  rather than adding a global `.bak` extension entry, which would claim every backup in the corpus.

## Mutants

Every edit's occurrence count asserted before writing and the replacement asserted after; green
baseline verified immediately before each score; `cp`-restore from a shasum-verified backup with
`shasum -c` after each.

| # | Mutant | Result |
|---|---|---|
| M1 | delete `basenameLanguageMap["routes"]` | DEAD — unit + fixture |
| M2 | delete `extensionLanguageMap[".routes"]` | DEAD — unit + fixture |
| M3 | widen to a `routes.` **prefix** (`isPlayRoutesFile`'s spelling) | DEAD — unit **and forbidden entity hits: 1**, the demonstration that the fixture's forbidden row is fireable |
| M4 | case-INsensitive basename lookup | DEAD |
| M5 | route both entries to `"yaml"` — classified as something nothing consumes | DEAD — unit + fixture drops to the base binary's score |
| M6 | replace both with the `conf/` path anchor | DEAD |
| **N1** | add `".route": "scala"` (singular) — **ALIVE at review**, the `.routes` half had zero forbidden rows | **re-scored DEAD** |
| **N2** | `strings.Contains(norm, "/routes/")` at the natural edit site — **ALIVE at review**; the two rows advertised for it could not fire | **re-scored DEAD** (3 rows) |
| **N3** | swap the extension/basename lookup order | **Equivalent under the current tables — recorded, not fixed.** The consequence is that the "extension consulted first" rationale is *inert*; the comment now says what actually holds: `basenameLanguageMap` is keyed on the FULL basename, so `routes.rb` is simply not the string `routes`. |
| **M6′** | the `conf/` **directory** anchor — scored **fixture-blind at 29/29** in review | **now DEAD by the fixture too (29/30, extracted 94)**, because `main/resources/routes` was added |

## Ratchet

`scala-play-mini` re-baselined **from a run on the rebased tree**, not carried across the rebase:

```
  entity_found                 29 -> 30   the maven-layout route
  entity_expected              29 -> 30
  entity_extracted_total       90 -> 97   +5 Route (the rule pack, now (?m)-enabled)
                                          +1 SCOPE.Operation + 1 carrier (main/resources/routes)
  relationship_extracted_total 210 -> 224 +7 ROUTES_TO (all unresolved), +7 CONTAINS
  relationship_found / expected  5 / 10, unchanged
```

Base binary on this fixture: **23/30 (76.7%), 81, 201**. Diffed entity-by-entity: 16 added, **0
removed, 0 re-kinded, 0 renamed**.

`bash scripts/quality/run.sh --ratchet` → exit 0, *"37 gated fixtures held their baseline (28 at
100% must-have recall)"*.

**The ratchet is not blind to this change** — the fixture is in the PR. **The `cmd/grafel` digest pin
still is**: `selftestdata/fixture/` is `main.go` + `util.py`, so `./cmd/grafel` passing unchanged is
a fact about the pin, not evidence about this change.

## Verification

`go test -count=1` exit 0 on `internal/classifier`, `internal/custom/scala`, `internal/quality`,
`internal/extractors`, `internal/engine`, `internal/daemon/watch` and `./cmd/grafel` (147s).
`gofmt -l` clean, `go vet ./internal/... ./cmd/...` clean.

Two `internal/daemon/watch` inotify-accounting tests
(`TestEventReleaseIsDeductedFromTheOwningRepo`, `TestInterleavedDirectoryFillsAcrossReposAreNot-
DoubleCharged`) failed once under load and passed on a clean re-run of the full package; they
concern watch-descriptor budgeting and touch no classification path. Reported rather than hidden.

Closes #6952
Refs #6927, #6934, #6946, #6949, #6951, #6953, #6957, #6959

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
