### PR TITLE
fix(#6940): the polling change-detector never converged on a path git reports and the walker refuses — observe the manifest's verdict instead of re-deriving four gates

### DIFF
--- a/internal/daemon/watch/change_poller.go
+++ b/internal/daemon/watch/change_poller.go
@@ -447,13 +447,21 @@ func (p *ChangePoller) pollRepo(abs string) (changedOut, discoveredOut []string)
 	return changed, discovered
 }
 
-// maxDeclinedPaths caps the per-repo decline set. The set is bounded in
-// practice by what `git status -unormal` reports as FILES (an untracked subtree
-// arrives as one collapsed `dir/` line), but a cap keeps a pathological repo
-// from turning a convergence fix into unbounded daemon memory. Past the cap the
-// poller stops recording and reverts to the pre-#6940 behaviour for the
-// overflow — it OVER-fires rather than dropping a path, which is the direction
-// this file chooses everywhere else.
+// maxDeclinedPaths caps BOTH per-repo maps a decline passes through — pending
+// and refused. Both sets are bounded in practice by what `git status -unormal`
+// reports as FILES (an untracked subtree arrives as one collapsed `dir/` line),
+// but a cap keeps a pathological repo from turning a convergence fix into
+// unbounded daemon memory.
+//
+// pending is capped for a specific reason (#6961 review): it drains ONLY on a
+// completed index pass, so it is exactly the debounced / circuit-broken repo —
+// the scenario condition (2) is built around — where it would otherwise grow
+// without limit while nothing ever removed an entry.
+//
+// Past the cap the poller stops recording and reverts to the pre-#6940
+// behaviour for the overflow — it OVER-fires rather than dropping a path, which
+// is the direction this file chooses everywhere else. That direction is
+// asserted, not asserted-about: see TestDeclineTracker_CapOverflowOverFires.
 const maxDeclinedPaths = 4096
 
 // declineTracker is the #6940 convergence state for one repo.
@@ -519,6 +527,9 @@ func (t *declineTracker) noteSubmitted(discovered []string, at time.Time) {
 		if _, ok := t.pending[rel]; ok {
 			continue // keep the FIRST submission time
 		}
+		if len(t.pending) >= maxDeclinedPaths {
+			continue // overflow: this path keeps re-reporting, as it did before #6940
+		}
 		t.pending[rel] = at
 	}
 }
@@ -532,9 +543,25 @@ func (t *declineTracker) reconcile(m *diff.Manifest, logger *slog.Logger, abs st
 
 	// Forgiveness FIRST. A refusal is an observation about one past index
 	// pass, not a permanent verdict: once the manifest holds the path the
-	// indexer has plainly changed its mind (the .gitignore rule was dropped,
-	// the sparse cone widened, the extension list grew), and half 1 sweeps it
-	// from here on anyway.
+	// indexer has plainly changed its mind, and half 1 sweeps it from here on
+	// anyway.
+	//
+	// Only ONE of the ways the indexer can change its mind SELF-TRIGGERS, and
+	// it is the one driven end to end by
+	// TestChangePoller_DeclineIsForgivenWhenTheIndexerChangesItsMind: dropping
+	// a .gitignore rule, because the .gitignore is itself a manifest key, so
+	// half 1 reports the edit and the reindex it asks for re-walks the repo.
+	// The other two do NOT (#6961 review):
+	//
+	//   - Widening a sparse cone edits .git/info/sparse-checkout, which is no
+	//     manifest key, and the newly included path is suppressed — so it
+	//     cannot request the pass that would forgive it. It stays invisible
+	//     until an unrelated change triggers a stamping pass, or the daemon
+	//     restarts. That is bounded and self-healing, but it IS a behaviour
+	//     change against pre-#6940, where the next cycle picked it up.
+	//   - Growing the indexed-extension list means upgrading grafel, which
+	//     restarts the daemon — and nothing here is persisted, so the whole
+	//     decline set is gone. That one heals by construction.
 	//
 	// The order is deliberate and it is what makes the two "is it stamped?"
 	// tests in this function INDEPENDENTLY graded. Promote-then-forgive would

--- a/internal/daemon/watch/change_poller.go
+++ b/internal/daemon/watch/change_poller.go
@@ -65,6 +65,22 @@
 // bounded number of cycles, not first-cycle detection, because first-cycle
 // detection is exactly what hid the bug.
 //
+// CONVERGENCE ON A PATH THE WALKER REFUSES (#6940). WalkRepo's file branch has
+// FOUR gates — extension filter, entry-type gate, file-level ignore layer,
+// sparse filter — and a single path is not enough to evaluate two of them (the
+// ignore layer needs the stack the walk accumulates while descending; sparse
+// needs opts.Sparse). So the poller cannot ask "would the indexer stamp this?"
+// by re-deriving the gates, and the first version of this file looped forever
+// on an untracked `photo.png` or a tracked-but-gitignored `gen.go`.
+//
+// It does not have to ask. The MANIFEST already answers it, after the fact: a
+// path grafel reported, that an index pass has since completed WITHOUT
+// stamping, is by definition a path the indexer declined — whichever gate did
+// it, including gates that do not exist yet. See declineTracker: no gate is
+// duplicated, so there is no second copy of any predicate to drift out of
+// agreement with the walker (the mistake #6940 lists as option 4, and the one
+// MA-1 already made once).
+//
 // WARM-UP (arm D of #6932). A fresh worktree's first `git status` costs
 // 2.4-9.0 s until git's untracked cache exists; every subsequent one is ~60 ms.
 // AddRepo therefore sets core.untrackedCache=true and runs one throwaway
@@ -148,6 +164,10 @@ type ChangePoller struct {
 
 	mu    sync.Mutex
 	repos map[string]struct{}
+	// declines holds one declineTracker per repo — the #6940 convergence
+	// state. It is keyed by the same absolute path as repos and dropped by
+	// RemoveRepo.
+	declines map[string]*declineTracker
 
 	cycles  uint64 // atomic — completed poll cycles
 	submits uint64 // atomic — sink invocations
@@ -176,6 +196,7 @@ func NewChangePoller(cfg ChangePollerConfig, sink EventSink, logger *slog.Logger
 		sink:          sink,
 		logger:        logger,
 		repos:         make(map[string]struct{}),
+		declines:      make(map[string]*declineTracker),
 		stopCh:        make(chan struct{}),
 		doneCh:        make(chan struct{}),
 	}
@@ -226,6 +247,7 @@ func (p *ChangePoller) RemoveRepo(repoPath string) {
 	}
 	p.mu.Lock()
 	delete(p.repos, abs)
+	delete(p.declines, abs)
 	p.mu.Unlock()
 }
 
@@ -297,7 +319,7 @@ func (p *ChangePoller) PollOnce() map[string][]string {
 
 	out := make(map[string][]string, len(repos))
 	for _, abs := range repos {
-		changed := p.pollRepo(abs)
+		changed, discovered := p.pollRepo(abs)
 		if len(changed) == 0 {
 			continue
 		}
@@ -307,6 +329,13 @@ func (p *ChangePoller) PollOnce() map[string][]string {
 		p.logger.Info("change-poller: changes detected — enqueuing reindex",
 			"repo", abs, "changed", len(changed), "bulk", bulk)
 		p.sink(abs, bulk)
+		// Only paths we ACTUALLY asked for a reindex of become pending, and
+		// only after the request went out: "the indexer declined it" is a
+		// claim about a pass that had the chance to stamp it. Recording
+		// pending on a cycle that submitted nothing would let an unrelated
+		// index pass decline a path grafel never asked about — the mirror
+		// defect (#6902), a change silently missed instead of over-reported.
+		p.trackerFor(abs).noteSubmitted(discovered, time.Now().UTC())
 	}
 	return out
 }
@@ -314,13 +343,17 @@ func (p *ChangePoller) PollOnce() map[string][]string {
 // pollRepo computes the changed set for one repo. Both halves of hybrid B live
 // here: git for DISCOVERY of paths the manifest has never heard of, and the
 // manifest's own key set for the CHANGE DECISION.
-func (p *ChangePoller) pollRepo(abs string) []string {
+//
+// It also returns the DISCOVERED paths — the candidates that are not manifest
+// keys. PollOnce hands those to the decline tracker once it has actually
+// submitted them (#6940).
+func (p *ChangePoller) pollRepo(abs string) (changedOut, discoveredOut []string) {
 	if p.stateDir == nil {
-		return nil
+		return nil, nil
 	}
 	stateDir := p.stateDir(abs)
 	if stateDir == "" {
-		return nil
+		return nil, nil
 	}
 	m := diff.LoadManifest(stateDir)
 	if len(m.Files) == 0 {
@@ -328,8 +361,15 @@ func (p *ChangePoller) pollRepo(abs string) []string {
 		// unreadable). Every file would read as new and the poller would ask
 		// for a reindex on every cycle forever. Initial indexing belongs to the
 		// scheduler, not here.
-		return nil
+		return nil, nil
 	}
+
+	// #6940: reconcile the decline tracker against the manifest we just read,
+	// BEFORE the candidate set is built. This is where "reported, and an index
+	// pass has since declined to stamp it" is decided, and where a path the
+	// indexer has since changed its mind about is let back in.
+	tr := p.trackerFor(abs)
+	tr.reconcile(m, p.logger, abs)
 
 	cand := make(map[string]struct{}, len(m.Files)+16)
 	// Half 1 — the manifest's key set. This is what converges edit-then-revert
@@ -358,14 +398,40 @@ func (p *ChangePoller) pollRepo(abs string) []string {
 	if !ok {
 		p.logger.Warn("change-poller: git status failed — sweeping the manifest key set only", "repo", abs)
 	}
+	//
+	// A path the tracker has recorded as DECLINED is not taken either: an
+	// index pass has already had it in front of it and did not stamp it, so
+	// it can only read as new for as long as the poller keeps offering it.
+	// That is #6940, and it is the same non-convergence as the deletion case
+	// entering through a different gate.
+	var discovered []string
 	for _, f := range files {
-		if _, known := cand[f]; known || existsOnDisk(abs, f) {
+		if _, known := cand[f]; known {
+			continue
+		}
+		if tr.declined(f) {
+			continue
+		}
+		if existsOnDisk(abs, f) {
 			cand[f] = struct{}{}
+			discovered = append(discovered, f)
 		}
 	}
 	for _, d := range dirs {
 		for _, rel := range walkUntrackedSubtree(abs, d) {
+			if _, known := cand[rel]; known {
+				continue
+			}
+			// The subtree walk applies the gates it can see, but it is rooted
+			// BELOW the repo root, so it does not inherit the root ignore
+			// stack and knows nothing of sparse state — it can hand back a
+			// path the real, root-rooted index walk then refuses. Same
+			// tracker, same reason.
+			if tr.declined(rel) {
+				continue
+			}
 			cand[rel] = struct{}{}
+			discovered = append(discovered, rel)
 		}
 	}
 
@@ -377,7 +443,141 @@ func (p *ChangePoller) pollRepo(abs string) []string {
 
 	changed, _ := diff.Filter(abs, rels, m)
 	sort.Strings(changed)
-	return changed
+	sort.Strings(discovered)
+	return changed, discovered
+}
+
+// maxDeclinedPaths caps the per-repo decline set. The set is bounded in
+// practice by what `git status -unormal` reports as FILES (an untracked subtree
+// arrives as one collapsed `dir/` line), but a cap keeps a pathological repo
+// from turning a convergence fix into unbounded daemon memory. Past the cap the
+// poller stops recording and reverts to the pre-#6940 behaviour for the
+// overflow — it OVER-fires rather than dropping a path, which is the direction
+// this file chooses everywhere else.
+const maxDeclinedPaths = 4096
+
+// declineTracker is the #6940 convergence state for one repo.
+//
+// WHAT IT KNOWS, and why it needs no gate of its own. WalkRepo's four file
+// gates cannot be evaluated from a single path (the ignore layer needs the
+// stack the walk builds while descending; sparse needs opts.Sparse). But the
+// poller does not need to PREDICT the verdict — it can observe it. A path is
+// declined when all three hold:
+//
+//  1. the poller discovered it and SUBMITTED a reindex request naming it,
+//  2. an index pass has since completed — m.IndexedAt is stamped by every
+//     SaveManifestAtCommit, whether or not the file set changed, so it is
+//     proof a pass ran and not merely that something changed, and
+//  3. the manifest still does not hold the path.
+//
+// That is exactly "reported, offered to the indexer, and not stamped", and it
+// is gate-agnostic: it converges the extension filter, the ignore layer, the
+// sparse filter and any gate added later, with no predicate duplicated.
+//
+// IT IS REVERSIBLE, which is the half that keeps blocker 1's mirror closed. A
+// decline is dropped the moment the manifest holds the path — un-ignore a
+// gitignored file and the .gitignore edit is itself a manifest key, so the
+// poller reports it, the reindex re-walks the repo, the file is stamped, and
+// the next cycle lets it back in as an ordinary manifest key. Nothing here is
+// persisted: a daemon restart re-learns each decline at the cost of one cycle.
+type declineTracker struct {
+	mu sync.Mutex
+	// pending maps a submitted-but-unstamped path to the time of the FIRST
+	// submission naming it. Earliest wins, so a path re-offered every cycle
+	// still converges rather than sliding its own deadline forward.
+	pending map[string]time.Time
+	// refused holds paths condition (1)-(3) have been met for.
+	refused map[string]struct{}
+	// capWarned suppresses repeated overflow warnings for one repo.
+	capWarned bool
+}
+
+// trackerFor returns the decline tracker for abs, creating it on first use.
+func (p *ChangePoller) trackerFor(abs string) *declineTracker {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	tr, ok := p.declines[abs]
+	if !ok {
+		tr = &declineTracker{
+			pending: make(map[string]time.Time),
+			refused: make(map[string]struct{}),
+		}
+		p.declines[abs] = tr
+	}
+	return tr
+}
+
+// noteSubmitted records that the poller asked for a reindex naming these
+// discovered paths at time at.
+func (t *declineTracker) noteSubmitted(discovered []string, at time.Time) {
+	if len(discovered) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, rel := range discovered {
+		if _, ok := t.pending[rel]; ok {
+			continue // keep the FIRST submission time
+		}
+		t.pending[rel] = at
+	}
+}
+
+// reconcile applies the manifest just read to the tracker: promote pending
+// paths an index pass has since declined, and forgive any refusal the manifest
+// now contradicts.
+func (t *declineTracker) reconcile(m *diff.Manifest, logger *slog.Logger, abs string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Forgiveness FIRST. A refusal is an observation about one past index
+	// pass, not a permanent verdict: once the manifest holds the path the
+	// indexer has plainly changed its mind (the .gitignore rule was dropped,
+	// the sparse cone widened, the extension list grew), and half 1 sweeps it
+	// from here on anyway.
+	//
+	// The order is deliberate and it is what makes the two "is it stamped?"
+	// tests in this function INDEPENDENTLY graded. Promote-then-forgive would
+	// let the promotion loop refuse a freshly stamped path and have this loop
+	// erase the evidence in the same call — two guards that only ever fail
+	// together, so neither is graded (#6902). Forgive-then-promote means a
+	// promotion that ignores the manifest leaves a stamped path REFUSED, which
+	// TestChangePoller_NewIndexableFileIsNeverDeclined can see.
+	for rel := range t.refused {
+		if _, stamped := m.Files[rel]; stamped {
+			delete(t.refused, rel)
+		}
+	}
+
+	for rel, submittedAt := range t.pending {
+		if _, stamped := m.Files[rel]; stamped {
+			delete(t.pending, rel) // the indexer took it; nothing to decline
+			continue
+		}
+		if !m.IndexedAt.After(submittedAt) {
+			continue // no pass has completed since we asked
+		}
+		delete(t.pending, rel)
+		if len(t.refused) >= maxDeclinedPaths {
+			if !t.capWarned {
+				t.capWarned = true
+				logger.Warn("change-poller: decline set full — further refused paths will keep re-reporting",
+					"repo", abs, "cap", maxDeclinedPaths)
+			}
+			continue
+		}
+		t.refused[rel] = struct{}{}
+		logger.Debug("change-poller: path reported but never stamped — the indexer declines it",
+			"repo", abs, "path", rel)
+	}
+}
+
+// declined reports whether rel is currently a known refusal.
+func (t *declineTracker) declined(rel string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_, ok := t.refused[rel]
+	return ok
 }
 
 // existsOnDisk reports whether rel names an entry inside repoRoot that passes
@@ -400,12 +600,15 @@ func (p *ChangePoller) pollRepo(abs string) []string {
 // promise: WalkRepo applies three further gates the predicate cannot see — the
 // indexed-extension filter, the file-level ignore layer (#6931/#6933), and the
 // sparse-checkout filter. A git-reported path that clears the entry-type gate
-// and is then refused by one of those three still enters the candidate set and
-// still cannot converge. An untracked `photo.png` is the driven example; a
-// tracked-but-gitignored file is the second, widened by #6933. That residual is
-// filed as #6940 and deliberately NOT fixed here —
-// closing it means teaching the poller the walk's inherited ignore stack and
-// sparse state, which is a different change with a different cost.
+// and is then refused by one of those three still ENTERS the candidate set: an
+// untracked `photo.png` is the driven example, a tracked-but-gitignored file
+// the second (widened by #6933).
+//
+// Entering the candidate set is no longer the same thing as never converging.
+// #6940 is closed one level up, by declineTracker, which does not reproduce the
+// three gates at all — it observes that an index pass was offered the path and
+// did not stamp it. This predicate therefore stays exactly what it is: the
+// entry-type axis, in both directions, and no promise beyond it.
 //
 // The delegation is what keeps the one axis it DOES decide from drifting: the
 // poller's entry-type test IS the walker's, and TestExistsOnDisk_AgreesWithWalker

--- a/internal/daemon/watch/change_poller.go
+++ b/internal/daemon/watch/change_poller.go
@@ -525,7 +525,20 @@ func (t *declineTracker) noteSubmitted(discovered []string, at time.Time) {
 	defer t.mu.Unlock()
 	for _, rel := range discovered {
 		if _, ok := t.pending[rel]; ok {
-			continue // keep the FIRST submission time
+			// Keep the FIRST submission time. A path re-offered on every
+			// cycle must not slide its own deadline forward, or condition (2)
+			// could never be met while the poller kept reporting it.
+			//
+			// It is SAFE to keep the first only because of the call ordering:
+			// pollRepo reconciles against the manifest BEFORE the caller
+			// submits, so at most one noteSubmitted lands between any two
+			// reconciles and a stale-but-earlier stamp cannot outlive the pass
+			// that answers it. That ordering is a dependency of this line, not
+			// an incidental fact — MP-2 of the #6961 review is the mutant that
+			// overwrites instead, and
+			// TestDeclineTracker_KeepsTheFirstSubmissionTime is what fails
+			// when it does.
+			continue
 		}
 		if len(t.pending) >= maxDeclinedPaths {
 			continue // overflow: this path keeps re-reporting, as it did before #6940

--- a/internal/daemon/watch/poll_convergence_6940_test.go
+++ b/internal/daemon/watch/poll_convergence_6940_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -202,7 +203,11 @@ func TestChangePoller_SparseFilteredPathConverges(t *testing.T) {
 	cpGitRun(t, repo, "config", "--local", "core.sparseCheckout", "true")
 	cpGitRun(t, repo, "config", "--local", "core.sparseCheckoutCone", "true")
 	if si := gitmeta.ProbeRepo(repo); !si.IsSparse {
-		t.Skip("fixture did not become sparse; the sparse gate is unreachable here")
+		// NOT a skip (#6961 review): the two config lines above make this
+		// outcome deterministic, and CI runs without -v, so a skip here would
+		// delete the only sparse leg in silence — removing just those two
+		// lines turned the whole test into "SKIP ... PASS, exit 0".
+		t.Fatal("the probe does not see the sparse checkout this fixture just created — the sparse gate is UNTESTED, not unreachable")
 	}
 
 	cpWriteFile(t, repo, "outside/gen.go", "package outside\n")
@@ -474,5 +479,185 @@ func TestDeclineTracker_EqualTimestampIsNotProofOfACompletedPass(t *testing.T) {
 	}, logger, "/repo")
 	if !tr.declined("photo.png") {
 		t.Fatal("a manifest stamped strictly AFTER the submission did not decline the unstamped path — the equality assertion above is vacuous")
+	}
+}
+
+// --- condition (1): only DISCOVERED paths, only after the request went out ---
+
+// M1b, from the #6961 review. The tracker must record only paths that arrived
+// through DISCOVERY, never a manifest key that half 1 swept. Recording manifest
+// keys is a silent missed change, and it is reachable in three ordinary steps:
+//
+//  1. delete a manifest key — the poller reports it (correctly),
+//  2. the pass prunes it and advances IndexedAt, so under the mutant the path
+//     is now refused,
+//  3. RECREATE it. It is no longer a manifest key, so it can only arrive
+//     through discovery — and discovery skips refused paths. The recreated
+//     file is then never indexed until some unrelated change triggers a
+//     stamping pass, or the daemon restarts.
+//
+// The shipped code is right because `discovered` excludes anything already in
+// `cand`; this is what fails when that stops being true.
+func TestChangePoller_RecreatedManifestKeyIsNeverRefused(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+
+	if err := os.Remove(filepath.Join(repo, "alpha.go")); err != nil {
+		t.Fatal(err)
+	}
+	if got := cpCycle(t, p, repo); !cpContains(got, "alpha.go") {
+		t.Fatalf("the deletion of a manifest key was not reported: %v", got)
+	}
+	cpIndexPass(t, repo, state)
+	if keys := cpManifestKeys(t, state); cpContains(keys, "alpha.go") {
+		t.Fatalf("fixture premise broken: the pass did not prune the deleted key: %v", keys)
+	}
+	if n := cpConverges(t, p, repo, 6); n != 0 {
+		t.Fatalf("the pruned deletion still reported for %d cycles", n)
+	}
+	// Nothing about a deletion is a REFUSAL: the indexer did not decline the
+	// path, it agreed the path is gone.
+	if n := cpDeclineCount(t, p, repo); n != 0 {
+		t.Fatalf("a swept manifest key was recorded as declined (%d entries) — its recreation would be invisible", n)
+	}
+
+	cpWriteFile(t, repo, "alpha.go", "package a\n\nfunc Alpha() { _ = 7 }\n")
+	if got := cpCycle(t, p, repo); !cpContains(got, "alpha.go") {
+		t.Fatalf("the RECREATED file was never reported (%v) — it would stay unindexed until an unrelated change or a daemon restart", got)
+	}
+}
+
+// M7, from the same review: pending is recorded only AFTER the sink call, so a
+// cycle that submits nothing records nothing.
+//
+// The guard is currently UNREACHABLE, and this test says why by pinning the
+// premise rather than asserting the guard directly: every discovered path is by
+// construction absent from the manifest, and diff.isChanged returns true
+// unconditionally for a path the manifest lacks (diff.go, "new file"), so
+// discovered is always a SUBSET of changed and a cycle with a non-empty
+// discovered set always submits. If that ever stops holding — a Filter that can
+// drop a discovered path — this assertion fails first, and that is exactly the
+// moment the guard starts carrying weight.
+func TestChangePoller_EveryDiscoveredPathIsSubmitted(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, submits := cpNewTestPoller(t, repo, state)
+
+	// A quiescent cycle submits nothing and must record nothing.
+	if got := cpCycle(t, p, repo); len(got) != 0 {
+		t.Fatalf("fixture premise broken: the repo is not quiescent: %v", got)
+	}
+	abs, err := filepath.Abs(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := p.trackerFor(abs)
+	tr.mu.Lock()
+	pend := len(tr.pending)
+	tr.mu.Unlock()
+	if pend != 0 {
+		t.Fatalf("a cycle that submitted nothing recorded %d pending path(s)", pend)
+	}
+	if len(*submits) != 0 {
+		t.Fatalf("a quiescent cycle submitted %d reindex requests", len(*submits))
+	}
+
+	// The premise: discovered is a subset of changed, so "discovered but not
+	// submitted" cannot arise. Driven with both discovery shapes at once — an
+	// untracked file and an untracked subtree — plus a modified manifest key.
+	cpWriteFile(t, repo, "new.go", "package a\n\nfunc New() {}\n")
+	cpWriteFile(t, repo, "sub/deep.go", "package sub\n")
+	cpWriteFile(t, repo, "beta.go", "package a\n\nfunc Beta() { _ = 1 }\n")
+	changed, discovered := p.pollRepo(abs)
+	if len(discovered) == 0 {
+		t.Fatal("fixture premise broken: nothing was discovered, so the subset claim is vacuous")
+	}
+	for _, d := range discovered {
+		if !cpContains(changed, d) {
+			t.Fatalf("discovered path %q is NOT in the changed set %v — a cycle can now discover a path it does not submit, and the pending guard is load-bearing", d, changed)
+		}
+	}
+}
+
+// The cap's DIRECTION is the claim: past it the poller over-fires rather than
+// dropping a path. Both maps are capped, and both caps are asserted here —
+// pending because it drains only on a completed pass, refused because it is
+// what suppresses reporting. Driven against the tracker directly: 4096 is far
+// too many paths to route through a git fixture.
+func TestDeclineTracker_CapOverflowOverFires(t *testing.T) {
+	tr := &declineTracker{
+		pending: make(map[string]time.Time),
+		refused: make(map[string]struct{}),
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	at := time.Now().UTC()
+
+	paths := make([]string, 0, maxDeclinedPaths+10)
+	for i := 0; i < maxDeclinedPaths+10; i++ {
+		paths = append(paths, "junk/"+strconv.Itoa(i)+".png")
+	}
+	tr.noteSubmitted(paths, at)
+	tr.mu.Lock()
+	pend := len(tr.pending)
+	tr.mu.Unlock()
+	if pend > maxDeclinedPaths {
+		t.Fatalf("pending grew to %d, past the cap of %d — it drains only on a completed pass, so this is the unbounded case", pend, maxDeclinedPaths)
+	}
+
+	tr.reconcile(&diff.Manifest{
+		IndexedAt: at.Add(time.Second),
+		Files:     map[string]diff.FileEntry{"alpha.go": {}},
+	}, logger, "/repo")
+
+	tr.mu.Lock()
+	ref := len(tr.refused)
+	tr.mu.Unlock()
+	if ref == 0 {
+		t.Fatal("nothing was refused at all — the cap assertions here would pass for the wrong reason")
+	}
+	if ref > maxDeclinedPaths {
+		t.Fatalf("refused grew to %d, past the cap of %d", ref, maxDeclinedPaths)
+	}
+	// The overflow must still be REPORTED. A cap that silently suppressed the
+	// paths it could not record would be the mirror defect at scale.
+	var suppressed, overflowing int
+	for _, rel := range paths {
+		if tr.declined(rel) {
+			suppressed++
+		} else {
+			overflowing++
+		}
+	}
+	if suppressed != maxDeclinedPaths {
+		t.Fatalf("expected exactly %d suppressed paths, got %d", maxDeclinedPaths, suppressed)
+	}
+	if overflowing != 10 {
+		t.Fatalf("expected the 10 over-cap paths to keep re-reporting (over-firing), got %d", overflowing)
+	}
+
+	// The two caps must be graded SEPARATELY, or they mask each other: with
+	// pending capped, a promotion loop that ignored its own cap would still
+	// never see more than maxDeclinedPaths candidates in one pass. pending is
+	// drained now, so this second round reaches the promotion cap directly.
+	extra := make([]string, 0, 10)
+	for i := 0; i < 10; i++ {
+		extra = append(extra, "second-round/"+strconv.Itoa(i)+".png")
+	}
+	tr.noteSubmitted(extra, at)
+	tr.reconcile(&diff.Manifest{
+		IndexedAt: at.Add(2 * time.Second),
+		Files:     map[string]diff.FileEntry{"alpha.go": {}},
+	}, logger, "/repo")
+	tr.mu.Lock()
+	ref2 := len(tr.refused)
+	tr.mu.Unlock()
+	if ref2 != maxDeclinedPaths {
+		t.Fatalf("refused is %d after a second round, cap is %d — the promotion cap is not enforced", ref2, maxDeclinedPaths)
+	}
+	for _, rel := range extra {
+		if tr.declined(rel) {
+			t.Fatalf("%q was suppressed past the cap — over the cap the poller must OVER-fire, not drop a path", rel)
+		}
 	}
 }

--- a/internal/daemon/watch/poll_convergence_6940_test.go
+++ b/internal/daemon/watch/poll_convergence_6940_test.go
@@ -1,0 +1,432 @@
+package watch
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/walk"
+	"github.com/cajasmota/grafel/internal/gitmeta"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// #6940 — a path git REPORTS and the walker REFUSES.
+//
+// WalkRepo's file branch has four gates; walk.IndexableEntryType (which the
+// poller shares) reproduces one of them. A path that clears the entry-type
+// gate and is then refused by the extension filter, the file-level ignore
+// layer or the sparse filter used to enter the candidate set, get stamped by
+// nothing, and read as new on EVERY cycle — one full reindex enqueued per repo
+// per interval, forever.
+//
+// Every test here asserts CONVERGENCE — a bounded number of cycles after which
+// the path stops being reported — because first-cycle detection is what hid
+// the two earlier instances of this same defect class.
+//
+// The opposite direction is asserted just as hard (#6902): an assertion that
+// the loop stopped cannot see a change that is now MISSED, and the mirror
+// defect (a path the indexer WILL stamp being refused by the poller) is the
+// blocker #6935 had to fix. See the three ...IsNeverDeclined /
+// ...WithoutACompletedIndexPass / ...ForgivenWhenTheIndexerChangesItsMind
+// cases below.
+
+// cpDeclineCount reports how many paths the poller currently refuses for repo.
+// It reads the tracker, not a log line: the decline set is the mechanism.
+func cpDeclineCount(t *testing.T, p *ChangePoller, repo string) int {
+	t.Helper()
+	abs, err := filepath.Abs(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := p.trackerFor(abs)
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	return len(tr.refused)
+}
+
+// --- gate 1: the indexed-extension filter ---------------------------------
+
+// An untracked `photo.png`: git reports it, walk.IndexableEntryType accepts it
+// (it is a regular file), and shouldSkipFileByExt refuses it. It can never be
+// stamped, so a candidate set that keeps offering it never converges.
+func TestChangePoller_ExtensionFilteredPathConverges(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, submits := cpNewTestPoller(t, repo, state)
+
+	cpWriteFile(t, repo, "photo.png", "\x89PNG not really\n")
+
+	// Premise 1: git reports it, and keeps reporting it — it is untracked, so
+	// nothing short of committing or ignoring it will make git stop.
+	if out := cpGitRun(t, repo, "status", "--porcelain", "-unormal"); !strings.Contains(out, "photo.png") {
+		t.Fatalf("fixture premise broken: git does not report photo.png: %q", out)
+	}
+	// Premise 2: the walker refuses it — this is the gate under test, and if
+	// the extension list ever grew to cover .png the test would be vacuous.
+	files, _, err := walk.WalkRepo(repo, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cpContains(files, "photo.png") {
+		t.Fatalf("fixture premise broken: the walker INDEXES photo.png, so no gate is under test: %v", files)
+	}
+
+	// Cycle 1 reports it. That is correct and must stay correct: on the first
+	// cycle the poller genuinely cannot tell a refused path from a new one.
+	if got := cpCycle(t, p, repo); !cpContains(got, "photo.png") {
+		t.Fatalf("first cycle did not report the newly discovered path: %v", got)
+	}
+	if n := len(*submits); n != 1 {
+		t.Fatalf("expected exactly one submission for the discovery, got %d", n)
+	}
+
+	// The index pass runs and declines it: the manifest cannot hold it.
+	cpIndexPass(t, repo, state)
+	if keys := cpManifestKeys(t, state); cpContains(keys, "photo.png") {
+		t.Fatalf("fixture premise broken: the index pass stamped photo.png: %v", keys)
+	}
+	// git still reports it. This is exactly the input the old candidate set
+	// took unconditionally.
+	if out := cpGitRun(t, repo, "status", "--porcelain", "-unormal"); !strings.Contains(out, "photo.png") {
+		t.Fatalf("fixture premise broken: git stopped reporting photo.png, so the loop is untested: %q", out)
+	}
+
+	before := len(*submits)
+	if n := cpConverges(t, p, repo, 6); n != 0 {
+		t.Fatalf("photo.png was still reported for %d cycles after the index pass declined it", n)
+	}
+	if after := len(*submits); after != before {
+		t.Fatalf("poller enqueued %d more reindexes after convergence", after-before)
+	}
+	if n := cpDeclineCount(t, p, repo); n != 1 {
+		t.Fatalf("expected exactly one recorded decline, got %d", n)
+	}
+}
+
+// --- gate 3: the file-level ignore layer (#6931/#6933) ---------------------
+
+// A TRACKED but gitignored file. Ignore rules do not apply to tracked files, so
+// git reports every edit to it forever, while WalkRepo's igStack.MatchFile
+// refuses it — the second driven shape in #6940, and the one #6933 widened
+// into existence. This repo has two such files today (#6937).
+func TestChangePoller_TrackedButGitignoredPathConverges(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpWriteFile(t, repo, ".gitignore", "gen.go\n")
+	cpWriteFile(t, repo, "gen.go", "package a\n\nfunc Gen() {}\n")
+	cpGitRun(t, repo, "add", "-A")
+	cpGitRun(t, repo, "add", "-f", "gen.go")
+	cpGitRun(t, repo, "commit", "-q", "-m", "tracked-but-ignored")
+	cpIndexPass(t, repo, state)
+
+	// Premise: the ignore layer refuses a file git tracks.
+	if keys := cpManifestKeys(t, state); cpContains(keys, "gen.go") {
+		t.Fatalf("fixture premise broken: gen.go IS indexed, so the ignore gate is not under test: %v", keys)
+	}
+
+	p, submits := cpNewTestPoller(t, repo, state)
+	cpWriteFile(t, repo, "gen.go", "package a\n\nfunc Gen() { _ = 1 }\n")
+	if out := cpGitRun(t, repo, "status", "--porcelain", "-unormal"); !strings.Contains(out, "gen.go") {
+		t.Fatalf("fixture premise broken: git does not report the tracked-but-ignored edit: %q", out)
+	}
+
+	if got := cpCycle(t, p, repo); !cpContains(got, "gen.go") {
+		t.Fatalf("first cycle did not report gen.go: %v", got)
+	}
+	cpIndexPass(t, repo, state)
+	if keys := cpManifestKeys(t, state); cpContains(keys, "gen.go") {
+		t.Fatalf("fixture premise broken: the index pass stamped gen.go: %v", keys)
+	}
+	if out := cpGitRun(t, repo, "status", "--porcelain", "-unormal"); !strings.Contains(out, "gen.go") {
+		t.Fatalf("fixture premise broken: git stopped reporting gen.go: %q", out)
+	}
+
+	before := len(*submits)
+	if n := cpConverges(t, p, repo, 6); n != 0 {
+		t.Fatalf("gen.go was still reported for %d cycles after the index pass declined it", n)
+	}
+	if after := len(*submits); after != before {
+		t.Fatalf("poller enqueued %d more reindexes after convergence", after-before)
+	}
+}
+
+// --- gate 4: the sparse-checkout filter ------------------------------------
+
+// cpIndexPassSparse is cpIndexPass with the sparse probe the real incremental
+// indexer performs, so the sparse gate is actually applied.
+func cpIndexPassSparse(t *testing.T, repo, state string) {
+	t.Helper()
+	si := gitmeta.ProbeRepo(repo)
+	files, _, err := walk.WalkRepo(repo, &walk.Options{Sparse: &si})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	m := diff.LoadManifest(state)
+	changed, _ := diff.Filter(repo, files, m)
+	diff.UpdateManifestScoped(repo, changed, files, m)
+	if err := diff.SaveManifestAtCommit(state, m, "", ""); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+}
+
+// An UNTRACKED file outside the sparse cone. Sparse checkout does not remove
+// untracked files, so the path is on disk and git reports its directory — but
+// WalkRepo's sparse filter refuses it by repo-relative path, and the poller's
+// subtree walk (rooted below the repo root, with no sparse state) hands it over
+// as a candidate.
+func TestChangePoller_SparseFilteredPathConverges(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpWriteFile(t, repo, "src/keep.go", "package src\n")
+	cpGitRun(t, repo, "add", "-A")
+	cpGitRun(t, repo, "commit", "-q", "-m", "src")
+	// --no-cone deliberately: git's CONE patterns are `/*` + `!/*/` + `/src/`,
+	// and gitmeta.IsPathIncluded treats a bare `*` as match-all, so a cone
+	// checkout makes its own filter include everything. That is a real gap in
+	// the sparse implementation and it is not #6940; a non-cone pattern set is
+	// the shape grafel's filter actually applies, so it is the one that puts
+	// the SPARSE GATE under test here rather than a no-op.
+	if out, err := cpGitTry(repo, "sparse-checkout", "set", "--no-cone", "src"); err != nil {
+		t.Skipf("git sparse-checkout unavailable here: %v\n%s", err, out)
+	}
+	// git >= 2.32 writes core.sparseCheckout into the WORKTREE-scoped config
+	// (.git/config.worktree, via extensions.worktreeConfig), and
+	// gitmeta.ProbeRepo reads `config --local` only — so the probe does not see
+	// a sparse checkout this git just created. That gap is real and is not
+	// #6940; mirroring the flag into --local here keeps the SPARSE GATE, which
+	// is what this test is about, reachable rather than silently untested.
+	cpGitRun(t, repo, "config", "--local", "core.sparseCheckout", "true")
+	cpGitRun(t, repo, "config", "--local", "core.sparseCheckoutCone", "true")
+	if si := gitmeta.ProbeRepo(repo); !si.IsSparse {
+		t.Skip("fixture did not become sparse; the sparse gate is unreachable here")
+	}
+
+	cpWriteFile(t, repo, "outside/gen.go", "package outside\n")
+	cpIndexPassSparse(t, repo, state)
+	keys := cpManifestKeys(t, state)
+	if len(keys) == 0 {
+		t.Fatal("fixture premise broken: nothing indexed at all")
+	}
+	if cpContains(keys, "outside/gen.go") {
+		t.Fatalf("fixture premise broken: the sparse gate did not refuse outside/gen.go: %v", keys)
+	}
+
+	p, _ := cpNewTestPoller(t, repo, state)
+	got := cpCycle(t, p, repo)
+	if !cpContains(got, "outside/gen.go") {
+		// Not a skip: if the untracked subtree stops reaching the candidate
+		// set, the sparse loop is not "unreachable here", it is UNTESTED, and
+		// a skip would hide that for as long as it lasted.
+		t.Fatalf("the poller did not surface outside/gen.go as a candidate (%v) — the sparse case is untested", got)
+	}
+	cpIndexPassSparse(t, repo, state)
+	if n := cpConverges(t, p, repo, 6); n != 0 {
+		t.Fatalf("outside/gen.go was still reported for %d cycles after the sparse gate declined it", n)
+	}
+}
+
+// cpGitTry runs git and returns its output and error rather than failing the
+// test — for optional fixture steps (sparse-checkout) that may be unsupported.
+func cpGitTry(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// --- the other direction (#6902): what must NOT be declined ----------------
+
+// A genuinely new, indexable file must never be declined. It is discovered on
+// cycle 1 exactly like photo.png is, and the ONLY thing that separates them is
+// what the index pass then does with it. If the tracker keyed on "reported and
+// not yet stamped" alone, this file would be dropped and every later edit to it
+// silently missed — the mirror of the loop the rest of this file closes.
+func TestChangePoller_NewIndexableFileIsNeverDeclined(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+
+	cpWriteFile(t, repo, "gamma.go", "package a\n\nfunc Gamma() {}\n")
+	if got := cpCycle(t, p, repo); !cpContains(got, "gamma.go") {
+		t.Fatalf("cycle 1 did not report the new file: %v", got)
+	}
+	cpIndexPass(t, repo, state)
+	if keys := cpManifestKeys(t, state); !cpContains(keys, "gamma.go") {
+		t.Fatalf("fixture premise broken: the index pass did not stamp gamma.go: %v", keys)
+	}
+	// Quiet once the manifest agrees...
+	if n := cpConverges(t, p, repo, 6); n != 0 {
+		t.Fatalf("an indexed file kept being reported for %d cycles", n)
+	}
+	if n := cpDeclineCount(t, p, repo); n != 0 {
+		t.Fatalf("an indexed file was recorded as declined (%d entries) — later edits to it would be invisible", n)
+	}
+	// ...and STILL detected when it changes. This is the assertion a
+	// convergence test cannot make for itself.
+	cpWriteFile(t, repo, "gamma.go", "package a\n\nfunc Gamma() { _ = 2 }\n")
+	if got := cpCycle(t, p, repo); !cpContains(got, "gamma.go") {
+		t.Fatalf("an edit to an indexed file was MISSED: %v", got)
+	}
+}
+
+// A decline requires proof that an index pass actually ran: m.IndexedAt is
+// stamped by every manifest save, so it distinguishes "the indexer looked and
+// said no" from "our request has not been serviced yet". Without that premise
+// the poller would drop a perfectly indexable file whose reindex was merely
+// debounced or circuit-broken, and never look at it again.
+func TestChangePoller_NoDeclineWithoutACompletedIndexPass(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, submits := cpNewTestPoller(t, repo, state)
+
+	cpWriteFile(t, repo, "delta.go", "package a\n\nfunc Delta() {}\n")
+	for i := 1; i <= 3; i++ {
+		got := cpCycle(t, p, repo)
+		if !cpContains(got, "delta.go") {
+			t.Fatalf("cycle %d stopped reporting delta.go although NO index pass ever ran: %v", i, got)
+		}
+	}
+	if n := len(*submits); n != 3 {
+		t.Fatalf("expected a submission on each of 3 cycles (level-triggered), got %d", n)
+	}
+	if n := cpDeclineCount(t, p, repo); n != 0 {
+		t.Fatalf("a path was declined with no completed index pass to justify it (%d entries)", n)
+	}
+}
+
+// A decline is an observation about one past pass, not a life sentence. Drop
+// the ignore rule and the indexer changes its mind; the poller must follow it
+// back. The chain is real, not stipulated: .gitignore is itself a manifest key,
+// so editing it is detected by the manifest sweep, the reindex re-walks the
+// repo, and gen.go is stamped.
+func TestChangePoller_DeclineIsForgivenWhenTheIndexerChangesItsMind(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpWriteFile(t, repo, ".gitignore", "gen.go\n")
+	cpWriteFile(t, repo, "gen.go", "package a\n\nfunc Gen() {}\n")
+	cpGitRun(t, repo, "add", "-A")
+	cpGitRun(t, repo, "add", "-f", "gen.go")
+	cpGitRun(t, repo, "commit", "-q", "-m", "tracked-but-ignored")
+	cpIndexPass(t, repo, state)
+	if keys := cpManifestKeys(t, state); !cpContains(keys, ".gitignore") {
+		t.Fatalf("fixture premise broken: .gitignore is not itself indexed, so the forgiveness chain is untested: %v", keys)
+	}
+
+	p, _ := cpNewTestPoller(t, repo, state)
+	cpWriteFile(t, repo, "gen.go", "package a\n\nfunc Gen() { _ = 1 }\n")
+	cpCycle(t, p, repo)
+	cpIndexPass(t, repo, state)
+	if n := cpConverges(t, p, repo, 6); n != 0 {
+		t.Fatalf("gen.go did not converge (%d cycles) — the premise of this test is the decline", n)
+	}
+	if n := cpDeclineCount(t, p, repo); n != 1 {
+		t.Fatalf("expected gen.go to be declined, got %d declines", n)
+	}
+
+	// Now un-ignore it.
+	cpWriteFile(t, repo, ".gitignore", "# nothing ignored any more\n")
+	got := cpCycle(t, p, repo)
+	if !cpContains(got, ".gitignore") {
+		t.Fatalf("the .gitignore edit itself was not detected: %v", got)
+	}
+	cpIndexPass(t, repo, state)
+	if keys := cpManifestKeys(t, state); !cpContains(keys, "gen.go") {
+		t.Fatalf("fixture premise broken: the re-walk did not stamp the un-ignored gen.go: %v", keys)
+	}
+	// The decline must be forgiven, and a later edit detected again.
+	cpCycle(t, p, repo)
+	if n := cpDeclineCount(t, p, repo); n != 0 {
+		t.Fatalf("gen.go is still declined after the indexer stamped it (%d entries)", n)
+	}
+	cpWriteFile(t, repo, "gen.go", "package a\n\nfunc Gen() { _ = 3 }\n")
+	if got := cpCycle(t, p, repo); !cpContains(got, "gen.go") {
+		t.Fatalf("an edit to the now-indexed gen.go was MISSED: %v", got)
+	}
+}
+
+// A decline is per repo. Two repos polled by one poller must not share a
+// refusal, or a path refused in one silences the same relative path in the
+// other — a missed change with no visible cause.
+func TestChangePoller_DeclinesAreScopedToOneRepo(t *testing.T) {
+	repoA, stateA := cpNewRepo(t)
+	repoB, stateB := cpNewRepo(t)
+	cpIndexPass(t, repoA, stateA)
+	cpIndexPass(t, repoB, stateB)
+
+	var submits []string
+	p := NewChangePoller(ChangePollerConfig{
+		StateDir: func(rp string) string {
+			if rp == repoA {
+				return stateA
+			}
+			return stateB
+		},
+		DisableWarmUp: true,
+	}, func(rp string, bulk bool) { submits = append(submits, rp) }, nil)
+	for _, r := range []string{repoA, repoB} {
+		if err := p.AddRepo(r); err != nil {
+			t.Fatalf("AddRepo: %v", err)
+		}
+	}
+	t.Cleanup(func() { p.Stop() })
+
+	// Same relative path in both: refused in A (a .png), indexable in B.
+	cpWriteFile(t, repoA, "shared.png", "binary-ish\n")
+	cpWriteFile(t, repoB, "shared.go", "package a\n\nfunc S() {}\n")
+	p.PollOnce()
+	cpIndexPass(t, repoA, stateA)
+	cpIndexPass(t, repoB, stateB)
+	p.PollOnce()
+
+	if n := cpDeclineCount(t, p, repoA); n != 1 {
+		t.Fatalf("repo A should hold exactly the one decline, got %d", n)
+	}
+	if n := cpDeclineCount(t, p, repoB); n != 0 {
+		t.Fatalf("repo B holds %d declines it never earned", n)
+	}
+	cpWriteFile(t, repoB, "shared.go", "package a\n\nfunc S() { _ = 1 }\n")
+	res := p.PollOnce()
+	got := res[repoB]
+	sort.Strings(got)
+	if !cpContains(got, "shared.go") {
+		t.Fatalf("repo B's edit was missed: %v", got)
+	}
+	if r := res[repoA]; len(r) != 0 {
+		t.Fatalf("repo A re-fired after convergence: %v", r)
+	}
+}
+
+// RemoveRepo must drop the tracker with the repo — otherwise a re-registered
+// repo starts life refusing paths that were decided in an earlier era.
+func TestChangePoller_RemoveRepoDropsTheDeclineSet(t *testing.T) {
+	repo, state := cpNewRepo(t)
+	cpIndexPass(t, repo, state)
+	p, _ := cpNewTestPoller(t, repo, state)
+	cpWriteFile(t, repo, "photo.png", "not a png\n")
+	cpCycle(t, p, repo)
+	cpIndexPass(t, repo, state)
+	cpCycle(t, p, repo)
+	if n := cpDeclineCount(t, p, repo); n != 1 {
+		t.Fatalf("expected one decline before RemoveRepo, got %d", n)
+	}
+	p.RemoveRepo(repo)
+	if n := cpDeclineCount(t, p, repo); n != 0 {
+		t.Fatalf("RemoveRepo left %d declines behind", n)
+	}
+	// The refusal is gone but the file is not: re-registering the repo must
+	// re-learn the decline from scratch, one cycle at a time.
+	if _, err := os.Stat(filepath.Join(repo, "photo.png")); err != nil {
+		t.Fatalf("fixture disappeared: %v", err)
+	}
+	if err := p.AddRepo(repo); err != nil {
+		t.Fatalf("re-AddRepo: %v", err)
+	}
+	if got := cpCycle(t, p, repo); !cpContains(got, "photo.png") {
+		t.Fatalf("a re-registered repo inherited a stale refusal: %v", got)
+	}
+}

--- a/internal/daemon/watch/poll_convergence_6940_test.go
+++ b/internal/daemon/watch/poll_convergence_6940_test.go
@@ -661,3 +661,46 @@ func TestDeclineTracker_CapOverflowOverFires(t *testing.T) {
 		}
 	}
 }
+
+// MP-2, from the #6961 review: noteSubmitted keeps the FIRST submission time,
+// and nothing observed it. A path re-offered on every cycle must not slide its
+// own deadline forward — under an overwriting tracker the newest stamp can
+// always be younger than the manifest the next reconcile reads, so condition
+// (2) is never met and the path never converges.
+//
+// Asserted twice, because the stored value and its consequence are different
+// claims: the map still holds T1, and a manifest stamped BETWEEN T1 and T2 —
+// the interval that separates the two — is proof of a completed pass.
+func TestDeclineTracker_KeepsTheFirstSubmissionTime(t *testing.T) {
+	tr := &declineTracker{
+		pending: make(map[string]time.Time),
+		refused: make(map[string]struct{}),
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	t1 := time.Now().UTC()
+	t2 := t1.Add(2 * time.Second)
+
+	tr.noteSubmitted([]string{"a.go"}, t1)
+	tr.noteSubmitted([]string{"a.go"}, t2)
+
+	tr.mu.Lock()
+	got, ok := tr.pending["a.go"]
+	tr.mu.Unlock()
+	if !ok {
+		t.Fatal("the path left the pending set entirely")
+	}
+	if !got.Equal(t1) {
+		t.Fatalf("pending holds %v, want the FIRST submission %v — a re-offered path slid its own deadline forward", got, t1)
+	}
+
+	// The consequence: a pass that completed between the two submissions is
+	// proof, and must decline. Under an overwriting tracker this manifest is
+	// older than the stored stamp and the path stays pending forever.
+	tr.reconcile(&diff.Manifest{
+		IndexedAt: t1.Add(time.Second),
+		Files:     map[string]diff.FileEntry{"alpha.go": {}},
+	}, logger, "/repo")
+	if !tr.declined("a.go") {
+		t.Fatal("a pass that completed after the first submission did not decline the path — the second submission's stamp is being used")
+	}
+}

--- a/internal/daemon/watch/poll_convergence_6940_test.go
+++ b/internal/daemon/watch/poll_convergence_6940_test.go
@@ -1,12 +1,15 @@
 package watch
 
 import (
+	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/walk"
 	"github.com/cajasmota/grafel/internal/gitmeta"
@@ -428,5 +431,48 @@ func TestChangePoller_RemoveRepoDropsTheDeclineSet(t *testing.T) {
 	}
 	if got := cpCycle(t, p, repo); !cpContains(got, "photo.png") {
 		t.Fatalf("a re-registered repo inherited a stale refusal: %v", got)
+	}
+}
+
+// --- the boundary condition (2) rests on -------------------------------------
+
+// MP-1, from the #6961 review: `!m.IndexedAt.After(submittedAt)` is what makes
+// condition (2) PROOF that an index pass ran rather than a coincidence, and
+// nothing observed the strictness — relaxing it to `Before` (i.e. ">=") left
+// the whole package green. Two independent nanosecond clock reads do not
+// collide in practice, so this is not a live defect; it is an ungraded claim,
+// and a "simplification" of the comparison would ship green.
+//
+// Both halves are asserted, because an equality case that declines nothing is
+// also what a tracker that declines NOTHING AT ALL looks like: the positive
+// control drives the very same tracker one nanosecond further and requires the
+// decline to appear.
+func TestDeclineTracker_EqualTimestampIsNotProofOfACompletedPass(t *testing.T) {
+	tr := &declineTracker{
+		pending: make(map[string]time.Time),
+		refused: make(map[string]struct{}),
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	at := time.Now().UTC()
+	tr.noteSubmitted([]string{"photo.png"}, at)
+
+	// EXACTLY equal: a manifest stamped at the same instant we submitted is not
+	// evidence that a pass has since completed.
+	tr.reconcile(&diff.Manifest{
+		IndexedAt: at,
+		Files:     map[string]diff.FileEntry{"alpha.go": {}},
+	}, logger, "/repo")
+	if tr.declined("photo.png") {
+		t.Fatal("a manifest stamped at the SAME instant as the submission was taken as proof a pass completed")
+	}
+
+	// Positive control: one nanosecond later is proof, and must decline — else
+	// the assertion above passes for the wrong reason.
+	tr.reconcile(&diff.Manifest{
+		IndexedAt: at.Add(time.Nanosecond),
+		Files:     map[string]diff.FileEntry{"alpha.go": {}},
+	}, logger, "/repo")
+	if !tr.declined("photo.png") {
+		t.Fatal("a manifest stamped strictly AFTER the submission did not decline the unstamped path — the equality assertion above is vacuous")
 	}
 }


### PR DESCRIPTION
Closes #6940.

`walk.WalkRepo`'s file branch has **four** gates; the poller can cheaply reproduce **one** (`walk.IndexableEntryType`, the entry-type axis). A path git reports that clears that gate and is then refused by the extension filter, the file-level ignore layer or the sparse filter entered the candidate set, was stamped by nothing, and read as new on **every cycle, forever** — one full reindex enqueued per repo per interval. `photo.png` and a tracked-but-gitignored `gen.go` were both driven at 5/5 cycles in #6940.

## The mechanism, and why it needs no gate of its own

The three unreproducible gates were the reason this was left open: two of them (the inherited ignore stack, `opts.Sparse`) are not answerable from a single path. **They do not have to be.** The poller does not need to *predict* the walker's verdict — it can *observe* it.

`declineTracker` records a path as refused when all three hold:

1. the poller **submitted** a reindex request naming it,
2. an index pass has since **completed** — `Manifest.IndexedAt` is stamped by every `SaveManifestAtCommit`, whether or not the file set changed, so it is proof a pass *ran*, not merely that something changed,
3. the manifest **still does not hold** the path.

That is exactly "reported, offered to the indexer, and not stamped". It is gate-agnostic — it converges the extension filter, the ignore layer, the sparse filter and any gate added later — and it **duplicates no predicate**, so there is no second copy to drift out of agreement with the walker. That was #6940's option 4 and the mistake MA-1 already made once. `existsOnDisk`'s doc comment keeps promising exactly the one axis it decides; nothing was promised away.

Alternatives priced and rejected: re-walking per discovered path (option 1) pays the walk this poller exists to avoid, every cycle, for every such path; `git check-ignore` (option 3) closes one of the three gates and adds a process per cycle.

## Both directions are graded (#6902)

An assertion that the loop stopped cannot see a change that is now **missed** — the mirror defect is blocker 1 of #6935 (a path the indexer *will* stamp being refused by the poller).

- **A decline needs a completed pass.** A file whose reindex was merely debounced or circuit-broken is re-reported every cycle, level-triggered, and never dropped.
- **A decline is forgiven** the moment the manifest holds the path, and the forgiveness chain is tested end to end rather than stipulated: un-ignore `gen.go` → the `.gitignore` edit is *itself* a manifest key → the poller reports it → the reindex re-walks the repo → `gen.go` is stamped → the decline is dropped and the next edit is detected.
- **Declines are per repo** and die with `RemoveRepo`; a re-registered repo re-learns them.
- Nothing is persisted: a daemon restart costs one extra cycle per refused path. The set is capped (`maxDeclinedPaths`), past which the poller **over-fires** rather than dropping a path — the direction this file chooses everywhere.

## Ordering, so the two guards are not mutually masking

Forgiveness runs **before** promotion. Promote-then-forgive lets the promotion loop refuse a freshly stamped path and the forgiveness loop erase the evidence in the same call: two guards that only ever fail together, so neither is graded. Forgive-then-promote leaves a stamped path visibly refused. The mutant that deletes promotion's stamped-check was **ALIVE** under the original order and is **DEAD** under this one — the reorder is the grading.

## Tests — convergence as convergence, per gate

`internal/daemon/watch/poll_convergence_6940_test.go`, all through the real poller, real git, real `diff` manifest round-trip, with an index pass between cycles. Every case asserts a **bounded number of cycles** after which the path stops being reported, via the existing `cpConverges` helper — not first-cycle detection, which is what hid the two earlier instances.

| case | gate |
|---|---|
| `ExtensionFilteredPathConverges` | 1 — `shouldSkipFileByExt` (`photo.png`) |
| `TrackedButGitignoredPathConverges` | 3 — `igStack.MatchFile` (`gen.go`, tracked via `add -f`) |
| `SparseFilteredPathConverges` | 4 — sparse filter, via an untracked subtree outside the pattern set |
| `NewIndexableFileIsNeverDeclined` | mirror: indexed file stays detectable after an edit |
| `NoDeclineWithoutACompletedIndexPass` | mirror: 3 cycles, no pass, still reported, zero declines |
| `DeclineIsForgivenWhenTheIndexerChangesItsMind` | mirror: un-ignore → stamped → detected again |
| `DeclinesAreScopedToOneRepo` / `RemoveRepoDropsTheDeclineSet` | scope and lifetime |

Each case pins its own premise first (git reports it; the walker refuses it; the manifest does not hold it) so it cannot go vacuous if a gate moves. The sparse case **fails rather than skips** if the path stops reaching the candidate set — that state is "untested", not "unreachable".

**Two adjacent gaps found while making the sparse case reachable, both real and neither #6940** — recorded here, to be filed separately:

- `gitmeta.ProbeRepo` reads `git config --local`, but git ≥ 2.32 writes `core.sparseCheckout` into the **worktree-scoped** config (`.git/config.worktree`). A sparse checkout created by a current git is invisible to the probe. The test mirrors the flag into `--local` to keep the gate reachable, and says why.
- `gitmeta.IsPathIncluded` treats a bare `*` pattern as match-all, and git's **cone** patterns are `/*` + `!/*/` + `/src/` — so a cone checkout makes grafel's own sparse filter include everything. The test uses `--no-cone` deliberately, and says why.

## Verification

- `go test -count=1` green on `./internal/daemon/watch/` (159.9 s), `./internal/daemon/` (31.3 s), `./cmd/grafel/` (156.6 s). macOS/APFS.
- **Mutants — 6 scored, 6 DEAD**, each edit proved landed by an exact occurrence count against a shasum-verified backup, with a green baseline immediately before:
  1. drop the decline guard on git-reported files → DEAD (4 tests, incl. both repro shapes)
  2. decline without requiring a completed pass (the permissive direction) → DEAD (`NoDeclineWithoutACompletedIndexPass`)
  3. delete forgiveness → DEAD (`DeclineIsForgivenWhenTheIndexerChangesItsMind`)
  4. promotion ignores whether the manifest stamped the path → **ALIVE under promote-then-forgive, DEAD after the reorder** (`NewIndexableFileIsNeverDeclined`)
  5. one tracker shared across repos → DEAD (scope + lifetime)
  6. drop the decline guard on subtree-walked paths → DEAD (`SparseFilteredPathConverges`)

Nothing here is `runtime.GOOS`-conditional; `ci:full` is added for the macOS leg, which otherwise never runs these tests. All measurement is macOS/APFS — the target is Linux containers on overlayfs and nothing has been measured there.

## Scope

Poll mode only. fsnotify mode is untouched (its sink is repo-level, so it has no candidate set to poison), `PollingEnabled()` is untouched, and `auto` still resolves to fsnotify — this unblocks #6932 arm B part 2 rather than being part of it.

---

## Review round 2 — all four asks addressed (`281210545`)

1. **M1b — condition (1), first half.** `TestChangePoller_RecreatedManifestKeyIsNeverRefused`: delete a manifest key → pass prunes it → recreate it → must be reported, with `cpDeclineCount == 0`. Mutant (pending recorded from `changed ∪ discovered` — the naive `changed`-only form does not compile, as the reviewer also found) is **DEAD** on exactly that test.
2. **M7 — condition (1), second half: ALIVE and UNREACHABLE, reported as such rather than graded away.** Every discovered path is absent from the manifest, and `diff.isChanged` returns true unconditionally for a path the manifest lacks, so `discovered ⊆ changed` always and a cycle with a non-empty discovered set always submits. There is no input that reaches the guard today. `TestChangePoller_EveryDiscoveredPathIsSubmitted` pins that premise (both discovery shapes) and asserts the reachable half — a quiescent cycle records no pending. If `Filter` ever gains a way to drop a discovered path, that test fails first, which is the moment the guard becomes load-bearing.
3. **The cap — bounded, not re-worded.** `pending` is now capped too: it drains *only* on a completed pass, so it was unbounded in exactly the debounced / circuit-broken case this design is built around. `TestDeclineTracker_CapOverflowOverFires` asserts the **direction** (past the cap, paths keep re-reporting rather than being dropped) and drives the two caps in **separate rounds** — with `pending` capped, a promotion loop ignoring its own cap never sees more than the cap in one pass, so scoring them together grades neither. Mutants **M6 (refused cap) DEAD, M6b (pending cap) DEAD**.
4. **Sparse `t.Skip` → `t.Fatal`.** Scored the reviewer's own mutation: deleting the two `config --local` mirror lines gave `SKIP … PASS, exit 0` before; it is now **DEAD** (`--- FAIL`), so the only sparse leg cannot vanish unseen on a `-v`-less CI run.
5. **Comments narrowed, no behaviour change.** Forgiveness names only the trigger that self-triggers (`.gitignore` is itself a manifest key); the sparse-cone case is recorded as what it is — no manifest key changes, the declined path is suppressed, so it heals on an unrelated pass or a daemon restart, a real bounded behaviour change against pre-#6940 — and the extension-list case heals by construction, since growing it means an upgrade that restarts the daemon and drops the unpersisted set.

**Recorded, not fixed here** (being filed separately): production convergence turns on the manifest save at `incremental.go:716`, whose own comment invites its deletion — and deleting it resurrects #6940 with every test in this PR still green, because `cpIndexPass` performs the save itself. Also confirmed by the reviewer against git 2.50.1: the two `gitmeta` sparse gaps above are one issue — grafel's sparse support is inert on any git ≥ 2.32 and would over-include in cone mode if the probe ever fired.

Verification for this round: `go test -count=1` green on `./internal/daemon/watch/` (156.2 s), `./internal/daemon/` (30.9 s), `./cmd/grafel/` (148.5 s), macOS/APFS.

---

## Review round 3 — MP-2 (`e425573d7`)

**Both halves of the ask, not either/or.** `noteSubmitted` keeping the FIRST submission time was documented and unobserved, and it is only *safe* because of a call ordering nothing wrote down — `pollRepo` reconciles against the manifest **before** the caller submits, so at most one `noteSubmitted` lands between any two `reconcile`s. The comment now names that ordering as the dependency it is, **and** `TestDeclineTracker_KeepsTheFirstSubmissionTime` pins the sentence directly, asserting the stored value and its consequence separately (they are different claims): `pending` still holds `T1` after a second submission at `T2`, and a manifest stamped **between** `T1` and `T2` is proof of a completed pass and must decline. **MP-2 is DEAD** — RED on the overwriting tracker, GREEN restored from a SHA-256-verified `cp`.

**Two mutually-masking pairs came out of one design, and that is a property of the shape.** First promotion/forgiveness (`M3`/`M4` — fixed by reordering to forgive-then-promote), then the two caps (`M6` came back ALIVE because the `pending` cap meant a promotion loop ignoring its own cap never saw more than the cap in one pass — fixed by driving them in separate rounds). Anyone adding a guard to `declineTracker` should assume the same and **score compound guards part by part**; a single mutant over both halves grades neither.

Verification for this round: `go test -count=1` green on `./internal/daemon/watch/` (161.0 s), `./internal/daemon/` (31.8 s), `./cmd/grafel/` (148.7 s), macOS/APFS.
