### PR TITLE
fix(#6975): blazor.go ran the whole Blazor rule set over every C# file — 72% of the gate's entities on aspnetcore-mvc were its false positives

### DIFF
--- a/cmd/grafel/blazor_gate_tests_edges_6975_test.go
+++ b/cmd/grafel/blazor_gate_tests_edges_6975_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6975 / #6973 — the EDGE side of the un-gated Blazor extractor.
+//
+// WHY A COUNT ASSERTION CANNOT SEE THIS DEFECT. On the `aspnetcore-mvc` corpus
+// repo, turning the custom-extractor gate ON (GRAFEL_INPROC_CUSTOM_EXTRACTORS=1,
+// in-process Index(), macOS/APFS) moved entities 39,765 -> 75,174 (+89.0%)
+// while TESTS edges moved 43,621 -> 36,982 (-6,639). #6973 measured explicit
+// TESTS at +8 net while 7,221 edges were substituted underneath. Any assertion
+// of the form "count went up" or "count did not change" is satisfied by that
+// by construction. This test therefore names ONE SPECIFIC EDGE and requires it
+// to be present with the gate ON.
+//
+// THE MECHANISM. `internal/custom/csharp/blazor.go` had no file gate, so
+// `var repo = new OrderRepository(_db);` in ordinary C# minted a
+// SCOPE.Operation/function literally named `OrderRepository`, in a DIFFERENT
+// file from the real class of that name. The two collide in the repo-wide
+// byName index (internal/resolve/refs.go indexByName), whose collision arm
+// deletes the entry and sets ambigName — so the surviving name resolves to
+// nothing and the testmap stub `scope:operation:<file>#<member>` loses its
+// byName global fallback. The seed TESTS edge disappears and DeriveTestsWalkUp
+// loses its starting point.
+//
+// SCOPE NOTE. The general declaration-vs-reference eviction in indexByName is
+// #6976 and is deliberately NOT addressed here; it accounts for the residual
+// edges the file gate does not recover. This test pins only what the gate is
+// responsible for.
+func TestBlazorGateKeepsTestsEdges6975(t *testing.T) {
+	repo := t.TempDir()
+	write := func(rel, body string) {
+		t.Helper()
+		p := filepath.Join(repo, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The production type. Its NAME is the one the false positive duplicated.
+	write("src/OrderRepository.cs", `
+namespace Shop.Data;
+
+public class OrderRepository
+{
+    public int Count()
+    {
+        return 0;
+    }
+}
+`)
+	// An ordinary consumer that constructs it. `new OrderRepository(` here is
+	// the exact site that used to mint the colliding SCOPE.Operation.
+	write("src/OrderService.cs", `
+namespace Shop.Services;
+
+public class OrderService
+{
+    public int Total()
+    {
+        var repo = new OrderRepository();
+        var mapper = new OrderMapper();
+        return repo.Count();
+    }
+}
+`)
+	// The test that must keep its TESTS edge.
+	write("tests/OrderRepositoryTests.cs", `
+namespace Shop.Tests;
+
+public class OrderRepositoryTests
+{
+    [Fact]
+    public void CountReturnsZero()
+    {
+        var repo = new OrderRepository();
+        Assert.Equal(0, repo.Count());
+    }
+}
+`)
+
+	testsEdgesFor := func(arm string) map[string]bool {
+		t.Helper()
+		state := t.TempDir()
+		t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+		switch arm {
+		case "off":
+			t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+		case "on":
+			t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+		}
+		if err := Index(repo, filepath.Join(state, "graph.json"), "blazor_gate_6975", nil, false, false); err != nil {
+			t.Fatalf("Index(arm=%s): %v", arm, err)
+		}
+		doc, err := graph.LoadGraphFromDir(state)
+		if err != nil {
+			t.Fatalf("LoadGraphFromDir(arm=%s): %v", arm, err)
+		}
+		byID := map[string]*graph.Entity{}
+		for i := range doc.Entities {
+			byID[doc.Entities[i].ID] = &doc.Entities[i]
+		}
+		out := map[string]bool{}
+		for i := range doc.Relationships {
+			r := &doc.Relationships[i]
+			if r.Kind != "TESTS" {
+				continue
+			}
+			from, ok1 := byID[r.FromID]
+			to, ok2 := byID[r.ToID]
+			if !ok1 || !ok2 {
+				continue
+			}
+			out[from.Name+" -> "+to.Name] = true
+		}
+		return out
+	}
+
+	// The gate-OFF arm establishes that the edge exists at all, so a
+	// gate-ON failure below is attributable to the custom extractors and not
+	// to the fixture never having produced the edge. Without this control the
+	// assertion could pass vacuously in the wrong direction.
+	off := testsEdgesFor("off")
+	if len(off) == 0 {
+		t.Fatal("control arm (gate OFF) produced no TESTS edges at all; the fixture cannot grade anything")
+	}
+	on := testsEdgesFor("on")
+
+	// Every TESTS edge present with the gate OFF must survive the gate being
+	// turned ON. Named individually — the failure message lists the missing
+	// edges, not a delta.
+	var lost []string
+	for e := range off {
+		if !on[e] {
+			lost = append(lost, e)
+		}
+	}
+	if len(lost) > 0 {
+		t.Errorf("custom extractors destroyed %d TESTS edge(s) that exist without them:\n  %s",
+			len(lost), strings.Join(lost, "\n  "))
+	}
+
+	// And the specific false positive must be gone: no SCOPE.Operation named
+	// `OrderRepository` may be minted from OrderService.cs. This is what makes
+	// the edge assertion above non-accidental.
+	state := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+	if err := Index(repo, filepath.Join(state, "graph.json"), "blazor_gate_6975", nil, false, false); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := graph.LoadGraphFromDir(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if p, _ := e.PropLookup("provenance"); strings.HasPrefix(p, "INFERRED_FROM_BLAZOR_") &&
+			!strings.HasSuffix(e.SourceFile, ".razor") && !strings.HasSuffix(e.SourceFile, ".razor.cs") {
+			t.Errorf("blazor provenance %q on non-razor file %s (entity %s %q)",
+				p, e.SourceFile, e.Kind, e.Name)
+		}
+	}
+}

--- a/cmd/grafel/custom_extractor_dangling_6105_test.go
+++ b/cmd/grafel/custom_extractor_dangling_6105_test.go
@@ -204,6 +204,30 @@ public class Address {
     private String id;
 }
 `,
+		// #6975 — THE COLLISION TARGET, AND WHY IT LIVES IN ITS OWN FILE NOW.
+		// TestCustomExtractorDependsOnServiceDoesNotMisbind6123's non-vacuity
+		// guard needs an UNQUALIFIED SCOPE.Operation named
+		// `PostgreSqlContainer` to exist, or a mis-bind through the
+		// operation-family byName hint would be undetectable. That entity used
+		// to appear by accident: internal/custom/csharp/blazor.go had no file
+		// gate and its code-method pattern had no line anchor, so the
+		// `new PostgreSqlContainer()` call site below minted one. #6975 closed
+		// both holes, so the fixture now DECLARES the colliding name, in a
+		// `.razor.cs` code-behind file — the one extension that legitimately
+		// reaches that extractor. The base C# extractor cannot supply it: it
+		// qualifies method names (`OrderTests.Setup`), so a method of this name
+		// in an ordinary class would be `Fixtures.PostgreSqlContainer` and
+		// would not collide.
+		"cs/Fixtures.razor.cs": `namespace Shop.Tests
+{
+    public partial class Fixtures
+    {
+        void PostgreSqlContainer()
+        {
+        }
+    }
+}
+`,
 		"cs/OrderTests.cs": `using Testcontainers.PostgreSql;
 
 namespace Shop.Tests
@@ -688,9 +712,17 @@ func TestCustomExtractorSchemaFieldRefsStayInTheirOwnFile6105(t *testing.T) {
 // ExternalServiceTargetID at external_service.go:102), not by Name. So
 // `service:X` could never bind to a service node even where one existed, and
 // on a leaf-name collision it binds to whatever else is called X — here the
-// SCOPE.Operation the base C# extractor made for the `new PostgreSqlContainer()`
-// call site, reached through the DEPENDS_ON_SERVICE operation-family hint
-// (refs.go:1782).
+// SCOPE.Operation named `PostgreSqlContainer`, reached through the
+// DEPENDS_ON_SERVICE operation-family hint (refs.go:1782).
+//
+// #6975 CORRECTED THIS COMMENT'S ATTRIBUTION. That collider was never made by
+// the base C# extractor, which qualifies method names (`OrderTests.Setup`).
+// It was made by internal/custom/csharp/blazor.go, which had no file gate and
+// an unanchored code-method pattern, so `new PostgreSqlContainer()` in
+// ordinary C# minted an unqualified SCOPE.Operation of that name. That is the
+// defect #6975 fixed, so the fixture now declares the colliding name
+// explicitly in cs/Fixtures.razor.cs rather than relying on the bug to
+// supply it. See the note there.
 //
 // THE FIX. test_doubles.go now mints the canonical target ref rather than the
 // unaddressable Name. Where a matching service node exists the edge binds to it

--- a/internal/custom/csharp/blazor.go
+++ b/internal/custom/csharp/blazor.go
@@ -44,31 +44,67 @@ var (
 	// GRAFEL_INPROC_CUSTOM_EXTRACTORS, in-process Index()) this rule alone
 	// produced 21,320 entities in a repo with no Blazor at all.
 	//
-	// THE FIX IS AN ANCHOR, NOT A REQUIRED MODIFIER. A C# declaration begins
-	// its own line (only indentation precedes it), so `^[ \t]*` excludes every
-	// mid-expression `new X(` while still admitting the modifier-less methods
-	// that are idiomatic inside a `@code` block (`void Increment()`).
-	// Requiring an access modifier would have been the obvious tightening and
-	// is the WRONG one: measured over the 105 `.razor` files in
-	// archigraph-corpora, the old pattern finds 126 declaration sites, this
-	// one finds 110 (87%), and a required-modifier variant finds only 97
-	// (77%) — it drops exactly the bare `@code` methods.
+	// TIGHTENING 1 — AN ANCHOR, NOT A REQUIRED MODIFIER. A C# declaration
+	// begins its own line (only indentation precedes it), so `^[ \t]*`
+	// excludes every MID-EXPRESSION `new X(` while still admitting the
+	// modifier-less members that are legal inside a `@code` block
+	// (`void Increment()`), which a required access modifier would drop.
 	//
-	// The return-type alternation is `[\w\.\?]+(?:<[^;\n]*>)?(?:\[\])?`
+	// THE CORPUS DOES NOT ADJUDICATE THAT CHOICE, and an earlier revision of
+	// this comment claimed it did — it cited 110 sites for the anchor against
+	// 97 for a required-modifier variant and concluded the modifier "drops
+	// exactly the bare `@code` methods". Once tightening 2 lands, the two
+	// variants select the IDENTICAL 97 sites over the 105 `.razor` files in
+	// archigraph-corpora: 28 distinct names, zero sites found by either one
+	// alone, in either direction. Every real method in that corpus carries an
+	// access modifier. The anchor is preferred on mechanism, not on a
+	// measured margin: it rejects a match for being in the wrong POSITION,
+	// which is the actual defect, where a required modifier is a proxy that
+	// merely correlates with it on code that follows one convention. The
+	// modifier-less case is therefore pinned synthetically
+	// (TestBlazorGateAdmitsRazorCodeBehind6975), not by the corpus.
+	//
+	// TIGHTENING 2 — THE ANCHOR IS NOT ENOUGH ON ITS OWN, AND AN EARLIER
+	// REVISION OF THIS COMMENT CLAIMED IT WAS. An anchor only excludes `new X(`
+	// when something precedes it on the line. A LINE-LEADING one — the second
+	// line of `var svc =\n    new OrderService(db);`, or a bare statement — is
+	// still parsed as "type `new`, method `OrderService`" and mints exactly
+	// #6973's collider. Measured over the same corpus C#: 2,503 line-leading
+	// `new X(` sites, plus 1,661 `return F(` (type `return`, method `F`) and
+	// 293 `else if (` (type `else`, method `if`). The file gate keeps those out
+	// of `.cs`, but `.razor.cs` IS ordinary C#, so inside the gate the shape
+	// survives untouched.
+	//
+	// It is not only a `.cs` problem. On the corpus `.razor` files this
+	// rejection removes 13 of the anchor's 110 matches, and ENUMERATING them
+	// rather than counting shows all 13 are non-declarations: 9 `else if (`
+	// and 4 `await <Method>(` call sites — the latter minting operations named
+	// after a method being CALLED, which is the collider shape again. No
+	// declaration is lost on this corpus. The pattern therefore CAPTURES the type token as
+	// group 1 and Extract rejects the match when that token is a statement or
+	// expression keyword rather than a type — see blazorNonTypeKeywords. Go's
+	// RE2 has no lookahead, so this cannot be expressed in the pattern itself.
+	//
+	// TIGHTENING 3 — the return type is `[\w\.\?]+(?:<[^;\n]*>)?(?:\[\])?`
 	// rather than a fixed `Task|void|…` list, and the generic argument is
 	// `[^;\n]*` rather than `[^>\n]+`, because NESTED generics are common
 	// (`Task<List<Order>>`) and an inner-`>`-terminated class loses them
-	// silently — a mutant run caught that regression here before it shipped.
-	// Greediness plus the `\s+(\w+)\s*\(` tail makes it settle on the last
-	// `>` that still leaves a name and an open paren on the line.
+	// silently — a mutant run caught that regression before it shipped.
+	// The `\n` in that class is load-bearing in the OTHER direction and is
+	// graded separately (TestBlazorCodeMethodGenericDoesNotSpanLines6975):
+	// without it, `[^;]*` is greedy across newlines, so a `<` on one line
+	// reaches a `>` many lines below and invents a method out of two unrelated
+	// declarations. Greediness plus the `\s+(\w+)\s*\(` tail then makes it
+	// settle on the last `>` that still leaves a name and an open paren.
 	//
-	// Over the 3,721 `.cs` files in the same corpora the old pattern found
-	// 38,983 sites and this one still finds 23,474: the anchor alone does NOT
-	// solve the false-positive problem, the file gate in Extract does. What
-	// the anchor buys is that the `new X(` class does not return the moment
-	// another dialect widens that gate.
+	// WHAT EACH TIGHTENING IS WORTH, over the 3,721 `.cs` files in the corpora:
+	// the old pattern found 38,983 sites, the anchor alone 23,474, and the
+	// anchor plus the keyword rejection 18,842. The regex alone does NOT solve
+	// the false-positive problem — the file gate in Extract does. What these
+	// buy is that the collider shape does not survive INSIDE the gate, and does
+	// not return the moment another dialect widens it.
 	reBlazorCodeMethod = regexp.MustCompile(
-		`(?m)^[ \t]*(?:(?:private|protected|public|internal|static|virtual|override|sealed|abstract|partial|async|extern|unsafe)\s+)*[\w\.\?]+(?:<[^;\n]*>)?(?:\[\])?\s+(\w+)\s*\(`,
+		`(?m)^[ \t]*(?:(?:private|protected|public|internal|static|virtual|override|sealed|abstract|partial|async|extern|unsafe)\s+)*([\w\.\?]+)(?:<[^;\n]*>)?(?:\[\])?\s+(\w+)\s*\(`,
 	)
 	reBlazorComponentTag = regexp.MustCompile(
 		`<([A-Z][A-Za-z0-9_]*)(?:\s+[^>]*)?>`,
@@ -83,6 +119,43 @@ var (
 		`(?m)^@inherits\s+(\w+)`,
 	)
 )
+
+// blazorNonTypeKeywords are C# tokens that can occupy reBlazorCodeMethod's
+// TYPE slot on a line-leading match without the line being a declaration.
+//
+// #6975. `^[ \t]*` excludes a mid-expression `new X(` but not a line-leading
+// one, and a line-leading `new OrderService(db);` parses as "type `new`,
+// method `OrderService`" — precisely #6973's collider, an unqualified
+// SCOPE.Operation named after a real class. Measured over the corpus C#:
+// 2,503 line-leading `new X(`, 1,666 `return F(`, 293 `else if (`. The file
+// gate keeps those out of plain `.cs`, but `.razor.cs` is ordinary C# and the
+// shape survives inside the gate, so it has to be rejected on its own terms.
+//
+// WHY A MAP AND NOT A PATTERN: Go's RE2 has no lookahead, so "an identifier
+// that is not one of these" cannot be written in the regex.
+//
+// Only the TYPE slot is filtered. The NAME slot needs no companion filter and
+// deliberately does not have one — two guards that only ever fire together
+// grade neither. A keyword in the name slot is already unreachable: `if (`,
+// `while (`, `foreach (`, `switch (`, `catch (`, `using (` and `lock (` put
+// the paren straight after the keyword, and the pattern requires `\s+` between
+// the type and the name, so those lines produce no match at any start
+// position. `else if (` is the exception — the name slot holds `if` — and it
+// is rejected here on its TYPE token, `else`.
+var blazorNonTypeKeywords = map[string]bool{
+	// Statement keywords that can lead a line and be followed by `ident(`.
+	"return": true, "new": true, "else": true, "throw": true, "await": true,
+	"yield": true, "goto": true, "break": true, "continue": true,
+	"case": true, "default": true, "do": true, "try": true, "finally": true,
+	"checked": true, "unchecked": true, "stackalloc": true, "delegate": true,
+	// Contextual/operator keywords that appear in the same slot.
+	"in": true, "is": true, "as": true, "out": true, "ref": true,
+	"params": true, "typeof": true, "sizeof": true, "nameof": true,
+	"when": true, "with": true, "and": true, "or": true, "not": true,
+	// LINQ query clause keywords.
+	"from": true, "select": true, "where": true, "let": true,
+	"orderby": true, "group": true, "join": true, "into": true,
+}
 
 // blazorBuiltinComponents are Blazor/HTML built-in components not emitted as entities.
 var blazorBuiltinComponents = map[string]bool{
@@ -137,23 +210,38 @@ func (e *blazorExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	//     `.razor`, `.razor.cs` and `.cshtml` file in archigraph-corpora
 	//     (7 C#-bearing repos) with these exact patterns: the five DIRECTIVE
 	//     rules (@page, @inject, [Parameter], @layout, @inherits) score
-	//     **zero** across all 3,721 `.cs` files and fire only in the 105
-	//     `.razor` files (25/119/10/4/0). Only the code-method and
-	//     component-tag rules fire in `.cs` — 38,983 and 12,991 sites, all of
-	//     them false positives. So no rule here loses a real construct by
-	//     being denied plain `.cs`.
+	//     **zero** across all 3,721 `.cs` files. They fire in the 105 `.razor`
+	//     files (25/119/10/4/0 = 158 sites) and, to a much smaller extent, in
+	//     the 1,119 `.cshtml` files (9/39/0/0/1 = 49 sites) — an earlier
+	//     revision of this comment said "only in `.razor`", which was false
+	//     over its own stated population. `.cshtml` is classified UNSUPPORTED
+	//     (classifier/unsupported.go:132, #6343) so it never reaches an
+	//     extractor either way, but the sentence is the evidence for this
+	//     gate and it should be true. Only the code-method and component-tag
+	//     rules fire in `.cs` — 38,983 and 12,991 sites, all of them false
+	//     positives. So no rule here loses a real construct by being denied
+	//     plain `.cs`.
 	//
 	//  2. What can actually reach this function. `.razor` classifies as
-	//     language "razor" (classifier.go:345), not "csharp", and there is no
-	//     tree-sitter grammar for it, so a `.razor` file has TSTree == nil and
-	//     never passes the `file.TSTree != nil` guard at cmd/grafel/index.go
-	//     that admits custom extractors at all. The language check above
-	//     therefore already excludes `.razor` — **the only extension that both
-	//     carries Blazor and reaches this code today is `.razor.cs`.** (The
-	//     same reasoning applies to blazor_deep.go:179's `.razor` arm, which
-	//     is dead for exactly this reason; out of scope here, filed separately.)
-	//     `.razor` is kept in the gate so this extractor becomes correct rather
-	//     than newly wrong if a razor grammar is ever registered.
+	//     language "razor" (classifier.go:345), not "csharp", so the
+	//     `file.Language != "csharp"` check above rejects it outright — that
+	//     check is live and load-bearing, pinned by
+	//     TestBlazorLanguageGuardRejectsNonCSharp6975. Independently, there is
+	//     no tree-sitter grammar for razor, so a `.razor` file also has
+	//     TSTree == nil and never passes the `file.TSTree != nil` guard at
+	//     cmd/grafel/index.go that admits custom extractors at all. Either
+	//     alone is sufficient: **the only extension that both carries Blazor
+	//     and reaches this code today is `.razor.cs`.** (The same reasoning
+	//     applies to blazor_deep.go:179's `.razor` arm, which is dead for
+	//     exactly this reason; out of scope here, filed separately.)
+	//
+	//     `.razor` is kept in the SUFFIX gate because the suffix pair is what
+	//     names the Blazor file family, and blazor_deep.go:179 uses the same
+	//     pair. It is NOT kept as forward-compatibility for a future razor
+	//     grammar, which is what an earlier revision of this comment claimed:
+	//     registering a grammar would not help, because the language check
+	//     would still reject the file. Reaching `.razor` needs that check
+	//     widened as well, which is a separate decision and is not taken here.
 	//
 	// MARKUP RULES vs CODE RULES. `.razor` and `.razor.cs` are not
 	// interchangeable: `@`-directives and PascalCase component tags are Razor
@@ -203,8 +291,15 @@ func (e *blazorExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	}
 
 	// 3. @code block methods -> SCOPE.Operation/function
+	//
+	// Group 1 is the TYPE token, group 2 the method name. A match whose type
+	// slot holds a statement keyword is not a declaration — see
+	// blazorNonTypeKeywords (#6975).
 	for _, m := range reBlazorCodeMethod.FindAllStringSubmatchIndex(src, -1) {
-		name := src[m[2]:m[3]]
+		if blazorNonTypeKeywords[src[m[2]:m[3]]] {
+			continue
+		}
+		name := src[m[4]:m[5]]
 		ent := makeEntity(name, "SCOPE.Operation", "function", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_CODE_METHOD")
 		add(ent)

--- a/internal/custom/csharp/blazor.go
+++ b/internal/custom/csharp/blazor.go
@@ -3,6 +3,7 @@ package csharp
 import (
 	"context"
 	"regexp"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -27,8 +28,47 @@ var (
 	reBlazorInject = regexp.MustCompile(
 		`(?m)^@inject\s+(\w+(?:<[^>]+>)?)\s+(\w+)`,
 	)
+	// reBlazorCodeMethod matches a METHOD DECLARATION in a Blazor `@code`
+	// block or `.razor.cs` code-behind.
+	//
+	// #6975. The previous pattern was
+	//
+	//	(?m)(?:private|protected|public|internal)?\s+(?:async\s+)?(?:Task|void|[\w<>\[\]]+)\s+(\w+)\s*\(
+	//
+	// with the access modifier OPTIONAL and no anchor, so it matched anywhere
+	// on a line — including the middle of an expression. `var svc = new
+	// OrderService(` therefore parsed as "type `new`, method `OrderService`"
+	// and minted a SCOPE.Operation/function named `OrderService`, colliding in
+	// the repo-wide byName index with the real class of that name. On the
+	// `aspnetcore-mvc` corpus repo (macOS/APFS, gate ON via
+	// GRAFEL_INPROC_CUSTOM_EXTRACTORS, in-process Index()) this rule alone
+	// produced 21,320 entities in a repo with no Blazor at all.
+	//
+	// THE FIX IS AN ANCHOR, NOT A REQUIRED MODIFIER. A C# declaration begins
+	// its own line (only indentation precedes it), so `^[ \t]*` excludes every
+	// mid-expression `new X(` while still admitting the modifier-less methods
+	// that are idiomatic inside a `@code` block (`void Increment()`).
+	// Requiring an access modifier would have been the obvious tightening and
+	// is the WRONG one: measured over the 105 `.razor` files in
+	// archigraph-corpora, the old pattern finds 126 declaration sites, this
+	// one finds 110 (87%), and a required-modifier variant finds only 97
+	// (77%) — it drops exactly the bare `@code` methods.
+	//
+	// The return-type alternation is `[\w\.\?]+(?:<[^;\n]*>)?(?:\[\])?`
+	// rather than a fixed `Task|void|…` list, and the generic argument is
+	// `[^;\n]*` rather than `[^>\n]+`, because NESTED generics are common
+	// (`Task<List<Order>>`) and an inner-`>`-terminated class loses them
+	// silently — a mutant run caught that regression here before it shipped.
+	// Greediness plus the `\s+(\w+)\s*\(` tail makes it settle on the last
+	// `>` that still leaves a name and an open paren on the line.
+	//
+	// Over the 3,721 `.cs` files in the same corpora the old pattern found
+	// 38,983 sites and this one still finds 23,474: the anchor alone does NOT
+	// solve the false-positive problem, the file gate in Extract does. What
+	// the anchor buys is that the `new X(` class does not return the moment
+	// another dialect widens that gate.
 	reBlazorCodeMethod = regexp.MustCompile(
-		`(?m)(?:private|protected|public|internal)?\s+(?:async\s+)?(?:Task|void|[\w<>\[\]]+)\s+(\w+)\s*\(`,
+		`(?m)^[ \t]*(?:(?:private|protected|public|internal|static|virtual|override|sealed|abstract|partial|async|extern|unsafe)\s+)*[\w\.\?]+(?:<[^;\n]*>)?(?:\[\])?\s+(\w+)\s*\(`,
 	)
 	reBlazorComponentTag = regexp.MustCompile(
 		`<([A-Z][A-Za-z0-9_]*)(?:\s+[^>]*)?>`,
@@ -72,6 +112,61 @@ func (e *blazorExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		return nil, nil
 	}
 
+	// -------------------------------------------------------------------------
+	// FILE GATE (#6975)
+	// -------------------------------------------------------------------------
+	//
+	// This extractor had NO file gate. Its sibling blazor_deep.go:179 has one,
+	// and every rule below describes a Blazor construct, so it ran the whole
+	// Blazor rule set over EVERY C# file in the repository. Measured on the
+	// `aspnetcore-mvc` corpus repo — a repo containing no Blazor — with the
+	// custom-extractor gate ON (GRAFEL_INPROC_CUSTOM_EXTRACTORS=1, in-process
+	// Index(), macOS/APFS): of the 35,409 entities the gate added,
+	// **25,479 (72.0%) came from this file** (21,320 code-method + 4,159
+	// component-tag). Those are name duplicates of real classes, they evict the
+	// real entry from the repo-wide byName index, and the resulting resolution
+	// failures cost 6,639 TESTS edges on that repo alone (#6973).
+	//
+	// WHICH EXTENSIONS THE GATE ADMITS, AND WHY — MEASURED, NOT COPIED.
+	// blazor_deep.go gates on `.razor || .razor.cs`; #6975 asks explicitly not
+	// to copy that without measuring, because Blazor code-behind lives in
+	// `.razor.cs` and a `.razor`-only gate would trade one silent loss for
+	// another. Two measurements decided it.
+	//
+	//  1. Which extensions carry the constructs. Scanning every `.cs`,
+	//     `.razor`, `.razor.cs` and `.cshtml` file in archigraph-corpora
+	//     (7 C#-bearing repos) with these exact patterns: the five DIRECTIVE
+	//     rules (@page, @inject, [Parameter], @layout, @inherits) score
+	//     **zero** across all 3,721 `.cs` files and fire only in the 105
+	//     `.razor` files (25/119/10/4/0). Only the code-method and
+	//     component-tag rules fire in `.cs` — 38,983 and 12,991 sites, all of
+	//     them false positives. So no rule here loses a real construct by
+	//     being denied plain `.cs`.
+	//
+	//  2. What can actually reach this function. `.razor` classifies as
+	//     language "razor" (classifier.go:345), not "csharp", and there is no
+	//     tree-sitter grammar for it, so a `.razor` file has TSTree == nil and
+	//     never passes the `file.TSTree != nil` guard at cmd/grafel/index.go
+	//     that admits custom extractors at all. The language check above
+	//     therefore already excludes `.razor` — **the only extension that both
+	//     carries Blazor and reaches this code today is `.razor.cs`.** (The
+	//     same reasoning applies to blazor_deep.go:179's `.razor` arm, which
+	//     is dead for exactly this reason; out of scope here, filed separately.)
+	//     `.razor` is kept in the gate so this extractor becomes correct rather
+	//     than newly wrong if a razor grammar is ever registered.
+	//
+	// MARKUP RULES vs CODE RULES. `.razor` and `.razor.cs` are not
+	// interchangeable: `@`-directives and PascalCase component tags are Razor
+	// MARKUP and cannot appear in a code-behind file, where `<Foo>` is a
+	// generic type argument, not a component reference. So the markup rules
+	// below are further restricted to `.razor`, and only the two code rules
+	// (methods, [Parameter]) run over code-behind.
+	isRazorMarkup := strings.HasSuffix(file.Path, ".razor")
+	isRazorCodeBehind := strings.HasSuffix(file.Path, ".razor.cs")
+	if !isRazorMarkup && !isRazorCodeBehind {
+		return nil, nil
+	}
+
 	src := string(file.Content)
 	var entities []types.EntityRecord
 	seen := make(map[string]bool)
@@ -85,22 +180,26 @@ func (e *blazorExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		entities = append(entities, ent)
 	}
 
-	// 1. @page routes -> SCOPE.Operation/endpoint
-	for _, m := range reBlazorPage.FindAllStringSubmatchIndex(src, -1) {
-		route := src[m[2]:m[3]]
-		ent := makeEntity(route, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_PAGE",
-			"route_path", route)
-		add(ent)
-	}
+	// Markup-only rule (#6975): `@`-directives are Razor markup and cannot
+	// appear in a `.razor.cs` code-behind file.
+	if isRazorMarkup {
+		// 1. @page routes -> SCOPE.Operation/endpoint
+		for _, m := range reBlazorPage.FindAllStringSubmatchIndex(src, -1) {
+			route := src[m[2]:m[3]]
+			ent := makeEntity(route, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_PAGE",
+				"route_path", route)
+			add(ent)
+		}
 
-	// 2. @inject -> SCOPE.Component (injected service)
-	for _, m := range reBlazorInject.FindAllStringSubmatchIndex(src, -1) {
-		serviceType := src[m[2]:m[3]]
-		ent := makeEntity(serviceType, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_INJECT",
-			"service_type", serviceType)
-		add(ent)
+		// 2. @inject -> SCOPE.Component (injected service)
+		for _, m := range reBlazorInject.FindAllStringSubmatchIndex(src, -1) {
+			serviceType := src[m[2]:m[3]]
+			ent := makeEntity(serviceType, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_INJECT",
+				"service_type", serviceType)
+			add(ent)
+		}
 	}
 
 	// 3. @code block methods -> SCOPE.Operation/function
@@ -111,15 +210,20 @@ func (e *blazorExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		add(ent)
 	}
 
-	// 4. PascalCase component tags -> SCOPE.UIComponent
-	for _, m := range reBlazorComponentTag.FindAllStringSubmatchIndex(src, -1) {
-		name := src[m[2]:m[3]]
-		if blazorBuiltinComponents[name] {
-			continue
+	// Markup-only rule (#6975): in `.razor.cs` code-behind `<Foo>` is a
+	// generic type argument, not a component reference — 12,991 such sites
+	// across the corpus's `.cs` files.
+	if isRazorMarkup {
+		// 4. PascalCase component tags -> SCOPE.UIComponent
+		for _, m := range reBlazorComponentTag.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			if blazorBuiltinComponents[name] {
+				continue
+			}
+			ent := makeEntity(name, "SCOPE.UIComponent", "component", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_COMPONENT_REF")
+			add(ent)
 		}
-		ent := makeEntity(name, "SCOPE.UIComponent", "component", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_COMPONENT_REF")
-		add(ent)
 	}
 
 	// 5. [Parameter] properties -> SCOPE.Pattern
@@ -131,20 +235,28 @@ func (e *blazorExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		add(ent)
 	}
 
-	// 6. @layout -> SCOPE.Component
-	for _, m := range reBlazorLayout.FindAllStringSubmatchIndex(src, -1) {
-		layoutName := src[m[2]:m[3]]
-		ent := makeEntity("layout:"+layoutName, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_LAYOUT")
-		add(ent)
+	// Markup-only rule (#6975): `@`-directives are Razor markup and cannot
+	// appear in a `.razor.cs` code-behind file.
+	if isRazorMarkup {
+		// 6. @layout -> SCOPE.Component
+		for _, m := range reBlazorLayout.FindAllStringSubmatchIndex(src, -1) {
+			layoutName := src[m[2]:m[3]]
+			ent := makeEntity("layout:"+layoutName, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_LAYOUT")
+			add(ent)
+		}
 	}
 
-	// 7. @inherits -> SCOPE.Component
-	for _, m := range reBlazorInherits.FindAllStringSubmatchIndex(src, -1) {
-		baseName := src[m[2]:m[3]]
-		ent := makeEntity("inherits:"+baseName, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_INHERITS")
-		add(ent)
+	// Markup-only rule (#6975): `@`-directives are Razor markup and cannot
+	// appear in a `.razor.cs` code-behind file.
+	if isRazorMarkup {
+		// 7. @inherits -> SCOPE.Component
+		for _, m := range reBlazorInherits.FindAllStringSubmatchIndex(src, -1) {
+			baseName := src[m[2]:m[3]]
+			ent := makeEntity("inherits:"+baseName, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_INHERITS")
+			add(ent)
+		}
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))

--- a/internal/custom/csharp/blazor.go
+++ b/internal/custom/csharp/blazor.go
@@ -69,9 +69,14 @@ var (
 	// when something precedes it on the line. A LINE-LEADING one — the second
 	// line of `var svc =\n    new OrderService(db);`, or a bare statement — is
 	// still parsed as "type `new`, method `OrderService`" and mints exactly
-	// #6973's collider. Measured over the same corpus C#: 2,503 line-leading
-	// `new X(` sites, plus 1,661 `return F(` (type `return`, method `F`) and
-	// 293 `else if (` (type `else`, method `if`). The file gate keeps those out
+	// #6973's collider. Measured over the corpus C# — POPULATION: every `.cs`
+	// file under the whole archigraph-corpora tree, 3,726 files — 2,503
+	// line-leading `new X(` sites, plus 1,666 `return F(` (type `return`,
+	// method `F`) and 293 `else if (` (type `else`, method `if`). Restricting
+	// the walk to the 7 C#-bearing repos by name gives 3,721 files and 1,661
+	// `return F(`; the other two counts are identical either way. Two numbers
+	// for one thing in a review record is worse than either, so: the figures
+	// here are the whole-tree ones. The file gate keeps those out
 	// of `.cs`, but `.razor.cs` IS ordinary C#, so inside the gate the shape
 	// survives untouched.
 	//
@@ -97,9 +102,9 @@ var (
 	// declarations. Greediness plus the `\s+(\w+)\s*\(` tail then makes it
 	// settle on the last `>` that still leaves a name and an open paren.
 	//
-	// WHAT EACH TIGHTENING IS WORTH, over the 3,721 `.cs` files in the corpora:
-	// the old pattern found 38,983 sites, the anchor alone 23,474, and the
-	// anchor plus the keyword rejection 18,842. The regex alone does NOT solve
+	// WHAT EACH TIGHTENING IS WORTH, over the same 3,726 `.cs` files:
+	// the old pattern found 39,009 sites, the anchor alone 23,490, and the
+	// anchor plus the keyword rejection 18,853. The regex alone does NOT solve
 	// the false-positive problem — the file gate in Extract does. What these
 	// buy is that the collider shape does not survive INSIDE the gate, and does
 	// not return the moment another dialect widens it.
@@ -132,7 +137,12 @@ var (
 // shape survives inside the gate, so it has to be rejected on its own terms.
 //
 // WHY A MAP AND NOT A PATTERN: Go's RE2 has no lookahead, so "an identifier
-// that is not one of these" cannot be written in the regex.
+// that is not one of these" cannot be written in the regex. That makes this map
+// the MECHANISM, not a convenience list beside it, so every one of its 40
+// entries is graded individually and by name —
+// TestBlazorNonTypeKeywordsIsGradedAsAnExactSet6975 requires each key to be
+// both REACHABLE by the pattern and SUPPRESSED by Extract. Deleting any single
+// entry turns that test red. Do not add a key without letting that test see it.
 //
 // Only the TYPE slot is filtered. The NAME slot needs no companion filter and
 // deliberately does not have one — two guards that only ever fire together
@@ -208,17 +218,17 @@ func (e *blazorExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	//
 	//  1. Which extensions carry the constructs. Scanning every `.cs`,
 	//     `.razor`, `.razor.cs` and `.cshtml` file in archigraph-corpora
-	//     (7 C#-bearing repos) with these exact patterns: the five DIRECTIVE
+	//     (whole tree) with these exact patterns: the five DIRECTIVE
 	//     rules (@page, @inject, [Parameter], @layout, @inherits) score
-	//     **zero** across all 3,721 `.cs` files. They fire in the 105 `.razor`
+	//     **zero** across all 3,726 `.cs` files. They fire in the 105 `.razor`
 	//     files (25/119/10/4/0 = 158 sites) and, to a much smaller extent, in
-	//     the 1,119 `.cshtml` files (9/39/0/0/1 = 49 sites) — an earlier
+	//     the 1,129 `.cshtml` files (9/39/0/0/1 = 49 sites) — an earlier
 	//     revision of this comment said "only in `.razor`", which was false
 	//     over its own stated population. `.cshtml` is classified UNSUPPORTED
 	//     (classifier/unsupported.go:132, #6343) so it never reaches an
 	//     extractor either way, but the sentence is the evidence for this
 	//     gate and it should be true. Only the code-method and component-tag
-	//     rules fire in `.cs` — 38,983 and 12,991 sites, all of them false
+	//     rules fire in `.cs` — 39,009 and 12,994 sites, all of them false
 	//     positives. So no rule here loses a real construct by being denied
 	//     plain `.cs`.
 	//
@@ -306,7 +316,7 @@ func (e *blazorExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	}
 
 	// Markup-only rule (#6975): in `.razor.cs` code-behind `<Foo>` is a
-	// generic type argument, not a component reference — 12,991 such sites
+	// generic type argument, not a component reference — 12,994 such sites
 	// across the corpus's `.cs` files.
 	if isRazorMarkup {
 		// 4. PascalCase component tags -> SCOPE.UIComponent

--- a/internal/custom/csharp/blazor_file_gate_6975_test.go
+++ b/internal/custom/csharp/blazor_file_gate_6975_test.go
@@ -1,0 +1,205 @@
+package csharp_test
+
+import (
+	"testing"
+)
+
+// #6975 — `internal/custom/csharp/blazor.go` had no file gate, so it ran the
+// whole Blazor rule set over every C# file in a repository, and
+// `reBlazorCodeMethod` made the access modifier optional with no line anchor,
+// so `var svc = new OrderService(` minted a SCOPE.Operation/function named
+// `OrderService`.
+//
+// WHY THESE TESTS ASSERT MEMBERSHIP, NOT CARDINALITY. The defect was invisible
+// to the existing suite because the entity count went UP — on `aspnetcore-mvc`
+// (gate ON, in-process Index(), macOS/APFS) entities went 39,765 -> 75,174,
+// +89.0%, while TESTS edges went 43,621 -> 36,982, -6,639. A count assertion
+// in either direction is satisfied by that. Every assertion below therefore
+// names a SPECIFIC entity that must exist or must not exist. The companion
+// edge-side assertion lives in cmd/grafel (TestBlazorGateKeepsTestsEdges6975):
+// it names the specific TESTS edge that the false positives were destroying.
+//
+// THE MUTANTS THESE ARE WRITTEN TO KILL, all in the more-permissive direction:
+//
+//	m1 — delete the `if !isRazorMarkup && !isRazorCodeBehind` gate entirely
+//	     => TestBlazorGateRejectsOrdinaryCSharp6975 fails (three entities).
+//	m2 — widen the gate to any `.cs` file
+//	     => TestBlazorGateRejectsOrdinaryCSharp6975 fails (same three).
+//	m3 — narrow the gate to `.razor` only, i.e. copy blazor_deep.go:179's
+//	     effect and drop code-behind
+//	     => TestBlazorGateAdmitsRazorCodeBehind6975 fails.
+//	m4 — restore the optional access modifier / drop the `^[ \t]*` anchor on
+//	     reBlazorCodeMethod
+//	     => TestBlazorCodeMethodIgnoresConstructorCalls6975 fails, INSIDE a
+//	     `.razor.cs` file, so the gate cannot mask it.
+//	m5 — run the markup rules over code-behind too (isRazorMarkup widened to
+//	     include `.razor.cs`)
+//	     => TestBlazorGateAdmitsRazorCodeBehind6975 fails: the generic
+//	     argument in `new Wrapper<Order>()` becomes a SCOPE.UIComponent.
+
+// TestBlazorGateRejectsOrdinaryCSharp6975 pins the gate. `OrderService.cs` is
+// ordinary ASP.NET Core C# with no Blazor whatsoever; before the gate it
+// yielded a SCOPE.Operation/function for every constructor call and a
+// SCOPE.UIComponent for every generic type argument.
+func TestBlazorGateRejectsOrdinaryCSharp6975(t *testing.T) {
+	src := `
+namespace Shop.Services;
+
+public class OrderService
+{
+    public async Task<List<Order>> ListAsync()
+    {
+        var repo = new OrderRepository(_db);
+        var mapper = new OrderMapper();
+        return await repo.AllAsync();
+    }
+}
+`
+	ents := extract(t, "custom_csharp_blazor", fi("Services/OrderService.cs", "csharp", src))
+
+	// The three entities the un-gated extractor minted here. Named
+	// individually rather than counted, so a mutant that keeps two of them
+	// still fails.
+	for _, bad := range []struct{ kind, name string }{
+		{"SCOPE.Operation", "OrderRepository"}, // `new OrderRepository(` as a "code method"
+		{"SCOPE.Operation", "ListAsync"},       // a real method, but not a Blazor one
+		{"SCOPE.UIComponent", "List"},          // `List<Order>` as a "component tag"
+	} {
+		if containsEntity(ents, bad.kind, bad.name) {
+			t.Errorf("ordinary C# file produced %s %q; blazor.go must not see plain .cs", bad.kind, bad.name)
+		}
+	}
+	if len(ents) != 0 {
+		t.Errorf("ordinary C# file produced %d entities, want 0: %+v", len(ents), ents)
+	}
+}
+
+// TestBlazorGateAdmitsRazorCodeBehind6975 pins the OTHER direction of the same
+// gate: Blazor code-behind lives in `.razor.cs`, and a `.razor`-only gate
+// copied from blazor_deep.go:179 would silently drop it. It also pins that
+// code-behind gets the CODE rules only — `<Foo>` there is a generic type
+// argument, not a component reference.
+func TestBlazorGateAdmitsRazorCodeBehind6975(t *testing.T) {
+	src := `
+namespace Shop.Pages;
+
+public partial class Counter : ComponentBase
+{
+    [Parameter] public int StartAt { get; set; }
+
+    protected override async Task<List<Order>> OnInitializedAsync()
+    {
+        var box = new Wrapper<Order>();
+    }
+
+    void IncrementCount()
+    {
+    }
+}
+`
+	ents := extract(t, "custom_csharp_blazor", fi("Pages/Counter.razor.cs", "csharp", src))
+
+	// Code rules DO run over code-behind.
+	// Declared with a NESTED generic return type (`Task<List<Order>>`) on
+	// purpose: an inner-`>`-terminated generic class in the pattern drops this
+	// declaration silently, which a mutant run caught during #6975.
+	if !containsEntity(ents, "SCOPE.Operation", "OnInitializedAsync") {
+		t.Error("code-behind: missing SCOPE.Operation OnInitializedAsync (a .razor-only gate loses this; so does an inner-`>` generic class)")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "IncrementCount") {
+		t.Error("code-behind: missing SCOPE.Operation IncrementCount (a modifier-less method must still be found)")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "param:StartAt") {
+		t.Error("code-behind: missing SCOPE.Pattern param:StartAt")
+	}
+
+	// Markup rules DO NOT. The component-tag rule is the one that grades this
+	// split, and it is graded on the GENERIC ARGUMENT, not the outer type: in
+	// `new Wrapper<Order>()` the substring `<Order>` is what
+	// reBlazorComponentTag matches, and `Wrapper` is not matched at all. An
+	// earlier revision of this test asserted the absence of `Wrapper` and was
+	// therefore satisfied by a mutant that ran the markup rules over
+	// code-behind — it named the wrong entity. The four `@`-directive rules
+	// cannot be graded here at all: they are `(?m)^@…`-anchored and a line
+	// beginning `@page` is not legal C#, so they are unreachable in a
+	// `.razor.cs` file whether or not the guard exists. The guard still covers
+	// them because the rule is about which SYNTAX a file carries, not about
+	// which rules happen to be reachable today.
+	if containsEntity(ents, "SCOPE.UIComponent", "Order") {
+		t.Error("code-behind: the generic argument in `new Wrapper<Order>()` produced a UIComponent; the component-tag rule is markup-only")
+	}
+	// And the constructor call must not become a method, even here.
+	if containsEntity(ents, "SCOPE.Operation", "Wrapper") {
+		t.Error("code-behind: `new Wrapper<Order>()` produced a SCOPE.Operation")
+	}
+}
+
+// TestBlazorCodeMethodIgnoresConstructorCalls6975 grades the regex on its own
+// merits, INSIDE a file the gate admits, so removing the gate cannot make this
+// pass and tightening the gate cannot make it pass vacuously. Every name below
+// appears only as a constructor call or a mid-expression call.
+func TestBlazorCodeMethodIgnoresConstructorCalls6975(t *testing.T) {
+	src := `
+public partial class Cart : ComponentBase
+{
+    private void Recalculate()
+    {
+        var a = new PriceCalculator(_rates);
+        Total = new MoneyFormatter().Format(a.Sum());
+        return new CartSnapshot(Items);
+    }
+}
+`
+	ents := extract(t, "custom_csharp_blazor", fi("Pages/Cart.razor.cs", "csharp", src))
+
+	for _, name := range []string{"PriceCalculator", "MoneyFormatter", "CartSnapshot"} {
+		if containsEntity(ents, "SCOPE.Operation", name) {
+			t.Errorf("constructor call `new %s(` minted a SCOPE.Operation; the code-method pattern must be line-anchored", name)
+		}
+	}
+	// Positive control: the real declaration on its own line IS still found,
+	// so the test cannot pass by the pattern matching nothing at all.
+	if !containsEntity(ents, "SCOPE.Operation", "Recalculate") {
+		t.Error("the real method declaration Recalculate was not found — pattern is now too narrow")
+	}
+}
+
+// TestBlazorMarkupStillExtractedFromRazor6975 is the vacuity guard for the
+// gate as a whole: a `.razor` markup file must still produce every rule's
+// output. Without this, gating to nothing at all would pass every test above.
+func TestBlazorMarkupStillExtractedFromRazor6975(t *testing.T) {
+	src := `@page "/counter"
+@layout MainLayout
+@inherits CounterBase
+@inject IOrderService Orders
+<MyCustomCard title="Hello" />
+
+@code {
+    [Parameter] public int StartAt { get; set; }
+
+    void IncrementCount()
+    {
+        var fmt = new MoneyFormatter();
+    }
+}
+`
+	ents := extract(t, "custom_csharp_blazor", fi("Pages/Counter.razor", "csharp", src))
+
+	for _, want := range []struct{ kind, name string }{
+		{"SCOPE.Operation", "/counter"},
+		{"SCOPE.Component", "layout:MainLayout"},
+		{"SCOPE.Component", "inherits:CounterBase"},
+		{"SCOPE.Component", "IOrderService"},
+		{"SCOPE.UIComponent", "MyCustomCard"},
+		{"SCOPE.Pattern", "param:StartAt"},
+		{"SCOPE.Operation", "IncrementCount"},
+	} {
+		if !containsEntity(ents, want.kind, want.name) {
+			t.Errorf("razor markup: missing %s %q", want.kind, want.name)
+		}
+	}
+	// The tightened code-method pattern must not re-open the defect here either.
+	if containsEntity(ents, "SCOPE.Operation", "MoneyFormatter") {
+		t.Error("razor markup: `new MoneyFormatter()` minted a SCOPE.Operation")
+	}
+}

--- a/internal/custom/csharp/blazor_file_gate_6975_test.go
+++ b/internal/custom/csharp/blazor_file_gate_6975_test.go
@@ -36,6 +36,17 @@ import (
 //	     include `.razor.cs`)
 //	     => TestBlazorGateAdmitsRazorCodeBehind6975 fails: the generic
 //	     argument in `new Wrapper<Order>()` becomes a SCOPE.UIComponent.
+//
+// Added after review, each of which was ALIVE against the first revision:
+//
+//	m6 — drop the blazorNonTypeKeywords rejection (R5 residual). The anchor
+//	     only excludes a MID-EXPRESSION `new X(`; a line-leading one survives,
+//	     and `.razor.cs` is ordinary C# so the gate does not cover it
+//	     => TestBlazorCodeMethodIgnoresConstructorCalls6975 fails.
+//	m7 — delete the `file.Language != "csharp"` guard (R3)
+//	     => TestBlazorLanguageGuardRejectsNonCSharp6975 fails.
+//	m8 — widen the generic class `[^;\n]*` to `[^;]*` (MB-1)
+//	     => TestBlazorCodeMethodGenericDoesNotSpanLines6975 fails.
 
 // TestBlazorGateRejectsOrdinaryCSharp6975 pins the gate. `OrderService.cs` is
 // ordinary ASP.NET Core C# with no Blazor whatsoever; before the gate it
@@ -139,6 +150,13 @@ public partial class Counter : ComponentBase
 // pass and tightening the gate cannot make it pass vacuously. Every name below
 // appears only as a constructor call or a mid-expression call.
 func TestBlazorCodeMethodIgnoresConstructorCalls6975(t *testing.T) {
+	// MID-EXPRESSION and LINE-LEADING forms are both present on purpose. The
+	// anchor alone handles only the first: an earlier revision of this test
+	// used exclusively mid-expression calls, and simply moving
+	// `new PriceCalculator(_rates)` onto its own continuation line — which is
+	// how a long assignment is formatted — made the fixture pass while the
+	// defect was fully intact. `.razor.cs` is ordinary C#, so the gate does
+	// not cover this shape; blazorNonTypeKeywords does.
 	src := `
 public partial class Cart : ComponentBase
 {
@@ -146,21 +164,50 @@ public partial class Cart : ComponentBase
     {
         var a = new PriceCalculator(_rates);
         Total = new MoneyFormatter().Format(a.Sum());
-        return new CartSnapshot(Items);
+        var snapshot =
+            new CartSnapshot(Items);
+        new AuditEntry(Items).Write();
+        return Publish(snapshot);
+    }
+
+    private void Refresh()
+    {
+        if (Items.Count == 0)
+            Clear();
+        else if (Items.Count > 100)
+            Trim();
     }
 }
 `
 	ents := extract(t, "custom_csharp_blazor", fi("Pages/Cart.razor.cs", "csharp", src))
 
-	for _, name := range []string{"PriceCalculator", "MoneyFormatter", "CartSnapshot"} {
+	// Mid-expression `new X(` — killed by the anchor.
+	for _, name := range []string{"PriceCalculator", "MoneyFormatter"} {
 		if containsEntity(ents, "SCOPE.Operation", name) {
-			t.Errorf("constructor call `new %s(` minted a SCOPE.Operation; the code-method pattern must be line-anchored", name)
+			t.Errorf("mid-expression `new %s(` minted a SCOPE.Operation; the code-method pattern must be line-anchored", name)
 		}
 	}
-	// Positive control: the real declaration on its own line IS still found,
-	// so the test cannot pass by the pattern matching nothing at all.
-	if !containsEntity(ents, "SCOPE.Operation", "Recalculate") {
-		t.Error("the real method declaration Recalculate was not found — pattern is now too narrow")
+	// LINE-LEADING `new X(` — survives the anchor, killed by the type-token
+	// keyword rejection. 2,503 such sites in the corpus C#.
+	for _, name := range []string{"CartSnapshot", "AuditEntry"} {
+		if containsEntity(ents, "SCOPE.Operation", name) {
+			t.Errorf("line-leading `new %s(` minted a SCOPE.Operation; the anchor does not exclude this shape, blazorNonTypeKeywords must", name)
+		}
+	}
+	// `return F(` — type slot holds `return`. 1,666 sites.
+	if containsEntity(ents, "SCOPE.Operation", "Publish") {
+		t.Error("`return Publish(` minted a SCOPE.Operation named Publish; the type slot holds `return`, not a type")
+	}
+	// `else if (` — type slot `else`, name slot `if`. 293 sites.
+	if containsEntity(ents, "SCOPE.Operation", "if") {
+		t.Error("`else if (` minted a SCOPE.Operation named `if`")
+	}
+	// Positive controls: the real declarations ARE still found, so the test
+	// cannot pass by the pattern (or the keyword filter) matching nothing.
+	for _, name := range []string{"Recalculate", "Refresh"} {
+		if !containsEntity(ents, "SCOPE.Operation", name) {
+			t.Errorf("the real method declaration %s was not found — pattern is now too narrow", name)
+		}
 	}
 }
 
@@ -201,5 +248,70 @@ func TestBlazorMarkupStillExtractedFromRazor6975(t *testing.T) {
 	// The tightened code-method pattern must not re-open the defect here either.
 	if containsEntity(ents, "SCOPE.Operation", "MoneyFormatter") {
 		t.Error("razor markup: `new MoneyFormatter()` minted a SCOPE.Operation")
+	}
+}
+
+// TestBlazorLanguageGuardRejectsNonCSharp6975 grades the `file.Language !=
+// "csharp"` guard, which a review mutant showed was ungraded: deleting it
+// passed both this package and all of cmd/grafel.
+//
+// The guard is what makes `.razor` unreachable. Both inputs below have a path
+// the SUFFIX gate admits, so only the language check can reject them, and both
+// carry content every rule matches — a vacuous pass is not available.
+func TestBlazorLanguageGuardRejectsNonCSharp6975(t *testing.T) {
+	src := `@page "/counter"
+@inject IOrderService Orders
+<MyCustomCard title="Hello" />
+
+@code {
+    void IncrementCount()
+    {
+    }
+}
+`
+	// "razor" is the language a real `.razor` file actually classifies as
+	// (classifier.go:345), which is why the extractor never sees one.
+	for _, lang := range []string{"razor", "vbnet", "java"} {
+		ents := extract(t, "custom_csharp_blazor", fi("Pages/Counter.razor", lang, src))
+		if len(ents) != 0 {
+			t.Errorf("language %q produced %d entities, want 0: %+v", lang, len(ents), ents)
+		}
+	}
+	// Control: the identical content under "csharp" DOES produce entities, so
+	// the loop above is rejecting on language and not on content.
+	if ents := extract(t, "custom_csharp_blazor", fi("Pages/Counter.razor", "csharp", src)); len(ents) == 0 {
+		t.Error("control: the same content under language \"csharp\" produced nothing")
+	}
+}
+
+// TestBlazorCodeMethodGenericDoesNotSpanLines6975 grades the `\n` in the
+// generic class `(?:<[^;\n]*>)?`, which a review mutant showed was ungraded:
+// widening it to `[^;]*` left this package and cmd/grafel green.
+//
+// Without the `\n` the class is greedy ACROSS LINES, so the `<` opening the
+// multi-line parameter list below reaches the `>` of the `=>` several lines
+// later and the pattern then reads ` Sum(` as a declaration — inventing a
+// method out of two unrelated constructs. `Sum` is declared nowhere.
+func TestBlazorCodeMethodGenericDoesNotSpanLines6975(t *testing.T) {
+	src := `
+public partial class Report : ComponentBase
+{
+    void Render(
+        Dictionary<string, int> counts)
+    {
+    }
+
+    int Total => Sum();
+}
+`
+	ents := extract(t, "custom_csharp_blazor", fi("Pages/Report.razor.cs", "csharp", src))
+
+	if containsEntity(ents, "SCOPE.Operation", "Sum") {
+		t.Error("a generic opened on one line reached a `>` several lines later and minted a SCOPE.Operation named Sum, which is declared nowhere")
+	}
+	// Positive control: the real declaration between them is still found, so
+	// the assertion above cannot pass by the rule producing nothing at all.
+	if !containsEntity(ents, "SCOPE.Operation", "Render") {
+		t.Error("the real method declaration Render was not found — pattern is now too narrow")
 	}
 }

--- a/internal/custom/csharp/blazor_keyword_set_6975_test.go
+++ b/internal/custom/csharp/blazor_keyword_set_6975_test.go
@@ -1,0 +1,166 @@
+package csharp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	extreg "github.com/cajasmota/grafel/internal/extractor"
+)
+
+// #6975, review mutant MB-2 — blazorNonTypeKeywords is graded as an EXACT SET,
+// key by key, not at whichever handful the corpus happens to exercise.
+//
+// WHY. MB-2 deleted ONE entry ("throw") and left the other 38; the package
+// stayed green. That single result is not interesting on its own — `throw`'s
+// reachability is genuinely thin, because the common `throw new
+// ArgumentException(x)` is already suppressed by the "new" key (the pattern
+// aligns on `new` as the type token and `ArgumentException` as the name), and
+// what "throw" uniquely guards is `throw Foo(...)`, legal only when Foo()
+// returns an exception. No live defect was claimed and none is claimed here.
+//
+// The finding is about the MAP. It is a 40-entry membership list (the review
+// said 39 — counted here, it is 40) that was graded at some members with
+// nothing saying which, so a later tidy-up, or a
+// merge dropping a line, removes a guard silently. Since Go's RE2 has no
+// lookahead, that map IS the mechanism — it is not a convenience list beside
+// the real check. A per-key assertion is the only thing that makes the set the
+// unit of grading rather than the handful of shapes a fixture happens to hit.
+//
+// It is an internal (package csharp) test because the map is unexported and
+// the point is to iterate the real thing. Exporting a copy for the test would
+// grade the copy.
+//
+// THE EXPECTATION IS A LITERAL LIST, NOT THE MAP ITSELF. The first revision of
+// this test ranged over blazorNonTypeKeywords to build its subtests, and
+// re-scoring MB-2 against it showed that was worthless: delete a key and the
+// key simply produces no subtest, so the suite stays green. A test driven by
+// the thing under test cannot detect a deletion. `wantKeywords` below is
+// therefore an independent copy, and the set comparison runs in BOTH
+// directions — a removed key fails, and a key added without a line here fails
+// too, which is what stops the list from drifting back to ungraded.
+//
+// TWO ASSERTIONS PER KEY, because suppression alone can pass vacuously. A key
+// whose line the pattern never matches in the first place would look
+// "suppressed" while contributing nothing, and adding such a key would be
+// invisible. So each key must ALSO be shown reachable: the raw pattern must
+// align on it as the type token with `Target` as the name. A key that fails
+// (1) is dead weight; a key that fails (2) is an unguarded shape.
+func TestBlazorNonTypeKeywordsIsGradedAsAnExactSet6975(t *testing.T) {
+	// An INDEPENDENT copy of the set, maintained by hand. Every entry is
+	// asserted below; the set equality at the end is what makes a deletion or
+	// an undeclared addition fail.
+	wantKeywords := []string{
+		// Statement keywords that can lead a line and be followed by `ident(`.
+		"return", "new", "else", "throw", "await",
+		"yield", "goto", "break", "continue",
+		"case", "default", "do", "try", "finally",
+		"checked", "unchecked", "stackalloc", "delegate",
+		// Contextual/operator keywords in the same slot.
+		"in", "is", "as", "out", "ref",
+		"params", "typeof", "sizeof", "nameof",
+		"when", "with", "and", "or", "not",
+		// LINQ query clause keywords.
+		"from", "select", "where", "let",
+		"orderby", "group", "join", "into",
+	}
+
+	// A line-leading `<token> Target(x);` inside a method body — the shape that
+	// survives the `^[ \t]*` anchor and mints #6973's collider.
+	src := func(token string) string {
+		return fmt.Sprintf(`
+public partial class Probe : ComponentBase
+{
+    void Anchor()
+    {
+        %s Target(x);
+    }
+}
+`, token)
+	}
+	mints := func(t *testing.T, token string) (target, anchor bool) {
+		t.Helper()
+		e := &blazorExtractor{}
+		ents, err := e.Extract(context.Background(), extreg.FileInput{
+			Path: "Pages/Probe.razor.cs", Language: "csharp", Content: []byte(src(token)),
+		})
+		if err != nil {
+			t.Fatalf("extract(%q): %v", token, err)
+		}
+		for i := range ents {
+			if ents[i].Kind != "SCOPE.Operation" {
+				continue
+			}
+			switch ents[i].Name {
+			case "Target":
+				target = true
+			case "Anchor":
+				anchor = true
+			}
+		}
+		return target, anchor
+	}
+
+	// CONTROL. An ordinary type token in the same slot DOES mint `Target`, so
+	// every "not minted" below is the map's doing and not the fixture's.
+	if target, anchor := mints(t, "Widget"); !target || !anchor {
+		t.Fatalf("control: `Widget Target(x);` minted Target=%v Anchor=%v, want both true — "+
+			"the fixture does not exercise the rule, so the per-key assertions cannot grade it",
+			target, anchor)
+	}
+
+	for _, kw := range wantKeywords {
+		t.Run(kw, func(t *testing.T) {
+			// (1) REACHABLE. The pattern must actually align on this key, or
+			// the key is dead weight and its presence is ungraded.
+			// FindAll, not Find: the fixture's own `void Anchor()` line
+			// matches first, and comparing against THAT is how the first
+			// revision of this test failed every key for the wrong reason.
+			var aligned bool
+			for _, m := range reBlazorCodeMethod.FindAllStringSubmatch(src(kw), -1) {
+				if m[1] == kw && m[2] == "Target" {
+					aligned = true
+					break
+				}
+			}
+			if !aligned {
+				t.Fatalf("reBlazorCodeMethod does not align on `%s Target(x);`, "+
+					"so this key suppresses nothing and its removal would be invisible", kw)
+			}
+			// (2) SUPPRESSED. Extract must reject the match on that token.
+			target, anchor := mints(t, kw)
+			if !anchor {
+				t.Fatal("the surrounding declaration Anchor was not extracted; the fixture is broken")
+			}
+			if target {
+				t.Errorf("`%s Target(x);` minted a SCOPE.Operation named Target — "+
+					"the %q key of blazorNonTypeKeywords is not suppressing it", kw, kw)
+			}
+		})
+	}
+
+	// SET EQUALITY, both directions. This is the assertion MB-2 defeats
+	// without: deleting a key from the map removes its subtest above and
+	// nothing else notices.
+	seen := map[string]bool{}
+	for _, kw := range wantKeywords {
+		if seen[kw] {
+			t.Errorf("wantKeywords lists %q twice", kw)
+		}
+		seen[kw] = true
+		if !blazorNonTypeKeywords[kw] {
+			t.Errorf("blazorNonTypeKeywords is MISSING %q — a guard was dropped; "+
+				"if the removal is deliberate, delete it from wantKeywords too and say why", kw)
+		}
+	}
+	for kw := range blazorNonTypeKeywords {
+		if !seen[kw] {
+			t.Errorf("blazorNonTypeKeywords has %q, which wantKeywords does not list — "+
+				"add it there so the per-key assertions above actually grade it", kw)
+		}
+	}
+	if len(blazorNonTypeKeywords) != len(wantKeywords) {
+		t.Errorf("blazorNonTypeKeywords has %d entries, wantKeywords %d",
+			len(blazorNonTypeKeywords), len(wantKeywords))
+	}
+}


### PR DESCRIPTION
`internal/custom/csharp/blazor.go` had **no file gate**, and `reBlazorCodeMethod` made the access modifier optional with no line anchor. Together those meant `var repo = new OrderRepository(_db);` in ordinary C# minted a `SCOPE.Operation/function` named `OrderRepository` — a name duplicate of a real class, in a different file, which evicts the real entry from the repo-wide `byName` index and takes the `TESTS` resolution path down with it (#6973).

> **Revised after review** ([reviewer](https://github.com/cajasmota/grafel/pull/6977#issuecomment-5574400334), [coordinator](https://github.com/cajasmota/grafel/pull/6977#issuecomment-5574428354)). Three mutants were ALIVE and two prose claims were false; a third false claim turned up while re-measuring. All are addressed in `f872add0d` and described below. **Every number in this body was measured by me, not carried over from the review.**

## Measured, before and after

`aspnetcore-mvc` from `archigraph-corpora`, **macOS/APFS**, `GRAFEL_INPROC_CUSTOM_EXTRACTORS=1`, in-process `Index()`, `GOMAXPROCS=3`. **Gate state: custom extractors ON**, which is *not* the default (#6966) — it is the configuration every custom-lane measurement on this board is taken in.

| arm | entities | `TESTS` |
|---|---|---|
| gate OFF | 39,765 | 43,621 |
| gate ON, before this change | 75,174 | 36,982 |
| gate ON, after this change | 50,266 | 40,888 |

- `blazor.go`'s own output on that repo: **25,479 → 0** (21,320 `INFERRED_FROM_BLAZOR_CODE_METHOD` + 4,159 `INFERRED_FROM_BLAZOR_COMPONENT_REF`) — 72.0% of the 35,409 entities the gate added, in a repo containing no Blazor. The issue's 25,469 figure reproduced within 10.
- The gate still keeps a **+26.4%** entity gain over the OFF arm.
- **3,906 of the 6,639 lost `TESTS` edges recovered — 58.8%.** That is the issue's causal control, **re-derived here**, not cited.
- The residual ~2,700 is the general declaration-vs-reference eviction in `refs.go` `indexByName`. That is **#6976** and is deliberately **not touched**.

`aspnetcore-mvc` has zero `.razor.cs` files and its 7 `.razor` files never reach this extractor, so these figures are invariant under the regex work below.

## The gate was measured, not copied

#6975 says explicitly not to copy `blazor_deep.go:179`'s `.razor` gate, because code-behind lives in `.razor.cs`. Two measurements decided it:

1. **Which extensions carry the constructs.** Over the whole `archigraph-corpora` tree — 3,726 `.cs`, 105 `.razor`, **0** `.razor.cs`, 1,129 `.cshtml` — the five `@`-directive rules score **zero** in `.cs`. They fire in `.razor` (25/119/10/4/0 = **158 sites**) and, smaller, in `.cshtml` (9/39/0/0/1 = **49 sites**). Only the code-method and component-tag rules fire in `.cs` — 39,009 and 12,994 sites, all false positives.
2. **What can actually reach this function.** `.razor` classifies as language `"razor"` (`classifier.go:345`), so the `file.Language != "csharp"` check rejects it outright. Independently, there is no tree-sitter grammar for razor, so a `.razor` file also has `TSTree == nil`. Either alone is sufficient: **the only extension that both carries Blazor and reaches this code today is `.razor.cs`.**

The gate admits `.razor || .razor.cs`, and the **markup** rules are further restricted to `.razor` — in code-behind `<Foo>` is a generic type argument, not a component reference.

> Finding, out of scope: `blazor_deep.go:179`'s `.razor` arm is dead for the same reason. Worth its own issue.

## The regex, fixed on its own merits

**Three tightenings, each independently graded.**

1. **Anchor** `^[ \t]*` — excludes a **mid-expression** `new X(`.
2. **Type-token keyword rejection** (`blazorNonTypeKeywords`) — the anchor does **not** exclude a **line-leading** `new X(`, and `.razor.cs` is ordinary C#, so that shape survived *inside* the gate. Measured over the corpus C#: **2,503** line-leading `new X(`, **1,666** `return F(`, **293** `else if (`. The pattern now captures the type token as group 1 and `Extract` rejects statement keywords. Go's RE2 has no lookahead, so this cannot live in the pattern — **that map is the mechanism**, which is why all 40 of its entries are now graded individually (see below). Only the type slot is filtered — a companion name-slot filter would only ever fire together with this one and grade neither.

> **Population, reconciled.** My `return F(` count was **1,661** and the reviewer's **1,666**; both are right over different walks. The whole `archigraph-corpora` tree has 3,726 `.cs` files and **1,666** sites; restricting to the 7 C#-bearing repos by name gives 3,721 files and 1,661. `new X(` (2,503) and `else if (` (293) are identical either way. **Every figure in this PR and in the code comments is now the whole-tree one, and says so** — two numbers for one thing in a review record is worse than either.
3. **`\n` in the generic class** `(?:<[^;\n]*>)?` — without it the class is greedy across lines and invents a method out of two unrelated constructs.

Effect on `.cs`: **39,009 → 23,490 (anchor) → 18,853 (anchor + keyword rejection)**. On `.razor` the rejection removes 13 of 110 matches, and **enumerating** them rather than counting shows all 13 are non-declarations — 9 `else if (` and 4 `await <Method>(` call sites, the collider shape again. No declaration lost.

## What review changed

| item | was | now |
|---|---|---|
| **R5** — line-leading `new X(` survived the anchor **inside the gate** | prose claimed the anchor covered it | `blazorNonTypeKeywords`; fixture carries both forms. The reviewer's diagnosis reproduced exactly: moving the old fixture's constructor call onto its own continuation line made the assertion pass with the defect intact |
| **R3** — `Language != "csharp"` guard | **ungraded** (deleting it passed this package *and* all of `cmd/grafel`) | `TestBlazorLanguageGuardRejectsNonCSharp6975` over `razor`/`vbnet`/`java` with a `csharp` control on identical content |
| **MB-1** — `\n` in the generic class | **ungraded** (`[^;]*` left both packages green) | `TestBlazorCodeMethodGenericDoesNotSpanLines6975` — mints `Sum`, declared nowhere, under the mutant; `Render` is the positive control |
| **Prose** — "directive rules fire only in `.razor`" | **false** over its own population (`.cshtml` has 49 sites) | both populations stated; `.cshtml` is unsupported (#6343) |
| **Prose** — `.razor` kept for "a future razor grammar" | **inert**, as R3 proves — the language check would reject it anyway | says the suffix pair names the Blazor file family, as `blazor_deep.go:179` has it |
| **Prose** — ratchet coverage | implied it covered this change | states it **cannot** — see below |

**A third false claim, found while re-measuring.** The comment said a required-modifier variant "drops exactly the bare `@code` methods", citing 110 vs 97. With the keyword rejection in place the two variants select the **identical 97 sites** over the corpus's 105 `.razor` files — 28 distinct names, **zero** found by either alone in either direction. Every real method there carries a modifier. The anchor is now justified on **mechanism** (it rejects a match for its *position*, which is the defect) rather than on a margin that does not exist, and the modifier-less case is stated as pinned **synthetically**, not by the corpus.

**A process note, because it nearly produced a fabricated result.** `(?:<[^;\n]*>)?` occurs **twice** — line 71 (doc comment) and line 90 (the regex). Editing the comment is a no-op that reads as ALIVE. The MB-1 mutant script asserts the fragment is on exactly `[71, 90]`, that line 90 is the regex, that line 90 changed, and that **line 71 still carries `[^;\n]`**.

## Grading the LOSS direction

Every assertion names a **specific entity or edge**. A cardinality assertion is blind here by construction: entities rose 89% while edges were destroyed, and #6973 measured explicit `TESTS` at +8 net while 7,221 edges were substituted.

- `cmd/grafel/blazor_gate_tests_edges_6975_test.go` indexes with the gate **OFF** first as a control, then requires **every** `TESTS` edge from that arm to survive the gate being **ON**, reporting missing edges by name.
- `internal/custom/csharp/blazor_file_gate_6975_test.go` names individual entities in both directions of the gate, plus a `.razor` vacuity guard.

## Mutants — 8/8 DEAD

Re-scored against the revised code. Each edit proven to land by an **occurrence count** and a **changed sha**; green baseline immediately before each; restored by `cp` from a shasum-verified backup.

| | mutant | verdict |
|---|---|---|
| m1 | delete the gate | **DEAD** |
| m2 | widen the gate to any `.cs` | **DEAD** |
| m3 | narrow the gate to `.razor` only | **DEAD** (3 tests) |
| m4 | restore the pre-#6975 unanchored regex | **DEAD** |
| m5 | run markup rules over code-behind | **DEAD** |
| m6 | drop the `blazorNonTypeKeywords` rejection (R5) | **DEAD** — names all four line-leading shapes |
| m7 | delete the `Language != "csharp"` guard (R3) | **DEAD** |
| m8 | widen the generic class to `[^;]*` (MB-1) | **DEAD** |
| m9 | delete any ONE of the 40 `blazorNonTypeKeywords` entries (MB-2) | **DEAD, 40/40** |
| m10 | add a key to the map that the test's literal does not list | **DEAD** |

## MB-2 — the keyword map is graded as an exact set

MB-2 deleted one entry (`"throw"`) and left the other 39; the package stayed green. `throw`'s own reachability is thin and **no live defect is claimed**: `throw new ArgumentException(x)` is already suppressed by the `"new"` key (the pattern aligns on `new` as the type token and `ArgumentException` as the name), and what `"throw"` uniquely guards is `throw Foo(...)`, legal only when `Foo()` returns an exception.

The finding is about the **map** — a **40-entry** membership list (the review said 39; counted, it is 40) graded at some members with nothing saying which. Since RE2 has no lookahead, that map *is* the mechanism. `TestBlazorNonTypeKeywordsIsGradedAsAnExactSet6975` now asserts per key that it is **reachable** (the pattern aligns on it as the type token of a line-leading `<kw> Target(x);`) and **suppressed** (`Extract` mints no `Target`), plus **set equality against an independent literal list in both directions**. It is an internal (`package csharp`) test because the map is unexported and the point is to iterate the real thing.

**Two of my own assertions were wrong first, and scoring is what said so.**

1. The first revision built its subtests by **ranging over `blazorNonTypeKeywords`**. Re-scoring MB-2 against it: **still ALIVE**. Deleting a key removes its subtest and nothing else notices — a test driven by the thing under test cannot detect a deletion. The expectation is now a hand-maintained literal, which is the whole point of "exact set".
2. The reachability check used `FindStringSubmatch`, which returns the **first** match in the source — the fixture's own `void Anchor()` line — so it failed every key for the wrong reason.

**40/40 single-key deletions DEAD**, plus the addition direction. 39 were scored by loop and **the 40th separately**: `while read` drops a final line with no trailing newline, and reporting 39/40 as "all" would have been the same class of error as the two above. One aborted edit worth recording: the first loop pass fed the entire keyword list to the mutant script as a single token, because **zsh does not word-split unquoted parameters** — the occurrence assertion rejected it rather than letting a green run read as ALIVE.

## How the prose errors were found

All three false claims in this PR's prose — "directive rules fire only in `.razor`", the ratchet line, and the 110-vs-97 margin — were found by **re-measuring, never by re-reading**. The 110-vs-97 figure had been relayed by the coordinator *and* independently verified by the reviewer, and it was still wrong once the keyword rejection changed what the variants select. Re-reading a sentence confirms it is well-formed; only re-running the measurement behind it can falsify it.

## Verification

- `go test -count=1` green on `internal/custom/csharp`, `cmd/grafel`, `internal/resolve`, `internal/extractors`.
- `gofmt -l` clean, `go vet` clean.
- **Golden ratchet**: 38 gated fixtures held baseline (29 at 100% must-have recall), no baseline moved. **What that does and does not show:** the golden set has 8 `.cs` files (which the gate now excludes) and 4 `.razor` files (which never reached this extractor), and **zero `.razor.cs`**. So the ratchet confirms only that removing the noise moved no baseline — it **cannot see the extension this gate newly admits**, and no fixture exercises it. `grafel quality` does run with custom extractors ON (`quality.go:45`), so the `.cs` half is real coverage.
- All numbers macOS/APFS, measured in `.../scratchpad/impl-6975-r7k/wt`.

Closes #6975
Refs #6973, #6966, #6976, #6104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
