### PR TITLE
fix(#6971): stampEntityIDs picked a twin_of anchor by arrival order — the guarded path was the rare one

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -4776,6 +4777,28 @@ func (i *Indexer) stampEntityIDs(records []types.EntityRecord) {
 	// preStampToFinal maps a record's pre-stamp ComputeID() to the final
 	// graph.EntityID() this function assigns it, but only when they differ.
 	preStampToFinal := make(map[string]string)
+	// ambiguous holds every pre-stamp key that TWO records with DIFFERENT final
+	// ids both claim. Issue #6971: this is the same decision, in the same
+	// shape, as internal/extractors/incremental.go's remapTwinOfAnchors — the
+	// incremental twin of this loop — and its doc comment carries the full
+	// reasoning. In short: types.EntityRecord.ComputeID concatenates
+	// OrgID+ProjectID+SourceFile+Kind+Name with NO separators while
+	// graph.EntityID NUL-separates every field, so {SourceFile:"x.go",
+	// Kind:"A", Name:"BC"} and {SourceFile:"x.go", Kind:"AB", Name:"C"} are ONE
+	// key and TWO entities. Keying a map on the COARSER id while storing the
+	// FINER one lets both records write the same slot, and the winner is
+	// whichever index comes last — so a twin_of naming that preimage would be
+	// repointed at an ARBITRARY one of two distinct entities (#6369's wrong-node
+	// hazard). Such a key is therefore SKIPPED, not resolved: skipping degrades
+	// to the pre-remap behaviour for that one facet — a dangling twin_of, which
+	// names an id no entity has and is thus detectable and inert — while
+	// resolving invents an answer this function has no evidence for, and a
+	// confidently-wrong anchor reads as VALID to classfold's twinAnchors and to
+	// the symbol index's facet-alias rule. (The underlying ComputeID separator
+	// problem is broader than this function and is filed as #6968; do not "fix"
+	// it here by changing ComputeID, which is an identity many other call sites
+	// already depend on.)
+	var ambiguous map[string]bool
 	for k := range records {
 		r := &records[k]
 		if r.Name == "" {
@@ -4783,10 +4806,26 @@ func (i *Indexer) stampEntityIDs(records []types.EntityRecord) {
 		}
 		preStampID := r.ComputeID()
 		finalID := graph.EntityID(i.repoTag, r.Kind, r.Name, r.SourceFile)
+		r.ID = finalID
+		if prior, seen := preStampToFinal[preStampID]; seen && prior != finalID {
+			if ambiguous == nil {
+				ambiguous = make(map[string]bool, 1)
+			}
+			ambiguous[preStampID] = true
+			slog.Default().Warn("index: two records share one pre-stamp entity id — "+
+				"a grafel.twin_of naming it will be left unremapped rather than pointed at "+
+				"an arbitrary one of them",
+				"pre_stamp_id", preStampID,
+				"source_file", r.SourceFile,
+				"kind", r.Kind,
+				"name", r.Name,
+				"final_id", finalID,
+				"other_final_id", prior)
+			continue
+		}
 		if preStampID != finalID {
 			preStampToFinal[preStampID] = finalID
 		}
-		r.ID = finalID
 	}
 	if len(preStampToFinal) == 0 {
 		return
@@ -4798,6 +4837,10 @@ func (i *Indexer) stampEntityIDs(records []types.EntityRecord) {
 		}
 		twin, ok := r.Properties[types.EntityTwinOfProperty]
 		if !ok || twin == "" {
+			continue
+		}
+		if ambiguous[twin] {
+			// LEAVE IT DANGLING, DELIBERATELY. See the note above.
 			continue
 		}
 		if final, remapped := preStampToFinal[twin]; remapped {

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -4766,6 +4766,14 @@ func (i *Indexer) stampEntityIDs(records []types.EntityRecord) {
 	if !recordsHaveTwinOf(records) {
 		for k := range records {
 			r := &records[k]
+			// INVARIANT, PINNED BY TestStampEntityIDs_BothPathsSkipTheSameRecords:
+			// this skip and the identical `r.Name == ""` skip in the slow path
+			// below must stay in lockstep. The two paths differ ONLY in whether
+			// they build the twin_of remap; they must stamp exactly the same SET
+			// of records. Drop this guard from one path alone and a record's
+			// identity starts depending on whether some UNRELATED record in the
+			// same batch happens to carry a grafel.twin_of — action at a
+			// distance, and a heisenbug when it bites. Edit one, edit both.
 			if r.Name == "" {
 				continue
 			}
@@ -4798,9 +4806,23 @@ func (i *Indexer) stampEntityIDs(records []types.EntityRecord) {
 	// problem is broader than this function and is filed as #6968; do not "fix"
 	// it here by changing ComputeID, which is an identity many other call sites
 	// already depend on.)
+	//
+	// ONE DETECTION GAP EXISTS AND IS UNREACHABLE BY CONSTRUCTION, so do not
+	// spend time rediscovering it: a colliding pair goes unnoticed if the FIRST
+	// record's preStampID happens to equal its own finalID, because the
+	// `preStampID != finalID` store below never runs and `seen` stays false for
+	// the second. That requires two DIFFERENT preimages under two DIFFERENT
+	// constructions — sha256(OrgID+ProjectID+SourceFile+Kind+Name) versus
+	// sha256(repo \0 kind \0 name \0 sourceFile), both truncated to 16 hex — to
+	// agree in the same 64 bits: a 2^-64 coincidence, not an input anyone can
+	// supply. There is no test here because there is no input to write.
+	// remapTwinOfAnchors has the identical gap for the identical reason; the two
+	// stay mirrored.
 	var ambiguous map[string]bool
 	for k := range records {
 		r := &records[k]
+		// Lockstep with the fast path's identical skip — see the INVARIANT note
+		// there.
 		if r.Name == "" {
 			continue
 		}

--- a/cmd/grafel/stamp_entity_ids_ambiguous_6971_test.go
+++ b/cmd/grafel/stamp_entity_ids_ambiguous_6971_test.go
@@ -156,6 +156,13 @@ func TestStampEntityIDs_AmbiguousPreStampKeyIsSkippedNotResolved(t *testing.T) {
 // So the assertion is deliberately a COMPARISON between the two paths, not a
 // restatement of either one's rule: the same empty-name record is stamped in
 // two batches identical but for a twin_of carrier, and the results must agree.
+//
+// KNOWN LIMIT OF THE Fatalf PINS BELOW: they call recordsHaveTwinOf on each
+// batch, i.e. they pin the PREDICATE, not the DISPATCH — they do not observe
+// which loop stampEntityIDs actually entered. Reviewer mutant R4 (force the
+// gate always-fast) therefore passes THIS test in isolation; it dies at suite
+// level on the #6275 twin_of tests, which can only pass if the slow path runs.
+// The coverage exists, just not where a reader of this test would look.
 func TestStampEntityIDs_BothPathsSkipTheSameRecords(t *testing.T) {
 	const (
 		repo         = "test_repo"
@@ -205,8 +212,18 @@ func TestStampEntityIDs_BothPathsSkipTheSameRecords(t *testing.T) {
 			fastBatch[0].ID, slowBatch[0].ID)
 	}
 
-	// Positive control: the paths agree because both SKIP, not because both are
-	// inert. A normally-named record must be stamped, identically, by each.
+	// The paths must agree by SKIPPING the record, not by both stamping it.
+	// Reviewer mutant R6 — delete the `Name == ""` skip from BOTH loops — kept
+	// the parity assertion above satisfied (both stamped 58e1ead07da096b0) and
+	// left the ENTIRE ./cmd/grafel/ package green. The lockstep was pinned; the
+	// rule the two loops are in lockstep ABOUT was not. This observes it.
+	if fastBatch[0].ID != "" || slowBatch[0].ID != "" {
+		t.Errorf("the empty-name record was STAMPED by both paths (fast=%q slow=%q); the paths must agree by SKIPPING it, not by both stamping it", fastBatch[0].ID, slowBatch[0].ID)
+	}
+
+	// Positive control for the other direction: agreement must not come from the
+	// loops being globally inert. A normally-named record must be stamped,
+	// identically, by each.
 	wantNamed := graph.EntityID(repo, "SCOPE.Component", namedRecName, file)
 	if fastBatch[1].ID != wantNamed {
 		t.Errorf("fast path did not stamp the named record: got %q want %q", fastBatch[1].ID, wantNamed)

--- a/cmd/grafel/stamp_entity_ids_ambiguous_6971_test.go
+++ b/cmd/grafel/stamp_entity_ids_ambiguous_6971_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6971 — stampEntityIDs builds preStampToFinal keyed by the record's
+// pre-stamp types.EntityRecord.ComputeID() and valued by the final
+// graph.EntityID(). ComputeID concatenates OrgID+ProjectID+SourceFile+Kind+Name
+// with NO separators; graph.EntityID NUL-separates every field. So two records
+// whose Kind/Name split the same characters are ONE key and TWO entities.
+//
+// Before the fix the map had no ambiguity check at all: both records wrote the
+// same slot and the survivor was whichever index came last, so a grafel.twin_of
+// naming that preimage was repointed at an ARBITRARY one of two distinct
+// entities — the #6369 wrong-node hazard, and strictly worse than a dangle
+// because classfold's twinAnchors and the symbol index's facet-alias rule read
+// a confidently-wrong anchor as valid.
+//
+// internal/extractors/incremental.go's remapTwinOfAnchors (#6965) already made
+// this decision for the INCREMENTAL path; #6971 is the same decision mirrored
+// onto the FULL-INDEX path, which is the one that runs by default. An ambiguous
+// key is SKIPPED, not resolved — the twin_of is left dangling deliberately.
+//
+// ARRIVAL ORDER IS THE HAZARD, so both orders are driven. An ordinary,
+// non-colliding facet/anchor pair rides along in the same batch as a positive
+// control: skipping EVERY key would "fix" the collision by disabling the remap
+// entirely, and that no-op must fail here.
+func TestStampEntityIDs_AmbiguousPreStampKeyIsSkippedNotResolved(t *testing.T) {
+	const (
+		repo          = "test_repo"
+		collidingFile = "x.go"
+		ordinaryFile  = "y.go"
+	)
+
+	// Both names NON-EMPTY: stampEntityIDs skips Name=="" via a DIFFERENT
+	// guard, so an empty-name pair would exercise that guard instead of the
+	// collision this test is about.
+	recA := types.EntityRecord{Kind: "A", Name: "BC", SourceFile: collidingFile}
+	recB := types.EntityRecord{Kind: "AB", Name: "C", SourceFile: collidingFile}
+
+	sharedPreStamp := recA.ComputeID()
+	finalA := graph.EntityID(repo, recA.Kind, recA.Name, recA.SourceFile)
+	finalB := graph.EntityID(repo, recB.Kind, recB.Name, recB.SourceFile)
+
+	// PREMISE PINS. If ComputeID ever gains field separators (#6968, the root
+	// fix) this test must fail LOUDLY rather than pass vacuously — at that
+	// point it is no longer testing the ambiguity guard at all.
+	if got := recB.ComputeID(); got != sharedPreStamp {
+		t.Fatalf("premise gone: ComputeID no longer collides for {Kind:%q,Name:%q} vs {Kind:%q,Name:%q} (%q vs %q) — "+
+			"if ComputeID gained separators (#6968) this test is now vacuous and must be rewritten, not deleted",
+			recA.Kind, recA.Name, recB.Kind, recB.Name, sharedPreStamp, got)
+	}
+	if finalA == finalB {
+		t.Fatalf("premise gone: graph.EntityID now ALSO collides for the pair (%q) — the two ids schemes no longer disagree", finalA)
+	}
+	if sharedPreStamp == finalA || sharedPreStamp == finalB {
+		t.Fatalf("premise gone: the shared pre-stamp id %q equals a final id (finalA=%q finalB=%q) — "+
+			"stampEntityIDs only records keys whose pre-stamp and final ids DIFFER, so nothing would be remapped either way",
+			sharedPreStamp, finalA, finalB)
+	}
+
+	// The ordinary pair: an anchor whose pre-stamp id is unambiguous, and a
+	// facet naming it. This must STILL be remapped after the fix.
+	ordinaryAnchor := types.EntityRecord{Kind: "SCOPE.Component", Name: "Ordinary", SourceFile: ordinaryFile}
+	ordinaryPreStamp := ordinaryAnchor.ComputeID()
+	ordinaryFinal := graph.EntityID(repo, ordinaryAnchor.Kind, ordinaryAnchor.Name, ordinaryAnchor.SourceFile)
+	if ordinaryPreStamp == ordinaryFinal {
+		t.Fatalf("premise gone: the control anchor's ComputeID and graph.EntityID coincide (%q) — it would never be remapped", ordinaryPreStamp)
+	}
+
+	for _, tc := range []struct {
+		name         string
+		collidersABi bool // true: recA before recB; false: recB before recA
+	}{
+		{name: "A_then_B", collidersABi: true},
+		{name: "B_then_A", collidersABi: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			first, second := recA, recB
+			if !tc.collidersABi {
+				first, second = recB, recA
+			}
+			collidingFacet := types.EntityRecord{
+				Kind: "SCOPE.Schema", Name: "Facet", SourceFile: collidingFile,
+				Properties: map[string]string{types.EntityTwinOfProperty: sharedPreStamp},
+			}
+			ordinaryFacet := types.EntityRecord{
+				Kind: "SCOPE.Schema", Name: "OrdinaryFacet", SourceFile: ordinaryFile,
+				Properties: map[string]string{types.EntityTwinOfProperty: ordinaryPreStamp},
+			}
+			records := []types.EntityRecord{first, second, collidingFacet, ordinaryAnchor, ordinaryFacet}
+
+			idx := &Indexer{repoTag: repo}
+			idx.stampEntityIDs(records)
+
+			// 1. The ambiguous anchor is left DANGLING, deliberately — the same
+			//    value in both arrival orders, never one of the two final ids.
+			gotTwin := records[2].Properties[types.EntityTwinOfProperty]
+			if gotTwin != sharedPreStamp {
+				which := "the SECOND colliding record's"
+				switch gotTwin {
+				case finalA:
+					which = "recA's"
+				case finalB:
+					which = "recB's"
+				}
+				t.Errorf("colliding facet grafel.twin_of = %q (%s final id); want it LEFT UNREMAPPED at the pre-stamp id %q — "+
+					"an ambiguous key must be skipped, not resolved by arrival order (finalA=%q finalB=%q)",
+					gotTwin, which, sharedPreStamp, finalA, finalB)
+			}
+
+			// 2. POSITIVE CONTROL: the unambiguous facet in the SAME batch is
+			//    still remapped. A guard that skipped every key would pass (1)
+			//    and fail here.
+			gotOrdinary := records[4].Properties[types.EntityTwinOfProperty]
+			if gotOrdinary != ordinaryFinal {
+				t.Errorf("ordinary facet grafel.twin_of = %q; want it remapped to the anchor's final id %q (pre-stamp %q) — "+
+					"the ambiguity guard must not disable the remap for unambiguous keys",
+					gotOrdinary, ordinaryFinal, ordinaryPreStamp)
+			}
+
+			// 3. Both colliders still get their OWN distinct final id stamped:
+			//    the ambiguity guard governs the remap map, never EntityRecord.ID.
+			wantFirst := graph.EntityID(repo, first.Kind, first.Name, first.SourceFile)
+			wantSecond := graph.EntityID(repo, second.Kind, second.Name, second.SourceFile)
+			if records[0].ID != wantFirst {
+				t.Errorf("first colliding record ID = %q; want %q", records[0].ID, wantFirst)
+			}
+			if records[1].ID != wantSecond {
+				t.Errorf("second colliding record ID = %q; want %q", records[1].ID, wantSecond)
+			}
+			if records[3].ID != ordinaryFinal {
+				t.Errorf("ordinary anchor ID = %q; want %q", records[3].ID, ordinaryFinal)
+			}
+		})
+	}
+}

--- a/cmd/grafel/stamp_entity_ids_ambiguous_6971_test.go
+++ b/cmd/grafel/stamp_entity_ids_ambiguous_6971_test.go
@@ -139,3 +139,79 @@ func TestStampEntityIDs_AmbiguousPreStampKeyIsSkippedNotResolved(t *testing.T) {
 		})
 	}
 }
+
+// TestStampEntityIDs_BothPathsSkipTheSameRecords pins the invariant that
+// stampEntityIDs' two loops — the fast path taken when no record in the batch
+// carries a grafel.twin_of, and the slow remap-building path taken when one
+// does — stamp exactly the SAME SET of records. They differ only in whether
+// they build the remap.
+//
+// Nothing held this before. Coordinator mutant MS-2 on #6971 removed the
+// `r.Name == ""` skip from the SLOW path only and survived the whole
+// ./cmd/grafel/ suite. Under it an empty-name record acquires an ID only when
+// some OTHER, entirely unrelated record in the same batch happens to carry a
+// twin_of — a record's identity depending on a stranger's properties, which is
+// action at a distance and reads as a heisenbug when it bites.
+//
+// So the assertion is deliberately a COMPARISON between the two paths, not a
+// restatement of either one's rule: the same empty-name record is stamped in
+// two batches identical but for a twin_of carrier, and the results must agree.
+func TestStampEntityIDs_BothPathsSkipTheSameRecords(t *testing.T) {
+	const (
+		repo         = "test_repo"
+		file         = "app/models/order.py"
+		carrierFile  = "app/models/carrier.py"
+		carrierName  = "Carrier"
+		carrierKind  = "SCOPE.Schema"
+		namedRecName = "Order"
+	)
+
+	// The record under test: Name == "", which BOTH paths must skip.
+	emptyName := func() types.EntityRecord {
+		return types.EntityRecord{Kind: "SCOPE.Component", Name: "", SourceFile: file, StartLine: 3}
+	}
+	// A normally-named record, present in both batches, so the batches differ
+	// in exactly one thing: the twin_of that selects the path.
+	named := func() types.EntityRecord {
+		return types.EntityRecord{Kind: "SCOPE.Component", Name: namedRecName, SourceFile: file, StartLine: 9}
+	}
+	// The path selector. Its twin_of names an anchor that is not in the batch,
+	// so it only flips recordsHaveTwinOf — it changes nothing else.
+	carrier := func() types.EntityRecord {
+		return types.EntityRecord{
+			Kind: carrierKind, Name: carrierName, SourceFile: carrierFile,
+			Properties: map[string]string{types.EntityTwinOfProperty: "not-an-anchor-in-this-batch"},
+		}
+	}
+
+	idx := &Indexer{repoTag: repo}
+
+	fastBatch := []types.EntityRecord{emptyName(), named()}
+	if recordsHaveTwinOf(fastBatch) {
+		t.Fatalf("premise gone: the twin_of-free batch takes the SLOW path — this test would compare the slow path with itself")
+	}
+	idx.stampEntityIDs(fastBatch)
+
+	slowBatch := []types.EntityRecord{emptyName(), named(), carrier()}
+	if !recordsHaveTwinOf(slowBatch) {
+		t.Fatalf("premise gone: the twin_of-carrying batch takes the FAST path — this test would compare the fast path with itself")
+	}
+	idx.stampEntityIDs(slowBatch)
+
+	if fastBatch[0].ID != slowBatch[0].ID {
+		t.Errorf("the SAME empty-name record was stamped differently by the two paths: fast=%q slow=%q — "+
+			"both loops must stamp the same SET of records; they differ only in whether they build the twin_of remap, "+
+			"so a record's identity must never depend on whether an unrelated record in the batch carries a grafel.twin_of",
+			fastBatch[0].ID, slowBatch[0].ID)
+	}
+
+	// Positive control: the paths agree because both SKIP, not because both are
+	// inert. A normally-named record must be stamped, identically, by each.
+	wantNamed := graph.EntityID(repo, "SCOPE.Component", namedRecName, file)
+	if fastBatch[1].ID != wantNamed {
+		t.Errorf("fast path did not stamp the named record: got %q want %q", fastBatch[1].ID, wantNamed)
+	}
+	if slowBatch[1].ID != wantNamed {
+		t.Errorf("slow path did not stamp the named record: got %q want %q", slowBatch[1].ID, wantNamed)
+	}
+}


### PR DESCRIPTION
## The asymmetry, closed

Two functions build the same map — pre-stamp `types.EntityRecord.ComputeID()` as the key, final `graph.EntityID()` as the value — and only one of them checked for collisions. The guarded one was the **incremental** path; the unguarded one was `cmd/grafel/index.go`'s `stampEntityIDs`, i.e. the **full index**, the path that runs by default.

`ComputeID` concatenates `OrgID+ProjectID+SourceFile+Kind+Name` with **no separators**; `graph.EntityID` NUL-separates every field. So `{SourceFile:"x.go", Kind:"A", Name:"BC"}` and `{SourceFile:"x.go", Kind:"AB", Name:"C"}` are **one key and two entities**. Without a check, both records wrote the same slot and the survivor was whichever index came last — a `grafel.twin_of` naming that preimage was repointed at an **arbitrary one of two distinct entities**. That is the #6369 wrong-node hazard, and it is strictly worse than a dangling anchor: a dangle names an id no entity has and is inert and detectable, while a confidently-wrong one reads as **valid** to `classfold`'s `twinAnchors` and to the symbol index's facet-alias rule.

## The fix

Mirrors `internal/extractors/incremental.go`'s `remapTwinOfAnchors` (#6965) — same detection (`seen && prior != finalID`), same verdict (**skip the ambiguous key, do not resolve it**), same warn carrying both final ids. The comment says it mirrors that function, so the two stay recognisably one decision. `EntityRecord.ID` stamping is untouched by the guard: both colliders still get their own distinct final id; only the remap map is governed.

**Scope is the guard.** `ComputeID` is **not** changed here. Adding separators is the root fix, it rewrites every id that function produces, and it is a migration — it belongs to #6968.

## Grading

A unit test on `stampEntityIDs` directly:

- **Both names non-empty** (`{Kind:"A",Name:"BC"}` / `{Kind:"AB",Name:"C"}`) — an empty `Name` is skipped by a *different* guard and would have tested that instead.
- **Both arrival orders driven**, because arrival order *is* the hazard; fixing the order proves half of it.
- **Premises pinned with `Fatalf`**: `ComputeID` must still collide, `EntityID` must still not, and the shared pre-stamp id must differ from both final ids. If #6968 ever lands, this test fails **loudly** instead of passing vacuously.
- An **ordinary, non-colliding** facet/anchor pair rides in the same batch as a built-in positive control.

### Mutants scored — all DEAD

macOS/APFS, in the branch worktree, `go test -count=1`, each edit proved landed by an exact occurrence count and restored by `cp` from a shasum-verified backup.

| mutant | result |
|---|---|
| disable the collision check (`false && seen && …`) | **RED** — and the wrong id **differs between the two arrival orders**, which is the hazard itself |
| skip **every** key — the silent no-op that "fixes" the bug by disabling the remap entirely | **RED** on the positive control, and on both #6275 tests |
| resolve to `prior` instead of skipping (the more-permissive direction) | **RED**, again order-dependent |
| move `r.ID = finalID` after the ambiguity branch | **RED** — the ambiguous record would ship an empty ID |

## Review rounds — two further mutants killed, and two results worth recording

**Silent no-op ruled out from both independent directions.** The primary risk here is a guard that looks correct on a corpus where #6968 measured **zero** collisions over 464k entities. There are exactly two ways to build one: *detect-but-don't-act* (delete the `ambiguous[twin]` consult) and *act-but-don't-record* (never write into `ambiguous`, i.e. first-writer-wins). Both are **DEAD** on the new test, **in both arrival orders**, and the failure output prints two *different* wrong ids depending on order — the hazard verbatim. Together with the `skip every key` mutant dying on the in-batch positive control *and* both #6275 tests, the no-op is closed from every side.

**Skip-not-resolve matches `remapTwinOfAnchors` exactly.** Read side by side: same detection (`seen && prior != finalID`), same lazily-made `ambiguous map[string]bool` at cap 1, same `continue` without storing, same warn keys (differing only in the `index:` / `incremental:` prefix), same single consult site with the same "LEAVE IT DANGLING, DELIBERATELY" verdict. The **only** intended delta is the `r.ID = finalID` hoist — necessary because this loop also stamps and the incremental one does not — and mutant 4 grades exactly that.

### `MS-2` — the two paths must stamp the same set of records

Removing the `Name == ""` skip from the **slow path only** survived the whole suite. Under it an empty-name record acquires an ID only when some *unrelated* record in the batch happens to carry a `twin_of` — action at a distance. `TestStampEntityIDs_BothPathsSkipTheSameRecords` now compares the two paths directly; MS-2 is **DEAD** (`fast="" slow="58e1ead07da096b0"`). The invariant is stated next to the fast-path guard, cross-referenced from the slow one.

### `R6` — the docstring asserted what nothing observed

Removing the skip from **both** paths kept the parity assertion satisfied (both stamped `58e1ead07da096b0`), kept the positive control passing, and left the entire package **green**. The lockstep was pinned; the rule the loops are in lockstep *about* was not — the claim that they "agree because both SKIP, not because both are inert" lived only in a comment. One assertion (the empty-name ID must be `""` from both paths) closes it: green unmutated, **R6 DEAD**. The named-record control is kept and relabelled as the control for the *other* direction.

**Recorded, not fixed** (non-blocking): the `Fatalf` premise pins call `recordsHaveTwinOf` on each batch, so they pin the **predicate**, not the **dispatch** — they never observe which loop `stampEntityIDs` entered. Forcing the gate always-fast therefore passes this test in isolation; it dies at suite level on the #6275 tests, which can only pass if the slow path runs. The comment now says so.

**Also recorded**: the one real detection gap — a pair missed when the *first* record's `preStampID` equals its own `finalID` — is unreachable by construction (two different preimages under two different constructions agreeing in the same 64 bits; ~2.5e-14 over the 464k corpus). No test, because there is no input to write. `remapTwinOfAnchors` has the identical gap for the identical reason.

## Verification

`go test -count=1 ./cmd/grafel/` — **green, exit 0**, on every round (146.8s / 139.9s / 161.3s). `cmd/grafel` is the only package touched. Note its digest pin hashes **fields, not ids**, so it cannot see an id change: the green digest is **not** evidence here — the unit test is.

Closes #6971
Refs #6968, #6965, #6369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
