### PR TITLE
docs(#6966): the custom-extractor gate cited a blocker that closed a month earlier, and quoted its cost with no denominator

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -527,8 +527,10 @@ func WithExportJSON(export bool) IndexOption {
 // tests running in the same binary.
 //
 // The default stays OFF. inProcCustomExtractors in inproc_custom.go gives the
-// qualitative rationale; the cost figures are at the gate itself, index.go:3944-3945
-// (+17.5% wall, +18.2% TotalAlloc, never measured at corpus scale). The one
+// qualitative rationale; the cost figures and their provenance are at the gate
+// itself, in classifyAndReadWithProgress — search for "The gate stays
+// default-OFF" rather than trusting a line number (this reference said
+// index.go:3944-3945 long after the gate had moved past line 4100). The one
 // caller that opts in is `grafel quality` over a golden fixture — see
 // qualityIndexOptions in quality.go.
 func WithCustomExtractors(enabled bool) IndexOption {
@@ -4137,11 +4139,31 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 				//   go, ruby — genuinely inert; identical content tuples.
 				//
 				// Pinned by TestInProcCustomExtractorsSupersedeIsNonDestructive and
-				// TestInProcCustomExtractorsJavaEnrichment. The gate stays
-				// default-OFF: its wall/alloc cost (+17.5% wall, +18.2%
-				// TotalAlloc) has never been measured at corpus scale, and #6105
-				// (synthetic Class:<Name> endpoints resolving to nothing) is still
-				// open. Flipping the default is a separate decision.
+				// TestInProcCustomExtractorsJavaEnrichment.
+				//
+				// COST, WITH ITS PROVENANCE (#6966). The figures long quoted
+				// here — +17.5% wall, +18.2% TotalAlloc — come from the #6106
+				// harness: one arm per process, alternated externally, 10 reps
+				// each, over the #5989 Go/Python/Java/JS/Ruby FIXTURES, not a
+				// corpus. Denominator: 1.82s -> 2.14s wall, 805.5MB -> 952.3MB
+				// TotalAlloc, 15360 -> 18583 entities (+21.0%). Peak HeapAlloc
+				// moved +4.6% (162.3 -> 169.7MB); every fixture peaked under
+				// ~170MB, so nothing in those numbers reaches the GB-scale
+				// regime epic #5954 targets. Quote them WITH the fixture scale
+				// or not at all.
+				//
+				// #6105 (synthetic Class:<Name> endpoints resolving to nothing)
+				// was the second stated blocker. It is CLOSED — fixed in #6127,
+				// which gave internal/custom/java structural refs the language
+				// segment the resolver parses. This comment asserted it was
+				// "still open" for a month afterwards; do not reintroduce a
+				// blocker claim without re-reading the issue's state.
+				//
+				// The gate nevertheless stays default-OFF, and that remains a
+				// deliberate decision rather than a blocked one: the cost/yield
+				// trade at corpus scale is measured and discussed on #6966, and
+				// flipping the default is the owner's call, not a side effect of
+				// touching this file.
 				//
 				// The `file.TSTree != nil` guard is load-bearing beyond avoiding
 				// a use-after-free: a subset of custom extractors work on file

--- a/internal/extractors/incremental_custom_extractors_6960_test.go
+++ b/internal/extractors/incremental_custom_extractors_6960_test.go
@@ -232,7 +232,9 @@ func TestIncrementalDispatchesCustomExtractorsWhenTheGateIsOn6960(t *testing.T) 
 // reindex", and with the gate off a full reindex emits no custom entities — so
 // an incremental pass that dispatched them unconditionally would be just as
 // divergent as one that never dispatched them, only in the opposite direction
-// (and would silently pay the +17.5% wall cost the gate exists to withhold).
+// (and would silently pay the extraction cost the gate exists to withhold —
+// +17.5% wall on the #6106 FIXTURES; see the gate comment in cmd/grafel for
+// that figure's denominator and #6966 for the corpus-scale number).
 func TestIncrementalSkipsCustomExtractorsWhenTheGateIsOff6960(t *testing.T) {
 	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
 


### PR DESCRIPTION
Comment-only. The gate at `classifyAndReadWithProgress` gave two reasons for staying default-OFF; one was false and the other was unfalsifiable as written.

## #6105 closed a month before this comment stopped saying so

The comment asserted #6105 (synthetic `Class:<Name>` endpoints resolving to nothing) was **"still open"**. It closed 2026-08-04, fixed in #6127 — which gave `internal/custom/java` structural refs the language segment the resolver parses. Anyone weighing the flip read that sentence and concluded a blocker stood. It is removed and replaced with the closure and its fixing PR.

## "+17.5% wall, +18.2% TotalAlloc" had no denominator

The figures are real. Their provenance, which the comment never carried, is PR #6106: one arm per process, alternated externally, 10 reps each, over the **#5989 fixtures — not a corpus**. Full denominator now in the comment:

| metric | OFF | ON |
|---|---|---|
| wall | 1.82 s | 2.14 s |
| TotalAlloc | 805.5 MB | 952.3 MB |
| peak HeapAlloc | 162.3 MB | 169.7 MB (+4.6%) |
| entities | 15360 | 18583 |

Every fixture peaked under ~170 MB, so none of it reaches the GB-scale regime epic #5954 targets. The comment now says to quote the figures with that scale or not at all. The `+17.5%` reference in `incremental_custom_extractors_6960_test.go` is qualified the same way.

## A stale line number

`WithCustomExtractors`' doc comment pointed at `index.go:3944-3945` for those figures. The gate has been past line 4100 for some time. Replaced with a searchable anchor instead of a number that will drift again.

## What this does NOT do

**It does not flip the gate.** The default stays OFF. The corpus-scale measurement the comment conceded was never taken is posted on #6966 (58 repos, gate OFF vs ON); the flip itself is the owner's decision and is not made here.

## Verification

`go test -count=1 ./cmd/grafel/ ./internal/extractors/` — both `ok`.

**No test can observe a comment.** That green suite is evidence nothing else was disturbed; it is not evidence the corrected comment is right. That rests on #6105's closed state, commit `a9c25f0` (`fix(#6105): …`, PR #6127), and the #6106 PR body quoted above — all checkable independently of this branch.

Refs #6966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
