### PR TITLE
test(#6968): the ComputeID collision scan came back zero — over 464k entities, and the prefix-pair surface is 12, not 8

### DIFF
--- a/internal/types/computeid_prefix_pairs_6968_test.go
+++ b/internal/types/computeid_prefix_pairs_6968_test.go
@@ -42,12 +42,22 @@ import (
 // than AllEntityKinds(). The corpus scan observed ten kinds that no
 // AllEntityKinds() entry declares — ChannelEvent, File, SCOPE.DI,
 // SCOPE.Interface, SCOPE.Middleware, SCOPE.Observability, SCOPE.Router,
-// SCOPE.Type, Stream, Subscription — all from internal/custom/** extractors.
+// SCOPE.Type, Stream, Subscription — all from internal/custom/** extractors,
+// and therefore all behind the default-OFF custom gate (#6966).
+//
 // One of them, SCOPE.Router, forms a THIRTEENTH prefix pair with the declared
-// SCOPE.Route, and both members are emitted on the corpus today. This test
-// cannot see that pair, because a free-form kind string is not enumerable from
-// the vocabulary; closing the gap means making those producers declare their
-// kinds, which is a separate change. Refs #6968.
+// SCOPE.Route. State its gate precisely, because the two members do not share
+// one: SCOPE.Route is emitted in BOTH gate states (36 entities, in
+// aspnetcore-docs-samples, awesome-compose and grafel), while SCOPE.Router
+// appears ONLY gate-ON (2 entities, in grafel and play-scala-starter; its sole
+// producer is internal/custom/scala/frameworks.go). So the pair has both
+// members only under gate-ON, and on a default index SCOPE.Router is not
+// emitted at all — it is not a live pair for users today.
+//
+// This test cannot see that pair in either gate state, because a free-form
+// kind string is not enumerable from the vocabulary; closing the gap means
+// making those producers declare their kinds, which is a separate change.
+// Refs #6968.
 func TestComputeIDKindPrefixPairs6968(t *testing.T) {
 	want := map[string]bool{
 		// The eight SCOPE.* pairs enumerated on the issue.
@@ -116,9 +126,6 @@ func TestComputeIDKindPrefixPairs6968(t *testing.T) {
 	}
 	for _, p := range removed {
 		t.Errorf("stale ComputeID prefix pair %s in this test's roster: it is no longer produced by AllEntityKinds(). Remove it from `want`.", p)
-	}
-	if len(added) == 0 && len(removed) == 0 && len(got) != len(want) {
-		t.Errorf("roster size %d != enumerated size %d", len(want), len(got))
 	}
 	if t.Failed() {
 		var all []string

--- a/internal/types/computeid_prefix_pairs_6968_test.go
+++ b/internal/types/computeid_prefix_pairs_6968_test.go
@@ -1,0 +1,131 @@
+package types
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// EntityRecord.ComputeID hashes OrgID+ProjectID+SourceFile+Kind+Name as a BARE
+// concatenation, with no separators, while graph.EntityID NUL-separates every
+// field. Two records that split the same characters differently across the
+// Kind/Name boundary therefore share one ComputeID and hold two distinct
+// EntityIDs — the #6968 disagreement.
+//
+// The Kind/Name boundary can only be crossed when one kind is a PROPER PREFIX
+// of another: kind A named B+X collides with kind A+B named X. That makes the
+// reachable surface a pure property of the kind vocabulary, and this test pins
+// it: the set of ordered prefix pairs over AllEntityKinds() must equal the
+// roster below, exactly.
+//
+// A NEW pair means a newly-added kind widened the surface — the guard fails and
+// whoever added the kind decides whether the pairing is safe. A REMOVED pair
+// means the roster has gone stale and must shrink. Neither direction is a
+// silent pass, and the test is deliberately over AllEntityKinds() (the emit
+// vocabulary) rather than over a source scan of kinds.go, so a constant that is
+// declared but never emittable cannot inflate it and a kind moved behind a
+// conversion cannot vanish from it.
+//
+// Scanning the corpus for a live instance (#6968) found none: 0 colliding
+// groups over 464,651 entities / 464,280 (SourceFile, ComputeID) groups with
+// the custom-extractor gate OFF, and 0 over 539,291 / 538,921 with it ON,
+// across 58 archigraph-corpora repos plus grafel itself (macOS/APFS). That
+// zero is corpus-relative and this test does NOT assert that no collision can
+// occur: a pair on the roster is reachable the moment two entities of the
+// paired kinds land in one file with completing names, and three of the twelve
+// pairs (SCOPE.External/SCOPE.ExternalEndpoint, Test/TestClass, Test/TestConfig)
+// already co-occur inside a single corpus repo. What this test does is convert
+// "we checked once" into "we keep checking".
+//
+// KNOWN BLIND SPOT, deliberately not papered over: the emit surface is WIDER
+// than AllEntityKinds(). The corpus scan observed ten kinds that no
+// AllEntityKinds() entry declares — ChannelEvent, File, SCOPE.DI,
+// SCOPE.Interface, SCOPE.Middleware, SCOPE.Observability, SCOPE.Router,
+// SCOPE.Type, Stream, Subscription — all from internal/custom/** extractors.
+// One of them, SCOPE.Router, forms a THIRTEENTH prefix pair with the declared
+// SCOPE.Route, and both members are emitted on the corpus today. This test
+// cannot see that pair, because a free-form kind string is not enumerable from
+// the vocabulary; closing the gap means making those producers declare their
+// kinds, which is a separate change. Refs #6968.
+func TestComputeIDKindPrefixPairs6968(t *testing.T) {
+	want := map[string]bool{
+		// The eight SCOPE.* pairs enumerated on the issue.
+		"SCOPE.Channel|SCOPE.ChannelBinding":    true,
+		"SCOPE.Event|SCOPE.EventBusEvent":       true,
+		"SCOPE.Event|SCOPE.EventFlow":           true,
+		"SCOPE.Event|SCOPE.EventType":           true,
+		"SCOPE.External|SCOPE.ExternalEndpoint": true,
+		"SCOPE.External|SCOPE.ExternalService":  true,
+		"SCOPE.Model|SCOPE.ModelEvent":          true,
+		"SCOPE.State|SCOPE.StateMachine":        true,
+		// Four more that the issue's SCOPE.*-only enumeration missed: the emit
+		// vocabulary also holds unprefixed and snake_case kinds, and they pair
+		// among themselves. "Test" + name "ClassFoo" against "TestClass" + name
+		// "Foo" is the most ordinary-looking of the twelve.
+		"Test|TestClass":                         true,
+		"Test|TestConfig":                        true,
+		"http_endpoint|http_endpoint_call":       true,
+		"http_endpoint|http_endpoint_definition": true,
+	}
+
+	kinds := AllEntityKinds()
+	if len(kinds) < 2 {
+		t.Fatalf("AllEntityKinds() returned %d kinds — the enumeration below would be vacuous", len(kinds))
+	}
+
+	got := map[string]bool{}
+	for _, a := range kinds {
+		for _, b := range kinds {
+			if a == b {
+				continue
+			}
+			as, bs := string(a), string(b)
+			if as == "" || bs == "" {
+				t.Errorf("empty entity kind in AllEntityKinds(): %q / %q", as, bs)
+				continue
+			}
+			// a is a PROPER prefix of b: an entity of kind a named
+			// strings.TrimPrefix(bs, as)+X has the same Kind+Name
+			// concatenation as one of kind b named X.
+			if len(as) < len(bs) && strings.HasPrefix(bs, as) {
+				got[as+"|"+bs] = true
+			}
+		}
+	}
+
+	var added, removed []string
+	for p := range got {
+		if !want[p] {
+			added = append(added, p)
+		}
+	}
+	for p := range want {
+		if !got[p] {
+			removed = append(removed, p)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+
+	for _, p := range added {
+		parts := strings.SplitN(p, "|", 2)
+		t.Errorf("NEW ComputeID prefix pair %s: an entity of kind %s named %q+X shares a ComputeID with one of kind %s named X in the same file, while their graph.EntityIDs differ (#6968). "+
+			"Either rename the kind so neither is a prefix of the other, or add the pair to the roster in this test with a note on why the collision is acceptable.",
+			p, parts[0], strings.TrimPrefix(parts[1], parts[0]), parts[1])
+	}
+	for _, p := range removed {
+		t.Errorf("stale ComputeID prefix pair %s in this test's roster: it is no longer produced by AllEntityKinds(). Remove it from `want`.", p)
+	}
+	if len(added) == 0 && len(removed) == 0 && len(got) != len(want) {
+		t.Errorf("roster size %d != enumerated size %d", len(want), len(got))
+	}
+	if t.Failed() {
+		var all []string
+		for p := range got {
+			all = append(all, p)
+		}
+		sort.Strings(all)
+		t.Log("full enumerated prefix-pair set:\n" + fmt.Sprint(strings.Join(all, "\n")))
+	}
+}


### PR DESCRIPTION
## The measurement came back zero, and here is precisely what the zero is over

This is the **measurement arm** of #6968. `ComputeID` is **not changed** — the decision to
attempt that depends on this number, and this number does not argue for paying a migration today.

The scan groups every emitted entity by `(SourceFile, ComputeID)` and reports every group holding
**more than one distinct `graph.EntityID`** — i.e. exactly the shape where the bare-concatenation
`ComputeID` folds two records that the NUL-separated `EntityID` keeps apart.

| custom-extractor gate | entities | `(SourceFile, ComputeID)` groups | colliding groups |
|---|---:|---:|---:|
| **OFF** (production default, the user-facing number) | 464,651 | 464,280 | **0** |
| ON (`grafel quality` only, #6966) | 539,291 | 538,921 | **0** |

59 repos: the 58 repos of `archigraph-corpora` plus grafel itself. macOS/APFS, `darwin 25.6.0`.
Every repo produced entities; no repo errored; no repo was skipped.

`OrgID`/`ProjectID` are a constant prefix within one index run, so omitting them from the grouping
key cannot change which records land in the same group — a constant prefix is collision-invariant.

### The zero is a measurement, not a no-op

The detector carried a **positive control**: injecting the two records
`{Kind:"SCOPE.State", Name:"MachineIdle"}` and `{Kind:"SCOPE.StateMachine", Name:"Idle"}` into a
scanned document, in one file, made it report exactly one group with two distinct `EntityID`s
(`f235d7936fd496bc` vs `a5df3da3a732b17b`, one shared `ComputeID` `f17b1cd3d49d3c9d`) while the
same repo reported zero without the injection. The scan ran the production `Index()` in-process
from this branch — not through the installed daemon.

### The reachable surface is twelve pairs, not eight

The issue's enumeration filtered to `SCOPE.*` identifiers in `kinds.go`. Enumerating
`AllEntityKinds()` — the **emit** vocabulary — gives **12** ordered proper-prefix pairs. The four
the `SCOPE.*` filter dropped are real emittable kinds:

```
Test          | TestClass                  <- "Test" named "ClassFoo" vs "TestClass" named "Foo"
Test          | TestConfig
http_endpoint | http_endpoint_call
http_endpoint | http_endpoint_definition
```

`Test|TestClass` is the most ordinary-looking of the twelve — considerably less contrived than the
`SCOPE.Event`/`SCOPE.EventType` case the issue nominated.

### Which pairs actually appeared, and how close they got

Corpus-wide kind counts (gate OFF; the ON numbers differ only in `SCOPE.External`, 9760 vs 9849):

| pair | member A | member B | both members in one repo |
|---|---:|---:|---|
| `SCOPE.External` / `SCOPE.ExternalEndpoint` | 9849 | 68 | **yes** — actix-examples, aspnetcore-docs-samples, awesome-compose, flask, grafel, nextjs, rails-actionpack, requests, sidekiq |
| `Test` / `TestClass` | 1584 | 356 | **yes** — django, flask-realworld, flask, grafel, requests |
| `Test` / `TestConfig` | 1584 | 7 | **yes** — click, flask-realworld, flask, requests |
| `SCOPE.Channel` / `SCOPE.ChannelBinding` | 9 | 0 | no |
| `SCOPE.Event` / `SCOPE.EventBusEvent` | 0 | 7 | no |
| `SCOPE.Event` / `SCOPE.EventFlow` | 0 | 22 | no |
| `SCOPE.Event` / `SCOPE.EventType` | 0 | 4 | no |
| `SCOPE.External` / `SCOPE.ExternalService` | 9849 | 0 | no |
| `SCOPE.Model` / `SCOPE.ModelEvent` | 0 | 5 | no |
| `SCOPE.State` / `SCOPE.StateMachine` | 0 | 2 | no |
| `http_endpoint` / `http_endpoint_call` | 0 | 83 | no |
| `http_endpoint` / `http_endpoint_definition` | 0 | 848 | no |

**Three of twelve pairs have both members alive inside one repo.** So the zero does not rest on
"these kinds never meet" — it rests on the narrower "they never met in the same file with names
that complete the boundary". That is a thinner margin than "latent by construction", and it is why
this PR adds a guard rather than closing the issue.

`SCOPE.Event`, `SCOPE.Model`, `SCOPE.State`, `SCOPE.ExternalService`, `SCOPE.ChannelBinding` and
`http_endpoint` produced **zero** entities across all 59 repos. Per the board's own rule, a zero
count is corpus-relative: it means these corpora do not exercise those producers, not that the
producers cannot fire.

### A thirteenth pair the vocabulary cannot see

The corpus scan observed **79 distinct kinds**, of which **ten are not declared by
`AllEntityKinds()`** — all emitted by `internal/custom/**`:

```
ChannelEvent  File  SCOPE.DI  SCOPE.Interface  SCOPE.Middleware
SCOPE.Observability  SCOPE.Router  SCOPE.Type  Stream  Subscription
```

`AllEntityKinds()`' own doc comment says it exists so tests can "validate that no producer leaks a
free-form kind string". Ten leak. One of them matters here directly: **`SCOPE.Router` forms a
thirteenth prefix pair with the declared `SCOPE.Route`, and both members are emitted on the corpus
today.** The guard in this PR cannot see it, because a free-form string is not enumerable from the
vocabulary. That is recorded as a named blind spot in the test rather than papered over; closing it
means making those producers declare their kinds, which is a separate change.

(`SCOPE.Type` is also on that list — the exact kind the issue body nominated as the motivating
example. It is emitted and undeclared. `SCOPE.TypeAlias` was not observed, so the pair is not live,
but it is outside the guard either way.)

### The consumer that is still undefended

Two call sites key a map on `ComputeID` and value it with `EntityID`:

- `internal/extractors/incremental.go` `remapTwinOfAnchors` — **guarded**. It builds an `ambiguous`
  set, warns, and leaves the `twin_of` dangling rather than picking a winner (#6960/#6965).
- `cmd/grafel/index.go` `stampEntityIDs` (~L4757) — **not guarded**. Same `preStampToFinal` map,
  same two hashes, and no ambiguity check: on a collision the last writer wins by iteration order
  and a `grafel.twin_of` naming that preimage is repointed at an arbitrary one of two distinct
  entities. That is the full-index path, i.e. the common one.

The measured collision count is zero, so nothing is wrong on today's corpus — but the defence that
#6965 added to the incremental path was never mirrored onto the full-index path, and only one of
the two is protected if a colliding pair ever appears. Worth its own issue; deliberately not fixed
here, since this arm must not change identity behaviour.

## What this PR adds

`TestComputeIDKindPrefixPairs6968` in `internal/types`. It enumerates `AllEntityKinds()` for
ordered proper-prefix pairs and pins the result at the twelve above, failing in **both** directions:

- a **new** pair — someone added a kind that widened the collision surface; the failure names the
  completing prefix and tells them to rename or to add the pair with a justification;
- a **stale** pair — the roster outlived the vocabulary and must shrink.

It enumerates the emit vocabulary rather than source-scanning `kinds.go`, so a declared-but-
unemittable constant cannot inflate it and a kind moved behind a conversion cannot vanish from it.

### Verification

- `go test -count=1 ./internal/types/` — **green** (full package suite, not a `-run` subset).
- No production code is touched — the diff is one new `_test.go` file — so no extractor is reached
  and `./cmd/grafel/` is not implicated. (Its digest hashes fields, not ids, so it could not have
  seen an id change in any case.)

### Mutants scored

Green baseline immediately before each; the edit's landing proved by an exact occurrence count;
`kinds.go` restored by `cp` from a `shasum`-verified backup (`0db31847…`, byte-identical before and
after), never by `git checkout --`.

| mutant | occurrences asserted | verdict |
|---|---|---|
| add `EntityKindOperationSynthetic = "SCOPE.OperationSynthetic"` to `AllEntityKinds()` | 2 | **DEAD** — fails naming `SCOPE.Operation\|SCOPE.OperationSynthetic` |
| drop `EntityKindStateMachine` from `AllEntityKinds()` | 1 removed | **DEAD** — fails naming the now-stale `SCOPE.State\|SCOPE.StateMachine` |

The first mutant's initial attempt did not compile; a build failure is not a kill, so it was
rewritten and re-scored against a compiling tree. Both were re-scored against the final version of
the test.

Refs #6968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
