### PR TITLE
fix(#6964): sparse-checkout support was inert — the probe read a scope git stopped writing in 2.32, and cone's `/*` was read as match-everything

### DIFF
--- a/internal/daemon/watch/poll_convergence_6940_test.go
+++ b/internal/daemon/watch/poll_convergence_6940_test.go
@@ -185,28 +185,22 @@ func TestChangePoller_SparseFilteredPathConverges(t *testing.T) {
 	cpWriteFile(t, repo, "src/keep.go", "package src\n")
 	cpGitRun(t, repo, "add", "-A")
 	cpGitRun(t, repo, "commit", "-q", "-m", "src")
-	// --no-cone deliberately: git's CONE patterns are `/*` + `!/*/` + `/src/`,
-	// and gitmeta.IsPathIncluded treats a bare `*` as match-all, so a cone
-	// checkout makes its own filter include everything. That is a real gap in
-	// the sparse implementation and it is not #6940; a non-cone pattern set is
-	// the shape grafel's filter actually applies, so it is the one that puts
-	// the SPARSE GATE under test here rather than a no-op.
+	// --no-cone deliberately, but no longer for the reason first recorded here.
+	// #6964 fixed both gaps this fixture used to work around, and the two
+	// `config --local` mirror lines that came with them are GONE (#6967): the
+	// probe now reads the scope git writes, so nothing needs mirroring, and
+	// cone patterns are matched properly, so a cone checkout no longer makes
+	// grafel's own filter include everything. --no-cone is kept because a
+	// verbatim pattern is the simplest shape for THIS test's subject, which is
+	// poll convergence, not sparse semantics — those are graded against real
+	// git in internal/gitmeta/sparse_realgit_6964_test.go.
 	if out, err := cpGitTry(repo, "sparse-checkout", "set", "--no-cone", "src"); err != nil {
 		t.Skipf("git sparse-checkout unavailable here: %v\n%s", err, out)
 	}
-	// git >= 2.32 writes core.sparseCheckout into the WORKTREE-scoped config
-	// (.git/config.worktree, via extensions.worktreeConfig), and
-	// gitmeta.ProbeRepo reads `config --local` only — so the probe does not see
-	// a sparse checkout this git just created. That gap is real and is not
-	// #6940; mirroring the flag into --local here keeps the SPARSE GATE, which
-	// is what this test is about, reachable rather than silently untested.
-	cpGitRun(t, repo, "config", "--local", "core.sparseCheckout", "true")
-	cpGitRun(t, repo, "config", "--local", "core.sparseCheckoutCone", "true")
 	if si := gitmeta.ProbeRepo(repo); !si.IsSparse {
-		// NOT a skip (#6961 review): the two config lines above make this
-		// outcome deterministic, and CI runs without -v, so a skip here would
-		// delete the only sparse leg in silence — removing just those two
-		// lines turned the whole test into "SKIP ... PASS, exit 0".
+		// NOT a skip (#6961 review): with the probe reading git's own scope
+		// resolution this outcome is deterministic, and CI runs without -v, so
+		// a skip here would delete the only sparse leg in silence.
 		t.Fatal("the probe does not see the sparse checkout this fixture just created — the sparse gate is UNTESTED, not unreachable")
 	}
 

--- a/internal/gitmeta/gitmeta_fifo_6416_test.go
+++ b/internal/gitmeta/gitmeta_fifo_6416_test.go
@@ -172,11 +172,18 @@ func TestParseSparsePatternFileFIFODoesNotHang(t *testing.T) {
 	p := mkfifoInGitTemp(t, dir, "info", "sparse-checkout")
 
 	var got []string
+	var haveFile bool
 	mustReturnGit(t, "parseSparsePatternFile with a FIFO sparse-checkout", func() {
-		got = parseSparsePatternFile(p)
+		got, haveFile = parseSparsePatternFile(p)
 	})
 	if len(got) != 0 {
 		t.Errorf("parseSparsePatternFile = %v, want none for a refused pattern file", got)
+	}
+	// A refused pattern file must read as NO FILE, not as an empty pattern
+	// set: ProbeRepo turns "no file" into "not sparse" (full index, a
+	// superset) and an empty pattern set into "exclude everything" (#6967).
+	if haveFile {
+		t.Error("parseSparsePatternFile reported the FIFO as a readable pattern file — that would index the repo to zero files")
 	}
 }
 
@@ -205,9 +212,12 @@ func TestGitMetaReadersStillReadRegularFiles(t *testing.T) {
 	}
 
 	sp := writeGitFile(t, dir, "# comment\nsrc/\n\napps/web/\n", "info", "sparse-checkout")
-	pats := parseSparsePatternFile(sp)
+	pats, haveFile := parseSparsePatternFile(sp)
 	if len(pats) != 2 || pats[0] != "src/" || pats[1] != "apps/web/" {
 		t.Errorf("parseSparsePatternFile = %v, want [src/ apps/web/]", pats)
+	}
+	if !haveFile {
+		t.Error("parseSparsePatternFile: a readable pattern file must report haveFile=true")
 	}
 }
 
@@ -221,7 +231,7 @@ func TestGitMetaSkipIsReported(t *testing.T) {
 
 	dir := t.TempDir()
 	p := mkfifoInGitTemp(t, dir, "info", "sparse-checkout")
-	mustReturnGit(t, "parseSparsePatternFile with a FIFO", func() { _ = parseSparsePatternFile(p) })
+	mustReturnGit(t, "parseSparsePatternFile with a FIFO", func() { _, _ = parseSparsePatternFile(p) })
 
 	out := buf.String()
 	if !strings.Contains(out, p) {
@@ -281,7 +291,7 @@ func TestGitMetaSkipNotReportedForAbsentFile(t *testing.T) {
 
 	dir := t.TempDir()
 	_ = readGitdirFile(filepath.Join(dir, ".git"))
-	_ = parseSparsePatternFile(filepath.Join(dir, "info", "sparse-checkout"))
+	_, _ = parseSparsePatternFile(filepath.Join(dir, "info", "sparse-checkout"))
 	_ = contentToken(filepath.Join(dir, "refs", "heads", "main"))
 	if buf.Len() != 0 {
 		t.Errorf("absent files reported %q, want silence", buf.String())

--- a/internal/gitmeta/sparse.go
+++ b/internal/gitmeta/sparse.go
@@ -64,9 +64,11 @@ type SparseInfo struct {
 	// It does NOT select a matching algorithm. Cone mode is a restriction on
 	// what git WRITES — directory prefixes expressed as `/*`, `!/*/`, `/dir/`
 	// — and those lines are ordinary gitignore-syntax patterns, so
-	// IsPathIncluded answers both modes with one matcher (#6964). The flag is
-	// reported because callers surface it, and because it is the only way to
-	// tell a cone repo from a non-cone one after the fact.
+	// IsPathIncluded answers both modes with one matcher (#6964).
+	//
+	// It is reported for callers, and consumed by none: there is no non-test
+	// reader of this field anywhere in the tree today. Said plainly so nobody
+	// re-derives behaviour from it.
 	ConeMode bool
 }
 
@@ -128,7 +130,30 @@ func ProbeRepo(repoPath string) SparseInfo {
 	coneMode := cone == "true"
 
 	// Parse the sparse-checkout pattern file.
-	patterns := parseSparsePatternFile(filepath.Join(gitDir, "info", "sparse-checkout"))
+	//
+	// NO PATTERN FILE MEANS NOT SPARSE, whatever the flag says (#6967 review).
+	// The flag alone is reachable — `git config --global core.sparseCheckout
+	// true` is the pre-2.25 manual workflow and still sits in real dotfiles —
+	// and in that state git populates the FULL tree: measured on git 2.50.1,
+	// `ls-files -v` tags every path 'H' and the working tree is complete.
+	// Reporting IsSparse=true with no patterns would hand the walker a
+	// SparseInfo that excludes every path (that is the deliberate contract for
+	// a constructed value), so the repo would index to ZERO files — silently,
+	// because the sparse layer is the one walk layer that skips without
+	// emitting a SkipEntry. This gate is here rather than in IsPathIncluded
+	// precisely so that contract is left alone.
+	//
+	// A file that EXISTS but yields no patterns is a different state and stays
+	// sparse: git checks out NOTHING for an empty (or comment-only) pattern
+	// file, also measured. So the test is the file, not the pattern count.
+	//
+	// An existing-but-unreadable file lands on "not sparse" too, which is the
+	// over-inclusive direction — a superset, the same direction every other
+	// failure in this file chooses.
+	patterns, haveFile := parseSparsePatternFile(filepath.Join(gitDir, "info", "sparse-checkout"))
+	if !haveFile {
+		return SparseInfo{}
+	}
 
 	return SparseInfo{
 		IsSparse: true,
@@ -138,16 +163,20 @@ func ProbeRepo(repoPath string) SparseInfo {
 }
 
 // parseSparsePatternFile reads the sparse-checkout pattern file and returns
-// non-empty, non-comment lines. Returns nil when the file is absent or
-// unreadable (a missing file is not an error — it just means no patterns).
-func parseSparsePatternFile(path string) []string {
+// its non-empty, non-comment lines plus whether the file was read at all.
+//
+// The second return exists because "no patterns" and "no file" are different
+// states in git and must not be collapsed: an empty pattern file checks out
+// nothing, an absent one checks out everything (#6967 review). Callers that
+// only want the lines can ignore it; ProbeRepo cannot.
+func parseSparsePatternFile(path string) ([]string, bool) {
 	// readGitMetaFile, not os.Open: open(2) is what blocks on a FIFO, so
 	// scanning rather than slurping made no difference to #6416. The pattern
 	// file is name-chosen ("info/sparse-checkout" under the git dir) and is
 	// read before any walk, so no entry-type gate sits in front of it.
 	data, err := readGitMetaFile(path, maxSparsePatternBytes)
 	if err != nil {
-		return nil
+		return nil, false
 	}
 
 	var patterns []string
@@ -159,7 +188,7 @@ func parseSparsePatternFile(path string) []string {
 		}
 		patterns = append(patterns, line)
 	}
-	return patterns
+	return patterns, true
 }
 
 // IsPathIncluded reports whether relPath (a repo-relative, forward-slash path
@@ -202,6 +231,11 @@ func parseSparsePatternFile(path string) []string {
 // ConeMode is informational only. Cone patterns are a subset of the general
 // syntax, so one matcher answers both; the flag is still reported for the
 // coverage badge and for callers that want to know how the repo was made.
+//
+// Known divergence, pre-existing and in the over-inclusive direction: a
+// pattern with a trailing space (`/src/ `) is stripped by
+// parseSparsePatternFile's TrimSpace and read as `/src/`, while git keeps the
+// space and matches nothing. grafel indexes a superset there.
 //
 // Cost: the pattern list is parsed on each call rather than cached, because
 // SparseInfo is a plain value that callers construct and mutate directly. The
@@ -274,10 +308,11 @@ func parseSparsePattern(raw string) (sparsePattern, bool) {
 	if strings.HasPrefix(line, "!") {
 		p.negate = true
 		line = line[1:]
-	} else if strings.HasPrefix(line, `\!`) || strings.HasPrefix(line, `\#`) {
-		// gitignore escape for a literal leading '!' or '#'.
-		line = line[1:]
 	}
+	// gitignore's `\!` / `\#` escapes need no handling here: path.Match reads
+	// a backslash as an escape too, so `\!foo` matches the literal "!foo"
+	// either way. Stripping the backslash would be a branch that cannot change
+	// an answer, and so could never be graded.
 	if strings.HasSuffix(line, "/") {
 		p.dirOnly = true
 	}

--- a/internal/gitmeta/sparse.go
+++ b/internal/gitmeta/sparse.go
@@ -12,7 +12,10 @@
 // Detection strategy (zero git-process overhead on non-sparse repos):
 //  1. Read the git-dir via `git rev-parse --git-dir` (already available via
 //     RunGit — 2-second timeout, returns "" on failure).
-//  2. Check git-config boolean `core.sparseCheckout`. If false/absent → not sparse.
+//  2. Check git-config boolean `core.sparseCheckout` with git's own scope
+//     resolution (worktree → local → global → system). Since git 2.32 the
+//     value lives in the WORKTREE scope, which `--local` cannot see (#6964).
+//     If false/absent → not sparse.
 //  3. Parse <git-dir>/info/sparse-checkout for the active pattern list.
 //
 // SparseInfo is intentionally lightweight — it is computed once per index
@@ -26,6 +29,7 @@ package gitmeta
 import (
 	"bufio"
 	"bytes"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -55,9 +59,14 @@ type SparseInfo struct {
 	// IsSparse is false or the pattern file is unreadable.
 	Patterns []string
 
-	// ConeMode is true when core.sparseCheckoutCone is enabled. In cone mode
-	// every pattern is treated as a directory prefix (recursive); in non-cone
-	// mode standard gitignore-style globs apply.
+	// ConeMode is true when core.sparseCheckoutCone is enabled.
+	//
+	// It does NOT select a matching algorithm. Cone mode is a restriction on
+	// what git WRITES — directory prefixes expressed as `/*`, `!/*/`, `/dir/`
+	// — and those lines are ordinary gitignore-syntax patterns, so
+	// IsPathIncluded answers both modes with one matcher (#6964). The flag is
+	// reported because callers surface it, and because it is the only way to
+	// tell a cone repo from a non-cone one after the fact.
 	ConeMode bool
 }
 
@@ -78,14 +87,44 @@ func ProbeRepo(repoPath string) SparseInfo {
 		gitDir = filepath.Join(repoPath, gitDir)
 	}
 
-	// Check core.sparseCheckout config flag.
-	enabled := RunGit(repoPath, "config", "--local", "--get", "core.sparseCheckout")
+	// Check the core.sparseCheckout config flag.
+	//
+	// SCOPE (#6964): this deliberately passes NO scope flag. `git config --get`
+	// resolves worktree → local → global → system, which is exactly how git
+	// itself resolves core.sparseCheckout, so the probe agrees with the working
+	// tree git actually produced:
+	//
+	//   * git >= 2.32 — `git sparse-checkout init/set` turns on
+	//     extensions.worktreeConfig and writes core.sparseCheckout /
+	//     core.sparseCheckoutCone into the WORKTREE scope
+	//     (<git-dir>/config.worktree). `--local` does NOT read that scope, so
+	//     the previous `--local --get` returned empty and every sparse repo
+	//     created by a modern git was probed as "not sparse" — measured on git
+	//     2.50.1 (Apple Git-155), where `--local --get` exits 1 with no output
+	//     while `--get` returns "true".
+	//   * git < 2.32 — the same keys are written to the LOCAL scope
+	//     (<git-dir>/config). `--get` reads local too, so this spelling is
+	//     strictly wider than the one it replaces: nothing that used to be
+	//     detected stops being detected.
+	//   * a value set by hand in --local (or inherited from --global/--system)
+	//     is honoured, because git honours it — a core.sparseCheckout=true in
+	//     the global config really does give a sparse working tree, verified by
+	//     driving `git read-tree -mu HEAD` under GIT_CONFIG_GLOBAL.
+	//
+	// `--worktree --get` was rejected: it is a hard error (exit 1) on any repo
+	// that has not enabled extensions.worktreeConfig, i.e. on every non-sparse
+	// repo and on every repo made sparse by git < 2.32.
+	//
+	// --bool normalises git's boolean spellings, so `core.sparseCheckout = 1`
+	// (or "yes"/"on") is read as true the way git reads it, instead of falling
+	// through the old literal `== "true"` comparison.
+	enabled := RunGit(repoPath, "config", "--bool", "--get", "core.sparseCheckout")
 	if enabled != "true" {
 		return SparseInfo{}
 	}
 
-	// Detect cone mode.
-	cone := RunGit(repoPath, "config", "--local", "--get", "core.sparseCheckoutCone")
+	// Detect cone mode. Same scope reasoning as above.
+	cone := RunGit(repoPath, "config", "--bool", "--get", "core.sparseCheckoutCone")
 	coneMode := cone == "true"
 
 	// Parse the sparse-checkout pattern file.
@@ -123,19 +162,50 @@ func parseSparsePatternFile(path string) []string {
 	return patterns
 }
 
-// IsPathIncluded reports whether relPath (repo-relative forward-slash path)
-// is covered by si's sparse pattern set.
+// IsPathIncluded reports whether relPath (a repo-relative, forward-slash path
+// to a FILE) is covered by si's sparse pattern set.
 //
 // When IsSparse is false every path is included (full checkout).
 // When Patterns is empty every path is excluded (nothing checked out).
 //
-// Cone mode: each non-negation pattern is a directory prefix; a file is
-// included when it starts with "<pattern>/" or equals the pattern exactly,
-// OR when the pattern is "/" (repo root match-all).
+// # Semantics (#6964)
 //
-// Non-cone mode: standard gitignore-style prefix / glob semantics. For
-// simplicity we use a prefix match: a file is included when one of its
-// ancestor directories or the file itself matches a pattern.
+// git's sparse-checkout pattern file uses gitignore syntax with the sense
+// inverted: a matching pattern INCLUDES, a matching negation (`!`) EXCLUDES,
+// and the LAST pattern that matches wins. A pattern that matches a DIRECTORY
+// carries its verdict down to everything beneath it, until some deeper path
+// matches a pattern of its own.
+//
+// So the decision walks the path prefix by prefix — "a", "a/b", "a/b/c.go" —
+// evaluating the whole pattern list against each prefix and letting the last
+// match set the running verdict. A prefix that matches nothing inherits its
+// parent's verdict; the file's verdict is whatever survives to the leaf. That
+// is what makes cone mode work: git writes
+//
+//	/*
+//	!/*/
+//	/src/
+//
+// where `/*` includes every root entry, `!/*/` (directory-only) takes back
+// every root DIRECTORY, and `/src/` puts src back. Before #6964 the code
+// stripped the leading slash, saw `*`, returned "included" for the very first
+// pattern and never reached the `/src/` restriction — every cone-mode sparse
+// repo was indexed in full, silently. The old comment claimed cone mode does
+// not use negation patterns; `!/*/` is the second line git itself writes.
+//
+// A directory that ends up excluded does NOT prune its subtree: git allows a
+// later pattern to re-include below it (`/*`, `!/*/`, `/services/payments/`
+// checks out services/payments while leaving services/orders absent). This
+// matches measured git 2.50.1 behaviour, not gitignore's "cannot re-include"
+// rule.
+//
+// ConeMode is informational only. Cone patterns are a subset of the general
+// syntax, so one matcher answers both; the flag is still reported for the
+// coverage badge and for callers that want to know how the repo was made.
+//
+// Cost: the pattern list is parsed on each call rather than cached, because
+// SparseInfo is a plain value that callers construct and mutate directly. The
+// list is a handful of short lines and parsing is a few string ops per line.
 func IsPathIncluded(si SparseInfo, relPath string) bool {
 	if !si.IsSparse {
 		return true
@@ -144,47 +214,146 @@ func IsPathIncluded(si SparseInfo, relPath string) bool {
 		return false
 	}
 
-	// Normalise: no leading slash, forward slashes only.
-	rel := filepath.ToSlash(relPath)
-	rel = strings.TrimPrefix(rel, "/")
+	// Normalise: forward slashes, no leading slash, no empty components.
+	rel := strings.TrimPrefix(filepath.ToSlash(relPath), "/")
+	comps := splitPathComponents(rel)
+	if len(comps) == 0 {
+		return false
+	}
 
-	for _, pat := range si.Patterns {
-		// Negation patterns (!) are not implemented here — cone mode doesn't
-		// use them; non-cone repos with negation patterns are rare. Treat
-		// negation lines as excluders (file is excluded when a negation matches).
-		negation := strings.HasPrefix(pat, "!")
-		p := strings.TrimPrefix(pat, "!")
-		p = strings.TrimPrefix(p, "/")
-		p = strings.TrimSuffix(p, "/")
+	pats := make([]sparsePattern, 0, len(si.Patterns))
+	for _, raw := range si.Patterns {
+		if p, ok := parseSparsePattern(raw); ok {
+			pats = append(pats, p)
+		}
+	}
+	if len(pats) == 0 {
+		return false
+	}
 
-		var match bool
-		if si.ConeMode {
-			// In cone mode, pat is a directory prefix.
-			if p == "" || p == "*" {
-				match = true // wildcard / root
-			} else {
-				match = rel == p ||
-					strings.HasPrefix(rel, p+"/")
-			}
-		} else {
-			// Non-cone: treat as a path prefix.
-			// A pattern "services/payments" covers "services/payments/file.go".
-			if p == "" || p == "*" || p == "**" {
-				match = true
-			} else {
-				match = rel == p ||
-					strings.HasPrefix(rel, p+"/")
+	included := false
+	for i := 1; i <= len(comps); i++ {
+		prefix := comps[:i]
+		isDir := i < len(comps) // only the final component is the file itself
+		for _, p := range pats {
+			if p.matches(prefix, isDir) {
+				included = !p.negate
 			}
 		}
+	}
+	return included
+}
 
-		if match {
-			if negation {
-				return false
-			}
+// sparsePattern is one parsed line of a sparse-checkout / gitignore pattern
+// file.
+type sparsePattern struct {
+	// negate is true for a leading '!' — the line EXCLUDES what it matches.
+	negate bool
+	// dirOnly is true for a trailing '/' — the line matches directories only.
+	dirOnly bool
+	// anchored is true when the pattern is rooted at the repo top. Per
+	// gitignore rules that is any pattern with a leading slash, or with a
+	// slash anywhere other than at the end.
+	anchored bool
+	// segs are the slash-separated glob segments. A "**" segment matches zero
+	// or more path components; every other segment is matched with path.Match,
+	// whose '*' and '?' never cross a '/' and which honours '\' escapes and
+	// '[...]' classes.
+	segs []string
+}
+
+// parseSparsePattern parses one raw line. ok is false for a line that cannot
+// select anything (empty, or "/" alone).
+func parseSparsePattern(raw string) (sparsePattern, bool) {
+	line := strings.TrimSpace(raw)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return sparsePattern{}, false
+	}
+
+	var p sparsePattern
+	if strings.HasPrefix(line, "!") {
+		p.negate = true
+		line = line[1:]
+	} else if strings.HasPrefix(line, `\!`) || strings.HasPrefix(line, `\#`) {
+		// gitignore escape for a literal leading '!' or '#'.
+		line = line[1:]
+	}
+	if strings.HasSuffix(line, "/") {
+		p.dirOnly = true
+	}
+
+	trimmed := strings.Trim(line, "/")
+	if trimmed == "" {
+		// "/" or "!/" — selects the repo root itself, nothing beneath a name.
+		return sparsePattern{}, false
+	}
+
+	// Anchored when rooted with a leading slash, or when a slash appears
+	// anywhere before the (optional) trailing one.
+	p.anchored = strings.HasPrefix(line, "/") || strings.Contains(trimmed, "/")
+	p.segs = splitPathComponents(trimmed)
+	if len(p.segs) == 0 {
+		return sparsePattern{}, false
+	}
+	return p, true
+}
+
+// matches reports whether the pattern selects the path made of comps, where
+// isDir says whether that path is a directory.
+func (p sparsePattern) matches(comps []string, isDir bool) bool {
+	if p.dirOnly && !isDir {
+		return false
+	}
+	if p.anchored {
+		return globSegments(p.segs, comps)
+	}
+	// Unanchored: the pattern may start at any component, but must still run
+	// to the end of the path.
+	for i := range comps {
+		if globSegments(p.segs, comps[i:]) {
 			return true
 		}
 	}
 	return false
+}
+
+// globSegments matches pattern segments against path segments from the start,
+// consuming both entirely. "**" matches zero or more path segments.
+func globSegments(pat, comps []string) bool {
+	if len(pat) == 0 {
+		return len(comps) == 0
+	}
+	if pat[0] == "**" {
+		for i := 0; i <= len(comps); i++ {
+			if globSegments(pat[1:], comps[i:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(comps) == 0 {
+		return false
+	}
+	// path.Match, not filepath.Match: sparse patterns are always
+	// forward-slash and '\' is an escape character on every platform.
+	ok, err := path.Match(pat[0], comps[0])
+	if err != nil || !ok {
+		return false
+	}
+	return globSegments(pat[1:], comps[1:])
+}
+
+// splitPathComponents splits a forward-slash path, dropping empty components
+// so "a//b/" yields ["a", "b"].
+func splitPathComponents(s string) []string {
+	parts := strings.Split(s, "/")
+	out := parts[:0]
+	for _, c := range parts {
+		if c != "" {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 // CoverageStatus returns CoverageStatusPartial when the SparseInfo indicates

--- a/internal/gitmeta/sparse_realgit_6964_test.go
+++ b/internal/gitmeta/sparse_realgit_6964_test.go
@@ -1,0 +1,428 @@
+// Real-git grading for sparse-checkout support (#6964).
+//
+// The two defects this file exists to pin BOTH failed toward INCLUSION, which
+// is why they survived: a sparse repo indexed in full produces a superset, so
+// nothing errors and nothing goes missing.
+//
+//  1. ProbeRepo read `git config --local`, but git >= 2.32 writes
+//     core.sparseCheckout into the WORKTREE scope — every sparse repo made by
+//     a modern git probed as "not sparse".
+//  2. IsPathIncluded stripped the leading slash off cone mode's first pattern
+//     `/*`, saw a bare `*`, and returned "included" for every path before the
+//     `/src/` restriction was ever reached.
+//
+// Two rules follow from that, and this file is built around them:
+//
+//   - Nothing here hand-writes a config value or a pattern file. Every fixture
+//     drives `git sparse-checkout set` and lets git write whatever it writes —
+//     a hand-written config reproduces defect 1 by construction.
+//   - The ground truth is git's own per-path verdict (`git ls-files -v`, where
+//     the 'S' tag is skip-worktree, i.e. NOT checked out), so the EXCLUSION
+//     direction is asserted for every tracked path. A test that only checks
+//     included-is-included passes against both defects at once.
+//
+// Measured on git 2.50.1 (Apple Git-155), macOS/APFS. Every claim about which
+// scope git writes is re-derived at runtime by rgSparseScopes, so a different
+// git version reports what it actually does instead of being assumed.
+package gitmeta_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/gitmeta"
+)
+
+// rgRun runs git in dir and fails the test on error.
+func rgRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := rgTry(dir, args...)
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return out
+}
+
+// rgTry runs git in dir and returns combined output plus the error.
+func rgTry(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	// A developer's own git config must not decide what this fixture measures.
+	// A path that does not exist, not /dev/null: git reads a missing config
+	// file as empty on every platform, while /dev/null has no Windows spelling.
+	absent := filepath.Join(dir, ".absent-gitconfig-6964")
+	cmd.Env = append(cmd.Environ(),
+		"GIT_CONFIG_GLOBAL="+absent,
+		"GIT_CONFIG_SYSTEM="+absent,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+	)
+	b, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(b)), err
+}
+
+// rgVersion reports the git under test, so a failure names the version it was
+// measured on — the whole defect is a version/scope mismatch.
+func rgVersion(t *testing.T, dir string) string {
+	t.Helper()
+	return rgRun(t, dir, "--version")
+}
+
+// rgFixture builds a committed repo with a tree that has content at the root,
+// in several top-level directories, and nested two deep — enough for a cone
+// set, a nested cone set and a non-cone pattern to each produce a DIFFERENT
+// answer.
+func rgFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	// No -b: the branch name is irrelevant here and -b needs git >= 2.28,
+	// which would narrow the versions this file can grade on.
+	rgRun(t, dir, "init", "-q", ".")
+	for _, f := range rgFixtureFiles {
+		writeFileUnder(t, dir, f)
+	}
+	rgRun(t, dir, "add", "-A")
+	rgRun(t, dir, "commit", "-qm", "init")
+	return dir
+}
+
+// writeFileUnder creates rel (with its parent directories) under dir.
+func writeFileUnder(t *testing.T, dir, rel string) {
+	t.Helper()
+	abs := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(abs, []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+var rgFixtureFiles = []string{
+	"root.txt",
+	"src/a.go",
+	"src/sub/b.go",
+	"services/payments/h.go",
+	"services/payments/deep/d.go",
+	"services/orders/h.go",
+	"cmd/m.go",
+}
+
+// rgGitVerdicts returns git's own per-path answer for every tracked path:
+// true = checked out (included), false = skip-worktree (excluded).
+//
+// `git ls-files -v` tags each index entry; the 'S' tag is skip-worktree, which
+// is exactly what sparse-checkout sets on a path outside the pattern set.
+func rgGitVerdicts(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+	out := rgRun(t, dir, "ls-files", "-v")
+	verdicts := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if len(line) < 3 || line[1] != ' ' {
+			continue
+		}
+		verdicts[line[2:]] = line[0] != 'S'
+	}
+	return verdicts
+}
+
+// rgSparseScopes reports, for this git, which config scopes hold
+// core.sparseCheckout after `git sparse-checkout set` ran. It is diagnostic:
+// it turns "git 2.32 moved the value" from an assumption in a comment into a
+// measurement printed by any failing run.
+func rgSparseScopes(t *testing.T, dir string) string {
+	t.Helper()
+	var parts []string
+	for _, scope := range []string{"--local", "--worktree", ""} {
+		args := []string{"config"}
+		if scope != "" {
+			args = append(args, scope)
+		}
+		args = append(args, "--get", "core.sparseCheckout")
+		out, err := rgTry(dir, args...)
+		name := scope
+		if name == "" {
+			name = "(no scope flag)"
+		}
+		if err != nil {
+			parts = append(parts, name+"=<unset/error>")
+			continue
+		}
+		parts = append(parts, name+"="+out)
+	}
+	return strings.Join(parts, " ")
+}
+
+// assertMatchesGit compares grafel's sparse verdict against git's for every
+// tracked path, and refuses to pass unless BOTH directions were exercised —
+// an all-included comparison is exactly what both defects produce.
+func assertMatchesGit(t *testing.T, dir string, si gitmeta.SparseInfo) {
+	t.Helper()
+	verdicts := rgGitVerdicts(t, dir)
+	if len(verdicts) == 0 {
+		t.Fatal("fixture premise broken: git reported no tracked paths")
+	}
+	paths := make([]string, 0, len(verdicts))
+	for p := range verdicts {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	var wantIn, wantOut int
+	for _, p := range paths {
+		want := verdicts[p]
+		got := gitmeta.IsPathIncluded(si, p)
+		if want {
+			wantIn++
+		} else {
+			wantOut++
+		}
+		if got != want {
+			t.Errorf("IsPathIncluded(%q) = %v, git says checked-out=%v\n  patterns=%v cone=%v\n  scopes: %s\n  %s",
+				p, got, want, si.Patterns, si.ConeMode, rgSparseScopes(t, dir), rgVersion(t, dir))
+		}
+	}
+	// Without this the whole comparison could be satisfied by "include
+	// everything", which is precisely the broken behaviour.
+	if wantOut == 0 {
+		t.Fatalf("fixture is not grading the EXCLUSION direction: git checked out all %d tracked paths (patterns=%v)", wantIn, si.Patterns)
+	}
+	if wantIn == 0 {
+		t.Fatalf("fixture is not grading the INCLUSION direction: git excluded all %d tracked paths (patterns=%v)", wantOut, si.Patterns)
+	}
+	t.Logf("%s | %d included / %d excluded | cone=%v patterns=%v | scopes: %s",
+		rgVersion(t, dir), wantIn, wantOut, si.ConeMode, si.Patterns, rgSparseScopes(t, dir))
+}
+
+// probeAfterSparseSet drives a real `git sparse-checkout set` and returns the
+// SparseInfo grafel derives from the repo git just produced. It fails — rather
+// than skipping — when the probe does not see the sparse checkout, because
+// that state is the defect, not an unsupported environment.
+func probeAfterSparseSet(t *testing.T, dir string, setArgs ...string) gitmeta.SparseInfo {
+	t.Helper()
+	rgRun(t, dir, append([]string{"sparse-checkout", "set"}, setArgs...)...)
+
+	si := gitmeta.ProbeRepo(dir)
+	if !si.IsSparse {
+		t.Fatalf("ProbeRepo says NOT sparse for a repo `git sparse-checkout set %v` just made sparse — defect 1 (#6964).\n  scopes: %s\n  %s",
+			setArgs, rgSparseScopes(t, dir), rgVersion(t, dir))
+	}
+	if len(si.Patterns) == 0 {
+		t.Fatalf("ProbeRepo read no patterns from the file git wrote (scopes: %s)", rgSparseScopes(t, dir))
+	}
+	return si
+}
+
+// TestProbeRepo_SeesASparseCheckoutMadeByRealGit pins defect 1 on its own
+// axis: the probe must read the scope this git writes, whichever that is.
+func TestProbeRepo_SeesASparseCheckoutMadeByRealGit(t *testing.T) {
+	dir := rgFixture(t)
+	before := gitmeta.ProbeRepo(dir)
+	if before.IsSparse {
+		t.Fatal("fixture premise broken: a fresh full checkout probed as sparse")
+	}
+
+	si := probeAfterSparseSet(t, dir, "src")
+	if !si.ConeMode {
+		t.Errorf("`sparse-checkout set src` is cone mode by default on %s, but ConeMode=false (scopes: %s)", rgVersion(t, dir), rgSparseScopes(t, dir))
+	}
+
+	// Diagnostic, not an assertion: record which scope THIS git used. On git
+	// >= 2.32 --local is empty and the value lives in the worktree scope; on
+	// older git it is in --local. `--get` covers both, which is the fix.
+	t.Logf("%s | scopes after `sparse-checkout set src`: %s", rgVersion(t, dir), rgSparseScopes(t, dir))
+}
+
+// TestProbeRepo_DisableIsSeenAsNotSparse grades the other direction of the
+// probe: reading a wider set of scopes must not make a repo look sparse
+// forever after it has been un-sparsed.
+func TestProbeRepo_DisableIsSeenAsNotSparse(t *testing.T) {
+	dir := rgFixture(t)
+	if si := probeAfterSparseSet(t, dir, "src"); !si.IsSparse {
+		t.Fatal("unreachable: probeAfterSparseSet already asserts this")
+	}
+	rgRun(t, dir, "sparse-checkout", "disable")
+	if si := gitmeta.ProbeRepo(dir); si.IsSparse {
+		t.Errorf("ProbeRepo still reports sparse after `sparse-checkout disable` (scopes: %s)", rgSparseScopes(t, dir))
+	}
+}
+
+// TestSparse_ConeMatchesGit — cone mode, one directory. This is the exact
+// shape defect 2 turned into match-everything: git writes `/*`, `!/*/`,
+// `/src/`, and the old code returned true on the first line.
+func TestSparse_ConeMatchesGit(t *testing.T) {
+	dir := rgFixture(t)
+	si := probeAfterSparseSet(t, dir, "src")
+	if !si.ConeMode {
+		t.Fatalf("expected cone mode, got patterns=%v", si.Patterns)
+	}
+	assertMatchesGit(t, dir, si)
+}
+
+// TestSparse_NestedConeMatchesGit — cone mode, a nested directory. A separate
+// axis from the single-directory case: git writes the intermediate
+// `!/src/*/` line, so a matcher that mishandles the second-level negation
+// passes the flat case and fails here.
+func TestSparse_NestedConeMatchesGit(t *testing.T) {
+	dir := rgFixture(t)
+	si := probeAfterSparseSet(t, dir, "services/payments")
+	if !si.ConeMode {
+		t.Fatalf("expected cone mode, got patterns=%v", si.Patterns)
+	}
+	assertMatchesGit(t, dir, si)
+}
+
+// TestSparse_NonConeMatchesGit — non-cone is a SEPARATE axis, not a variant
+// of the cone one: git writes the pattern verbatim rather than the
+// `/*` + `!/*/` scaffolding, so neither fixture stands for the other.
+func TestSparse_NonConeMatchesGit(t *testing.T) {
+	dir := rgFixture(t)
+	si := probeAfterSparseSet(t, dir, "--no-cone", "/services/payments/")
+	if si.ConeMode {
+		t.Fatalf("expected non-cone mode, got patterns=%v", si.Patterns)
+	}
+	assertMatchesGit(t, dir, si)
+}
+
+// TestSparse_NonConeUnanchoredMatchesGit — a non-cone pattern with no leading
+// slash. gitignore anchors any pattern containing an inner slash, so
+// "services/payments" is root-anchored while a bare name would float; git's
+// own verdict decides.
+func TestSparse_NonConeUnanchoredMatchesGit(t *testing.T) {
+	dir := rgFixture(t)
+	si := probeAfterSparseSet(t, dir, "--no-cone", "services/payments", "src/sub")
+	assertMatchesGit(t, dir, si)
+}
+
+// TestSparse_NonConeDoubleStarMatchesGit — a `**` segment, which matches zero
+// or more path components and is the one glob construct a per-component
+// matcher gets wrong by default. Non-cone only: git refuses glob characters in
+// a cone-mode directory argument.
+func TestSparse_NonConeDoubleStarMatchesGit(t *testing.T) {
+	dir := rgFixture(t)
+	// The matched directory is THREE levels down, so "**" has to swallow two
+	// components. With a one-level target, path.Match("**", "src") answers
+	// true on its own and a matcher with no "**" support looks correct.
+	si := probeAfterSparseSet(t, dir, "--no-cone", "/**/deep/")
+	if !gitmeta.IsPathIncluded(si, "services/payments/deep/d.go") {
+		t.Errorf("services/payments/deep/d.go must be INCLUDED by %v", si.Patterns)
+	}
+	if gitmeta.IsPathIncluded(si, "services/payments/h.go") {
+		t.Errorf("services/payments/h.go must be EXCLUDED by %v", si.Patterns)
+	}
+	assertMatchesGit(t, dir, si)
+}
+
+// TestSparse_NonConeNegationMatchesGit — negation in a NON-cone file, where a
+// later include takes back an earlier exclude. The old code returned false the
+// moment any negation matched, ignoring pattern order entirely.
+func TestSparse_NonConeNegationMatchesGit(t *testing.T) {
+	dir := rgFixture(t)
+	si := probeAfterSparseSet(t, dir, "--no-cone", "/*", "!/services/", "!/cmd/")
+	if si.ConeMode {
+		t.Fatalf("expected non-cone mode, got patterns=%v", si.Patterns)
+	}
+	assertMatchesGit(t, dir, si)
+}
+
+// TestSparse_ConeRootFilesStayIncluded states the single most surprising cone
+// rule as its own claim, so it cannot be lost inside a bulk comparison:
+// `/*` + `!/*/` keeps root-level FILES and drops root-level DIRECTORIES.
+// A matcher that prunes a path once an ancestor directory is excluded would
+// still match git on the bulk comparison for `set src`, but gets this wrong.
+func TestSparse_ConeRootFilesStayIncluded(t *testing.T) {
+	dir := rgFixture(t)
+	si := probeAfterSparseSet(t, dir, "src")
+
+	if !gitmeta.IsPathIncluded(si, "root.txt") {
+		t.Errorf("root.txt must be INCLUDED by cone patterns %v (git checks it out)", si.Patterns)
+	}
+	if gitmeta.IsPathIncluded(si, "cmd/m.go") {
+		t.Errorf("cmd/m.go must be EXCLUDED by cone patterns %v — this is the direction both #6964 defects fail in", si.Patterns)
+	}
+	if !gitmeta.IsPathIncluded(si, "src/sub/b.go") {
+		t.Errorf("src/sub/b.go must be INCLUDED by cone patterns %v (a cone directory is recursive)", si.Patterns)
+	}
+}
+
+// TestSparse_ReInclusionUnderAnExcludedDirectory pins a rule that gitignore
+// and sparse-checkout do NOT share: gitignore cannot re-include under an
+// excluded directory, sparse-checkout can. Measured against git, so it is the
+// tool's answer and not a reading of the docs.
+func TestSparse_ReInclusionUnderAnExcludedDirectory(t *testing.T) {
+	dir := rgFixture(t)
+	si := probeAfterSparseSet(t, dir, "--no-cone", "/*", "!/*/", "/services/payments/")
+
+	verdicts := rgGitVerdicts(t, dir)
+	if !verdicts["services/payments/h.go"] {
+		t.Skipf("this git does not re-include under an excluded directory (%s); nothing to pin", rgVersion(t, dir))
+	}
+	if !gitmeta.IsPathIncluded(si, "services/payments/h.go") {
+		t.Errorf("services/payments/h.go: git checks it out, grafel excludes it (patterns=%v)", si.Patterns)
+	}
+	if gitmeta.IsPathIncluded(si, "services/orders/h.go") {
+		t.Errorf("services/orders/h.go must stay EXCLUDED (patterns=%v)", si.Patterns)
+	}
+	assertMatchesGit(t, dir, si)
+}
+
+// TestSparse_BooleanSpelling — git accepts "1"/"yes"/"on" for a boolean, and
+// the probe compared the raw string to "true". This is the permissive
+// direction's mirror: a repo that IS sparse being read as full.
+func TestSparse_BooleanSpelling(t *testing.T) {
+	for _, v := range []string{"true", "1", "yes", "on"} {
+		t.Run(v, func(t *testing.T) {
+			dir := rgFixture(t)
+			// The pattern file still comes from git; only the flag spelling
+			// is under test here.
+			rgRun(t, dir, "sparse-checkout", "set", "--no-cone", "/src/")
+			rgClearWorktreeFlag(t, dir)
+			rgRun(t, dir, "config", "--local", "core.sparseCheckout", v)
+			if si := gitmeta.ProbeRepo(dir); !si.IsSparse {
+				t.Errorf("core.sparseCheckout=%q read as not sparse (scopes: %s)", v, rgSparseScopes(t, dir))
+			}
+		})
+	}
+	t.Run("false", func(t *testing.T) {
+		dir := rgFixture(t)
+		rgRun(t, dir, "sparse-checkout", "set", "--no-cone", "/src/")
+		rgClearWorktreeFlag(t, dir)
+		rgRun(t, dir, "config", "--local", "core.sparseCheckout", "0")
+		if rgAnySparseOnDisk(t, dir) {
+			t.Fatalf("fixture premise broken: git still resolves core.sparseCheckout=true (scopes: %s)", rgSparseScopes(t, dir))
+		}
+		if si := gitmeta.ProbeRepo(dir); si.IsSparse {
+			t.Errorf("ProbeRepo reports sparse for core.sparseCheckout=0 (scopes: %s)", rgSparseScopes(t, dir))
+		}
+	})
+}
+
+// rgClearWorktreeFlag removes core.sparseCheckout from the WORKTREE scope, so
+// a value written into --local is the one git resolves. Scope precedence is
+// system < global < local < worktree; without this the spelling under test is
+// outranked by the "true" `sparse-checkout set` wrote, and the subtest passes
+// no matter what the probe does.
+func rgClearWorktreeFlag(t *testing.T, dir string) {
+	t.Helper()
+	if out, err := rgTry(dir, "config", "--worktree", "--unset", "core.sparseCheckout"); err != nil {
+		// git < 2.32 never wrote it there; nothing to clear.
+		t.Logf("no worktree-scoped core.sparseCheckout to clear: %v (%s)", err, out)
+	}
+	if out, _ := rgTry(dir, "config", "--worktree", "--get", "core.sparseCheckout"); out != "" {
+		t.Fatalf("worktree scope still holds core.sparseCheckout=%q", out)
+	}
+}
+
+// rgAnySparseOnDisk asks git itself whether sparse-checkout is in effect,
+// using the same resolution order the probe now uses.
+func rgAnySparseOnDisk(t *testing.T, dir string) bool {
+	t.Helper()
+	out, err := rgTry(dir, "config", "--bool", "--get", "core.sparseCheckout")
+	return err == nil && out == "true"
+}

--- a/internal/gitmeta/sparse_realgit_6964_test.go
+++ b/internal/gitmeta/sparse_realgit_6964_test.go
@@ -55,8 +55,16 @@ func rgTry(dir string, args ...string) (string, error) {
 	// A path that does not exist, not /dev/null: git reads a missing config
 	// file as empty on every platform, while /dev/null has no Windows spelling.
 	absent := filepath.Join(dir, ".absent-gitconfig-6964")
+	globalCfg := absent
+	if v := os.Getenv("GIT_CONFIG_GLOBAL"); v != "" {
+		// A test that is deliberately measuring the GLOBAL scope sets this
+		// (via t.Setenv, so ProbeRepo's own git child sees it too). Overriding
+		// it here would hide from `git ls-files -v` the very config whose
+		// effect the test is comparing against.
+		globalCfg = v
+	}
 	cmd.Env = append(cmd.Environ(),
-		"GIT_CONFIG_GLOBAL="+absent,
+		"GIT_CONFIG_GLOBAL="+globalCfg,
 		"GIT_CONFIG_SYSTEM="+absent,
 		"GIT_CONFIG_NOSYSTEM=1",
 		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
@@ -107,6 +115,11 @@ var rgFixtureFiles = []string{
 	"root.txt",
 	"src/a.go",
 	"src/sub/b.go",
+	// Root-level `deep/`, so a `/**/deep/` pattern asks "**" to match ZERO
+	// components. Without it "**" is only ever handed >= 1 component, where
+	// path.Match("**", "src") answers true on its own and a matcher with no
+	// "**" support looks correct (review mutant RX2).
+	"deep/e.go",
 	"services/payments/h.go",
 	"services/payments/deep/d.go",
 	"services/orders/h.go",
@@ -290,13 +303,32 @@ func TestSparse_NonConeMatchesGit(t *testing.T) {
 	assertMatchesGit(t, dir, si)
 }
 
-// TestSparse_NonConeUnanchoredMatchesGit — a non-cone pattern with no leading
-// slash. gitignore anchors any pattern containing an inner slash, so
-// "services/payments" is root-anchored while a bare name would float; git's
-// own verdict decides.
-func TestSparse_NonConeUnanchoredMatchesGit(t *testing.T) {
+// TestSparse_NonConeInnerSlashIsAnchoredMatchesGit — a non-cone pattern with
+// no LEADING slash but an INNER one. gitignore anchors on either, so
+// "services/payments" is root-anchored despite the missing leading slash.
+//
+// Renamed from ...UnanchoredMatchesGit, which is what it was called while
+// reaching only the anchored branch: both its patterns contain an inner slash.
+// The axis is real, the old name promised a different one.
+func TestSparse_NonConeInnerSlashIsAnchoredMatchesGit(t *testing.T) {
 	dir := rgFixture(t)
 	si := probeAfterSparseSet(t, dir, "--no-cone", "services/payments", "src/sub")
+	assertMatchesGit(t, dir, si)
+}
+
+// TestSparse_NonConeTrulyUnanchoredMatchesGit — a bare name, the only shape
+// that reaches the UNANCHORED branch of sparsePattern.matches: it must float
+// and match a directory called "payments" at ANY depth.
+//
+// This branch had no fixture anywhere in the tree (review mutant RX1), and
+// forcing anchored=true disagrees with git in the EXCLUSION direction — files
+// git checks out, silently dropped.
+func TestSparse_NonConeTrulyUnanchoredMatchesGit(t *testing.T) {
+	dir := rgFixture(t)
+	si := probeAfterSparseSet(t, dir, "--no-cone", "payments")
+	if !gitmeta.IsPathIncluded(si, "services/payments/h.go") {
+		t.Errorf("a bare %q must float and match services/payments (patterns=%v)", "payments", si.Patterns)
+	}
 	assertMatchesGit(t, dir, si)
 }
 
@@ -306,12 +338,18 @@ func TestSparse_NonConeUnanchoredMatchesGit(t *testing.T) {
 // a cone-mode directory argument.
 func TestSparse_NonConeDoubleStarMatchesGit(t *testing.T) {
 	dir := rgFixture(t)
-	// The matched directory is THREE levels down, so "**" has to swallow two
-	// components. With a one-level target, path.Match("**", "src") answers
-	// true on its own and a matcher with no "**" support looks correct.
+	// The fixture has `deep/` at the ROOT and again three levels down, so one
+	// pattern asks "**" to match ZERO components and MORE THAN ONE. Either
+	// alone leaves a hole: with only the deep target, a "**" that means
+	// one-or-more still passes; with only a one-level target,
+	// path.Match("**", "src") answers true on its own and no "**" support at
+	// all looks correct.
 	si := probeAfterSparseSet(t, dir, "--no-cone", "/**/deep/")
 	if !gitmeta.IsPathIncluded(si, "services/payments/deep/d.go") {
 		t.Errorf("services/payments/deep/d.go must be INCLUDED by %v", si.Patterns)
+	}
+	if !gitmeta.IsPathIncluded(si, "deep/e.go") {
+		t.Errorf(`deep/e.go must be INCLUDED by %v — "**" has to match ZERO components here`, si.Patterns)
 	}
 	if gitmeta.IsPathIncluded(si, "services/payments/h.go") {
 		t.Errorf("services/payments/h.go must be EXCLUDED by %v", si.Patterns)
@@ -425,4 +463,114 @@ func rgAnySparseOnDisk(t *testing.T, dir string) bool {
 	t.Helper()
 	out, err := rgTry(dir, "config", "--bool", "--get", "core.sparseCheckout")
 	return err == nil && out == "true"
+}
+
+// --- the flag without a pattern file (#6967 review blocker) -----------------
+//
+// Reading the config with git's own scope resolution is what makes the
+// GLOBAL/SYSTEM scope reachable at all, and `git config --global
+// core.sparseCheckout true` is the pre-2.25 manual sparse workflow — still in
+// real dotfiles. In a repo with no <git-dir>/info/sparse-checkout, git
+// populates the FULL tree; a probe that answered "sparse, no patterns" would
+// make the walker drop every file, and drop it SILENTLY (the sparse layer
+// emits no SkipEntry). The two tests below hold the two halves apart: no file
+// means not sparse, an EMPTY file means sparse-and-nothing.
+
+// TestProbeRepo_GlobalFlagWithoutAPatternFileIsNotSparse is the blocker case.
+func TestProbeRepo_GlobalFlagWithoutAPatternFileIsNotSparse(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "gitconfig")
+	// t.Setenv, not the per-command env: ProbeRepo shells out to git itself,
+	// and it must see the same global config `git ls-files` sees.
+	t.Setenv("GIT_CONFIG_GLOBAL", cfg)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	dir := rgFixture(t)
+	// Written BY git into the global scope — nothing here hand-writes config.
+	rgRun(t, dir, "config", "--global", "core.sparseCheckout", "true")
+	if got := rgRun(t, dir, "config", "--get", "core.sparseCheckout"); got != "true" {
+		t.Fatalf("fixture premise broken: git resolves core.sparseCheckout=%q, want true", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git", "info", "sparse-checkout")); !os.IsNotExist(err) {
+		t.Fatalf("fixture premise broken: a pattern file exists (%v); this case is about its ABSENCE", err)
+	}
+
+	// git's own verdict: everything is checked out.
+	verdicts := rgGitVerdicts(t, dir)
+	if len(verdicts) == 0 {
+		t.Fatal("fixture premise broken: no tracked paths")
+	}
+	for p, in := range verdicts {
+		if !in {
+			t.Fatalf("fixture premise broken: git did NOT check out %q, so the flag alone is not a full checkout on %s", p, rgVersion(t, dir))
+		}
+	}
+
+	si := gitmeta.ProbeRepo(dir)
+	if si.IsSparse {
+		t.Fatalf("ProbeRepo reports sparse for core.sparseCheckout=true with NO pattern file — every path would be dropped silently (patterns=%v, scopes: %s)",
+			si.Patterns, rgSparseScopes(t, dir))
+	}
+	if got := si.CoverageStatus(); got != gitmeta.CoverageStatusFull {
+		t.Errorf("CoverageStatus = %q, want %q", got, gitmeta.CoverageStatusFull)
+	}
+	// The consequence, asserted separately from the flag that causes it.
+	for p := range verdicts {
+		if !gitmeta.IsPathIncluded(si, p) {
+			t.Errorf("IsPathIncluded(%q) = false, but git checks it out — this is the whole-repo wipeout", p)
+		}
+	}
+}
+
+// TestProbeRepo_EmptyPatternFileStaysSparse is the other half, and it is what
+// stops the blocker fix from being written as "no PATTERNS means not sparse".
+// git writes an empty pattern file for `sparse-checkout set --stdin` with
+// empty input, and then checks out NOTHING — so grafel must stay sparse and
+// exclude everything, exactly the constructed-value contract that
+// sparse_test.go and sparse_walker_test.go already pin.
+func TestProbeRepo_EmptyPatternFileStaysSparse(t *testing.T) {
+	dir := rgFixture(t)
+	if out, err := rgTryStdin(dir, "", "sparse-checkout", "set", "--no-cone", "--stdin"); err != nil {
+		t.Skipf("this git cannot write an empty pattern set: %v\n%s", err, out)
+	}
+
+	pf := filepath.Join(dir, ".git", "info", "sparse-checkout")
+	data, err := os.ReadFile(pf)
+	if err != nil {
+		t.Fatalf("fixture premise broken: git wrote no pattern file at all (%v) — that is the ABSENT case, not the empty one", err)
+	}
+	if len(strings.TrimSpace(string(data))) != 0 {
+		t.Fatalf("fixture premise broken: pattern file is not empty: %q", data)
+	}
+
+	verdicts := rgGitVerdicts(t, dir)
+	for p, in := range verdicts {
+		if in {
+			t.Fatalf("fixture premise broken: git still checks out %q for an empty pattern set", p)
+		}
+	}
+
+	si := gitmeta.ProbeRepo(dir)
+	if !si.IsSparse {
+		t.Fatalf("ProbeRepo reports NOT sparse for an empty pattern file — git checks out nothing here, so grafel would index a superset of the whole repo (scopes: %s)", rgSparseScopes(t, dir))
+	}
+	for p := range verdicts {
+		if gitmeta.IsPathIncluded(si, p) {
+			t.Errorf("IsPathIncluded(%q) = true, but git checks nothing out for an empty pattern set", p)
+		}
+	}
+}
+
+// rgTryStdin is rgTry with stdin, for `sparse-checkout set --stdin`.
+func rgTryStdin(dir, stdin string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Stdin = strings.NewReader(stdin)
+	absent := filepath.Join(dir, ".absent-gitconfig-6964")
+	cmd.Env = append(cmd.Environ(),
+		"GIT_CONFIG_GLOBAL="+absent,
+		"GIT_CONFIG_SYSTEM="+absent,
+		"GIT_CONFIG_NOSYSTEM=1",
+	)
+	b, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(b)), err
 }


### PR DESCRIPTION
Closes #6964.

grafel's sparse-checkout support did nothing on any current git. Two independent defects, either of which alone makes it inert; together, a sparse repo was indexed **in full, silently**.

Both were re-verified at runtime here before being fixed, on **git 2.50.1 (Apple Git-155), macOS/APFS** — and every version-dependent claim below is now re-derived by the tests at runtime (`rgSparseScopes` prints the scopes *this* git used into any failure), so a different git reports what it actually does instead of being assumed.

## Defect 1 — the probe read a scope git stopped writing in 2.32

`ProbeRepo` asked `git config --local --get core.sparseCheckout`. Since git 2.32, `git sparse-checkout init/set` turns on `extensions.worktreeConfig` and writes `core.sparseCheckout` / `core.sparseCheckoutCone` into the **worktree** scope (`<git-dir>/config.worktree`), which `--local` cannot read. Measured in a `t.TempDir()` repo:

```
--local=<unset/error>   --worktree=true   (no scope flag)=true
```

**The fix passes no scope flag at all**, which is not "swapping one hardcoded scope for another" — it is git's own resolution order (worktree → local → global → system), so the probe agrees with the working tree git actually produced:

| case | `--local` (before) | `--get` (after) |
|---|---|---|
| git ≥ 2.32, `sparse-checkout set` | **misses it** (worktree scope) | reads it |
| git < 2.32, `sparse-checkout init` | reads it (local scope) | reads it — `--get` covers local too |
| value set by hand in `--local` | reads it | reads it |
| value inherited from `--global`/`--system` | misses it | reads it — **and git honours it**: driving `git read-tree -mu HEAD` under `GIT_CONFIG_GLOBAL` with `core.sparseCheckout=true` really does produce a sparse working tree |

So the new spelling is **strictly wider** than the one it replaces: nothing that used to be detected stops being detected, on any version.

`--worktree --get` was considered and rejected: it is a hard error (exit 1) on any repo that has not enabled `extensions.worktreeConfig` — i.e. on every non-sparse repo and every repo made sparse by git < 2.32.

`--bool` is added alongside, so `core.sparseCheckout = 1` / `yes` / `on` is read the way git reads it rather than falling through the old literal `== "true"` comparison.

## Defect 2 — cone's `/*` was read as match-everything

`IsPathIncluded` did `p = strings.TrimPrefix(p, "/")` and then `if p == "" || p == "*" { match = true }`. Git's cone mode writes exactly:

```
/*
!/*/
/src/
```

`/*` normalised to `*`, matched everything, returned "included" on the **first** line, and the `/src/` restriction that expresses the user's actual intent was never reached. The adjacent comment — *"Negation patterns (!) are not implemented here — cone mode doesn't use them"* — asserted the exact thing that would have made someone look: `!/*/` is the **second line git itself writes**. That comment is gone, replaced by behaviour.

### What the matcher does now

Sparse patterns are gitignore syntax with the sense inverted: a match **includes**, a `!` match **excludes**, and the **last** match wins. A pattern matching a *directory* carries its verdict down until something deeper matches.

So the decision walks the path prefix by prefix — `a`, `a/b`, `a/b/c.go` — evaluating the whole list against each prefix, last match setting a running verdict that the next prefix inherits. Patterns are parsed properly: negation, directory-only (`/` suffix), anchoring (leading slash *or* an inner slash, per gitignore), `**` as zero-or-more components, and `path.Match` for the rest (so `*` never crosses `/`, and `?`, `[...]`, `\` escapes work).

`ConeMode` **no longer selects an algorithm**, and its doc comment now says so. Cone mode is a restriction on what git *writes*, not on how those lines are read — cone patterns are a subset of the general syntax, so one matcher answers both. The flag is still reported, because callers surface it.

One rule that gitignore and sparse-checkout do **not** share, and which is measured rather than read off the docs: an excluded directory does **not** prune its subtree. `/*` + `!/*/` + `/services/payments/` checks out `services/payments` while leaving `services/orders` absent. A matcher that prunes gets this wrong and still matches git on the simple cone case — hence a test of its own.

## Why nobody noticed

Both defects fail toward **inclusion**. A sparse repo indexed in full is a *superset*: no error, no missing entity, just extra work and extra graph. Same silent class as #6321, #6940, #6946.

## Grading — against real git, never a hand-written config

`internal/gitmeta/sparse_realgit_6964_test.go`. **Nothing in it hand-writes a config value or a pattern file** — that is the single rule that matters here, because a hand-written fixture reproduces defect 1 *by construction*, and that is precisely how this survived. Every case drives `git sparse-checkout set …` in a `t.TempDir()` repo and lets git write whatever it writes.

**Ground truth is git's own per-path verdict.** `git ls-files -v` tags every index entry; the `S` tag is skip-worktree, i.e. *not* checked out. `assertMatchesGit` compares grafel's answer to git's for **every tracked path**, so the **exclusion direction is asserted for every path in every case** — and it `t.Fatal`s if either direction turns out to be unexercised, because an all-included comparison is satisfied by exactly the broken behaviour.

Cone and non-cone are **separate axes**, and no fixture stands in for another:

| test | axis |
|---|---|
| `ProbeRepo_SeesASparseCheckoutMadeByRealGit` | defect 1 alone — probe sees what real git just created |
| `ProbeRepo_DisableIsSeenAsNotSparse` | the other direction — a wider scope read must not make a repo look sparse forever |
| `Sparse_ConeMatchesGit` | cone, one directory — the `/*` + `!/*/` + `/src/` shape defect 2 broke |
| `Sparse_NestedConeMatchesGit` | cone, nested — git adds `!/services/*/`, so a matcher that mishandles the second-level negation passes the flat case and fails here |
| `Sparse_NonConeMatchesGit` | non-cone, anchored pattern written verbatim |
| `Sparse_NonConeUnanchoredMatchesGit` | non-cone, no leading slash |
| `Sparse_NonConeDoubleStarMatchesGit` | `**` spanning **two** components |
| `Sparse_NonConeNegationMatchesGit` | negation where a later include takes back an earlier exclude |
| `Sparse_ConeRootFilesStayIncluded` | the surprising cone rule stated on its own: root **files** stay, root **directories** go |
| `Sparse_ReInclusionUnderAnExcludedDirectory` | re-inclusion below an excluded directory (sparse ≠ gitignore) |
| `Sparse_BooleanSpelling` | `1`/`yes`/`on` are sparse; `0` is not |

## Mutants (round 1) — 13 scored, 13 DEAD

Preferring the **more permissive** direction, since that is the direction both shipped defects already fail in. Each edit was proved landed by an exact occurrence count, with a green baseline immediately before and a restore by `cp` from a SHA-256-verified backup (never `git checkout --`).

Defects 1 and 2 were scored **separately**, with the other fix kept in place — scored together, either one masks the other and neither is graded.

| # | mutant | verdict |
|---|---|---|
| M1 | probe back to `--local --get` (**defect 1 alone**, defect-2 fix kept) | DEAD — 8 tests |
| M2 | old trim-prefix matcher restored (**defect 2 alone**, defect-1 fix kept) | DEAD — 5 tests |
| M3 | negation ignored, every match includes (*permissive*) | DEAD |
| M4 | first match wins instead of last (*permissive* — cone's `/*` is first) | DEAD |
| M5 | directory-only gate dropped, so `!/*/` also matches root files | DEAD |
| M6 | anchoring dropped, every pattern floats (*permissive*) | DEAD |
| M7 | parent verdict not inherited by deeper prefixes | DEAD |
| M8 | no prefix walk, leaf path only | DEAD |
| M9 | `--bool` dropped from the probe | DEAD (**see below**) |
| M10 | `**` loses its zero-or-more-components meaning | DEAD (**see below**) |
| M11 | empty pattern set includes everything (*permissive*) | DEAD |
| M12 | `ConeMode` short-circuits to include-all — the shape of the original bug's excuse (*permissive*) | DEAD |
| M13 | a pattern need not consume the whole path (*permissive*) | DEAD |

**M9 and M10 were ALIVE on the first scoring, and both were vacuous fixtures rather than acceptable gaps.** Recording them because each is an instance of a pattern worth expecting:

- **M9** — the boolean-spelling case ran `sparse-checkout set` and *then* wrote the spelling under test into `--local`. Scope precedence is system < global < local < **worktree**, so the `true` git had just written into the worktree scope outranked it and the subtest passed no matter what the probe did. Fixed by clearing the worktree-scoped flag first (`rgClearWorktreeFlag`, which asserts the clear worked), leaving git's own pattern file untouched.
- **M10** — the `**` case matched a directory **one** level down, where `path.Match("**", "src")` answers true on its own and a matcher with no `**` support looks correct. Fixed by moving the target **three** levels down so `**` must swallow two components.

## The `--local` mirror lines in #6961 — deleted here

#6961 **merged** as `6fbea8186` (an earlier draft of this body said it was still open — stale). This branch is rebased onto it and both mirror lines in `internal/daemon/watch/poll_convergence_6940_test.go` are **deleted in this PR** rather than left as a follow-up:

- `config --local core.sparseCheckout true` — unnecessary: the probe reads the scope git writes.
- `config --local core.sparseCheckoutCone true` — **inert, not "actively wrong"** as an earlier draft said. `sparse-checkout set --no-cone` writes `core.sparseCheckoutCone=false` into the *worktree* scope, which outranks local, so the no-scope-flag probe already resolves `false`. It was actively wrong only under the old `--local` probe.

The comment that justified `--no-cone` by pointing at defect 2 is rewritten: `--no-cone` stays because a verbatim pattern is the simplest shape for that test's subject (poll convergence), and sparse semantics are graded against real git here instead.

`TestChangePoller_SparseFilteredPathConverges` **passes and does not skip** on the merged tree with this change: `--- PASS (2.92s)`, exit 0.

---

## Review round 2 — blocker fixed, two ungraded mutants killed (`f50379c3c`)

Rebased onto `6fbea8186`. Full independent review: comment 5566980699.

### BLOCKER — the flag without a pattern file would have indexed a repo to **zero files**

Dropping the scope flag is right and strictly wider, and that is exactly the problem: it made the **global/system** scope reachable for the first time, and `git config --global core.sparseCheckout true` is the **pre-2.25 manual sparse workflow** — still in real dotfiles. Re-measured here on git 2.50.1, in a repo with no `<git-dir>/info/sparse-checkout`:

| | |
|---|---|
| git | `ls-files -v` tags **every** path `H`; the working tree is complete |
| grafel, as reviewed | `IsSparse=true, Patterns=nil` → `IsPathIncluded` short-circuits to `false` → the walker drops **every file** |

and it drops them **silently**: sparse is the one walk layer that skips with no `SkipEntry` and nothing on `PrintSkipped`, so there would not even be a `[skip]` line to explain an empty graph. Total loss, in the exclusion direction, newly reachable.

**The gate belongs in `ProbeRepo`, not `IsPathIncluded`.** The constructed-value contract `IsSparse=true, Patterns=nil → exclude` is pinned deliberately by `sparse_test.go` and `sparse_walker_test.go` and is correct; what was wrong is `ProbeRepo` *manufacturing* that value. And it keys on **the file, not the pattern count** — those are different states in git, measured:

| state | git checks out | grafel now |
|---|---|---|
| pattern file **absent** | **everything** | not sparse → full index |
| pattern file present but **empty** | **nothing** | sparse, excludes everything |
| pattern file present, comment-only | nothing | sparse, excludes everything |

An existing-but-*unreadable* file (the #6416 FIFO case) also lands on "not sparse" — the over-inclusive direction, which is the direction this file chooses everywhere. `parseSparsePatternFile` now returns that distinction, and `gitmeta_fifo_6416_test.go` gains an assertion that a refused pattern file reads as *no file* rather than as an empty pattern set, because that is now the difference between a superset and a zero-file graph.

Neither new test hand-writes anything: the global flag is written **by git** into a `GIT_CONFIG_GLOBAL` the test process sets with `t.Setenv` (so `ProbeRepo`'s own git child resolves the same config `git ls-files -v` does), and the empty pattern file is written **by git** via `sparse-checkout set --no-cone --stdin` with empty input.

### Mutants — 4 more scored, 4 DEAD, each on exactly the test it targets

Green baseline immediately before each, edit proved landed by an exact occurrence count, restore by `cp` from a SHA-256-verified backup, re-scored a second time against the final head.

| # | mutant | verdict |
|---|---|---|
| B1 | the reviewed code: no pattern-file gate | DEAD — `ProbeRepo_GlobalFlagWithoutAPatternFileIsNotSparse` |
| B2 | the **wrong** fix: gate on the pattern **count** too | DEAD — `ProbeRepo_EmptyPatternFileStaysSparse` |
| RX1 | `anchored = true` always | DEAD — `Sparse_NonConeTrulyUnanchoredMatchesGit` |
| RX2 | `**` means one-or-more instead of zero-or-more | DEAD — `Sparse_NonConeDoubleStarMatchesGit` |

*(B2's first form left `haveFile` unused and failed to compile. A build break is not a kill; it was re-scored in a compiling form.)*

### Two more vacuous fixtures — and the lesson, since this is now four

RX1 and RX2 were ALIVE because of fixtures whose names claimed more than their bodies reached:

- `TestSparse_NonConeUnanchoredMatchesGit` used `"services/payments"` and `"src/sub"` — **both contain an inner slash, so gitignore anchors both**. The unanchored branch of `sparsePattern.matches` had no fixture anywhere in the tree. Renamed to `..._NonConeInnerSlashIsAnchoredMatchesGit` (a real axis, just not the one the name promised), and a genuine bare-name case added.
- `TestSparse_NonConeDoubleStarMatchesGit` only ever had `deep/` at depth ≥ 2, so `**` was never asked to match **zero** components. A root-level `deep/e.go` is now in the fixture, so one pattern exercises zero *and* more-than-one in one comparison.

**Four of these in one change — two I found myself (M9, M10), two found by review. The generalisable point: driving real git does not by itself guarantee a fixture reaches the axis its name claims.** My own M10 fix moved the `**` target from one level to three, which fixed too *few*: it closed "no `**` support at all" and left "`**` means one-or-more" open. A fixture needs its *named branch* proved reachable, and the cheapest proof is the mutant that ought to kill it.

### Smaller corrections

- Removed the `\!` / `\#` de-escaping in `parseSparsePattern`: `path.Match` reads the backslash as an escape too, so it was a branch that could never change an answer, and therefore could never be graded.
- Documented the one known divergence from git, pre-existing and over-inclusive: a pattern with a **trailing space** (`/src/ `) is stripped by `parseSparsePatternFile`'s `TrimSpace` and read as `/src/`, while git keeps the space and matches nothing.
- `ConeMode`'s doc no longer claims callers surface it — it has **zero non-test readers** in the tree.

### Not changed, and why

The matcher itself. The review drove 22 adversarial pattern shapes through real `git sparse-checkout set` against `git ls-files -v`; 21 matched exactly and the 22nd is the pre-existing trailing-space divergence above. I have no counter-example either.

## Verification

`go test -count=1`, macOS/APFS, git 2.50.1 (Apple Git-155), on the final head `f50379c3c` rebased onto `6fbea8186`:

- `./internal/gitmeta/` — 39.2 s
- `./internal/daemon/walk/` — 13.4 s (the only consumer of `IsPathIncluded`)
- `./internal/extractors/` — 52.6 s (calls `ProbeRepo`)
- `./internal/daemon/` — 32.4 s
- `./internal/daemon/watch/` — 160.7 s, and `TestChangePoller_SparseFilteredPathConverges` re-run alone: `--- PASS (2.92s)`, not a skip
- `./cmd/grafel/` — 157.5 s (calls `ProbeRepo`; also carries the whole-graph digest pin)

`go vet` and `gofmt -l` clean on every touched package.

Nothing here is `runtime.GOOS`-conditional. `ci:full` is applied and re-applied after every push (a push fires `synchronize`, not `labeled`): all measurement is macOS, the macOS leg does not run without the label, and this change is exactly the kind a platform difference in git behaviour would break.

## Behaviour change — smaller than the first draft of this body claimed

The original wording promised cone-mode users a smaller graph. **That is wrong, and the review measured it.** On a real cone-sparse `django` (cone on `django/db`): 7043 tracked, 6897 skip-worktree, 146 files on disk, and `WalkRepo` returns **146 files with sparse and 146 without — delta 0**. git had already removed the out-of-cone files from the working tree, so the walker never saw them; the graph was cone-limited before this PR, by git rather than by grafel.

What actually changes:

1. **`CoverageStatus` flips `full` → `partial`** on a genuinely sparse repo. Cosmetic: written at `cmd/grafel/index.go`, carried through `graph.Document`, surfaced as a dashboard field. No consumer degrades or treats it as a problem.
2. **Untracked files outside the cone are now excluded.** git does not delete what it never tracked, so these are the paths the filter actually removes — and this is exactly the #6940/#6961 case, where such a path was re-reported by the poller forever.
3. `ConeMode` is now honestly documented as having **no non-test reader anywhere in the tree**, so nothing depended on it selecting an algorithm.

The blocker case above is the one place where the delta would have been enormous, and in the wrong direction.

Refs #6940, #6961.
