### PR TITLE
fix(#6976): a mention of a name evicted the sole declaration of it — six producers now say so, and one tier reads it

### DIFF
--- a/internal/custom/csharp/aspnet_request_response.go
+++ b/internal/custom/csharp/aspnet_request_response.go
@@ -78,6 +78,9 @@ func (e *aspnetReqRespExtractor) Extract(ctx context.Context, file extractor.Fil
 		ent := makeEntity(dtoType, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "aspnet_core", "provenance", "INFERRED_FROM_ASPNET_FROM_BODY",
 			"dto_kind", "request")
+		// #6976 — a `[FromBody] Foo foo` parameter annotation mentions the DTO
+		// type; the DTO class is declared in its own file.
+		markReferenceShaped(&ent)
 		add(ent)
 	}
 
@@ -102,6 +105,9 @@ func (e *aspnetReqRespExtractor) Extract(ctx context.Context, file extractor.Fil
 		ent := makeEntity(typeName, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "aspnet_core", "provenance", "INFERRED_FROM_ASPNET_RETURN_TYPE",
 			"dto_kind", "response")
+		// #6976 — an `ActionResult<Foo>` return annotation mentions `Foo`; the
+		// declaration is elsewhere.
+		markReferenceShaped(&ent)
 		add(ent)
 	}
 

--- a/internal/custom/csharp/blazor.go
+++ b/internal/custom/csharp/blazor.go
@@ -296,6 +296,8 @@ func (e *blazorExtractor) Extract(ctx context.Context, file extractor.FileInput)
 			ent := makeEntity(serviceType, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
 			setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_INJECT",
 				"service_type", serviceType)
+			// #6976 — `@inject IFoo Foo` names a service DECLARED elsewhere.
+			markReferenceShaped(&ent)
 			add(ent)
 		}
 	}
@@ -327,6 +329,9 @@ func (e *blazorExtractor) Extract(ctx context.Context, file extractor.FileInput)
 			}
 			ent := makeEntity(name, "SCOPE.UIComponent", "component", file.Path, file.Language, lineOf(src, m[0]))
 			setProps(&ent, "framework", "blazor", "provenance", "INFERRED_FROM_BLAZOR_COMPONENT_REF")
+			// #6976 — a `<Foo>` markup tag is a USE of the component declared
+			// in Foo.razor, not a second declaration of the name `Foo`.
+			markReferenceShaped(&ent)
 			add(ent)
 		}
 	}

--- a/internal/custom/csharp/dotnet_di.go
+++ b/internal/custom/csharp/dotnet_di.go
@@ -186,6 +186,10 @@ func (e *dotnetDIExtractor) Extract(ctx context.Context, file extractor.FileInpu
 			ent := makeEntity(provider, "SCOPE.Class", "", file.Path, "csharp", c.line)
 			setProps(&ent, "framework", "dotnet_di", "provenance", "INFERRED_FROM_DOTNET_DI_PROVIDER",
 				"di_role", "provider")
+			// #6976 — the carrier is a CONSTRUCTOR PARAMETER TYPE; the class
+			// it names is declared in its own file. Largest single producer
+			// in the measured eviction residual (403 claimants).
+			markReferenceShaped(&ent)
 			ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
 				ToID: "consumer:" + c.name,
 				Kind: string(types.RelationshipKindInjectedInto),

--- a/internal/custom/csharp/helpers.go
+++ b/internal/custom/csharp/helpers.go
@@ -197,3 +197,36 @@ func csSharedDispatchVerbOwner(src string) string {
 	}
 	return ""
 }
+
+// referenceShapedProp is the #6976 producer-side marker: this record was
+// minted from a MENTION of a name — a constructor parameter type, an
+// `ActionResult<T>` return annotation, an `@inject` service type, a `<Foo>`
+// markup tag — and NOT from the declaration of that name, which lives in
+// another file and is extracted separately.
+//
+// WHY IT IS STAMPED HERE AND NOT DERIVED DOWNSTREAM. internal/resolve's
+// byName index has the whole types.EntityRecord and still cannot tell the two
+// apart: no field means it, `provenance` is a producer id rather than a
+// semantic class, makeEntity above stamps StartLine == EndLine for the ENTIRE
+// C# custom lane (genuine declarations included) so span is a lane signal, and
+// the same makeEntity stamps QualityScore 1.0 uniformly. The emit site is the
+// only place that knows. Without the marker, a mention of `JsonResult` in one
+// controller evicted the sole real declaration of `JsonResult` from the
+// repository-wide name index and took every bare-name edge to it down with it.
+//
+// The spelling is shared with resolve.ReferenceShapedProp, which is the only
+// reader. The two are literal strings on both sides — the same arrangement
+// `local_scope` (#6467) uses between the JS extractor and the same reader —
+// and reference_shaped_marker_6976_test.go pins them equal so they cannot
+// drift.
+//
+// SCOPE (#6976). Stamped on the six measured reference-shaped producers in the
+// `aspnetcore-mvc` eviction population, NOT across the ~340-producer custom
+// lane. An unmarked producer keeps its pre-#6976 behaviour exactly.
+const referenceShapedProp = "reference_shaped"
+
+// markReferenceShaped stamps referenceShapedProp on a record. One helper so
+// every stamped emit site is greppable through a single symbol.
+func markReferenceShaped(e *types.EntityRecord) {
+	setProps(e, referenceShapedProp, "true")
+}

--- a/internal/custom/csharp/reference_shaped_marker_6976_test.go
+++ b/internal/custom/csharp/reference_shaped_marker_6976_test.go
@@ -1,0 +1,230 @@
+package csharp_test
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/grafel/internal/custom/csharp"
+	extreg "github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6976 — the producer side of the declaration-outranks-reference tier.
+//
+// internal/resolve cannot derive "is this record a declaration or a mention?"
+// from the record: no field means it, `provenance` is a producer id rather
+// than a semantic class, helpers.go's makeEntity stamps StartLine == EndLine
+// for the ENTIRE C# custom lane so span ranks the lane and not the record, and
+// the same makeEntity stamps QualityScore 1.0 uniformly. The emit site is the
+// only place that knows, so the marker is stamped there and this file pins it.
+//
+// WHY THE EXPECTATION IS AN INDEPENDENT LITERAL. wantMarked6976 below is
+// hand-written, NOT derived from any production table. A test that ranges over
+// the collection under test cannot detect a deletion from it — that exact
+// mistake shipped once in this area and was caught only by re-scoring (#6975
+// follow-up). Deleting a markReferenceShaped call must turn a row RED.
+//
+// THE MUTANTS THESE ARE WRITTEN TO KILL, more-permissive direction first:
+//
+//	m1 — delete any one of the six markReferenceShaped calls
+//	     => that producer's row in TestReferenceShapedProducersAreMarked6976
+//	        fails by name.
+//	m2 — stamp markReferenceShaped unconditionally in makeEntity (the
+//	     "mark the whole lane" shortcut)
+//	     => TestDeclarationShapedProducersAreNotMarked6976 fails: an @page
+//	        route, an [ApiController] route and a Blazor @code method are
+//	        declaration-shaped and must stay unmarked.
+//	m3 — change the stamped VALUE to anything but "true"
+//	     => every marked row fails, because resolve.isReferenceShaped tests
+//	        for the exact string.
+//	m4 — rename the property on one side only
+//	     => TestReferenceShapedPropSpelling_6976 in internal/resolve fails,
+//	        and so does every row here, because the rows read the constant
+//	        through resolve.ReferenceShapedProp rather than a local copy.
+
+// wantMarked6976 is the closed scope of #6976: the SIX measured producers in
+// the `aspnetcore-mvc` eviction population that mint an entity from a MENTION
+// of a name declared elsewhere. Written out by hand.
+//
+// Deliberately NOT a repo-wide taxonomy of the ~340 custom producers — see the
+// scope note on resolve.ReferenceShapedProp. Adding a seventh producer means
+// adding a row here.
+var wantMarked6976 = []struct {
+	provenance string
+	why        string
+}{
+	{"INFERRED_FROM_DOTNET_DI_PROVIDER", "constructor parameter type; the class is declared in its own file"},
+	{"INFERRED_FROM_ASPNET_RETURN_TYPE", "ActionResult<T> return annotation mentions T"},
+	{"INFERRED_FROM_ASPNET_FROM_BODY", "[FromBody] parameter annotation mentions the DTO type"},
+	{"INFERRED_FROM_FROM_BODY", "the validation lane's [FromBody] rule, same shape"},
+	{"INFERRED_FROM_BLAZOR_COMPONENT_REF", "a <Foo> markup tag is a USE of the component declared in Foo.razor"},
+	{"INFERRED_FROM_BLAZOR_INJECT", "@inject IFoo names a service declared elsewhere"},
+}
+
+// wantUnmarked6976 is the negative control, and it is what stops the fix from
+// being implemented as "mark the whole C# custom lane". Each of these
+// producers reads a DECLARATION: it is entitled to the repository-wide byName
+// slot and marking it would cost its own resolution.
+var wantUnmarked6976 = []string{
+	"INFERRED_FROM_BLAZOR_PAGE",        // @page "/counter" declares the route
+	"INFERRED_FROM_BLAZOR_CODE_METHOD", // a method DECLARATION in an @code block
+	"INFERRED_FROM_BLAZOR_PARAMETER",   // a [Parameter] property declaration
+}
+
+// csharpFixtures6976 are the sources that make every producer above fire. One
+// map, consumed by both directions, so the marked and unmarked verdicts are
+// read off the SAME extraction run and cannot drift apart.
+func csharpFixtures6976() map[string]extreg.FileInput {
+	return map[string]extreg.FileInput{
+		"custom_csharp_dotnet_di": {
+			Path: "src/Controllers/HomeController.cs", Language: "csharp",
+			Content: []byte(`
+public class HomeController {
+    public HomeController(ActionContext context, IWrapperProvider wrapper) { }
+}
+`),
+		},
+		"custom_csharp_aspnet_reqresp": {
+			Path: "src/Controllers/OrderController.cs", Language: "csharp",
+			Content: []byte(`
+[ApiController]
+public class OrderController : ControllerBase {
+    [HttpPost]
+    public ActionResult<OrderResponse> Create([FromBody] OrderRequest body) { return null; }
+}
+`),
+		},
+		"custom_csharp_validation": {
+			Path: "src/Controllers/PayController.cs", Language: "csharp",
+			Content: []byte(`
+public class PayController : ControllerBase {
+    public IActionResult Pay([FromBody] PaymentRequest body) { return null; }
+}
+`),
+		},
+		"custom_csharp_blazor": {
+			Path: "src/Pages/Counter.razor", Language: "csharp",
+			Content: []byte(`@page "/counter"
+@inject IWeatherService Weather
+
+<WeatherTable Rows="@rows" />
+
+@code {
+    [Parameter] public int Start { get; set; }
+
+    private void IncrementCount() { }
+}
+`),
+		},
+	}
+}
+
+// extractByProvenance6976 runs every fixture through its extractor and returns
+// provenance -> whether the emitted record carries the reference marker, plus
+// the entity name, so a row that never fired is distinguishable from a row
+// that fired unmarked.
+func extractByProvenance6976(t *testing.T) map[string]struct {
+	marked bool
+	name   string
+} {
+	t.Helper()
+	got := map[string]struct {
+		marked bool
+		name   string
+	}{}
+	for key, in := range csharpFixtures6976() {
+		e, ok := extreg.Get(key)
+		if !ok {
+			t.Fatalf("%s not registered", key)
+		}
+		recs, err := e.Extract(context.Background(), in)
+		if err != nil {
+			t.Fatalf("%s extract: %v", key, err)
+		}
+		for i := range recs {
+			collect6976(got, &recs[i])
+		}
+	}
+	return got
+}
+
+func collect6976(got map[string]struct {
+	marked bool
+	name   string
+}, r *types.EntityRecord) {
+	p := r.Properties["provenance"]
+	if p == "" {
+		return
+	}
+	// A provenance that fires more than once must agree with itself; OR-ing
+	// would let one marked record vouch for an unmarked sibling.
+	if prev, seen := got[p]; seen && prev.marked != (r.Properties[resolve.ReferenceShapedProp] == "true") {
+		got[p] = struct {
+			marked bool
+			name   string
+		}{false, prev.name + "|DISAGREES:" + r.Name}
+		return
+	}
+	got[p] = struct {
+		marked bool
+		name   string
+	}{r.Properties[resolve.ReferenceShapedProp] == "true", r.Name}
+}
+
+func TestReferenceShapedProducersAreMarked6976(t *testing.T) {
+	got := extractByProvenance6976(t)
+	for _, w := range wantMarked6976 {
+		t.Run(w.provenance, func(t *testing.T) {
+			v, fired := got[w.provenance]
+			if !fired {
+				t.Fatalf("fixture is vacuous: %s emitted no record, so this row asserts "+
+					"nothing. Fix the fixture, not the expectation.", w.provenance)
+			}
+			if !v.marked {
+				t.Errorf("%s emitted %q WITHOUT %s=true — %s. Unmarked, a mention of a name "+
+					"still evicts the sole declaration of that name from the repository-wide "+
+					"index and takes every bare-name edge to it down with it (#6976).",
+					w.provenance, v.name, resolve.ReferenceShapedProp, w.why)
+			}
+		})
+	}
+}
+
+func TestDeclarationShapedProducersAreNotMarked6976(t *testing.T) {
+	got := extractByProvenance6976(t)
+	for _, p := range wantUnmarked6976 {
+		t.Run(p, func(t *testing.T) {
+			v, fired := got[p]
+			if !fired {
+				t.Fatalf("fixture is vacuous: %s emitted no record, so this control asserts "+
+					"nothing", p)
+			}
+			if v.marked {
+				t.Errorf("%s emitted %q WITH %s=true, but it reads a DECLARATION. Marking it "+
+					"costs it the repository-wide slot it is entitled to; #6976 is scoped to "+
+					"records minted from a MENTION, not to the C# custom lane.",
+					p, v.name, resolve.ReferenceShapedProp)
+			}
+		})
+	}
+}
+
+// TestMarkedProducersAreExactlyTheMeasuredSix6976 closes the scope in the
+// other direction: nothing in the fixtures above may acquire the marker
+// without a row in wantMarked6976. Without this, a future "stamp it in
+// makeEntity" shortcut would pass both tests above.
+func TestMarkedProducersAreExactlyTheMeasuredSix6976(t *testing.T) {
+	want := map[string]bool{}
+	for _, w := range wantMarked6976 {
+		want[w.provenance] = true
+	}
+	for p, v := range extractByProvenance6976(t) {
+		if v.marked && !want[p] {
+			t.Errorf("%s emitted %q with %s=true but is not one of the six measured "+
+				"producers #6976 scopes the marker to. Either it is genuinely "+
+				"reference-shaped — then add a row to wantMarked6976 with the measurement "+
+				"that justifies it — or the stamp leaked.", p, v.name, resolve.ReferenceShapedProp)
+		}
+	}
+}

--- a/internal/custom/csharp/reference_shaped_marker_6976_test.go
+++ b/internal/custom/csharp/reference_shaped_marker_6976_test.go
@@ -43,9 +43,12 @@ import (
 //	        and so does every row here, because the rows read the constant
 //	        through resolve.ReferenceShapedProp rather than a local copy.
 
-// wantMarked6976 is the closed scope of #6976: the SIX measured producers in
-// the `aspnetcore-mvc` eviction population that mint an entity from a MENTION
-// of a name declared elsewhere. Written out by hand.
+// wantMarked6976 is the closed scope of #6976: six producers that mint an
+// entity from a MENTION of a name declared elsewhere. FIVE were measured in
+// the `aspnetcore-mvc` eviction population; the sixth, BLAZOR_INJECT, is
+// classified by SHAPE and is not in that population at all — #6976 names it
+// nowhere. Saying "six measured" would assert a measurement that was never
+// taken. Written out by hand.
 //
 // Deliberately NOT a repo-wide taxonomy of the ~340 custom producers — see the
 // scope note on resolve.ReferenceShapedProp. Adding a seventh producer means

--- a/internal/custom/csharp/validation.go
+++ b/internal/custom/csharp/validation.go
@@ -288,6 +288,9 @@ func (e *csharpValidationExtractor) Extract(ctx context.Context, file extractor.
 			"validation_framework", "FromBody",
 			"provenance", "INFERRED_FROM_FROM_BODY",
 		)
+		// #6976 — same shape as the aspnet [FromBody] rule: a parameter type
+		// annotation naming a DTO declared in another file.
+		markReferenceShaped(&dtoEnt)
 		add(dtoEnt)
 	}
 

--- a/internal/resolve/reference_decl_tier_6976_test.go
+++ b/internal/resolve/reference_decl_tier_6976_test.go
@@ -1,0 +1,459 @@
+// Package resolve — #6976: a record minted from a MENTION of a name evicted
+// the sole real DECLARATION of that name from the repository-wide byName
+// index, and took every bare-name edge to it down with it.
+//
+// THE SHAPE, from `aspnetcore-mvc` with the custom-extractor gate ON. The
+// .NET DI extractor reads a constructor parameter `ActionContext context` in
+// HomeController.cs and mints a SCOPE.Class named `ActionContext` in THAT
+// file. The class `ActionContext` is declared in ActionContext.cs and
+// extracted there. Two entities, one name, different files — so indexByName
+// took its default arm: `delete(byName, "ActionContext")` + ambiguous, for the
+// whole repository. Every bare-name TESTS edge naming `ActionContext` then
+// dangled, in files that had never heard of HomeController.
+//
+// WHY THE ASSERTIONS ARE ON EDGES AND NOT ON COUNTS. This defect survived a
+// measurement that reported explicit TESTS at +8 net while 7,221 edges were
+// SUBSTITUTED (#6973): a cardinality assertion cannot see a substitution. So
+// every case below names the id the edge must land on.
+package resolve_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const (
+	declFile6976 = "src/Mvc/ActionContext.cs"
+	ctrlFile6976 = "src/Mvc/Controllers/HomeController.cs"
+	apiFile6976  = "src/Mvc/Api/ApiController.cs"
+	testFile6976 = "test/Mvc.Test/ActionContextTest.cs"
+
+	// Stand-ins for the production sha256 ids — distinct by construction so
+	// no case can pass by ID collision.
+	declID6976     = "d000000000000001" // the real `class ActionContext`
+	ctrlRefID6976  = "d000000000000002" // DI provider mention in HomeController.cs
+	apiRefID6976   = "d000000000000003" // return-type mention in ApiController.cs
+	otherDecl6976  = "d000000000000004" // a SECOND real declaration of the name
+	placeholder976 = "d000000000000005" // a per-import placeholder for the name
+	localBind6976  = "d000000000000006" // a function-body local named the same
+	testerID6976   = "d000000000000009" // the test entity carrying the edge
+
+	sharedName6976 = "ActionContext"
+)
+
+// declRecord6976 is the real `public class ActionContext` — unmarked, the
+// thing every consumer of the name wants.
+func declRecord6976(id, file string) types.EntityRecord {
+	return types.EntityRecord{
+		ID: id, Kind: "SCOPE.Class", Name: sharedName6976,
+		SourceFile: file, Language: "csharp", StartLine: 12, EndLine: 40,
+	}
+}
+
+// refRecord6976 is a reference-shaped record: the entity a custom extractor
+// mints when it reads a MENTION of the name. `reference_shaped` is stamped at
+// the emit site (internal/custom/csharp) — see resolve.ReferenceShapedProp.
+func refRecord6976(id, file, provenance string) types.EntityRecord {
+	return types.EntityRecord{
+		ID: id, Kind: "SCOPE.Class", Name: sharedName6976,
+		SourceFile: file, Language: "csharp", StartLine: 7, EndLine: 7,
+		Properties: map[string]string{
+			"framework":                  "dotnet_di",
+			"provenance":                 provenance,
+			resolve.ReferenceShapedProp:  "true",
+			"grafel_fixture_marker_only": "6976",
+		},
+	}
+}
+
+// testerRecord6976 carries the bare-name TESTS edge the mechanism destroyed.
+func testerRecord6976() types.EntityRecord {
+	return types.EntityRecord{
+		ID: testerID6976, Kind: "SCOPE.Pattern", Name: "ActionContextTest",
+		Subtype: "unit", SourceFile: testFile6976, Language: "csharp",
+		Relationships: []types.RelationshipRecord{
+			{FromID: testerID6976, ToID: sharedName6976, Kind: "TESTS"},
+		},
+	}
+}
+
+// resolveTESTS6976 runs the production index + rewrite over recs and returns
+// the ToID the single TESTS edge ended up on. It fails the test if the fixture
+// stops carrying exactly one such edge, so no case can pass vacuously.
+func resolveTESTS6976(t *testing.T, recs []types.EntityRecord) string {
+	t.Helper()
+	cp := append([]types.EntityRecord(nil), recs...)
+	for i := range cp {
+		cp[i].Relationships = append([]types.RelationshipRecord(nil), cp[i].Relationships...)
+	}
+	idx := resolve.BuildIndex(cp)
+	resolve.ReferencesEmbedded(cp, idx)
+
+	got, seen := "", 0
+	for i := range cp {
+		for _, r := range cp[i].Relationships {
+			if r.Kind == "TESTS" {
+				seen++
+				got = r.ToID
+			}
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("fixture is vacuous: found %d TESTS edge(s), want exactly 1", seen)
+	}
+	return got
+}
+
+// bothOrders6976 runs one case in both extraction orders. Extraction order is
+// not stable across runs, so a tier that only works in one direction is a bug
+// that reports itself as a flake.
+func bothOrders6976(t *testing.T, a, b types.EntityRecord, check func(t *testing.T, got string)) {
+	t.Helper()
+	tester := testerRecord6976()
+	for _, o := range []struct {
+		tag  string
+		recs []types.EntityRecord
+	}{
+		{"a-then-b", []types.EntityRecord{a, b, tester}},
+		{"b-then-a", []types.EntityRecord{b, a, tester}},
+	} {
+		t.Run(o.tag, func(t *testing.T) {
+			check(t, resolveTESTS6976(t, o.recs))
+		})
+	}
+}
+
+// TestDeclarationOutranksReference_6976 is the reported defect. The bare-name
+// TESTS edge must land on the DECLARATION's id, in either extraction order.
+func TestDeclarationOutranksReference_6976(t *testing.T) {
+	bothOrders6976(t,
+		declRecord6976(declID6976, declFile6976),
+		refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER"),
+		func(t *testing.T, got string) {
+			if got != declID6976 {
+				t.Errorf("TESTS -> %q, want the declaration %q (%s): a record minted from a "+
+					"constructor-parameter MENTION of %q evicted the sole declaration of that "+
+					"name from the repository-wide index, leaving the edge unresolvable (#6976)",
+					got, declID6976, declFile6976, sharedName6976)
+			}
+		})
+}
+
+// TestTwoDeclarationsStillCollide_6976 is the OTHER direction, and it is the
+// one that matters more: the tier must not start resolving names that are
+// GENUINELY ambiguous between two real declarations. A confidently-wrong bind
+// reads as valid and is worse than a dangling reference (#6369).
+func TestTwoDeclarationsStillCollide_6976(t *testing.T) {
+	bothOrders6976(t,
+		declRecord6976(declID6976, declFile6976),
+		declRecord6976(otherDecl6976, apiFile6976),
+		func(t *testing.T, got string) {
+			if got != sharedName6976 {
+				t.Errorf("TESTS -> %q, want the edge LEFT UNRESOLVED as %q: two real "+
+					"declarations of one name are genuinely ambiguous, and the #6976 tier "+
+					"must not invent a winner for them (#6369 wrong-node hazard)",
+					got, sharedName6976)
+			}
+		})
+}
+
+// TestTwoReferencesStillCollide_6976 — two mentions and no declaration is not
+// a case where anything real is lost, and it must behave exactly as it did
+// before this tier: ambiguous, so lookupBareWithLocality and then
+// external.Synthesize still get their turn. Ambiguity is load-bearing (#6427),
+// and this tier does not trade it away.
+func TestTwoReferencesStillCollide_6976(t *testing.T) {
+	bothOrders6976(t,
+		refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER"),
+		refRecord6976(apiRefID6976, apiFile6976, "INFERRED_FROM_ASPNET_RETURN_TYPE"),
+		func(t *testing.T, got string) {
+			if got != sharedName6976 {
+				t.Errorf("TESTS -> %q, want the edge LEFT UNRESOLVED as %q: with no "+
+					"declaration of the name in the repository, two references must still "+
+					"collide into ambiguity rather than have one of them win arbitrarily",
+					got, sharedName6976)
+			}
+		})
+}
+
+// TestDeclarationReclaimsFromReferenceOnlyAmbiguity_6976 — once two references
+// have raised ambiguity, a declaration arriving LATER must still take the
+// slot. Without nameAmbigRef the name would stay dead for the rest of the
+// index, and which arm you land in would depend on file-walk order.
+func TestDeclarationReclaimsFromReferenceOnlyAmbiguity_6976(t *testing.T) {
+	recs := []types.EntityRecord{
+		refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER"),
+		refRecord6976(apiRefID6976, apiFile6976, "INFERRED_FROM_ASPNET_RETURN_TYPE"),
+		declRecord6976(declID6976, declFile6976),
+		testerRecord6976(),
+	}
+	if got := resolveTESTS6976(t, recs); got != declID6976 {
+		t.Errorf("TESTS -> %q, want the declaration %q: a declaration extracted AFTER two "+
+			"references must still reclaim the name — otherwise the tier's outcome depends "+
+			"on file-walk order (#6369's nameAmbigImport, same reason)", got, declID6976)
+	}
+}
+
+// TestLoneReferenceStillOccupiesTheSlot_6976 — withholding references from
+// byName entirely is NOT what this tier does, and the difference is
+// observable. A mention whose declaration is not in the indexed tree (a
+// framework type, a partial checkout) is the only claimant on its name, and
+// the edges that name it must still bind to it. Same clause #6369 keeps for a
+// lone import placeholder.
+func TestLoneReferenceStillOccupiesTheSlot_6976(t *testing.T) {
+	recs := []types.EntityRecord{
+		refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER"),
+		testerRecord6976(),
+	}
+	if got := resolveTESTS6976(t, recs); got != ctrlRefID6976 {
+		t.Errorf("TESTS -> %q, want the lone reference %q: the tier is a PRECEDENCE between "+
+			"competing records, not a blanket skip — an unclaimed name may still be occupied "+
+			"by a reference", got, ctrlRefID6976)
+	}
+}
+
+// TestReferenceDoesNotOutrankImportPlaceholder_6976 and its local-binding twin
+// pin the two pairings #6369 and #6467 already decided, in the direction this
+// tier could have broken them. A placeholder and a mention are both
+// non-declarations: neither may hand the other the repository-wide slot, so
+// the pairing must fall through to ambiguity and let the external-library
+// binder run.
+func TestReferenceDoesNotOutrankImportPlaceholder_6976(t *testing.T) {
+	placeholder := types.EntityRecord{
+		ID: placeholder976, Kind: "SCOPE.Component", Name: sharedName6976,
+		Subtype: "import", SourceFile: apiFile6976, Language: "csharp",
+		Properties: map[string]string{"provenance": "INFERRED_FROM_IMPORT_STATEMENT"},
+	}
+	bothOrders6976(t,
+		refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER"),
+		placeholder,
+		func(t *testing.T, got string) {
+			if got != sharedName6976 {
+				t.Errorf("TESTS -> %q, want the edge LEFT UNRESOLVED as %q: an import "+
+					"placeholder and a mention are both non-declarations, so neither may "+
+					"win the repository-wide slot from the other (#6369 + #6976)",
+					got, sharedName6976)
+			}
+		})
+}
+
+func TestReferenceDoesNotOutrankLocalBinding_6976(t *testing.T) {
+	local := types.EntityRecord{
+		ID: localBind6976, Kind: "SCOPE.Component", Name: sharedName6976,
+		Subtype: "const", SourceFile: apiFile6976, Language: "csharp",
+		Properties: map[string]string{"local_scope": "true"},
+	}
+	bothOrders6976(t,
+		refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER"),
+		local,
+		func(t *testing.T, got string) {
+			if got != sharedName6976 {
+				t.Errorf("TESTS -> %q, want the edge LEFT UNRESOLVED as %q: a function-body "+
+					"local and a mention are both non-declarations of the repository-wide "+
+					"name (#6467 + #6976)", got, sharedName6976)
+			}
+		})
+}
+
+// TestUnmarkedRecordIsUnchanged_6976 pins the SCOPE of the marker. This tier
+// is opt-in per producer: an entity that carries no `reference_shaped` stamp
+// competes exactly as it did before #6976 — which for two unmarked records of
+// one name means ambiguity. It is the control for every case above: if the
+// tier had been keyed on something derivable from the record (span, provenance
+// presence, confidence — all of which were measured and rejected), this case
+// would have changed too.
+func TestUnmarkedRecordIsUnchanged_6976(t *testing.T) {
+	unmarked := refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER")
+	delete(unmarked.Properties, resolve.ReferenceShapedProp)
+	bothOrders6976(t,
+		declRecord6976(declID6976, declFile6976),
+		unmarked,
+		func(t *testing.T, got string) {
+			if got != sharedName6976 {
+				t.Errorf("TESTS -> %q, want the edge LEFT UNRESOLVED as %q: without the "+
+					"producer-side stamp the record must behave exactly as it did before "+
+					"#6976 — the tier reads the marker and nothing else", got, sharedName6976)
+			}
+		})
+}
+
+// TestReferenceShapedPropSpelling_6976 pins the wire spelling. The producers
+// in internal/custom/csharp stamp this key as a literal string (the same
+// arrangement `local_scope` uses between the JS extractor and this package),
+// and a graph written by an older indexer carries whatever was current then.
+// Renaming the key silently un-marks every producer, which this package cannot
+// detect on its own — the corpus would just quietly regress.
+func TestReferenceShapedPropSpelling_6976(t *testing.T) {
+	if resolve.ReferenceShapedProp != "reference_shaped" {
+		t.Fatalf("ReferenceShapedProp = %q, want %q: the six producers in "+
+			"internal/custom/csharp stamp the literal string, so changing this constant "+
+			"un-marks all of them", resolve.ReferenceShapedProp, "reference_shaped")
+	}
+}
+
+// TestReferenceDoesNotReclaimPlaceholderOnlyAmbiguity_6976 grades the
+// ambigName early-return arm, which the pairing tests above never reach. Two
+// placeholders raise placeholder-only ambiguity; #6369 lets a real declaration
+// arriving later reclaim the name. A mention is not a real declaration, so it
+// must NOT — otherwise the very case #6427 kept ambiguous for the
+// external-library binder gets a confident wrong bind instead.
+func TestReferenceDoesNotReclaimPlaceholderOnlyAmbiguity_6976(t *testing.T) {
+	ph := func(id, file string) types.EntityRecord {
+		return types.EntityRecord{
+			ID: id, Kind: "SCOPE.Component", Name: sharedName6976,
+			Subtype: "import", SourceFile: file, Language: "csharp",
+			Properties: map[string]string{"provenance": "INFERRED_FROM_IMPORT_STATEMENT"},
+		}
+	}
+	recs := []types.EntityRecord{
+		ph(placeholder976, apiFile6976),
+		ph("d00000000000000a", ctrlFile6976),
+		refRecord6976(ctrlRefID6976, declFile6976, "INFERRED_FROM_ASPNET_RETURN_TYPE"),
+		testerRecord6976(),
+	}
+	if got := resolveTESTS6976(t, recs); got != sharedName6976 {
+		t.Errorf("TESTS -> %q, want the edge LEFT UNRESOLVED as %q: placeholder-only "+
+			"ambiguity yields to a DECLARATION arriving later (#6369), and a mention is "+
+			"not one — reclaiming here would hand the name to a record that declares "+
+			"nothing", got, sharedName6976)
+	}
+}
+
+// TestSameIDReindexDoesNotReRaiseReferenceStatus_6976 grades the AND-ing in
+// the insert tail. EntityID is sha256(repo, kind, name, sourceFile) and hashes
+// neither Subtype nor Properties, so a declaration and a mention of the same
+// name in the SAME file share one id by construction and arrive as re-indexes
+// of one entity. If a trailing marked record could flip the flag back on, the
+// flag would describe the last record that mentioned the name rather than the
+// entity sitting in byName — and the next file's real declaration would take
+// the "declaration reclaims from a reference" arm instead of colliding, so a
+// genuinely ambiguous name would silently resolve to whichever file was walked
+// last. That is #6369's follow-up bug, one tier over.
+func TestSameIDReindexDoesNotReRaiseReferenceStatus_6976(t *testing.T) {
+	sameID := "d00000000000000b"
+	decl := declRecord6976(sameID, declFile6976)
+	mention := refRecord6976(sameID, declFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER")
+	competitor := declRecord6976(otherDecl6976, apiFile6976)
+
+	recs := []types.EntityRecord{decl, mention, competitor, testerRecord6976()}
+	if got := resolveTESTS6976(t, recs); got != sharedName6976 {
+		t.Errorf("TESTS -> %q, want the edge LEFT UNRESOLVED as %q: %s carries BOTH a "+
+			"declaration record and a mention record on one id, so the id is a "+
+			"declaration; the second real declaration in %s makes the name genuinely "+
+			"ambiguous and must not be resolved to either",
+			got, sharedName6976, declFile6976, apiFile6976)
+	}
+}
+
+// TestSameFilePairingIsUnchanged_6976 scopes the tier to CROSS-FILE pairings,
+// which is the only shape the defect has: the reference is minted in the file
+// that MENTIONS the name and the declaration lives in its own file. #6976's
+// own body says why the same-file case is different — "#6104's facet rule
+// rescues same-name pairs that are two views of one thing in one file. It does
+// not apply here because the claimants live in different files, which is
+// precisely the case that goes to the destructive default arm."
+//
+// THIS IS NOT A HYPOTHETICAL. The golden fixture csharp-aspnet-core-mini has
+// `IUserService` with NO declaration anywhere in the tree and two claimants in
+// ONE file, Controllers/UsersController.cs: the .NET DI pass's SCOPE.Class
+// (reference-shaped) and the YAML rule-pack's `Dependency` (unmarked, and also
+// a mention — internal/engine/detector.go is not one of the six producers and
+// is deliberately out of scope). Before this scoping the pair stopped
+// colliding and the unmarked record took the slot outright, which moved
+// `UserService -IMPLEMENTS-> IUserService` off the SCOPE.Class node and
+// regressed the fixture's must-have relationship_found 13 -> 12. Ambiguity was
+// carrying that edge to a better answer through the kind-hint path, which is
+// exactly why this tier narrows WHICH records compete rather than softening
+// the default arm.
+func TestSameFilePairingIsUnchanged_6976(t *testing.T) {
+	// Both claimants in ONE file, as the fixture has them. Distinct kinds, so
+	// distinct ids — a real collision, not a re-index of one entity.
+	marked := refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER")
+	unmarked := types.EntityRecord{
+		ID: apiRefID6976, Kind: "Dependency", Name: sharedName6976,
+		SourceFile: ctrlFile6976, Language: "csharp",
+		Properties: map[string]string{"framework": "csharp", "pattern_type": "yaml_driven"},
+	}
+	bothOrders6976(t, marked, unmarked, func(t *testing.T, got string) {
+		if got != sharedName6976 {
+			t.Errorf("TESTS -> %q, want the edge LEFT UNRESOLVED as %q: two claimants in one "+
+				"file are the #6104 shape, not the #6976 one, and must keep colliding — "+
+				"resolving them hands the slot to whichever record happens to be unmarked "+
+				"(golden fixture csharp-aspnet-core-mini, must-have IMPLEMENTS edge)",
+				got, sharedName6976)
+		}
+	})
+}
+
+// TestCrossFileTierStillFiresWhenSameFileIsScopedOut_6976 is the control for
+// the test above: the narrowing must not cost the fix. Same two records, the
+// reference moved to its own file — the reported shape — and the declaration
+// must win.
+func TestCrossFileTierStillFiresWhenSameFileIsScopedOut_6976(t *testing.T) {
+	bothOrders6976(t,
+		declRecord6976(declID6976, declFile6976),
+		refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER"),
+		func(t *testing.T, got string) {
+			if got != declID6976 {
+				t.Errorf("TESTS -> %q, want the declaration %q: scoping the tier to "+
+					"cross-file pairings must not disarm it for the shape it exists to fix",
+					got, declID6976)
+			}
+		})
+}
+
+// TestHolderFileFollowsTheSlot_6976 grades the bookkeeping the cross-file test
+// rests on. nameHolderFile must describe the entity CURRENTLY in byName, not
+// the last record that touched the name. When a declaration reclaims the slot
+// from a cross-file reference, the recorded file has to move to the
+// declaration's file — otherwise a SECOND reference arriving from the FIRST
+// reference's file reads as same-file, the tier steps aside, and the pair
+// falls to the default arm that destroys the declaration all over again.
+//
+// Three records, in the order the walk produces them: a reference in
+// HomeController.cs, the declaration in ActionContext.cs, then a second
+// reference (different kind, so a different id) back in HomeController.cs.
+func TestHolderFileFollowsTheSlot_6976(t *testing.T) {
+	secondRef := refRecord6976("d00000000000000c", ctrlFile6976, "INFERRED_FROM_ASPNET_RETURN_TYPE")
+	secondRef.Kind = "SCOPE.Schema" // distinct kind => distinct id => a real second claimant
+
+	recs := []types.EntityRecord{
+		refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER"),
+		declRecord6976(declID6976, declFile6976),
+		secondRef,
+		testerRecord6976(),
+	}
+	if got := resolveTESTS6976(t, recs); got != declID6976 {
+		t.Errorf("TESTS -> %q, want the declaration %q: after the declaration reclaimed the "+
+			"slot, the recorded holder file must be %s. Leaving it at %s makes the second "+
+			"reference look same-file, the tier stands down, and the declaration is evicted "+
+			"again — the defect, reintroduced two records later",
+			got, declID6976, declFile6976, ctrlFile6976)
+	}
+}
+
+// TestHolderFileFollowsTheSlotAfterPlaceholderDisplacement_6976 is the same
+// bookkeeping claim on the OTHER arm that hands the slot over: #6369's "a real
+// declaration displaces the placeholder that happened to be extracted first".
+// The recorded file has to move there too, for the same reason.
+func TestHolderFileFollowsTheSlotAfterPlaceholderDisplacement_6976(t *testing.T) {
+	placeholder := types.EntityRecord{
+		ID: placeholder976, Kind: "SCOPE.Component", Name: sharedName6976,
+		Subtype: "import", SourceFile: ctrlFile6976, Language: "csharp",
+		Properties: map[string]string{"provenance": "INFERRED_FROM_IMPORT_STATEMENT"},
+	}
+	recs := []types.EntityRecord{
+		placeholder,
+		declRecord6976(declID6976, declFile6976),
+		refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER"),
+		testerRecord6976(),
+	}
+	if got := resolveTESTS6976(t, recs); got != declID6976 {
+		t.Errorf("TESTS -> %q, want the declaration %q: the declaration displaced a "+
+			"placeholder from %s, so the holder file must become %s. Left at %s, the "+
+			"reference that follows reads as same-file, the tier stands down, and the "+
+			"declaration is evicted", got, declID6976, ctrlFile6976, declFile6976, ctrlFile6976)
+	}
+}

--- a/internal/resolve/reference_decl_tier_6976_test.go
+++ b/internal/resolve/reference_decl_tier_6976_test.go
@@ -457,3 +457,138 @@ func TestHolderFileFollowsTheSlotAfterPlaceholderDisplacement_6976(t *testing.T)
 			"declaration is evicted", got, declID6976, ctrlFile6976, declFile6976, ctrlFile6976)
 	}
 }
+
+// allOrders6976 runs one case in EVERY claimant order. bothOrders6976 covers
+// the two orders of a pair; this covers the whole permutation space of a set of
+// any size, because the hole this file shipped with was a THREE-claimant one
+// that neither order of any pair can reach. Hand-picking a representative order
+// is what let it through: the same-file three-claimant set binds in `ref, ref,
+// decl` and stays ambiguous in the other two rotations, so a test that sampled
+// one order would have reported either "unchanged" or "broken" depending on
+// which one it happened to sample.
+func allOrders6976(t *testing.T, claimants []types.EntityRecord, check func(t *testing.T, order string, got string)) {
+	t.Helper()
+	var perm func(prefix, rest []types.EntityRecord)
+	seen := 0
+	perm = func(prefix, rest []types.EntityRecord) {
+		if len(rest) == 0 {
+			tag := ""
+			for _, r := range prefix {
+				if tag != "" {
+					tag += ","
+				}
+				tag += r.ID
+			}
+			seen++
+			t.Run(tag, func(t *testing.T) {
+				recs := append(append([]types.EntityRecord(nil), prefix...), testerRecord6976())
+				check(t, tag, resolveTESTS6976(t, recs))
+			})
+			return
+		}
+		for i := range rest {
+			next := append(append([]types.EntityRecord(nil), rest[:i]...), rest[i+1:]...)
+			perm(append(append([]types.EntityRecord(nil), prefix...), rest[i]), next)
+		}
+	}
+	perm(nil, claimants)
+
+	want := 1
+	for i := 2; i <= len(claimants); i++ {
+		want *= i
+	}
+	if seen != want {
+		t.Fatalf("enumeration is incomplete: ran %d order(s), want %d (%d! for %d claimants)",
+			seen, want, len(claimants), len(claimants))
+	}
+}
+
+// sameFileUnmarked6976 is the unmarked same-file claimant from the golden
+// fixture's shape: internal/engine/detector.go's YAML rule-pack `Dependency`.
+// It is a mention too, but its producer is deliberately out of scope, so it
+// carries no marker — which is exactly why it must not be handed the slot.
+func sameFileUnmarked6976(id string) types.EntityRecord {
+	return types.EntityRecord{
+		ID: id, Kind: "Dependency", Name: sharedName6976,
+		SourceFile: ctrlFile6976, Language: "csharp",
+		Properties: map[string]string{"framework": "csharp", "pattern_type": "yaml_driven"},
+	}
+}
+
+// TestSameFileThreeClaimantsStayAmbiguous_6976 closes the hole the pairing test
+// above could not see, and it is enumerated rather than sampled.
+//
+// THE DEFECT, as an independent review exhibited it. The two arms that decide a
+// same-file pairing are scoped to cross-file claimants; the RECLAIM path out of
+// `ambigName` was not. So three claimants in ONE file — two reference-shaped,
+// one unmarked — bound to the unmarked record in claimant order `ref, ref,
+// decl` and stayed ambiguous in the other two rotations, against a parent that
+// is ambiguous in all three. Two things wrong with that, and the second is
+// worse than the first:
+//
+//   - the winner is the UNMARKED record — the IUserService mechanism that
+//     regressed csharp-aspnet-core-mini 13 -> 12, reappearing in the one shape
+//     the cross-file scoping was added to prevent. The fixture escapes only
+//     because it has two claimants rather than three;
+//   - a same-file outcome that is order-INDEPENDENT on the parent becomes
+//     order-DEPENDENT here, in a file whose own comments say "extraction order
+//     is not stable, so both directions are needed". A tier that is right in
+//     one order out of six does not report itself as a bug, it reports itself
+//     as a flake.
+//
+// Fixed by raising nameAmbigRef only for a CROSS-FILE reference pair, so the
+// reclaim it authorises is cross-file too. See indexByName.
+func TestSameFileThreeClaimantsStayAmbiguous_6976(t *testing.T) {
+	// Distinct kinds => distinct ids => three real claimants, not re-indexes
+	// of one entity. All three in Controllers/HomeController.cs.
+	refA := refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER")
+	refB := refRecord6976(apiRefID6976, ctrlFile6976, "INFERRED_FROM_ASPNET_RETURN_TYPE")
+	refB.Kind = "SCOPE.Schema"
+	unmarked := sameFileUnmarked6976(otherDecl6976)
+
+	allOrders6976(t, []types.EntityRecord{refA, refB, unmarked},
+		func(t *testing.T, order, got string) {
+			if got != sharedName6976 {
+				t.Errorf("order %s: TESTS -> %q, want the edge LEFT UNRESOLVED as %q. Three "+
+					"claimants in ONE file are the #6104 shape; resolving them hands the "+
+					"repo-wide slot to whichever record happens to be unmarked, and makes "+
+					"a same-file outcome depend on extraction order",
+					order, got, sharedName6976)
+			}
+		})
+}
+
+// TestSameFilePairingIsEnumerated_6976 re-states the pairing case above over
+// the full permutation space rather than a hand-picked order, so the same-file
+// claim this file makes is observed at both sizes it can have: 2! + 3! = 8
+// orders, none of which may resolve.
+func TestSameFilePairingIsEnumerated_6976(t *testing.T) {
+	allOrders6976(t, []types.EntityRecord{
+		refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER"),
+		sameFileUnmarked6976(apiRefID6976),
+	}, func(t *testing.T, order, got string) {
+		if got != sharedName6976 {
+			t.Errorf("order %s: TESTS -> %q, want %q (unresolved)", order, got, sharedName6976)
+		}
+	})
+}
+
+// TestCrossFileThreeClaimantsStillReclaim_6976 is the control: scoping
+// nameAmbigRef to cross-file pairs must not cost the fix. The SAME three-record
+// shape with the claimants in three different files must land on the
+// declaration in ALL SIX orders — including `ref, ref, decl`, which is the one
+// order that goes through the nameAmbigRef reclaim path the guard narrows.
+func TestCrossFileThreeClaimantsStillReclaim_6976(t *testing.T) {
+	refA := refRecord6976(ctrlRefID6976, ctrlFile6976, "INFERRED_FROM_DOTNET_DI_PROVIDER")
+	refB := refRecord6976(apiRefID6976, apiFile6976, "INFERRED_FROM_ASPNET_RETURN_TYPE")
+	decl := declRecord6976(declID6976, declFile6976)
+
+	allOrders6976(t, []types.EntityRecord{refA, refB, decl},
+		func(t *testing.T, order, got string) {
+			if got != declID6976 {
+				t.Errorf("order %s: TESTS -> %q, want the declaration %q: narrowing the "+
+					"reference-only-ambiguity flag to cross-file pairs must not disarm the "+
+					"reclaim for the shape the tier exists to fix", order, got, declID6976)
+			}
+		})
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1996,10 +1996,32 @@ func (idx *Index) indexByName(name, id, srcFile string, isFacet bool, facetAncho
 				}
 				idx.nameAmbigImport[name] = true
 			}
-			if isRef && idx.nameHolderRef[name] {
-				// #6976 — both sides are references; no declaration of this
-				// name has been seen. Recoverable by one arriving later,
-				// exactly as placeholder-only ambiguity is.
+			if isRef && idx.nameHolderRef[name] &&
+				idx.nameHolderFile[name] != srcFile {
+				// #6976 — both sides are references, IN DIFFERENT FILES; no
+				// declaration of this name has been seen. Recoverable by one
+				// arriving later, exactly as placeholder-only ambiguity is.
+				//
+				// SCOPED TO CROSS-FILE, and this is where the scoping has to
+				// live. The reclaim branch at the top of indexByName reads
+				// nameAmbigRef, but by the time it runs nameHolderFile has
+				// already been deleted (three lines below), so it cannot
+				// re-derive which files raised the ambiguity — a cross-file
+				// guard added THERE would compare against an empty string and
+				// always fire. Raising the flag only for a cross-file
+				// reference pair is what makes the reclaim cross-file.
+				//
+				// Without it, three claimants in ONE file — two references and
+				// one unmarked record — bind in claimant order `ref, ref,
+				// decl` and stay ambiguous in the other two orders, so a
+				// same-file outcome that is order-INDEPENDENT before #6976
+				// becomes order-DEPENDENT, and the record that wins is the
+				// unmarked one: the exact IUserService mechanism that regressed
+				// csharp-aspnet-core-mini and that the cross-file scoping on
+				// the two arms above exists to prevent. That fixture escapes
+				// only because it has two claimants rather than three.
+				// TestSameFileThreeClaimantsStayAmbiguous_6976 enumerates all
+				// six orders.
 				if idx.nameAmbigRef == nil {
 					idx.nameAmbigRef = make(map[string]bool)
 				}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -469,6 +469,23 @@ type Index struct {
 	// by indexByName, excluded from index parity.
 	nameHolderLocal map[string]bool
 
+	// nameHolderRef[name] = true when the entity currently occupying
+	// byName[name] was minted from a MENTION of the name rather than from a
+	// declaration of it (#6976) — see isReferenceShaped. nameAmbigRef[name] =
+	// true when ambigName[name] was raised by a reference-vs-reference
+	// collision ALONE, so a declaration arriving later can still reclaim the
+	// slot, exactly as nameAmbigImport does for placeholder-only ambiguity.
+	// Same build-time bookkeeping category as the maps above — lazily
+	// created, read only by indexByName, excluded from index parity.
+	nameHolderRef map[string]bool
+	nameAmbigRef  map[string]bool
+
+	// nameHolderFile[name] = the normalised SourceFile of the entity
+	// currently occupying byName[name]. Read only by the #6976 tier, which
+	// is scoped to CROSS-FILE pairings — see indexByName. Same build-time
+	// bookkeeping category as the maps above.
+	nameHolderFile map[string]string
+
 	// byQualifiedName[qualified_name] = entity_id. Direct lookup for
 	// stubs whose ToID is an entity QualifiedName verbatim (e.g. markdown
 	// CONTAINS edges where ToID = "<file>::<heading-slug>"). Issue #100.
@@ -1590,9 +1607,10 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		// (even across kinds) flips the name to ambiguous. Shared with the
 		// module-partitioned index writer (insertModuleEntry) so the two
 		// production paths cannot drift.
-		idx.indexByName(e.Name, e.ID, isFacet, facetAnchor,
+		idx.indexByName(e.Name, e.ID, sourceFile, isFacet, facetAnchor,
 			isImportPlaceholderKind(e.Kind, e.Subtype),
-			isLocalBindingKind(e.Subtype, e.Properties))
+			isLocalBindingKind(e.Subtype, e.Properties),
+			isReferenceShaped(e.Properties))
 	}
 	return idx
 }
@@ -1738,6 +1756,45 @@ func isLocalBindingKind(_ string, props map[string]string) bool {
 	return props["local_scope"] == "true"
 }
 
+// ReferenceShapedProp is the producer-stamped marker that an entity record was
+// minted from a MENTION of a name — a constructor parameter type, a return
+// type annotation, a `<Foo>` component tag — rather than from the declaration
+// of that name. The declaration lives in another file and is extracted
+// separately; this record is a second, weaker claimant on the same name.
+//
+// #6976 — WHY THE MARKER IS PRODUCER-SIDE. `indexByName` sees the whole
+// types.EntityRecord and still cannot derive this. Measured on the 6,274
+// records that evict a sole real declaration on `aspnetcore-mvc`: no field
+// means declaration-vs-reference; `provenance` is a producer id, not a
+// semantic class (three of the twelve evicting producers are
+// declaration-shaped, and 58 evicting claimants carry no provenance at all);
+// the span signal is useless because internal/custom/csharp/helpers.go's
+// makeEntity stamps StartLine == EndLine for the ENTIRE C# custom lane,
+// genuine declarations included; and the same makeEntity stamps
+// QualityScore 1.0 uniformly. The emit site is the only place that knows
+// whether it just read a declaration or a call site, so that is where the
+// marker is stamped.
+//
+// SCOPE. This is deliberately NOT a repo-wide taxonomy of the ~340 custom
+// producers. It is stamped on the six MEASURED producers in the
+// `aspnetcore-mvc` eviction population that mint an entity from a mention;
+// every other producer stays unmarked and behaves exactly as before. An
+// unmarked reference is the pre-#6976 status quo, not a regression.
+//
+// The property convention mirrors #6467's `local_scope`: an extractor-stamped
+// Properties key with a single named predicate in this package, rather than a
+// new EntityRecord field or a Subtype convention. A Subtype is load-bearing
+// for denoise, docs and the #6104 facet rule, so overloading it would move
+// consumers that have nothing to do with resolution.
+const ReferenceShapedProp = "reference_shaped"
+
+// isReferenceShaped reports whether a record carries the #6976 producer-side
+// marker. Deliberately a property read and nothing else: the point of the
+// marker is that no heuristic over the record can stand in for it.
+func isReferenceShaped(props map[string]string) bool {
+	return props[ReferenceShapedProp] == "true"
+}
+
 // indexByName is the sole writer of byName / ambigName. Both production index
 // builders (flat BuildIndex and the module-partitioned insertModuleEntry) go
 // through it, so the two paths stay edge-set-identical by construction.
@@ -1791,7 +1848,36 @@ func isLocalBindingKind(_ string, props map[string]string) bool {
 // keeps a single-record name resolvable at all. The claim this tier supports
 // is therefore the narrow one: a local binding neither TAKES the repo-wide
 // slot from an import placeholder nor KEEPS it against one.
-func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string, isImport, isLocal bool) {
+// #6976 — "NOT A PLACEHOLDER AND NOT A LOCAL" IS STILL NOT "A DECLARATION".
+// The two tiers above rank on placeholder-ness and on addressability. A record
+// minted from a MENTION of a name — a constructor parameter type, an
+// `ActionResult<T>` return annotation, a `<Foo>` markup tag — is neither a
+// placeholder nor a local, so it landed in the declaration bucket and
+// annihilated the sole real declaration of the name: `delete(byName)` +
+// ambiguous, for the whole repository. Measured on `aspnetcore-mvc` with the
+// custom-extractor gate ON: of 3,236 gate-introduced evictions, 1,222 destroy
+// a sole base-path declaration, 2,014 are reference-vs-reference (nothing real
+// is lost), and ZERO are declaration-vs-declaration — so the regression is
+// entirely a ranking problem and no legitimate ambiguity is at stake.
+//
+// The tier has the same shape as the two above, and the same three clauses:
+//
+//   - a reference neither displaces an unmarked incumbent nor blanks it;
+//   - an unmarked record RECLAIMS the slot from a reference that was extracted
+//     first (extraction order is not stable, so both directions are needed);
+//   - two references still collide into ambiguity exactly as before, so no
+//     arbitrary winner is invented for a name no declaration claims.
+//     nameAmbigRef remembers that such ambiguity is reference-only so a
+//     declaration arriving later can still reclaim, mirroring nameAmbigImport.
+//
+// A reference is also barred from RECLAIMING placeholder-only ambiguity and
+// from displacing a placeholder incumbent, for the reason #6467 barred a local
+// from both: it is not a declaration of the name in any scope, so the pairing
+// must fall through to ambiguity and let lookupBareWithLocality and then
+// external.Synthesize run. Ambiguity is load-bearing here and is not traded
+// away — this tier narrows WHICH records compete, it does not soften the
+// default arm.
+func (idx *Index) indexByName(name, id, srcFile string, isFacet bool, facetAnchor string, isImport, isLocal, isRef bool) {
 	if name == "" {
 		return
 	}
@@ -1800,13 +1886,19 @@ func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string,
 		// #6369 — placeholder-only ambiguity yields to a real declaration.
 		// #6467 — a function-local binding is not one: it must not reclaim a
 		// name that only placeholders contested.
-		if isImport || isLocal || !idx.nameAmbigImport[name] {
+		// #6976 — nor is a reference-shaped record; and reference-only
+		// ambiguity yields to a declaration on the same terms.
+		if isImport || isLocal || isRef ||
+			!(idx.nameAmbigImport[name] || idx.nameAmbigRef[name]) {
 			return
 		}
 		delete(idx.ambigName, name)
 		delete(idx.nameAmbigImport, name)
+		delete(idx.nameAmbigRef, name)
 		delete(idx.nameHolderImport, name)
 		delete(idx.nameHolderLocal, name)
+		delete(idx.nameHolderRef, name)
+		delete(idx.nameHolderFile, name)
 		delete(idx.aliasAnchor, nk)
 	}
 	existing, held := idx.byName[name]
@@ -1819,7 +1911,8 @@ func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string,
 		// ORPHANED facet must NOT suppress ambiguity against an unrelated
 		// same-named definition.
 		switch {
-		case isImport && !idx.nameHolderImport[name] && !idx.nameHolderLocal[name]:
+		case isImport && !idx.nameHolderImport[name] && !idx.nameHolderLocal[name] &&
+			!idx.nameHolderRef[name]:
 			// #6369 — a real declaration already owns the name: the
 			// placeholder neither displaces it nor blanks it.
 			//
@@ -1828,7 +1921,12 @@ func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string,
 			// binding, this pairing falls to the default arm and collides,
 			// so the name goes ambiguous and the import can still reach the
 			// external-library binder.
-		case !isImport && !isLocal && idx.nameHolderImport[name]:
+			//
+			// #6976 — nor does a reference-shaped incumbent count. A
+			// placeholder and a mention are both non-declarations; letting
+			// the placeholder yield to a mention would hand the repo-wide
+			// slot to a record neither of them declares.
+		case !isImport && !isLocal && !isRef && idx.nameHolderImport[name]:
 			// #6369 — the real declaration displaces the placeholder that
 			// happened to be extracted first.
 			//
@@ -1836,8 +1934,10 @@ func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string,
 			// declaration of the name in any scope but its own, so it
 			// collides instead.
 			idx.byName[name] = id
+			idx.setNameHolderFile(name, srcFile)
 			delete(idx.nameHolderImport, name)
 			delete(idx.nameHolderLocal, name)
+			delete(idx.nameHolderRef, name)
 			delete(idx.aliasAnchor, nk)
 			if isFacet {
 				idx.setAliasAnchor(nk, facetAnchor)
@@ -1847,7 +1947,42 @@ func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string,
 		case !isFacet && idx.aliasAnchor[nk] == id:
 			// the anchor itself, arriving after its facet: take over
 			idx.byName[name] = id
+			idx.setNameHolderFile(name, srcFile)
 			delete(idx.aliasAnchor, nk)
+		case isRef && idx.nameHolderFile[name] != srcFile &&
+			!idx.nameHolderRef[name] && !idx.nameHolderImport[name] &&
+			!idx.nameHolderLocal[name]:
+			// #6976 — the incumbent is a declaration of the name, in ANOTHER
+			// file: the reference neither displaces it nor blanks it. Ordered
+			// AFTER the #6104 facet arms so the facet/anchor pairing is
+			// decided first and this tier cannot change which record anchors
+			// an alias.
+			//
+			// SCOPED TO CROSS-FILE PAIRINGS. Two claimants in ONE file are
+			// #6104's shape — two views of one construct — and #6976's own
+			// body says so. Measured cost of not scoping it: golden fixture
+			// csharp-aspnet-core-mini has `IUserService` with no declaration
+			// anywhere and two same-file claimants, the .NET DI pass's
+			// SCOPE.Class (marked) and internal/engine/detector.go's YAML
+			// rule-pack `Dependency` (unmarked, and also a mention — that
+			// producer is deliberately out of scope). Unscoped, the pair
+			// stopped colliding, the unmarked record took the slot outright,
+			// and the fixture's must-have
+			// `UserService -IMPLEMENTS-> IUserService` moved off the
+			// SCOPE.Class node: relationship_found 13 -> 12.
+		case !isRef && !isImport && !isLocal && idx.nameHolderRef[name] &&
+			idx.nameHolderFile[name] != srcFile:
+			// #6976 — the declaration reclaims the slot from a cross-file
+			// reference that happened to be extracted first.
+			idx.byName[name] = id
+			idx.setNameHolderFile(name, srcFile)
+			delete(idx.nameHolderRef, name)
+			delete(idx.nameHolderImport, name)
+			delete(idx.nameHolderLocal, name)
+			delete(idx.aliasAnchor, nk)
+			if isFacet {
+				idx.setAliasAnchor(nk, facetAnchor)
+			}
 		default:
 			// any other pairing is a real collision
 			delete(idx.byName, name)
@@ -1861,12 +1996,24 @@ func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string,
 				}
 				idx.nameAmbigImport[name] = true
 			}
+			if isRef && idx.nameHolderRef[name] {
+				// #6976 — both sides are references; no declaration of this
+				// name has been seen. Recoverable by one arriving later,
+				// exactly as placeholder-only ambiguity is.
+				if idx.nameAmbigRef == nil {
+					idx.nameAmbigRef = make(map[string]bool)
+				}
+				idx.nameAmbigRef[name] = true
+			}
 			delete(idx.nameHolderImport, name)
 			delete(idx.nameHolderLocal, name)
+			delete(idx.nameHolderRef, name)
+			delete(idx.nameHolderFile, name)
 		}
 		return
 	}
 	idx.byName[name] = id
+	idx.setNameHolderFile(name, srcFile)
 	switch {
 	case !isImport:
 		delete(idx.nameHolderImport, name)
@@ -1919,9 +2066,40 @@ func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string,
 		}
 		idx.nameHolderLocal[name] = true
 	}
+	// #6976 — reference status is AND-ed, never re-raised, for the same reason
+	// the two flags above are. EntityID is sha256(repo, kind, name,
+	// sourceFile) and hashes neither Subtype nor Properties, so a
+	// reference-shaped record and a declaration for the same name in the same
+	// file share ONE id by construction and arrive here as re-indexes of one
+	// entity. An id known under any declaration is a declaration; letting a
+	// trailing reference record flip the flag back would make the flag
+	// describe the last record that mentioned the name rather than the entity
+	// sitting in byName — the exact bookkeeping bug #6369's follow-up fixed.
+	switch {
+	case !isRef:
+		delete(idx.nameHolderRef, name)
+	case held && !idx.nameHolderRef[name]:
+		// same id, already claimed by a declaration-shaped record — leave it.
+	default:
+		if idx.nameHolderRef == nil {
+			idx.nameHolderRef = make(map[string]bool)
+		}
+		idx.nameHolderRef[name] = true
+	}
 	if isFacet {
 		idx.setAliasAnchor(nk, facetAnchor)
 	}
+}
+
+// setNameHolderFile records the SourceFile of the entity now occupying
+// byName[name] (#6976), creating the map on first use. Every byName write in
+// indexByName goes through it so the #6976 cross-file test cannot read a stale
+// file for a slot that has since changed hands.
+func (idx *Index) setNameHolderFile(name, srcFile string) {
+	if idx.nameHolderFile == nil {
+		idx.nameHolderFile = make(map[string]string)
+	}
+	idx.nameHolderFile[name] = srcFile
 }
 
 // setAliasAnchor records the #6104 facet anchor owning a byName /

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1776,10 +1776,13 @@ func isLocalBindingKind(_ string, props map[string]string) bool {
 // marker is stamped.
 //
 // SCOPE. This is deliberately NOT a repo-wide taxonomy of the ~340 custom
-// producers. It is stamped on the six MEASURED producers in the
-// `aspnetcore-mvc` eviction population that mint an entity from a mention;
-// every other producer stays unmarked and behaves exactly as before. An
-// unmarked reference is the pre-#6976 status quo, not a regression.
+// producers. It is stamped on six producers that mint an entity from a
+// mention: FIVE measured in the `aspnetcore-mvc` eviction population, plus
+// BLAZOR_INJECT, which is classified by SHAPE (`@inject IFoo Foo` names a
+// service declared elsewhere — the same shape as DOTNET_DI_PROVIDER, in the
+// same lane) and appears nowhere in that population. Every other producer
+// stays unmarked and behaves exactly as before. An unmarked reference is the
+// pre-#6976 status quo, not a regression.
 //
 // The property convention mirrors #6467's `local_scope`: an extractor-stamped
 // Properties key with a single named predicate in this package, rather than a

--- a/internal/resolve/symbol_index.go
+++ b/internal/resolve/symbol_index.go
@@ -116,6 +116,12 @@ type moduleEntry struct {
 	// byName slot.
 	localBinding bool
 
+	// referenceShaped is isReferenceShaped's verdict (#6976), precomputed for
+	// the same reason the two above are. A record minted from a MENTION of a
+	// name may not evict the declaration of that name from the repository-wide
+	// byName slot.
+	referenceShaped bool
+
 	// globalPos is the entity's position in the caller's ORIGINAL (flat)
 	// entity slice — the order BuildIndex consumes. M5 builds its symbol
 	// table per-module (so the merge visits entities grouped by module, not
@@ -208,6 +214,7 @@ func BuildModuleSymbols(key ModuleKey, entities []types.EntityRecord) *ModuleSym
 			properties:        e.Properties,
 			importPlaceholder: isImportPlaceholderKind(e.Kind, e.Subtype),
 			localBinding:      isLocalBindingKind(e.Subtype, e.Properties),
+			referenceShaped:   isReferenceShaped(e.Properties),
 		}
 		ms.entries = append(ms.entries, me)
 	}
@@ -447,6 +454,7 @@ func buildModuleSymbolsOrderedPos(key ModuleKey, entities []types.EntityRecord, 
 			properties:        e.Properties,
 			importPlaceholder: isImportPlaceholderKind(e.Kind, e.Subtype),
 			localBinding:      isLocalBindingKind(e.Subtype, e.Properties),
+			referenceShaped:   isReferenceShaped(e.Properties),
 			globalPos:         pos,
 		}
 		ms.entries = append(ms.entries, me)
@@ -943,7 +951,8 @@ func insertModuleEntry(
 	// (indexByName) so this path and flat BuildIndex cannot drift — including
 	// the #6104 facet rule and the #6369 import-placeholder precedence.
 	nameAnchor, nameIsFacet := me.mergeFacetAnchor()
-	idx.indexByName(me.name, me.id, nameIsFacet, nameAnchor, me.importPlaceholder, me.localBinding)
+	idx.indexByName(me.name, me.id, me.sourceFile, nameIsFacet, nameAnchor, me.importPlaceholder,
+		me.localBinding, me.referenceShaped)
 }
 
 // mergeFacetAnchor reports whether this module entry is a #6104 merge facet —


### PR DESCRIPTION
Closes #6976. Option A as recommended on the issue, sequenced after #6975 (`448d7bb38`), which this branches from.

**Tree measured in:** `/private/tmp/claude-501/-Users-jorgecajas-Projects-archigraph/c0fefed4-0195-4c81-9a94-07a7145710a4/scratchpad/impl-6976b-k7v2r/wt`. `aspnetcore-mvc` copied to scratch; `/Users/jorgecajas/Projects/archigraph-corpora` untouched. In-process `Index()`, one arm per process, `GOMAXPROCS=3`, `nice -n 10`, isolated `GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT`. macOS/APFS, Apple Silicon, 16 GB shared box.

**The gate, on every figure below (#6966):** OFF = `GRAFEL_INPROC_CUSTOM_EXTRACTORS` unset, ON/TIER = `=1`. This is not what users run. #6979 owns the gate-OFF population and is **not** folded in — with the gate off this arm is inert, verified below.

---

## The fix, both halves

**Upstream first, because the discriminator is not on the record.** The issue's diagnosis established that `indexByName` cannot derive "declaration or mention?" from a `types.EntityRecord`: no field means it, `provenance` is a producer id rather than a semantic class, `custom/csharp/helpers.go:15` sets `StartLine == EndLine` for the entire C# custom lane so span ranks the lane and not the record, and the same `makeEntity` stamps `QualityScore` 1.0 uniformly. So the emit site stamps it.

**1. `Properties["reference_shaped"] = "true"`, at six emit sites.** The property convention mirrors #6467's `local_scope` — an extractor-stamped key with one named predicate in `internal/resolve` — rather than a new `EntityRecord` field or a `Subtype` convention, because `Subtype` is load-bearing for denoise, docs and the #6104 facet rule and overloading it would move consumers that have nothing to do with resolution.

| producer | what it reads |
|---|---|
| `INFERRED_FROM_DOTNET_DI_PROVIDER` | a constructor **parameter type**; the class is declared in its own file |
| `INFERRED_FROM_ASPNET_RETURN_TYPE` | an `ActionResult<T>` **return annotation** |
| `INFERRED_FROM_ASPNET_FROM_BODY` | a `[FromBody]` **parameter annotation** |
| `INFERRED_FROM_FROM_BODY` | the validation lane's `[FromBody]` rule, same shape |
| `INFERRED_FROM_BLAZOR_COMPONENT_REF` | a `<Foo>` **markup tag** — a use of the component declared in `Foo.razor` |
| `INFERRED_FROM_BLAZOR_INJECT` | `@inject IFoo Foo` — a service declared elsewhere |

Auditing the ~340-producer custom lane is explicitly **out of scope**; an unmarked producer keeps its pre-#6976 behaviour exactly, and `TestMarkedProducersAreExactlyTheMeasuredSix6976` fails if the stamp leaks past these six.

**One substitution against the issue's recommended list, on the merits.** The issue named `BLAZOR_CODE_METHOD` among the four. `reBlazorCodeMethod` matches a **method declaration** in an `@code` block — its own comment says so — so marking it would be a false label, and its whole population (959 of the 1,222 sole-declaration evictions) is already dead with #6975's file gate. It is in the negative control instead, alongside `BLAZOR_PAGE` and `BLAZOR_PARAMETER`. `BLAZOR_INJECT` takes the sixth slot: same reference shape as `DOTNET_DI_PROVIDER`, same lane.

**2. One tier in `indexByName`, the #6369/#6467 shape, three clauses.** A reference neither displaces an unmarked incumbent nor blanks it; an unmarked record **reclaims** the slot from a reference extracted first (extraction order is not stable, so both directions are needed); two references still collide, and `nameAmbigRef` remembers that so a declaration arriving later can still reclaim. A reference is also barred from reclaiming placeholder-only ambiguity and from displacing a placeholder incumbent, for the reason #6467 barred a local from both. **Ambiguity is not traded away** — this narrows *which records compete*, it does not soften the default arm, so `lookupBareWithLocality` and `external.Synthesize` still get every case they exist to rescue.

**Scoped to CROSS-FILE pairings**, which the golden ratchet forced and which the issue body already argued for: *"#6104's facet rule rescues same-name pairs that are two views of one thing in one file. It does not apply here because the claimants live in different files."* See the ratchet section — this was a real regression, caught, diagnosed and fixed, not a baseline bump.

---

## Measured

Edge **sets**, not counts — `TESTS` `(from, to, source)` triples:

| | OFF | ON | **TIER** |
|---|---|---|---|
| `TESTS` | 43,620 | 40,887 | **44,192** |
| lost vs OFF | — | 6,353 | **1,227** |
| gained vs OFF | — | 3,620 | 1,799 |
| **targets that resolve to a real entity id** | 17,135 | 13,737 | **18,863** |
| dangling targets | 60.7% | 66.4% | **57.3%** |
| entities | 39,766 | 50,260 | **50,260** |
| `ENTRY_POINT_OF` | 73 | 69 | **73** |
| `STEP_IN_PROCESS` | 221 | 219 | **226** |
| `CONTAINS` | 71,674 | 90,118 | 90,118 |

**5,126 specific lost edges come back** — 3,305 `tests-walkup` and 1,821 explicit — and **5,126 of 5,126 point at an entity that exists in the tier graph.** The entity gain is untouched (50,260 = 50,260). **The earlier claim that "the only three kinds that move are TESTS, STEP_IN_PROCESS and ENTRY_POINT_OF" was wrong, and wrong in this PR's own diagnosed way — it was a per-kind CARDINALITY reading, and a cardinality reading cannot see a substitution.** The corrected set-level result is below.

(The ON figures differ from the issue's because #6975 landed in between: the Blazor lane no longer runs over every `.cs` file, so entities are 50,260 rather than 75,191 and the ON-arm damage is 6,353 rather than 14,070. Both arms re-measured on this tree; the OFF arm reproduces the issue's 39,766 entities exactly.)

### Named recovered edges, and their producers

A test whose entire fan-out was destroyed, `Endpoints_AccessParameters_InitializedFromProvider -> ActionDescriptorCollection` (`0037057ffef3c61c`):

```
explicit  OFF  -> 9c285b91edbadfc0  ActionDescriptorCollection [SCOPE.Component]
                  src/Mvc/Mvc.Core/src/Infrastructure/ActionDescriptorCollection.cs
          ON   -> scope:operation:src/Mvc/Mvc.Core/test/Routing/
                  ActionEndpointDataSourceBase.cs#ActionDescriptorCollection   UNRESOLVED
          TIER -> 9c285b91edbadfc0                                             restored

walk-up   OFF  -> 36e49e60b72304fc  DefaultActionDescriptorCollectionProvider.UpdateCollection
                  6b8fb52810da88ac  MockActionDescriptorCollectionProvider…(Benchmark)
                  ac1c4b1358b8e0c6  MockActionDescriptorCollectionProvider…(ActionSelector)
          ON   -> (none — the whole walk-up fan-out is gone)
          TIER -> all three restored, all three targets exist
```

Top recovered target names: `ValidationVisitorBenchmarkBase.GetActionContext` (338 edges), `RuntimePerformanceBenchmarkBase.IterationSetup` (254), `ActionEndpointFactory.CreateRequestDelegate` (254), `MvcAttributeRouteHandler.RouteAsync` (254), `MvcRouteHandler.RouteAsync` (254), `ActionContext` (254), `ModelStateDictionary` (205), `MvcOptions` (172), `ActionDescriptor` (166), `TagBuilder` (94).

Attribution — the custom-lane entities that share a name with a recovered target, by provenance: `DOTNET_DI_PROVIDER` 121, `ASPNET_RETURN_TYPE` 36, `FROM_BODY` 1, `ASPNET_FROM_BODY` 1, `DATA_ANNOTATION` 1 (declaration-shaped, correctly unmarked). **The producers doing the evicting are the producers that got marked.**

### The reverse direction, graded

Confident (hex-target) `TESTS` edges present in the arm but **not** in OFF: **ON 1,777, TIER 1,777 — identical.** The tier does not add a single confidently-wrong binding; it stops destroying correct ones. That is the #6369 hazard this could most easily have traded into, and it did not.

### ON → TIER, as a SET (this is the corrected finding 2)

**Gate ON throughout (#6966).** Reproduced on my own tree this round, not cited: parent
`448d7bb38` ON arm and this branch's TIER arm, in-process `Indexer.Run`, `GOMAXPROCS=3`,
`nice -n 10`, isolated `GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT`, corpus copied to scratch.

```
ON -> TIER whole-graph set diff:   only_on 5,636 rows    only_tier 8,952 rows
kinds whose in and out counts are EQUAL (pure substitution, invisible to a count table):
  CALLS 2,989  USES 257  IMPLEMENTS 133  RETURNS 108  INJECTED_INTO 70  CONTAINS 55
  EXTENDS 35  BINDS 17  ACCEPTS_INPUT 12  REGISTERS 9  RESOLVES_TO 5     = 3,690 rows
```

So **~3,690 non-`TESTS` edges change target with zero net count movement**, across eleven
kinds the old sentence did not mention. The three kinds that move in COUNT (`TESTS` +3,305,
`STEP_IN_PROCESS` +7, `ENTRY_POINT_OF` +4) were the only three that a per-kind count could
ever have revealed. This is #6973's blindness reappearing inside the PR that fixes #6973,
and it was the reviewer who caught it.

Classifying every `only_tier` row against the `only_on` rows with the same
`(kind, from, source)`:

| | rows |
|---|---|
| **UNRES → HEX** — the intended win | **5,050** (CALLS 2,629, TESTS 1,821, USES 257, RETURNS 108, IMPLEMENTS 94, INJECTED_INTO 66, EXTENDS 32, BINDS 17, ACCEPTS_INPUT 12, REGISTERS 9, RESOLVES_TO 5) |
| **HEX → HEX** — a confident target replaced by a DIFFERENT confident target | **406** (CALLS 360, IMPLEMENTS 39, INJECTED_INTO 4, EXTENDS 3) |
| → still unresolved | 45 |
| no `only_on` counterpart (net new edges, not substitutions) | 3,451 |

**The HEX→HEX population is the #6369 hazard class and it shipped ungraded.** The PR's
reverse-direction check cannot see it by construction: that check is `TESTS`-only and covers
only edges ABSENT from OFF, whereas every one of these is present in all three arms. Graded
against the OFF arm, which is the closest thing to ground truth available here:

| | count |
|---|---|
| TIER's new target is among OFF's targets for that `(kind, from, source)` — a **correction** | **402** |
| the pairing is absent from OFF entirely — ungradeable | 4 |
| **OFF endorsed the ON target and TIER moved AWAY** | **0** |

Under a stricter rule that demands OFF have exactly ONE target for the pairing before it is
allowed to vote: **69 corrections, 0 disagreements, 337 pairings where OFF is multi-target
and the comparison is not 1:1** (TIER's pick is inside OFF's set in all of them). Both
gradings agree on the number that matters: **not one substitution moves an edge off a target
the no-custom-lane arm endorsed.**

**Credit where it is due.** This population, its size, and the favourable direction of the
grading were all found by the independent reviewer, not by me — my own measurement asserted a
per-kind count and stopped there. My partition differs from theirs in the pairing rule (they
report UNRES→HEX 5,104 / HEX→HEX 271 with 85 corrections, 119 `ext:`→local and 56
uncorroborated third-target picks; I group by `(kind, from, source)` and cover every row,
which moves rows between the buckets). **The two independent partitions agree on the only
claim being made from them: zero edges move off an OFF-endorsed target.**

### Inert with the gate off

The gate-OFF dump is **byte-identical** between this branch and its parent `448d7bb38`: `cmp` exit **0** on **250,928 rows** (39,766 entity rows + 211,162 relationship rows) for `aspnetcore-mvc`. **Re-established after the round-2 fix below**, not carried over — that fix touches the reclaim branch, so the property was re-measured rather than assumed. No user's graph changes.

The reviewer added the stronger argument, which holds for every repo and not just the one measured: `reference_shaped` has exactly ONE writer in the tree, so with the gate off `isRef` is universally false, both new `case` arms are unreachable, every new conjunct is an identity, and the trailing `delete` runs on an always-empty map. **Inert by construction, not merely measured-inert.**

---

## Verification

- `go test -count=1` green on `./internal/resolve/`, `./internal/custom/csharp/` and `./cmd/grafel/` (the last because an extractor change moves `cmd/grafel`'s whole-graph digest pin). `gofmt -l` clean, `go vet` clean.
- **Golden ratchet** (`scripts/quality/run.sh --ratchet`): **OK — 38 gated fixtures held their baseline, 29 at 100% must-have recall.**

**The ratchet caught a real regression, and the enumerated fixture member is the fix's shape.** The first revision failed it: `csharp-aspnet-core-mini` `relationship_found` 13 → 12, on exactly one member — `UserService -IMPLEMENTS-> IUserService`. `IUserService` is declared **nowhere** in that fixture; it has two claimants in **one** file, `Controllers/UsersController.cs`: the .NET DI pass's `SCOPE.Class` (now marked) and `internal/engine/detector.go`'s YAML rule-pack `Dependency` (unmarked, and *also* a mention — that producer is out of scope). Unmarked-beats-marked made the pair stop colliding, the `Dependency` record took the slot outright, and the edge moved off the `SCOPE.Class` node the fixture pins. Ambiguity had been carrying that edge to a better answer through the kind-hint path. Scoping the tier to cross-file pairings restores it, costs **nothing** on the corpus (all figures above are post-scoping and identical to pre-scoping), and is pinned by `TestSameFilePairingIsUnchanged_6976` with `TestCrossFileTierStillFiresWhenSameFileIsScopedOut_6976` as its control. No baseline constant was touched.

## Round 2 — the cross-file scoping missed the reclaim path (`991f901f9`)

**Tree measured in:** `/private/tmp/claude-501/-Users-jorgecajas-Projects-archigraph/c0fefed4-0195-4c81-9a94-07a7145710a4/scratchpad/impl-6976b-k7v2r/wt`; parent arm in a detached worktree at `448d7bb38`. macOS/APFS, Apple Silicon.

The tier is scoped to CROSS-FILE pairings on two of the three places that can change a
same-file outcome. **The reclaim path out of `ambigName` did not get the guard.** So three
claimants in ONE file — two reference-shaped, one unmarked — bound to the **unmarked** record
in claimant order `ref, ref, decl` and stayed ambiguous in the other two rotations, against a
parent that is ambiguous in all three. Two things wrong with that:

- it is **order-DEPENDENT binding** in exactly the shape the cross-file scoping exists to
  prevent — in a file whose own comments say *"extraction order is not stable, so both
  directions are needed"*; and
- the winner is the **unmarked** record, which is the `IUserService` mechanism that regressed
  `csharp-aspnet-core-mini` 13 → 12. That fixture escapes only because it has **two**
  claimants rather than three.

**The guard has to live where `nameAmbigRef` is RAISED, not where it is read.** By the time
the reclaim branch runs, `nameHolderFile` has already been deleted, so the reviewer's
suggested `&& idx.nameHolderFile[name] != srcFile` **at the reclaim site** would compare
against an empty string and fire unconditionally — a no-op guard. Raising the flag only for a
cross-file reference pair is what makes the reclaim it authorises cross-file. That is their
second suggested form, and it is the one that works.

**Priced at ~4 production lines + ~20 test lines; the actual diff is one conjunct and 135
test lines.** The production change is:

```go
-  if isRef && idx.nameHolderRef[name] {
+  if isRef && idx.nameHolderRef[name] &&
+      idx.nameHolderFile[name] != srcFile {
```

The test side came in over the estimate on purpose: the cases are **enumerated, not sampled**.

### The test now observes what its name claims, across the whole space it names

`TestSameFilePairingIsUnchanged_6976` covered same-file **pairs** in both orders and its name
was read as covering same-file claimants generally — the reviewer exhibited a same-file set of
three that changes. Three rounds of hand-picked cases have now missed two holes on this
branch, so the new cases enumerate:

- `allOrders6976` runs a case in **every** claimant order and **fails if the enumeration is
  not n!** — a permutation helper that silently ran 4 of 6 orders would reproduce the class of
  defect it exists to catch.
- `TestSameFileThreeClaimantsStayAmbiguous_6976` — all **3! = 6** orders of two same-file
  references plus one same-file unmarked record; all six must stay unresolved.
- `TestSameFilePairingIsEnumerated_6976` — the 2-claimant set over its full 2! space, so the
  same-file claim is observed at both sizes it can have.
- `TestCrossFileThreeClaimantsStillReclaim_6976` — the **control**: the same three-record shape
  spread across three files must land on the declaration in all six orders, including
  `ref, ref, decl`, which is the one order that goes through the narrowed reclaim path.

### Mutants on the new conjunct — both directions, 2/2 DEAD

Each edit proven landed with an exact occurrence count **and** an assertion on the hit set
(anchor unique, count 1, mutated line re-grepped); scored with `-count=1`; restored by `cp`
from a sha256-verified backup (`c91d1972…d930c` → `694b0f2c…e0ab6`), zero `MUTANT` text
remaining afterwards.

| # | mutant | verdict |
|---|---|---|
| **M1** | drop the conjunct entirely — the **MORE PERMISSIVE** direction, i.e. the shipped bug | **DEAD** — `TestSameFileThreeClaimantsStayAmbiguous_6976`, and **only** the two `ref,ref,decl` orders fail (`d…02,d…03,d…04` and `d…03,d…02,d…04`). That is the reviewer's exhibit reproduced to the order. |
| **M2** | invert it to `== srcFile` — the restrictive direction | **DEAD** — `TestCrossFileThreeClaimantsStillReclaim_6976` (both `ref,ref,decl` orders) **and** `TestDeclarationReclaimsFromReferenceOnlyAmbiguity_6976`. |

The two halves of the conjunct are therefore graded **part by part with no masking pair**: M1
fails only the same-file test, and the cross-file reclaim tests are what catch M2. That keeps
true of the new line what the reviewer's V3/V4 established for the reference arm.

### Cost on the corpus: none

The gate-ON TIER dump for `aspnetcore-mvc` is **identical row for row before and after this
change** — 283,371 rows, `cmp` exit 0 on the sorted dumps — so every figure in the *Measured*
section above stands unchanged and was not re-derived from a stale file. Golden ratchet
re-run: **OK, 38 gated fixtures held their baseline, 29 at 100% must-have recall.**
`go test -count=1` green on `./internal/resolve/`, `./internal/custom/csharp/` and
`./cmd/grafel/`; `gofmt -l` and `go vet` clean.

## `e50c8653e` — "six MEASURED producers" was one measurement short

The reviewer's wording nit, fixed rather than argued: `wantMarked6976` and the scope note on
`resolve.ReferenceShapedProp` both said "the SIX **measured** producers in the
`aspnetcore-mvc` eviction population". **Five** were measured there. The sixth,
`INFERRED_FROM_BLAZOR_INJECT`, was justified by **shape** — `@inject IFoo Foo` names a service
declared elsewhere, the same shape as `DOTNET_DI_PROVIDER`, in the same lane — and #6976 names
it nowhere in that population. Both sites now say five measured plus one classified by shape.
Comment-only; `./cmd/grafel/` re-run anyway because `refs.go` is touched and it digest-pins
the whole graph.

## Mutation score — 16/16 DEAD, more-permissive direction first

Every mutant applied with an exact occurrence assertion, scored with `-count=1`, file restored and re-diffed after each.

| # | mutant | verdict |
|---|---|---|
| R1 | ref arm deleted — a reference may evict a declaration | DEAD `TestDeclarationOutranksReference_6976` |
| R2 | reclaim arm deleted — a declaration cannot take the slot back | DEAD same, `b-then-a` order |
| R3 | ref arm drops `!nameHolderRef` — reference outranks reference | DEAD `TestTwoReferencesStillCollide_6976` |
| R4 | `ambigName` guard drops `isRef` — a reference reclaims ambiguity | DEAD `TestReferenceDoesNotReclaimPlaceholderOnlyAmbiguity_6976` |
| R5 | import-displacement arm drops `!isRef` | DEAD `TestReferenceDoesNotOutrankImportPlaceholder_6976` |
| R6 | placeholder-yield arm drops `!nameHolderRef` | DEAD same, other order |
| R7 | `nameAmbigRef` never recorded | DEAD `TestDeclarationReclaimsFromReferenceOnlyAmbiguity_6976` |
| R8 | tail AND-ing dropped — a trailing mention re-raises reference status | DEAD `TestSameIDReindexDoesNotReRaiseReferenceStatus_6976` |
| R9 | cross-file scoping dropped from the ref arm | DEAD `TestSameFilePairingIsUnchanged_6976` |
| R10 | cross-file scoping dropped from the reclaim arm | DEAD same, other order |
| R11 | `nameHolderFile` not updated when a declaration reclaims | DEAD `TestHolderFileFollowsTheSlot_6976` |
| R12 | `nameHolderFile` not updated when a declaration displaces a placeholder | DEAD `TestHolderFileFollowsTheSlotAfterPlaceholderDisplacement_6976` |
| R13 | `nameHolderFile` not updated on the tail insert | DEAD `TestSameFilePairingIsUnchanged_6976` |
| P1 | one `markReferenceShaped` call deleted | DEAD that producer's row, by name |
| P2 | stamp applied to the whole C# lane in `makeEntity` | DEAD all three negative-control rows |
| P3 | stamped value is not `"true"` | DEAD every marked row |

R11 and R12 were **ALIVE** on the first scoring — the stale-holder-file cases — and were graded rather than argued away; each cost one ~20-line test. R13's first mutant text was not unique in the file and was reported unscored rather than silently passing; it is scored above with a unique anchor.

## What the tests assert, and why not counts

This defect survived a measurement that reported explicit `TESTS` at **+8 net while 7,221 edges were substituted** (#6973) — a cardinality assertion is blind to a substitution by construction. So every case in `reference_decl_tier_6976_test.go` names the id the edge must land on, runs the production `BuildIndex` + `ReferencesEmbedded` path, fails loudly if the fixture stops carrying exactly one `TESTS` edge, and runs in **both extraction orders**. `wantMarked6976` / `wantUnmarked6976` are hand-written **independent literals**, not derived from any production table, so deleting a `markReferenceShaped` call turns a row red by name.

Both directions are graded: `TestTwoDeclarationsStillCollide_6976` pins that two real declarations of one name stay ambiguous, and `TestUnmarkedRecordIsUnchanged_6976` is the control that the tier reads the marker and nothing derivable from the record.

Refs #6973, #6975, #6369, #6467, #6104, #6966, #6979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
