### PR TITLE
fix(#6960): the daemon's incremental re-extract never dispatched a custom extractor — the gate lived in cmd/grafel, which internal/extractors cannot import

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -3881,6 +3881,17 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 	// can consult feature toggles via the Config channel (Config wins; env var
 	// is the backward-compat fallback). Future work: merge a config file on top.
 	extractorCfg := extractor.ConfigFromEnv()
+	// #6960 — carry the PROGRAMMATIC half of the custom-extractor gate
+	// (WithCustomExtractors) in the config rather than only in Indexer state, so
+	// that one expression — extractors.CustomExtractorsEnabled — decides it on
+	// this path and on the daemon's incremental path, which has no Indexer and
+	// receives nothing but an *ExtractorConfig. Only the opt-in is stamped: a
+	// false here would OVERRIDE a set env var, which is not what an unset option
+	// means.
+	if i.customExtractors {
+		on := true
+		extractorCfg.InProcCustomExtractors = &on
+	}
 
 	// Use a shared atomic counter so all workers contribute to the same
 	// tick cadence without needing an additional mutex acquisition per file.
@@ -4138,7 +4149,7 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 				// the guard a file that FAILED to parse would still produce
 				// custom entities. See
 				// TestInProcCustomExtractorsNilTreeGuardIsLoadBearing.
-				if (i.customExtractors || inProcCustomExtractors()) && file.TSTree != nil {
+				if extractors.CustomExtractorsEnabled(&extractorCfg) && file.TSTree != nil {
 					customEnts, customErrs := extractors.RunCustomExtractors(ctx, file)
 					if len(customErrs) > 0 && verbose() {
 						for _, ce := range customErrs {

--- a/cmd/grafel/inproc_custom.go
+++ b/cmd/grafel/inproc_custom.go
@@ -1,8 +1,7 @@
 package main
 
 import (
-	"os"
-	"strings"
+	"github.com/cajasmota/grafel/internal/extractors"
 )
 
 // inProcCustomExtractors reports whether the DEFAULT in-process indexing path
@@ -30,7 +29,10 @@ import (
 // silently disables ~12 framework post-passes, and on a Django fixture it is a
 // NET LOSS (entities 201→186, http_endpoint_definition 18→4). That hole is
 // tracked separately as #6102 and is out of scope here.
+// #6960 — the env read itself now lives in internal/extractors
+// (InProcCustomExtractorsEnabled) so the daemon's incremental re-extract path
+// can consult the SAME gate. It cannot import cmd/grafel, and a second literal
+// reading of the variable here would be free to drift from that one.
 func inProcCustomExtractors() bool {
-	v := strings.TrimSpace(os.Getenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS"))
-	return v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
+	return extractors.InProcCustomExtractorsEnabled()
 }

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -54,6 +54,22 @@ type ExtractorConfig struct {
 	// Tri-state: nil means "not set in Config; fall through to env var".
 	JSEmitDestructureDetail *bool
 
+	// InProcCustomExtractors controls whether an in-process indexing pass
+	// dispatches the internal/custom/** framework extractors (issue #5989).
+	// Tri-state: nil means "not set in Config; fall through to the
+	// GRAFEL_INPROC_CUSTOM_EXTRACTORS env var".
+	//
+	// #6960 — this field is how the PROGRAMMATIC half of the full path's gate
+	// (cmd/grafel's WithCustomExtractors, i.customExtractors) becomes visible to
+	// a pass that has no Indexer. The daemon's incremental re-extraction is
+	// handed an *ExtractorConfig and nothing else; without this field its gate
+	// could read only the env half, so a full index opted in through
+	// WithCustomExtractors would emit custom entities that the next incremental
+	// pass silently dropped — #6960 surviving in the other lane. Read it through
+	// extractors.CustomExtractorsEnabled, never directly, so both paths evaluate
+	// one expression.
+	InProcCustomExtractors *bool
+
 	// IncrementalReindexSet records whether IncrementalReindex was explicitly
 	// set via Config (as opposed to being the zero value). This lets callers
 	// distinguish "Config says false" from "Config not consulted".

--- a/internal/extractors/custom_gate.go
+++ b/internal/extractors/custom_gate.go
@@ -3,6 +3,8 @@ package extractors
 import (
 	"os"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/extractor"
 )
 
 // InProcCustomExtractorsEnabled reports whether an in-process indexing path
@@ -26,4 +28,28 @@ import (
 func InProcCustomExtractorsEnabled() bool {
 	v := strings.TrimSpace(os.Getenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS"))
 	return v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
+}
+
+// CustomExtractorsEnabled is the WHOLE gate — the config half and the env half —
+// and is what every dispatch site should call.
+//
+// The full in-process path's condition was `i.customExtractors ||
+// inProcCustomExtractors()`. A pass with no Indexer cannot evaluate the first
+// half, and #6960's first cut read only the second, which left the original
+// defect alive in the WithCustomExtractors lane: a full index opted in
+// programmatically emits custom entities, and an incremental pass that saw only
+// an unset env var would drop them on the next edit. Routing the programmatic
+// opt-in through ExtractorConfig.InProcCustomExtractors — which TryIncremental
+// already receives — makes the two paths evaluate the same expression over the
+// same inputs.
+//
+// CONFIG WINS OVER ENV, deliberately, and in BOTH directions: an explicit
+// `false` in Config suppresses a set env var. That is ExtractorConfig's own
+// established precedence (#2320, "Config-first/env-fallback") and the tri-state
+// pointer is what distinguishes "Config says no" from "Config did not say".
+func CustomExtractorsEnabled(cfg *extractor.ExtractorConfig) bool {
+	if cfg != nil && cfg.InProcCustomExtractors != nil {
+		return *cfg.InProcCustomExtractors
+	}
+	return InProcCustomExtractorsEnabled()
 }

--- a/internal/extractors/custom_gate.go
+++ b/internal/extractors/custom_gate.go
@@ -1,0 +1,29 @@
+package extractors
+
+import (
+	"os"
+	"strings"
+)
+
+// InProcCustomExtractorsEnabled reports whether an in-process indexing path
+// should additionally dispatch the custom/framework extractors registered under
+// internal/custom/** (issue #5989) via RunCustomExtractors.
+//
+// ONE READER, TWO CALLERS. The env var used to be read only by
+// cmd/grafel/inproc_custom.go, which is why the daemon's incremental path could
+// not consult it without importing cmd/grafel. #6960: the gate lives here, in
+// the package that owns the dispatcher, and cmd/grafel/inproc_custom.go
+// delegates. A second literal reading of the same variable would be free to
+// drift from this one — that drift is the failure this placement prevents, and
+// it is exactly the failure that made incremental and full disagree.
+//
+// The default stays OFF; see cmd/grafel/inproc_custom.go for the cost rationale
+// and internal/extractors/incremental.go's dispatch site for why the incremental
+// path must read the SAME gate rather than choosing its own answer: the property
+// incremental owes its caller is "same graph as a full reindex", and a pass that
+// runs custom extractors when the full path did not is as wrong as one that
+// skips them when the full path did.
+func InProcCustomExtractorsEnabled() bool {
+	v := strings.TrimSpace(os.Getenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS"))
+	return v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -1077,6 +1077,47 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		// daemon runs this on a watcher tick, and a panic here would take down a
 		// path whose whole job is to not lose the user's graph.
 		records, extErr := safeExtract(ctx, ext, input)
+
+		// #6960 — Pass 2: the custom/framework extractors under internal/custom/**.
+		//
+		// THIS PATH HAD NO CUSTOM DISPATCH AT ALL. The ~340 framework extractors
+		// register under PREFIXED registry keys ("python_django", "custom_scala_di"),
+		// and the exact-key `Get(cr.Language)` above can never match one, so
+		// RunCustomExtractors is the only thing that selects them —
+		// custom_dispatch.go:192. It had two non-test call sites and neither was
+		// on this path, so a re-extraction emitted the base records only.
+		//
+		// THE GATE IS THE FIX, NOT THE CALL. By DEFAULT the full in-process path
+		// does not dispatch these either (cmd/grafel/inproc_custom.go), so the
+		// default-config graph was never wrong — the initial index emitted no
+		// custom entities to lose. Under GRAFEL_INPROC_CUSTOM_EXTRACTORS=1 it
+		// WAS: the full index emitted them, Step 5 above evicted them on the next
+		// edit, and this loop re-added nothing, so a changed file silently lost
+		// every custom entity while every unchanged file kept its own. Reading
+		// the same gate makes the two paths agree in BOTH directions — including
+		// the one an "entities survive" assertion cannot see, where incremental
+		// would ADD entities a default full reindex never produced.
+		//
+		// SEAM PLACEMENT IS LOAD-BEARING, exactly as at cmd/grafel/index.go:4138:
+		// after safeExtract (so base records exist to merge into) and BEFORE the
+		// Close() below, because custom extractors walk the same parse tree.
+		// Moving it after the Close is a use-after-free, not merely a no-op. The
+		// `input.TSTree != nil` guard is carried for the same reason it is there:
+		// a subset of custom extractors work on CONTENT and emit entities with no
+		// tree at all, so without it a file that FAILED to parse would still
+		// produce custom entities the full path would not.
+		if InProcCustomExtractorsEnabled() && input.TSTree != nil {
+			customEnts, customErrs := RunCustomExtractors(ctx, input)
+			for _, ce := range customErrs {
+				logger.Printf("incremental: custom extractor on %s: %v", rel, ce)
+			}
+			if len(customEnts) > 0 {
+				// MergeWithCustom, not append — the same #6104 non-destructive
+				// (SourceFile, Kind, Name) merge the full path applies.
+				records = MergeWithCustom(records, customEnts)
+			}
+		}
+
 		if input.TSTree != nil {
 			// Release the CGo allocation now rather than deferring to the end of
 			// the loop: peak RSS must stay at one live tree, not len(reallyChanged).

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -1090,23 +1090,38 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		// THE GATE IS THE FIX, NOT THE CALL. By DEFAULT the full in-process path
 		// does not dispatch these either (cmd/grafel/inproc_custom.go), so the
 		// default-config graph was never wrong — the initial index emitted no
-		// custom entities to lose. Under GRAFEL_INPROC_CUSTOM_EXTRACTORS=1 it
-		// WAS: the full index emitted them, Step 5 above evicted them on the next
-		// edit, and this loop re-added nothing, so a changed file silently lost
-		// every custom entity while every unchanged file kept its own. Reading
-		// the same gate makes the two paths agree in BOTH directions — including
-		// the one an "entities survive" assertion cannot see, where incremental
-		// would ADD entities a default full reindex never produced.
+		// custom entities to lose. With the gate ON it WAS: the full index
+		// emitted them, Step 5 above evicted them on the next edit, and this loop
+		// re-added nothing, so a changed file silently lost every custom entity
+		// while every unchanged file kept its own. Reading the same gate makes
+		// the two paths agree in BOTH directions — including the one an "entities
+		// survive" assertion cannot see, where incremental would ADD entities a
+		// default full reindex never produced.
 		//
-		// SEAM PLACEMENT IS LOAD-BEARING, exactly as at cmd/grafel/index.go:4138:
-		// after safeExtract (so base records exist to merge into) and BEFORE the
-		// Close() below, because custom extractors walk the same parse tree.
-		// Moving it after the Close is a use-after-free, not merely a no-op. The
-		// `input.TSTree != nil` guard is carried for the same reason it is there:
-		// a subset of custom extractors work on CONTENT and emit entities with no
-		// tree at all, so without it a file that FAILED to parse would still
-		// produce custom entities the full path would not.
-		if InProcCustomExtractorsEnabled() && input.TSTree != nil {
+		// BOTH HALVES OF THE GATE, not just the env var. The full path's
+		// condition is CustomExtractorsEnabled over the same ExtractorConfig, so
+		// the programmatic opt-in (cmd/grafel's WithCustomExtractors, which
+		// `grafel quality` uses and which is the only lane on by default
+		// anywhere) reaches this decision too. An env-only read here left the
+		// original defect alive in exactly that lane.
+		//
+		// SEAM PLACEMENT IS LOAD-BEARING, exactly as at cmd/grafel/index.go: after
+		// safeExtract (so base records exist to merge into) and BEFORE the Close()
+		// below, because custom extractors walk the same parse tree.
+		//
+		// MOVING IT AFTER THE Close() IS A SILENT NO-OP, NOT A CRASH, and an
+		// earlier version of this comment claiming a use-after-free was wrong —
+		// measured: the block below sets `input.TSTree = nil` immediately after
+		// Close(), so a dispatch moved past it fails the `!= nil` guard and simply
+		// never fires. It runs to completion and quietly emits nothing, which is
+		// worse to debug than a crash, not better.
+		//
+		// The `input.TSTree != nil` guard is carried for the reason the full
+		// path's is: a subset of custom extractors work on CONTENT and emit
+		// entities with no tree at all, so without it a file that FAILED to parse
+		// — or a language with no grammar at all, which is the case the dart test
+		// drives — would produce custom entities the full path never emits.
+		if CustomExtractorsEnabled(cfg) && input.TSTree != nil {
 			customEnts, customErrs := RunCustomExtractors(ctx, input)
 			for _, ce := range customErrs {
 				logger.Printf("incremental: custom extractor on %s: %v", rel, ce)
@@ -2050,18 +2065,21 @@ func entityRecordToGraphEntity(r types.EntityRecord, repoTag string) graph.Entit
 	// with the wrong id, so nothing downstream of it dangles. It surfaced only
 	// because a flow property happens to embed the id as text.
 	id := graph.EntityID(repoTag, r.Kind, r.Name, r.SourceFile)
-	// #6275 — r.Properties (and therefore any grafel.twin_of a #6104 merge
-	// facet carries) is copied VERBATIM here, with no equivalent of
-	// cmd/grafel/index.go's stampEntityIDs remap (old ComputeID() -> this
-	// freshly computed `id`). That is harmless TODAY only because the sole
-	// twin_of writer, internal/extractors/custom_dispatch.go's
-	// enrichFromTwin, is reachable exclusively from the full-index path
-	// (MergeWithCustom has no caller on this incremental path — see
-	// classfold.go's FoldFrameworkClassKinds doc comment, "TryIncremental
-	// runs no cross extractors at all"). If anything ever starts stamping
-	// twin_of from code reachable here, the #6275 orphaned-anchor bug comes
-	// back silently: this function would need the same pre-stamp-id ->
-	// final-id remap stampEntityIDs performs.
+	// #6275 — r.Properties (and therefore any grafel.twin_of a #6104 merge facet
+	// carries) is copied VERBATIM here. This function performs no remap of its
+	// own, and it must not: the old comment here said the omission was safe
+	// because "MergeWithCustom has no caller on this incremental path", and
+	// #6960 ADDED that caller (the custom dispatch in the Step 6 re-extract
+	// loop), so enrichFromTwin now writes twin_of from code reachable here. The
+	// predicted failure was real and was measured: SCOPE.Type|HomeController
+	// landed carrying twin_of="861a490cf84f2640" — a ComputeID() hash — while
+	// the anchor's actual graph id is the graph.EntityID above, a different
+	// preimage entirely, so the facet named nothing.
+	//
+	// The remap is done ONE LEVEL UP, in convertExtractedRecords via
+	// remapTwinOfAnchors, and it has to be: the mapping is pre-stamp id ->
+	// final id over the WHOLE batch, and this function sees one record. A
+	// per-record fix is not expressible here.
 	return graph.Entity{
 		ID:            id,
 		Name:          r.Name,
@@ -2077,6 +2095,88 @@ func entityRecordToGraphEntity(r types.EntityRecord, repoTag string) graph.Entit
 
 		Confidence: r.Confidence, // Phase 1C (#2769) — propagates extractor stamp.
 	}.WithProperties(r.Properties)
+}
+
+// remapTwinOfAnchors repoints every grafel.twin_of (#6104 merge-facet anchor)
+// that still names a record's PRE-STAMP id at the id this path is about to
+// derive for that record. It is the incremental equivalent of
+// cmd/grafel/index.go's stampEntityIDs remap, and it exists for exactly the
+// reason that function's #6275 comment gives: a twin_of value is an OPAQUE
+// Properties string. Every other cross-record reference in the pipeline —
+// relationship endpoints, fold remaps, resolver bindings — is rekeyed by some
+// downstream pass. Nothing anywhere rewrites twin_of, so an anchor left naming a
+// hash that never becomes an entity id is permanent, silent, and invisible to a
+// content-keyed parity comparison (which deliberately does not compare ids).
+//
+// WHY IT WAS NOT NEEDED BEFORE AND IS NOW. The sole twin_of writer is
+// custom_dispatch.go's enrichFromTwin, reached only through MergeWithCustom,
+// which until #6960 had no caller on this path. #6960's custom dispatch in the
+// Step 6 re-extract loop is that caller. entityRecordToGraphEntity's comment
+// named this trigger in advance; this function is the remap it prescribed.
+//
+// THE PREIMAGES DIFFER, which is the whole bug: enrichFromTwin stamps
+// effectiveID(&be), i.e. types.EntityRecord.ComputeID() —
+// sha256(OrgID+ProjectID+SourceFile+Kind+Name) — while this path mints
+// graph.EntityID(repoTag, Kind, Name, SourceFile). Same record, two hashes.
+//
+// BATCH SCOPE IS SUFFICIENT. The facet and its anchor are the two halves of one
+// (SourceFile, Kind, Name) merge decision made inside MergeWithCustom over ONE
+// file's records, and this runs over that same file's records — so an anchor is
+// never outside the batch. An anchor that somehow were outside it keeps its
+// pre-stamp value rather than acquiring a wrong one: the map lookup simply
+// misses.
+//
+// COST. recordsCarryTwinOf is one map lookup per record — no hashing — so the
+// overwhelmingly common batch, which carries no facet at all, pays nothing and
+// never computes the second sha256. Same shape as recordsHaveTwinOf on the full
+// path.
+func remapTwinOfAnchors(records []types.EntityRecord, repoTag string) {
+	if !recordsCarryTwinOf(records) {
+		return
+	}
+	preStampToFinal := make(map[string]string)
+	for k := range records {
+		r := &records[k]
+		if r.Name == "" {
+			continue
+		}
+		preStampID := r.ComputeID()
+		finalID := graph.EntityID(repoTag, r.Kind, r.Name, r.SourceFile)
+		if preStampID != finalID {
+			preStampToFinal[preStampID] = finalID
+		}
+	}
+	if len(preStampToFinal) == 0 {
+		return
+	}
+	for k := range records {
+		r := &records[k]
+		if r.Properties == nil {
+			continue
+		}
+		twin, ok := r.Properties[types.EntityTwinOfProperty]
+		if !ok || twin == "" {
+			continue
+		}
+		if final, remapped := preStampToFinal[twin]; remapped {
+			r.Properties[types.EntityTwinOfProperty] = final
+		}
+	}
+}
+
+// recordsCarryTwinOf reports whether ANY record in the batch carries a
+// grafel.twin_of property — the gate for the remap above, and a scan of cheap
+// map lookups rather than hashes.
+func recordsCarryTwinOf(records []types.EntityRecord) bool {
+	for k := range records {
+		if records[k].Properties == nil {
+			continue
+		}
+		if v := records[k].Properties[types.EntityTwinOfProperty]; v != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // convertExtractedRecords converts one file's extractor output into graph
@@ -2164,6 +2264,12 @@ func entityRecordToGraphEntity(r types.EntityRecord, repoTag string) graph.Entit
 // buildDocument's equivalent gate is corpus-wide because ITS input genuinely is
 // (merged spans every file), so it needs no second fold downstream.
 func convertExtractedRecords(records []types.EntityRecord, repoTag string, seenRel map[string]bool) ([]graph.Entity, []graph.Relationship) {
+	// #6275 / #6960 — repoint merge-facet anchors BEFORE any id is derived. See
+	// remapTwinOfAnchors: this is the incremental half of cmd/grafel/index.go's
+	// stampEntityIDs remap, and it became load-bearing the moment #6960 gave
+	// MergeWithCustom a caller on this path.
+	remapTwinOfAnchors(records, repoTag)
+
 	ents := make([]graph.Entity, 0, len(records))
 	var rels []graph.Relationship
 	// #6161 — entityPos maps a derived graph.EntityID → its index in `ents`, so a

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -80,6 +80,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -2130,11 +2131,42 @@ func entityRecordToGraphEntity(r types.EntityRecord, repoTag string) graph.Entit
 // overwhelmingly common batch, which carries no facet at all, pays nothing and
 // never computes the second sha256. Same shape as recordsHaveTwinOf on the full
 // path.
+//
+// THE TWO ID SCHEMES DISAGREE ABOUT FIELD BOUNDARIES, and this function is the
+// first code in the tree to key a map on the COARSER one while storing the
+// FINER one — which is what makes the disagreement reachable here and nowhere
+// else. types.EntityRecord.ComputeID concatenates OrgID+ProjectID+SourceFile+
+// Kind+Name with NO separators; graph.EntityID separates every field with NUL.
+// So {SourceFile:"x.go", Kind:"A", Name:"BC"} and {SourceFile:"x.go",
+// Kind:"AB", Name:"C"} are ONE key and TWO entities: measured,
+// ComputeID collides while EntityID does not.
+//
+// Without the check below, both records write the same map slot and the winner
+// is whichever index happens to come last — so a twin_of naming that preimage is
+// repointed at an ARBITRARY one of two distinct entities. That is the #6369
+// wrong-node hazard, and it is strictly worse than the dangling anchor this
+// function exists to prevent: a dangling twin_of names an id no entity has and
+// is therefore detectable and inert, while a confidently-wrong one reads as
+// valid to classfold's twinAnchors and to the symbol index's facet-alias rule,
+// which will then alias a name onto the wrong definition.
+//
+// SO AN AMBIGUOUS KEY IS SKIPPED, NOT RESOLVED, and warned about. Skipping
+// degrades exactly to the pre-remap behaviour for that one facet — the honest,
+// detectable failure — and it is the only outcome that does not require this
+// function to invent an answer it has no evidence for. Picking one silently, the
+// behaviour before this check, is the one option that is not defensible.
+// (The underlying ComputeID separator problem is broader than this function and
+// is filed separately; do not "fix" it here by changing ComputeID, which is an
+// identity many other call sites already depend on.)
 func remapTwinOfAnchors(records []types.EntityRecord, repoTag string) {
 	if !recordsCarryTwinOf(records) {
 		return
 	}
 	preStampToFinal := make(map[string]string)
+	// ambiguous holds every pre-stamp key that TWO records with DIFFERENT final
+	// ids both claim. See the collision note in the doc comment: such a key is
+	// dropped from the remap entirely rather than resolved by arrival order.
+	var ambiguous map[string]bool
 	for k := range records {
 		r := &records[k]
 		if r.Name == "" {
@@ -2142,6 +2174,22 @@ func remapTwinOfAnchors(records []types.EntityRecord, repoTag string) {
 		}
 		preStampID := r.ComputeID()
 		finalID := graph.EntityID(repoTag, r.Kind, r.Name, r.SourceFile)
+		if prior, seen := preStampToFinal[preStampID]; seen && prior != finalID {
+			if ambiguous == nil {
+				ambiguous = make(map[string]bool, 1)
+			}
+			ambiguous[preStampID] = true
+			slog.Default().Warn("incremental: two records share one pre-stamp entity id — "+
+				"a grafel.twin_of naming it will be left unremapped rather than pointed at "+
+				"an arbitrary one of them",
+				"pre_stamp_id", preStampID,
+				"source_file", r.SourceFile,
+				"kind", r.Kind,
+				"name", r.Name,
+				"final_id", finalID,
+				"other_final_id", prior)
+			continue
+		}
 		if preStampID != finalID {
 			preStampToFinal[preStampID] = finalID
 		}
@@ -2156,6 +2204,10 @@ func remapTwinOfAnchors(records []types.EntityRecord, repoTag string) {
 		}
 		twin, ok := r.Properties[types.EntityTwinOfProperty]
 		if !ok || twin == "" {
+			continue
+		}
+		if ambiguous[twin] {
+			// LEAVE IT DANGLING, DELIBERATELY. See the doc comment.
 			continue
 		}
 		if final, remapped := preStampToFinal[twin]; remapped {

--- a/internal/extractors/incremental_custom_extractors_6960_test.go
+++ b/internal/extractors/incremental_custom_extractors_6960_test.go
@@ -1,0 +1,477 @@
+// Package extractors_test — incremental_custom_extractors_6960_test.go
+//
+// Issue #6960: does the daemon's incremental re-extraction reach
+// RunCustomExtractors? It did not. The hop chain is
+//
+//	watcher → sched worker → cmd/grafel/daemon.go:daemonSchedulerIncremental
+//	        → extractors.TryIncremental → tryIncremental Step 6 re-extract loop
+//	        → Get(cr.Language) → safeExtract
+//
+// and Get is an EXACT-KEY registry lookup. Every custom/framework extractor
+// registers under a PREFIXED key ("custom_scala_di", "python_django"), so that
+// lookup can never select one; RunCustomExtractors — which does the prefix fan-
+// out — had two non-test call sites and neither is on this path.
+//
+// WHAT THE CONSEQUENCE ACTUALLY IS, which is narrower than the issue assumed.
+// Both full-index paths gate custom dispatch OFF by default
+// (cmd/grafel/index.go:4138 behind GRAFEL_INPROC_CUSTOM_EXTRACTORS,
+// internal/daemon/extract/subproc.go:364 behind the opt-in GRAFEL_SUBPROC_EXTRACT
+// branch), so in the DEFAULT configuration the initial index emits no custom
+// entities and there is nothing for an incremental pass to lose. The divergence
+// is real only with the gate ON — and there it is the silent-degradation shape:
+// the full index emits them, Step 5 evicts them on the next edit, and the loop
+// re-adds nothing, so a CHANGED file loses what every UNCHANGED file keeps.
+//
+// Both tests below drive the real TryIncremental and both require res.Done —
+// that is the proof the pass was INCREMENTAL and not a fallback to a full
+// reindex, which would compute the right answer for the wrong reason and read
+// as a false all-clear.
+package extractors_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/treesitter"
+)
+
+// A Play controller: the base scala extractor emits SCOPE.Component/Operation
+// for it, and internal/custom/scala's DI extractor emits SCOPE.DI records that
+// ONLY RunCustomExtractors can select. The two are the base/custom halves of
+// the same file, which is what makes the assertions below separable.
+const playControllerV1_6960 = `package controllers
+
+import javax.inject._
+import play.api.mvc._
+
+@Singleton
+class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+  def index() = Action { implicit request: Request[AnyContent] =>
+    Ok("hi")
+  }
+}
+`
+
+const playControllerV2_6960 = `package controllers
+
+import javax.inject._
+import play.api.mvc._
+
+@Singleton
+class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+  def index() = Action { implicit request: Request[AnyContent] =>
+    Ok("hello")
+  }
+  def about() = Action { implicit request: Request[AnyContent] =>
+    Ok("about")
+  }
+}
+`
+
+const playControllerRel6960 = "app/controllers/HomeController.scala"
+
+// The custom-only entity the assertions turn on. `singleton:HomeController` is
+// chosen over the sibling `inject:HomeController.scala:7` deliberately: the
+// latter embeds a LINE NUMBER, so an edit above it renames it and the test
+// would be asserting the edit rather than the dispatch.
+const customOnlyEntity6960 = "singleton:HomeController"
+
+// seedAndEdit6960 stands up a repo whose graph already holds the file's
+// entities, then edits the file, then runs one incremental pass. It returns the
+// resulting graph document. The seeded graph deliberately CONTAINS the custom
+// entity: that is the "initial index ran with the gate on" state, and it is what
+// makes the gate-on case a LOSS rather than merely an absence.
+func seedAndEdit6960(t *testing.T) *graph.Document {
+	t.Helper()
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	writeFile(t, repo, playControllerRel6960, playControllerV1_6960)
+	seed := []graph.Entity{
+		{
+			ID:   graph.EntityID("test-repo", "SCOPE.DI", customOnlyEntity6960, playControllerRel6960),
+			Name: customOnlyEntity6960, Kind: "SCOPE.DI", SourceFile: playControllerRel6960, Language: "scala",
+		},
+		{
+			ID:   graph.EntityID("test-repo", "SCOPE.Component", "HomeController", playControllerRel6960),
+			Name: "HomeController", Kind: "SCOPE.Component", SourceFile: playControllerRel6960, Language: "scala",
+		},
+	}
+	buildMinimalGraph(t, stateDir, seed, nil)
+	seedManifest(t, repo, stateDir)
+
+	writeFile(t, repo, playControllerRel6960, playControllerV2_6960)
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	// THE INCREMENTALITY PROOF. Done=false means TryIncremental declined and the
+	// caller runs a FULL index instead — on which custom dispatch is a different
+	// question entirely. Every assertion below is about the incremental path, so
+	// none of them means anything without this.
+	if !res.Done {
+		t.Fatalf("pass was NOT incremental — TryIncremental fell back (%s); every assertion "+
+			"in this test is about the incremental path and none survives a full reindex",
+			res.FallbackReason)
+	}
+	if res.ChangedFiles != 1 {
+		t.Fatalf("expected exactly the edited file to be re-extracted, got ChangedFiles=%d", res.ChangedFiles)
+	}
+
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+	return doc
+}
+
+func hasEntity6960(doc *graph.Document, kind, name string) bool {
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == kind && doc.Entities[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func anyEntityOfKind6960(doc *graph.Document, kind string) []string {
+	var out []string
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == kind {
+			out = append(out, doc.Entities[i].Name)
+		}
+	}
+	return out
+}
+
+// TestIncrementalDispatchesCustomExtractorsWhenTheGateIsOn6960 is the #6960
+// regression pin. With GRAFEL_INPROC_CUSTOM_EXTRACTORS=1 the full index emits
+// the SCOPE.DI records; before the fix, editing the file evicted them and the
+// re-extract loop re-added nothing.
+func TestIncrementalDispatchesCustomExtractorsWhenTheGateIsOn6960(t *testing.T) {
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+
+	doc := seedAndEdit6960(t)
+
+	// POSITIVE CONTROL, and not decoration: it proves the loop re-extracted the
+	// file at all. Without it, a pass that silently produced NOTHING for this
+	// file would fail the custom assertion below with the same message as a pass
+	// that ran only the base extractor, and the two are different bugs.
+	if !hasEntity6960(doc, "SCOPE.Operation", "about") {
+		t.Fatalf("premise: the edit added `def about()` and the base scala extractor did not "+
+			"emit it — the re-extraction did not happen, so this test is measuring nothing. "+
+			"entities: %v", entityNames6960(doc))
+	}
+
+	if !hasEntity6960(doc, "SCOPE.DI", customOnlyEntity6960) {
+		t.Errorf("#6960: SCOPE.DI|%s is absent after an INCREMENTAL pass with "+
+			"GRAFEL_INPROC_CUSTOM_EXTRACTORS=1. Only RunCustomExtractors selects the "+
+			"custom_scala_di extractor that produces it, so the re-extract loop never "+
+			"dispatched the custom pass: the file's custom entities were evicted in Step 5 "+
+			"and nothing re-added them. SCOPE.DI entities present: %v",
+			customOnlyEntity6960, anyEntityOfKind6960(doc, "SCOPE.DI"))
+	}
+}
+
+// TestIncrementalSkipsCustomExtractorsWhenTheGateIsOff6960 grades the direction
+// an "entities survive" assertion structurally cannot see: entities WRONGLY
+// ADDED. The correctness property this path owes is "same graph as a full
+// reindex", and with the gate off a full reindex emits no custom entities — so
+// an incremental pass that dispatched them unconditionally would be just as
+// divergent as one that never dispatched them, only in the opposite direction
+// (and would silently pay the +17.5% wall cost the gate exists to withhold).
+func TestIncrementalSkipsCustomExtractorsWhenTheGateIsOff6960(t *testing.T) {
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+
+	doc := seedAndEdit6960(t)
+
+	if !hasEntity6960(doc, "SCOPE.Operation", "about") {
+		t.Fatalf("premise: base re-extraction did not happen; entities: %v", entityNames6960(doc))
+	}
+	if got := anyEntityOfKind6960(doc, "SCOPE.DI"); len(got) != 0 {
+		t.Errorf("#6960: the incremental pass emitted SCOPE.DI entities %v with the gate OFF — "+
+			"a default full reindex emits none, so this is a divergence, not a bonus", got)
+	}
+}
+
+// TestCustomScalaDIIsSelectableAtAllForThisFile6960 is the premise the two tests
+// above rest on. Without it, "SCOPE.DI is absent" is satisfied by an extractor
+// that emits nothing for this content, and the gate-off test would pass no
+// matter what the incremental path did.
+func TestCustomScalaDIIsSelectableAtAllForThisFile6960(t *testing.T) {
+	ents, errs := extractors.RunCustomExtractors(context.Background(), extractor.FileInput{
+		Path:     playControllerRel6960,
+		Content:  []byte(playControllerV2_6960),
+		Language: "scala",
+	})
+	for _, e := range errs {
+		t.Logf("custom extractor error (non-fatal): %v", e)
+	}
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.DI" && e.Name == customOnlyEntity6960 {
+			found = true
+		}
+	}
+	if !found {
+		var got []string
+		for _, e := range ents {
+			got = append(got, e.Kind+"|"+e.Name)
+		}
+		t.Fatalf("premise: RunCustomExtractors on %s emits no SCOPE.DI|%s — the two incremental "+
+			"tests above are then vacuous in the gate-off direction. Emitted: %v",
+			playControllerRel6960, customOnlyEntity6960, got)
+	}
+
+	// And the other half of the premise: the EXACT-KEY dispatch cannot produce
+	// it. This is what makes the entity custom-only, i.e. what makes the
+	// gate-on assertion a test of RunCustomExtractors rather than of anything
+	// the base scala extractor might also happen to emit.
+	base, _ := extractors.Extract(context.Background(), extractor.FileInput{
+		Path:     playControllerRel6960,
+		Content:  []byte(playControllerV2_6960),
+		Language: "scala",
+	})
+	for _, e := range base {
+		if e.Kind == "SCOPE.DI" && e.Name == customOnlyEntity6960 {
+			t.Fatalf("premise: the BASE scala extractor also emits SCOPE.DI|%s, so the gate-on "+
+				"assertion does not distinguish custom dispatch from base extraction",
+				customOnlyEntity6960)
+		}
+	}
+}
+
+func entityNames6960(doc *graph.Document) []string {
+	out := make([]string, 0, len(doc.Entities))
+	for i := range doc.Entities {
+		out = append(out, doc.Entities[i].Kind+"|"+doc.Entities[i].Name)
+	}
+	return out
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The nil-tree guard
+// ─────────────────────────────────────────────────────────────────────────────
+
+// dart has NO tree-sitter grammar, so the re-extract loop's parse returns
+// ErrUnsupportedLanguage and input.TSTree stays nil — while the base dart
+// extractor is a source scanner that emits records anyway, so the pass does NOT
+// fall back and really does re-extract. That combination is what makes this file
+// able to observe the `input.TSTree != nil` guard: on a scala file the tree is
+// always there and the guard is unobservable.
+const dartClientV1_6960 = `import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text('hi');
+  }
+}
+`
+
+const dartClientV2_6960 = `import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text('hello');
+  }
+}
+`
+
+const dartClientRel6960 = "lib/home_page.dart"
+
+// TestIncrementalHonoursTheNilTreeGuard6960 grades the guard the fix carries
+// over from cmd/grafel/index.go:4138, in the permissive direction: WITHOUT it,
+// an incremental pass over a file that produced no parse tree emits custom
+// entities the full in-process path — which holds the identical
+// `file.TSTree != nil` condition — would never produce. That is the same
+// divergence as #6960 itself with the sign flipped, and no assertion about
+// entities SURVIVING can see it.
+func TestIncrementalHonoursTheNilTreeGuard6960(t *testing.T) {
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, repo, dartClientRel6960, dartClientV1_6960)
+	buildMinimalGraph(t, stateDir, []graph.Entity{{
+		ID:   graph.EntityID("test-repo", "SCOPE.Component", "HomePage", dartClientRel6960),
+		Name: "HomePage", Kind: "SCOPE.Component", SourceFile: dartClientRel6960, Language: "dart",
+	}}, nil)
+	seedManifest(t, repo, stateDir)
+
+	writeFile(t, repo, dartClientRel6960, dartClientV2_6960)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("pass was NOT incremental — fell back (%s)", res.FallbackReason)
+	}
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+
+	// PREMISE 1 — the re-extraction happened. Without it the absence asserted
+	// below is the absence of everything.
+	if !hasEntity6960(doc, "SCOPE.Component", "HomePage") {
+		t.Fatalf("premise: the base dart extractor emitted nothing for the re-extracted file; "+
+			"entities: %v", entityNames6960(doc))
+	}
+	// PREMISE 2 — the custom dart extractor WOULD emit for this content, with no
+	// tree. Without this the guard assertion is satisfied by an extractor that
+	// has nothing to say.
+	cus, _ := extractors.RunCustomExtractors(context.Background(), extractor.FileInput{
+		Path: dartClientRel6960, Content: []byte(dartClientV2_6960), Language: "dart",
+	})
+	wouldEmit := false
+	for _, e := range cus {
+		if e.Kind == "SCOPE.UIComponent" && e.Name == "HomePage" {
+			wouldEmit = true
+		}
+	}
+	if !wouldEmit {
+		t.Fatalf("premise: RunCustomExtractors(dart) emits no SCOPE.UIComponent|HomePage with a "+
+			"nil tree, so this test cannot observe the guard at all; emitted %d records", len(cus))
+	}
+
+	if got := anyEntityOfKind6960(doc, "SCOPE.UIComponent"); len(got) != 0 {
+		t.Errorf("#6960: the incremental pass dispatched custom extractors on a file with NO parse "+
+			"tree and emitted %v — cmd/grafel/index.go:4138 holds the same `file.TSTree != nil` "+
+			"guard, so the full path emits none of these and the two paths now disagree", got)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The merge, not an append
+// ─────────────────────────────────────────────────────────────────────────────
+
+// A Spring controller. The base java extractor and the custom java routing
+// extractor BOTH emit SCOPE.Operation|UserController.listUsers for it — the same
+// (SourceFile, Kind, Name) identity — which is what MergeWithCustom's #6104
+// contract exists for and what a plain append would double. Measured on this
+// content: MergeWithCustom yields 3 records where append yields 4.
+const springControllerV1_6960 = `package com.example;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class UserController {
+    @GetMapping("/users")
+    public String listUsers() {
+        return "[]";
+    }
+}
+`
+
+const springControllerV2_6960 = `package com.example;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class UserController {
+    @GetMapping("/users")
+    public String listUsers() {
+        return "[{}]";
+    }
+}
+`
+
+const springControllerRel6960 = "src/main/java/com/example/UserController.java"
+
+// TestIncrementalMergesCustomRecordsRatherThanAppending6960 grades the merge
+// call itself. `records = append(records, customEnts...)` compiles, satisfies
+// every assertion above (the scala custom records collide with nothing) and
+// still ships the #4405/#6104 hazard: two records with one identity, whose
+// entity ids are DERIVED from that identity downstream.
+func TestIncrementalMergesCustomRecordsRatherThanAppending6960(t *testing.T) {
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, repo, springControllerRel6960, springControllerV1_6960)
+	buildMinimalGraph(t, stateDir, []graph.Entity{{
+		ID:   graph.EntityID("test-repo", "SCOPE.Operation", "UserController.listUsers", springControllerRel6960),
+		Name: "UserController.listUsers", Kind: "SCOPE.Operation", SourceFile: springControllerRel6960, Language: "java",
+	}}, nil)
+	seedManifest(t, repo, stateDir)
+
+	writeFile(t, repo, springControllerRel6960, springControllerV2_6960)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("pass was NOT incremental — fell back (%s)", res.FallbackReason)
+	}
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+
+	// PREMISE — the base and custom passes really do collide on this content.
+	// Without it the cardinality assertion below is satisfied by a file where
+	// only one producer ever spoke, and append and merge are indistinguishable.
+	//
+	// The premise is computed WITH a parse tree, because that is the state the
+	// re-extract loop is in when it reaches the dispatch: java has a grammar, so
+	// input.TSTree is non-nil there, and the base java extractor emits nothing
+	// at all without one.
+	pf := treesitter.NewParserFactory(nil)
+	pr, perr := pf.Parse(context.Background(), []byte(springControllerV2_6960), "java")
+	if perr != nil || pr == nil || pr.TSTree == nil {
+		t.Fatalf("premise: the java fixture did not parse (%v) — the loop would have taken the "+
+			"nil-tree path instead of the dispatch this test grades", perr)
+	}
+	defer pr.TSTree.Close()
+	fi := extractor.FileInput{Path: springControllerRel6960, Content: []byte(springControllerV2_6960), Language: "java", TSTree: pr.TSTree}
+	base, _ := extractors.Extract(context.Background(), fi)
+	cus, _ := extractors.RunCustomExtractors(context.Background(), fi)
+	collides := false
+	for _, b := range base {
+		for _, c := range cus {
+			if b.SourceFile == c.SourceFile && b.Kind == c.Kind && b.Name == c.Name {
+				collides = true
+			}
+		}
+	}
+	if !collides {
+		t.Fatalf("premise: no (SourceFile, Kind, Name) collision between the base and custom java "+
+			"records for this file, so append and MergeWithCustom produce the same set and this "+
+			"test grades nothing (base=%d custom=%d)", len(base), len(cus))
+	}
+
+	n := 0
+	var survivor graph.Entity
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == "SCOPE.Operation" && doc.Entities[i].Name == "UserController.listUsers" {
+			n++
+			survivor = doc.Entities[i]
+		}
+	}
+	if n != 1 {
+		t.Fatalf("#6960: %d entities named SCOPE.Operation|UserController.listUsers after one "+
+			"incremental pass, want exactly 1 — the base and custom producers must not each land "+
+			"a record under one derived id", n)
+	}
+
+	// CARDINALITY ALONE DOES NOT GRADE THE MERGE, and asserting only n==1 was
+	// measured to be exactly that mistake: with `append` in place of
+	// MergeWithCustom the downstream entity dedupe still collapses the pair, so
+	// n stays 1 and the whole test passes on the mutant. What append LOSES is
+	// the #6104 invariant the merge exists for — "a merge never narrows a span".
+	// Measured on this fixture: MergeWithCustom keeps the method's real span
+	// (lines 8-11, the `@GetMapping` through the closing brace) while append
+	// leaves the custom record's single annotation line (8-8), and the flow
+	// entity built from the endpoint disappears with it.
+	if survivor.EndLine <= survivor.StartLine {
+		t.Errorf("#6960: SCOPE.Operation|UserController.listUsers survived one incremental pass "+
+			"with a collapsed span (start=%d end=%d). The custom records must go through "+
+			"MergeWithCustom, which unions the two producers' spans; a plain append leaves "+
+			"whichever record the dedupe happened to keep, narrowing the method to its annotation "+
+			"line", survivor.StartLine, survivor.EndLine)
+	}
+	if !hasEntity6960(doc, "SCOPE.Process", "http:GET:/api/users \u2192 UserController.listUsers") {
+		t.Errorf("#6960: the endpoint→handler flow entity is missing after the incremental pass — "+
+			"it is derived from the merged operation's span, so it is the downstream casualty of "+
+			"an un-merged append. entities: %v", entityNames6960(doc))
+	}
+}

--- a/internal/extractors/incremental_custom_extractors_6960_test.go
+++ b/internal/extractors/incremental_custom_extractors_6960_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cajasmota/grafel/internal/extractors"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // A Play controller: the base scala extractor emits SCOPE.Component/Operation
@@ -86,6 +87,14 @@ const customOnlyEntity6960 = "singleton:HomeController"
 // makes the gate-on case a LOSS rather than merely an absence.
 func seedAndEdit6960(t *testing.T) *graph.Document {
 	t.Helper()
+	return seedAndEdit6960WithConfig(t, nil)
+}
+
+// seedAndEdit6960WithConfig is seedAndEdit6960 with the ExtractorConfig the
+// daemon hands TryIncremental made explicit, so the CONFIG half of the gate can
+// be driven the way cmd/grafel's WithCustomExtractors reaches it.
+func seedAndEdit6960WithConfig(t *testing.T, cfg *extractor.ExtractorConfig) *graph.Document {
+	t.Helper()
 	repo := t.TempDir()
 	stateDir := t.TempDir()
 
@@ -105,7 +114,7 @@ func seedAndEdit6960(t *testing.T) *graph.Document {
 
 	writeFile(t, repo, playControllerRel6960, playControllerV2_6960)
 
-	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, cfg)
 	// THE INCREMENTALITY PROOF. Done=false means TryIncremental declined and the
 	// caller runs a FULL index instead — on which custom dispatch is a different
 	// question entirely. Every assertion below is about the incremental path, so
@@ -162,6 +171,49 @@ func TestIncrementalDispatchesCustomExtractorsWhenTheGateIsOn6960(t *testing.T) 
 		t.Fatalf("premise: the edit added `def about()` and the base scala extractor did not "+
 			"emit it — the re-extraction did not happen, so this test is measuring nothing. "+
 			"entities: %v", entityNames6960(doc))
+	}
+
+	// R4 GRADING — the merge's ARGUMENT ORDER. `MergeWithCustom(customEnts,
+	// records)` compiles and satisfies every other assertion in this file, while
+	// moving the #6104 facet onto the wrong node and narrowing this entity from
+	// the class body (6-10) to the annotation line (7-7) — the same span-
+	// narrowing hazard the java test exists for, one fixture over. Both halves
+	// are asserted because either alone survives the swap in some configuration:
+	// the span pins which record won, the anchor pins which record the facet
+	// describes.
+	var scalaType graph.Entity
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == "SCOPE.Type" && doc.Entities[i].Name == "HomeController" {
+			scalaType = doc.Entities[i]
+		}
+	}
+	if scalaType.ID == "" {
+		t.Fatalf("premise: no SCOPE.Type|HomeController in the graph — the custom scala frameworks "+
+			"extractor's record did not survive, so the merge assertions below grade nothing. "+
+			"entities: %v", entityNames6960(doc))
+	}
+	if scalaType.StartLine != 6 || scalaType.EndLine != 10 {
+		t.Errorf("#6960: SCOPE.Type|HomeController spans %d-%d, want 6-10 (the `@Singleton` line "+
+			"through the closing brace). A span of 7-7 is the signature of MergeWithCustom being "+
+			"called with its arguments swapped: the base record's span no longer widens the "+
+			"custom one and the entity collapses onto its declaration line",
+			scalaType.StartLine, scalaType.EndLine)
+	}
+	baseComponentID := ""
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == "SCOPE.Component" && doc.Entities[i].Name == "HomeController" {
+			baseComponentID = doc.Entities[i].ID
+		}
+	}
+	if baseComponentID == "" {
+		t.Fatalf("premise: no SCOPE.Component|HomeController — the base record the facet must "+
+			"anchor to is absent; entities: %v", entityNames6960(doc))
+	}
+	if got := scalaType.PropGet(types.EntityTwinOfProperty); got != baseComponentID {
+		t.Errorf("#6960: SCOPE.Type|HomeController's %s is %q, want the BASE record's id %q. The "+
+			"facet must hang off the custom record and name the base one; the reverse means the "+
+			"merge ran with base and custom exchanged",
+			types.EntityTwinOfProperty, got, baseComponentID)
 	}
 
 	if !hasEntity6960(doc, "SCOPE.DI", customOnlyEntity6960) {
@@ -473,5 +525,139 @@ func TestIncrementalMergesCustomRecordsRatherThanAppending6960(t *testing.T) {
 		t.Errorf("#6960: the endpoint→handler flow entity is missing after the incremental pass — "+
 			"it is derived from the merged operation's span, so it is the downstream casualty of "+
 			"an un-merged append. entities: %v", entityNames6960(doc))
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #6275 — the merge-facet anchor
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestIncrementalDoesNotOrphanMergeFacetAnchors6960 is the test the OLD comment
+// in entityRecordToGraphEntity asked for in advance: "if anything ever starts
+// stamping twin_of from code reachable here, the #6275 orphaned-anchor bug comes
+// back silently". #6960's dispatch is that "anything" — MergeWithCustom, and
+// therefore enrichFromTwin, is now reachable from the re-extract loop.
+//
+// The two ids have DIFFERENT PREIMAGES and that is the whole failure:
+// enrichFromTwin writes types.EntityRecord.ComputeID()
+// (sha256 over OrgID+ProjectID+SourceFile+Kind+Name) while this path mints
+// graph.EntityID(repoTag, Kind, Name, SourceFile). Without the remap the facet
+// names a hash no entity in the graph will ever carry — permanently, because
+// nothing downstream rewrites an opaque Properties string, and invisibly,
+// because a content-keyed parity comparison does not compare ids at all.
+func TestIncrementalDoesNotOrphanMergeFacetAnchors6960(t *testing.T) {
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+
+	doc := seedAndEdit6960(t)
+
+	ids := make(map[string]bool, len(doc.Entities))
+	for i := range doc.Entities {
+		ids[doc.Entities[i].ID] = true
+	}
+
+	// PREMISE — a facet is actually present. Without it "no orphaned anchor" is
+	// satisfied by a graph with no anchors, which is precisely the state this
+	// path was in BEFORE the fix and which must not read as a pass.
+	anchored := 0
+	for i := range doc.Entities {
+		e := doc.Entities[i]
+		twin := e.PropGet(types.EntityTwinOfProperty)
+		if twin == "" {
+			continue
+		}
+		anchored++
+		if !ids[twin] {
+			t.Errorf("#6275/#6960: %s|%s carries %s=%q, which matches NO entity id in the "+
+				"incremental graph. enrichFromTwin stamped a ComputeID() hash and this path mints "+
+				"graph.EntityID — different preimages — so the merge facet is orphaned and "+
+				"classfold's twinAnchors and the symbol index's facet-alias rule both read it as "+
+				"naming nothing",
+				e.Kind, e.Name, types.EntityTwinOfProperty, twin)
+		}
+	}
+	if anchored == 0 {
+		t.Fatalf("premise: no entity in the graph carries %s after a gate-ON incremental pass over "+
+			"a file whose custom and base records merge — the merge facet this test exists to "+
+			"check is not being produced, so the assertion above is vacuous. entities: %v",
+			types.EntityTwinOfProperty, entityNames6960(doc))
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The gate's OTHER half
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestIncrementalReadsTheProgrammaticGateHalf6960 grades the half an env-only
+// read cannot see. The full path's gate is one expression over the config AND
+// the env (cmd/grafel stamps WithCustomExtractors into
+// ExtractorConfig.InProcCustomExtractors), and `grafel quality` is the only lane
+// that opts in by default anywhere — so an incremental pass that consulted only
+// GRAFEL_INPROC_CUSTOM_EXTRACTORS would leave the original #6960 defect alive in
+// precisely the lane that is on.
+//
+// Both directions are driven, because the tri-state exists to express both:
+// config-on with the env UNSET must dispatch, and config-off with the env SET
+// must not (Config wins — #2320).
+func TestIncrementalReadsTheProgrammaticGateHalf6960(t *testing.T) {
+	t.Run("config on, env unset", func(t *testing.T) {
+		t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+		on := true
+		doc := seedAndEdit6960WithConfig(t, &extractor.ExtractorConfig{InProcCustomExtractors: &on})
+		if !hasEntity6960(doc, "SCOPE.Operation", "about") {
+			t.Fatalf("premise: base re-extraction did not happen; entities: %v", entityNames6960(doc))
+		}
+		if !hasEntity6960(doc, "SCOPE.DI", customOnlyEntity6960) {
+			t.Errorf("#6960: SCOPE.DI|%s absent with Config.InProcCustomExtractors=true and the env "+
+				"var unset — the incremental gate is reading only the env half, so a full index "+
+				"opted in through WithCustomExtractors still loses its custom entities on the next "+
+				"edit. SCOPE.DI present: %v", customOnlyEntity6960, anyEntityOfKind6960(doc, "SCOPE.DI"))
+		}
+	})
+
+	t.Run("config off, env set", func(t *testing.T) {
+		t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+		off := false
+		doc := seedAndEdit6960WithConfig(t, &extractor.ExtractorConfig{InProcCustomExtractors: &off})
+		if !hasEntity6960(doc, "SCOPE.Operation", "about") {
+			t.Fatalf("premise: base re-extraction did not happen; entities: %v", entityNames6960(doc))
+		}
+		if got := anyEntityOfKind6960(doc, "SCOPE.DI"); len(got) != 0 {
+			t.Errorf("#6960: SCOPE.DI entities %v emitted with an explicit Config false over a set "+
+				"env var. ExtractorConfig's precedence is Config-first (#2320) in BOTH directions; "+
+				"a gate that ORs the two cannot express a suppression and would diverge from a full "+
+				"index run with the same config", got)
+		}
+	})
+}
+
+// TestCustomExtractorsGateVocabulary6960 grades the helper in its OWN package.
+// Until this existed the only thing checking the exported gate was a delegating
+// table test in cmd/grafel — so a diff touching only custom_gate.go yields a
+// package set that never runs its own grader, the same trap the cmd/grafel
+// digest pin sets elsewhere.
+func TestCustomExtractorsGateVocabulary6960(t *testing.T) {
+	for _, tc := range []struct {
+		env  string
+		want bool
+	}{
+		{"1", true}, {"true", true}, {"TRUE", true}, {"yes", true}, {"Yes", true},
+		{" 1 ", true}, // trimmed
+		{"", false}, {"0", false}, {"false", false}, {"no", false}, {"garbage", false},
+		{"2", false}, {"on", false}, // NOT accepted — pins the vocabulary, not just truthiness
+	} {
+		t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", tc.env)
+		if got := extractors.InProcCustomExtractorsEnabled(); got != tc.want {
+			t.Errorf("InProcCustomExtractorsEnabled() with env %q = %v, want %v", tc.env, got, tc.want)
+		}
+		// The config-aware wrapper must agree whenever Config is silent, or the
+		// two dispatch sites do not in fact share one gate.
+		if got := extractors.CustomExtractorsEnabled(nil); got != tc.want {
+			t.Errorf("CustomExtractorsEnabled(nil) with env %q = %v, want %v", tc.env, got, tc.want)
+		}
+		if got := extractors.CustomExtractorsEnabled(&extractor.ExtractorConfig{}); got != tc.want {
+			t.Errorf("CustomExtractorsEnabled(empty cfg) with env %q = %v, want %v — a config that "+
+				"does not mention the toggle must fall through to the env, not read as false",
+				tc.env, got, tc.want)
+		}
 	}
 }

--- a/internal/extractors/incremental_twin_collision_6960_test.go
+++ b/internal/extractors/incremental_twin_collision_6960_test.go
@@ -1,0 +1,138 @@
+// Package extractors — incremental_twin_collision_6960_test.go
+//
+// remapTwinOfAnchors keys a map on types.EntityRecord.ComputeID and stores
+// graph.EntityID. The two disagree about FIELD BOUNDARIES:
+//
+//	ComputeID   OrgID + ProjectID + SourceFile + Kind + Name   — concatenated, NO separators
+//	EntityID    every field NUL-separated
+//
+// so a pair of records can be one key and two entities. This file is the direct
+// unit test for what happens then. It needs no fixture, no repo and no corpus:
+// the collision is a property of the two hash preimages, and the pair below is
+// constructed from that property rather than discovered in a codebase.
+package extractors
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const twinRepoTag6960 = "test-repo"
+
+// collidingPair6960 returns two records that share one ComputeID and have two
+// distinct EntityIDs: "A"+"BC" and "AB"+"C" concatenate identically.
+//
+// Both names are NON-EMPTY on purpose. The `r.Name == ""` guard in
+// remapTwinOfAnchors skips nameless records, so a pair that leans on an empty
+// name proves nothing about the reachable path — it would be testing the guard,
+// not the collision.
+func collidingPair6960() (types.EntityRecord, types.EntityRecord) {
+	a := types.EntityRecord{SourceFile: "x.go", Kind: "A", Name: "BC"}
+	b := types.EntityRecord{SourceFile: "x.go", Kind: "AB", Name: "C"}
+	return a, b
+}
+
+func TestRemapTwinOfAnchorsSkipsAmbiguousPreStampIDs6960(t *testing.T) {
+	a, b := collidingPair6960()
+
+	// PREMISE 1 — the two records really do collide under the map's key. If
+	// ComputeID ever gains separators this stops being true, and the test must
+	// fail loudly rather than pass vacuously: with no collision there is no
+	// ambiguity and the assertion below would hold for the wrong reason.
+	shared := a.ComputeID()
+	if shared != b.ComputeID() {
+		t.Fatalf("premise: ComputeID no longer collides for {%s,%s} and {%s,%s} (%s vs %s) — "+
+			"the separator-free preimage this test is built on is gone, so this test grades "+
+			"nothing and should be re-derived, not deleted",
+			a.Kind, a.Name, b.Kind, b.Name, shared, b.ComputeID())
+	}
+	// PREMISE 2 — and they are genuinely DIFFERENT entities. Without this the
+	// "ambiguous" case is a distinction without a difference and skipping is
+	// pointless.
+	finalA := graph.EntityID(twinRepoTag6960, a.Kind, a.Name, a.SourceFile)
+	finalB := graph.EntityID(twinRepoTag6960, b.Kind, b.Name, b.SourceFile)
+	if finalA == finalB {
+		t.Fatalf("premise: graph.EntityID also collides (%s) — the two records are one entity, "+
+			"so there is no wrong node to be pointed at", finalA)
+	}
+
+	// The facet: a third record whose twin_of names the shared preimage.
+	facet := types.EntityRecord{
+		SourceFile: "x.go", Kind: "SCOPE.Type", Name: "Facet",
+		Properties: map[string]string{types.EntityTwinOfProperty: shared},
+	}
+
+	records := []types.EntityRecord{a, b, facet}
+	remapTwinOfAnchors(records, twinRepoTag6960)
+
+	got := records[2].Properties[types.EntityTwinOfProperty]
+	if got == finalA || got == finalB {
+		t.Errorf("#6369/#6960: an ambiguous grafel.twin_of was remapped to %q — one of the two "+
+			"entities (%s / %s) that share the pre-stamp key %s. Which one is decided by arrival "+
+			"order, not by evidence, so this is a CONFIDENTLY WRONG anchor: classfold's "+
+			"twinAnchors and the symbol index's facet-alias rule both read it as valid and alias "+
+			"the name onto whichever record happened to come last. Leaving it dangling is the "+
+			"detectable failure and the intended behaviour",
+			got, finalA, finalB, shared)
+	}
+	if got != shared {
+		t.Errorf("ambiguous twin_of = %q, want it left at its pre-stamp value %q — the skip must "+
+			"leave the property untouched, not blank it, so the value remains diagnosable",
+			got, shared)
+	}
+
+	// REVERSED ORDER. The whole hazard is that the survivor is decided by index
+	// order, so a test that only ever sees one order cannot tell "skipped" from
+	// "happened to pick the one I asserted".
+	reversed := []types.EntityRecord{b, a, facet}
+	reversed[2].Properties = map[string]string{types.EntityTwinOfProperty: shared}
+	remapTwinOfAnchors(reversed, twinRepoTag6960)
+	if got := reversed[2].Properties[types.EntityTwinOfProperty]; got != shared {
+		t.Errorf("ambiguous twin_of = %q with the colliding records in the opposite order, want "+
+			"%q — the outcome must not depend on which record arrives first", got, shared)
+	}
+}
+
+// TestRemapTwinOfAnchorsStillRemapsUnambiguousKeys6960 is the positive control
+// for the test above: a check that skipped EVERYTHING would satisfy every
+// assertion there while silently reverting the #6275 fix this PR exists for.
+func TestRemapTwinOfAnchorsStillRemapsUnambiguousKeys6960(t *testing.T) {
+	anchor := types.EntityRecord{SourceFile: "x.go", Kind: "SCOPE.Component", Name: "Widget"}
+	pre := anchor.ComputeID()
+	final := graph.EntityID(twinRepoTag6960, anchor.Kind, anchor.Name, anchor.SourceFile)
+	if pre == final {
+		t.Fatalf("premise: ComputeID and EntityID agree for this record (%s), so there is no "+
+			"remap to perform and the assertion below is vacuous", pre)
+	}
+	facet := types.EntityRecord{
+		SourceFile: "x.go", Kind: "SCOPE.Type", Name: "Widget",
+		Properties: map[string]string{types.EntityTwinOfProperty: pre},
+	}
+
+	records := []types.EntityRecord{anchor, facet}
+	remapTwinOfAnchors(records, twinRepoTag6960)
+
+	if got := records[1].Properties[types.EntityTwinOfProperty]; got != final {
+		t.Errorf("unambiguous twin_of = %q, want the anchor's final id %q — the collision check "+
+			"must narrow the remap to ambiguous keys only, not disable it", got, final)
+	}
+}
+
+// TestRemapTwinOfAnchorsIsInertWithoutAFacet6960 pins the cheap pre-scan: a
+// batch carrying no twin_of at all must not be walked twice or hashed at all.
+// Asserted behaviourally — no record's properties change — because the counter
+// version of this claim would be a diagnostic signature, not the consequence.
+func TestRemapTwinOfAnchorsIsInertWithoutAFacet6960(t *testing.T) {
+	a, b := collidingPair6960()
+	a.Properties = map[string]string{"role": "class"}
+	records := []types.EntityRecord{a, b}
+	remapTwinOfAnchors(records, twinRepoTag6960)
+	if records[0].Properties["role"] != "class" || len(records[0].Properties) != 1 {
+		t.Errorf("a batch with no grafel.twin_of had its properties touched: %v", records[0].Properties)
+	}
+	if records[1].Properties != nil {
+		t.Errorf("a record with no properties gained a map: %v", records[1].Properties)
+	}
+}


### PR DESCRIPTION
Closes #6960.

## The answer to the question the issue asked

**No — the incremental path reaches neither `RunCustomExtractors` call site.** Traced hop by hop, then driven.

```
fs watcher / scheduler tick
  → cmd/grafel/daemon.go:1293  daemonSchedulerIncremental
  → internal/extractors.TryIncremental                 (incremental.go:393)
  → tryIncremental Step 6 "extract-changed-files" loop (incremental.go:~1000)
  → cls.ClassifyWithSize → Get(cr.Language)            (EXACT-KEY registry lookup)
  → safeExtract(ctx, ext, input)
  → [Pass 2.5 engine.Detector / classfold / scoped resolve / merge / write]
```

`Get` is an exact-key lookup. Every custom/framework extractor registers under a **prefixed** key — `custom_scala_di`, `python_django` — so that lookup can never select one. `RunCustomExtractors` (`custom_dispatch.go:208`) is the only dispatcher that does the prefix fan-out, and its two non-test call sites are `cmd/grafel/index.go:4142` and `internal/daemon/extract/subproc.go:364`, neither of which is on this path.

**Checked for indirect reference, per the #6957 lesson.** `RunCustomExtractors` is not held as a function value, not in a dispatch table, and not behind a registry indirection: `CustomExtractorsFor` has no non-test caller outside `custom_dispatch.go` itself, `MergeWithCustom`'s only production caller is `index.go:4154`, and `Get(cr.Language)` returns the single exactly-keyed extractor, not a composite that fans out. `internal/extractors/custom_registry.go` blank-imports all 22 `internal/custom/**` packages, so the extractors *are* registered in this very process — nothing structural prevented the call; there simply was no call.

## Driven, not read — and the incrementality proof

Mechanism: `extractors.TryIncremental` invoked directly, which **is** the production incremental entry point (`daemonSchedulerIncremental` is its only non-test caller). The proof that the pass was incremental rather than a silent full reindex is `res.Done == true` **and** `res.ChangedFiles == 1`: `TryIncremental` returns `Done=false` with a `FallbackReason` on every path where it declines and the caller runs a full index instead. Both assertions are `t.Fatalf` in the harness, so a fallback fails the test rather than passing it for the wrong reason. Log line from the run: `incremental: done changed=1 entities=8 rels=3 … flows_recomputed=true`.

Probe: a Play controller. Seed a graph containing its `SCOPE.DI|singleton:HomeController` (the "initial index ran with the gate on" state), edit the file, run one incremental pass.

| | before | after |
|---|---|---|
| `SCOPE.Operation\|about` (the edit, base extractor) | present | present |
| `SCOPE.DI\|singleton:HomeController` (custom-only) | **gone** | present |

Step 5 evicted the file's entities and the loop re-added only the base half.

## Why the consequence is narrower than the issue assumed — and why that decided the fix

Both full-index paths dispatch custom extractors only behind an **opt-in**:

- `cmd/grafel/index.go:4138` — `GRAFEL_INPROC_CUSTOM_EXTRACTORS`, default OFF;
- `internal/daemon/extract/subproc.go:364` — inside the `GRAFEL_SUBPROC_EXTRACT` branch, itself default OFF and described at `inproc_custom.go:20` as "an env var with zero writers anywhere in the tree".

So on a **default** configuration the initial index emits no custom entities either, and an incremental pass loses nothing — the graph was never wrong. With the gate **on**, it is exactly the silent-degradation shape #6921/#6923/#6928/#6940 share: a *changed* file loses what every *unchanged* file keeps, so the graph is right when you first look at it and wrong after you edit.

That is why the fix **reads the same gate** instead of dispatching unconditionally. The property this path owes its caller is "same graph as a full reindex", and a pass that runs custom extractors when the full path did not is as divergent as one that skips them when it did — plus it would silently pay the +17.5% wall / +18.2% alloc the gate exists to withhold.

## The fix: at the call site, with the gate lifted one package down

- `internal/extractors/custom_gate.go` (new) — `InProcCustomExtractorsEnabled()` now owns the env read. `incremental.go` cannot import `cmd/grafel`, so without this the incremental path would need a **second literal reading** of `GRAFEL_INPROC_CUSTOM_EXTRACTORS`, free to drift from the first. One reader, two callers.
- `cmd/grafel/inproc_custom.go` — `inProcCustomExtractors()` delegates. Its existing table test (`inproc_custom_extractors_5989_test.go`) now exercises the shared function.
- `internal/extractors/incremental.go` — the dispatch, placed **after** `safeExtract` and **before** `input.TSTree.Close()`, mirroring `index.go:4138`. Seam placement is load-bearing. **Correction from review:** moving it past the `Close()` is a silent **no-op**, not a use-after-free — `input.TSTree = nil` follows immediately, so the moved dispatch fails the `!= nil` guard and quietly emits nothing. The comment in the file said "use-after-free" and now says what was measured. The guard stays for the *other* reason (content-only extractors emitting with no tree, which the dart test grades), and `MergeWithCustom` — not `append` — applies the #6104 non-destructive (SourceFile, Kind, Name) merge.

Default behaviour is unchanged: with the gate off the added branch is not taken.

**Observed side effect, gate-on only, and it is the intended behaviour rather than a regression** (the facet it turns on is also what the #6275 blocker below was about): with the merge in place `class_kind_folds` goes 1 → 0 on the scala fixture and both `SCOPE.Component|HomeController` and `Controller|HomeController` survive. That is #6276's `twinAnchors` rule (`internal/engine/classfold.go:527`) firing correctly — the custom merge emits a `grafel.twin_of` facet, and a record some other record anchors is never a fold source. `cmd/grafel`'s `foldClassHierarchyShadows` holds the same exclusion, so the two paths agree.

## Can the ratchet or the digest pin see this?

**No, neither — by construction, exactly as the issue warned.** `cmd/grafel`'s digest pin runs with `GRAFEL_INPROC_CUSTOM_EXTRACTORS=""`, i.e. custom passes **off**, so it is structurally blind to this entire class; the full `./cmd/grafel/` suite is green here and would have been green with the defect in place. The extraction-quality ratchet grades a full index, not an incremental one, and there is no incremental leg at all. This is why the coverage added is four package-level tests rather than a threshold bump.

## Verification (macOS 15.6 / APFS, arm64), measured in `…/scratchpad/impl-6960-k7q2/wt`

- `go test -count=1 ./internal/extractors/` — **exit 0**, 37.2s.
- `go test -count=1 ./cmd/grafel/` — **exit 0**, 147.7s. Run despite nothing in `internal/extractors/...` pointing at it, because it digest-pins the whole graph.
- `gofmt -l ./cmd ./internal` — clean. `go vet` on both packages — clean.
- No entity/count constant moved, so nothing to re-enumerate.

## Mutants — scored with an exact occurrence count on every edit, restored by `cp` from a `shasum -a256`-verified backup (never `git checkout`), with a green baseline re-verified before each score

| # | Mutant | Verdict |
|---|---|---|
| M1 | `if false && InProcCustomExtractorsEnabled() && …` (the fix disabled — i.e. the pre-fix state) | **DEAD** — `…GateIsOn6960` fails: `SCOPE.DI entities present: []` |
| M2 | drop the gate, dispatch unconditionally (**more permissive**) | **DEAD** — `…GateIsOff6960` fails |
| M3 | drop the `input.TSTree != nil` guard (**more permissive**) | **ALIVE at first.** Production-distinguishable, not equivalent: `dart`/`clojure`/`erlang`/`fsharp`/`nim`/`graphql` have custom extractors and **no** tree-sitter grammar, and their base extractors are source scanners that emit records anyway, so the pass does not fall back — the custom entities would land where the full path emits none. **Graded** with `…HonoursTheNilTreeGuard6960` (dart, `SCOPE.UIComponent|HomePage`), then **DEAD** |
| M4 | `append(records, customEnts…)` in place of `MergeWithCustom` (**more permissive**) | **ALIVE against the first version of the test, which asserted only cardinality.** This is the finding worth carrying forward: **the `n != 1` count assertion could not see it and never fired** — the downstream entity dedupe collapses the duplicate pair, so the cardinality check held on the mutant while the defect was live. What is distinguishable is the *content*: the merge keeps the java method's real span `8-11` where append leaves the annotation line `8-8`, and the `SCOPE.Process` flow entity derived from it disappears. **Graded** by asserting the #6104 span invariant + the flow entity, then **DEAD**. The independent reviewer reproduced this on the first attempt, cardinality blindness included |

M2 also grades the gate function itself: removing the gate is indistinguishable from `InProcCustomExtractorsEnabled()` always returning true, and the two incremental tests differ **only** in the env value.

**Both directions are graded.** `…GateIsOn6960` sees entities wrongly *dropped*; `…GateIsOff6960` and `…HonoursTheNilTreeGuard6960` see entities wrongly *added* — which no "the entities survive" assertion can.

Every test carries its premise as a `t.Fatalf`: that the re-extraction happened at all (the base entity from the edit is present), that `RunCustomExtractors` emits the asserted record for that content (else the absence assertions are vacuous), that the **base** extractor does *not* also emit it (else the gate-on assertion does not distinguish custom dispatch from base extraction), and — for M4's fixture — that the base and custom records genuinely collide on `(SourceFile, Kind, Name)`.


---

## Review round 2 — the REQUEST-CHANGES blocker and the three cheap items, all addressed

### BLOCKER (fixed): the merge orphaned its own `grafel.twin_of` anchor — #6275

`entityRecordToGraphEntity`'s comment predicted this **by name**: the missing pre-stamp-id → final-id remap was safe *"only because … `MergeWithCustom` has no caller on this incremental path"*, and *"if anything ever starts stamping `twin_of` from code reachable here, the #6275 orphaned-anchor bug comes back silently"*. This PR added that caller. Reproduced on the PR's own scala fixture, gate ON: `SCOPE.Type|HomeController` carried `twin_of="861a490cf84f2640"`, matching **no** entity id in the graph.

The cause is mechanical: `enrichFromTwin` stamps `types.EntityRecord.ComputeID()` — `sha256(OrgID+ProjectID+SourceFile+Kind+Name)` — while this path mints `graph.EntityID(repoTag, Kind, Name, SourceFile)`. Different preimages, same record. The full path repoints the facet in `stampEntityIDs`; this path did not, so *"same graph as a full reindex"* was false for merged entity **properties** — the PR's central claim, and exactly where a content-keyed parity comparison is blind (it deliberately does not compare ids).

Fixed as the comment prescribed: **`remapTwinOfAnchors`**, applied in `convertExtractedRecords` before any id is derived. Batch scope is sufficient and stated in the code: the facet and its anchor are the two halves of *one* `MergeWithCustom` decision over *one* file's records. An anchor outside the batch keeps its pre-stamp value rather than acquiring a wrong one — the lookup simply misses. The cheap `recordsCarryTwinOf` pre-scan means a batch with no facet pays no second hash, mirroring `recordsHaveTwinOf` on the full path.

**And the comment is replaced.** It asserted a precondition this change invalidated, which is how the next reader gets misled; it now says what happened, what was measured, and why the remap lives one level up (the mapping is batch-wide; a per-record function cannot express it).

### Gate parity, both halves (was half-done)

The full path's gate is `i.customExtractors || inProcCustomExtractors()`, and the first cut read **only the env half** — leaving the original #6960 defect alive in the `WithCustomExtractors` lane, which `grafel quality` uses and which is the only lane on by default anywhere. The asymmetry was backwards.

The programmatic opt-in now travels in **`ExtractorConfig.InProcCustomExtractors`** (tri-state, `nil` = fall through to env) — the config `TryIncremental` already receives — and **both** dispatch sites evaluate one expression, `extractors.CustomExtractorsEnabled(cfg)`. Config wins over env in **both** directions, per ExtractorConfig's own #2320 precedence, which is why an explicit `false` is expressible and graded.

### R4 graded (~4 lines, as priced)

`MergeWithCustom(customEnts, records)` — arguments swapped — survived the entire suite while moving the facet and narrowing `SCOPE.Type|HomeController` **6-10 → 7-7**. Now asserted in the gate-on test, both halves: the span (which record won) *and* the anchor's target (which record the facet describes), since either alone survives the swap in some configuration.

### `custom_gate.go` now has a grader in its own package

A vocabulary table test next to the helper. Previously the only thing checking the exported gate was the delegating table test in `cmd/grafel`, so a diff touching only `custom_gate.go` produced a package set that never ran its grader — the same shape as the digest-pin trap. It pins the accepted vocabulary (`1`/`true`/`yes`, trimmed) rather than mere truthiness, and asserts `CustomExtractorsEnabled(nil)` and `CustomExtractorsEnabled(&ExtractorConfig{})` agree with it, or the two sites do not in fact share one gate.

### Round-2 mutants — same protocol (exact occurrence count on every edit, green baseline re-verified before each score, restore by `cp` from a `shasum -a256`-verified backup)

| # | Mutant | Verdict |
|---|---|---|
| N1 | `remapTwinOfAnchors` → early `return` (the blocker, un-fixed) | **DEAD** — `…DoesNotOrphanMergeFacetAnchors6960` fails with the reviewer's exact hash `861a490cf84f2640`; `…GateIsOn6960` fails too |
| N2 | `MergeWithCustom(customEnts, records)` — R4 | **DEAD** — span `7-7` (want `6-10`) **and** `grafel.twin_of` empty (want the base record's id) |
| N3 | gate reads the env half only | **DEAD** — both subtests of `…ReadsTheProgrammaticGateHalf6960` |
| N4 | `CustomExtractorsEnabled` ORs config with env instead of config-first (**more permissive**) | **DEAD** — the `config off, env set` subtest. Without this a config could never suppress |
| N5 | `InProcCustomExtractorsEnabled` → `return v != ""` (**more permissive**) | **DEAD** — `…GateVocabulary6960`, now inside `internal/extractors`, where R3 previously found nothing |

### Re-verification (macOS 15.6 / APFS, arm64, in `…/scratchpad/impl-6960-k7q2/wt`)

`go test -count=1 ./internal/extractor/ ./internal/extractors/` — **exit 0** (1.9s / 39.4s). `go test -count=1 ./cmd/grafel/` — **exit 0** (156.9s). `go build ./...` — OK. `go vet` on all three packages — clean. `gofmt -l ./cmd ./internal` — clean.

Unchanged from round 1, and the review confirmed both halves independently: the hop chain holds with no function-value or dispatch-table indirection, and **neither the ratchet nor the digest pin can see any of this** — eight `cmd/grafel` test files set `GRAFEL_INPROC_CUSTOM_EXTRACTORS` and none of them contains the string `Incremental`. These tests are the only protection.


---

## Round 3 — the coordinator's MI-1 found a hazard, and the remap is the first code exposed to it

**MI-1 itself (deleting the `r.Name == ""` guard) is left ALIVE deliberately** — not production-reachable on any constructible input, defensive rather than load-bearing, and manufacturing a fixture to force it would cost more than it protects. The guard stays; no test spent on it.

**What chasing it surfaced is real.** The two id schemes disagree about field boundaries:

| | preimage |
|---|---|
| `types.EntityRecord.ComputeID` | `OrgID + ProjectID + SourceFile + Kind + Name` — concatenated, **no separators** |
| `graph.EntityID` | every field **NUL-separated** |

So `{SourceFile:"x.go", Kind:"A", Name:"BC"}` and `{SourceFile:"x.go", Kind:"AB", Name:"C"}` are **one key and two entities**. `remapTwinOfAnchors` is the first code in the tree to key a map on the **coarser** id while storing the **finer** one, which is what makes the disagreement reachable here and nowhere else. Both records wrote the same slot; the survivor was whichever index came last — incidental, not intended — so a `twin_of` naming that preimage was repointed at an **arbitrary one of two distinct entities**.

That is the #6369 wrong-node hazard, and it is **strictly worse than the dangling anchor this PR fixes**: a dangling `twin_of` names an id no entity carries, so it is inert and detectable, while a confidently-wrong one reads as valid to `classfold`'s `twinAnchors` and to the symbol index's facet-alias rule, which will then alias a name onto the wrong definition.

**Resolution: an ambiguous key is SKIPPED, not resolved, and warned about** (`slog` Warn carrying the pre-stamp id and both final ids). Skipping degrades to exactly the pre-remap behaviour for that one facet — the honest, detectable failure — and it is the only outcome that does not require the function to invent an answer it has no evidence for. Silently picking one, the behaviour before this check, is the option that is not defensible. The comment states which and why.

The underlying `ComputeID` separator problem is broader than this function and is being filed separately; `ComputeID` is deliberately **not** touched here — many call sites already depend on that identity.

### Grading — a direct unit test on `remapTwinOfAnchors`, no fixture, no repo, no corpus

The colliding pair is *constructed from the hash property*, not discovered in a codebase, and **both names are non-empty** so the test exercises the reachable path rather than the `Name == ""` guard MI-1 targets. Premises are `t.Fatalf`: that `ComputeID` really collides (if it ever gains separators this test must fail loudly, not pass vacuously) and that `EntityID` really does not (otherwise there is no wrong node to point at). **Both collision orders are driven** — the entire hazard is that the survivor is decided by arrival order, so a single order cannot distinguish "skipped" from "happened to pick the one I asserted".

| # | Mutant | Verdict |
|---|---|---|
| MI-2 | disable the collision check (the behaviour before this commit) | **DEAD** — the facet is remapped to `e422d03bc35b0818`, i.e. the *second* record's id, demonstrating the arrival-order pick |
| MI-4 | skip **every** key, not just ambiguous ones (would silently revert the #6275 fix) | **DEAD** — the positive control fails, and so do `…GateIsOn6960` and `…DoesNotOrphanMergeFacetAnchors6960` |

Re-verified after restore: `./internal/extractor/` + `./internal/extractors/` **exit 0** (1.6s / 37.5s), `./cmd/grafel/` **exit 0** (144.5s), `go vet` on all three clean, `gofmt -l ./cmd ./internal` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
