### PR TITLE
fix(#6969): an oversized sparse pattern file was truncated silently, and truncation was the one input class failing toward EXCLUSION

### DIFF
--- a/internal/gitmeta/saferead.go
+++ b/internal/gitmeta/saferead.go
@@ -25,8 +25,15 @@ const (
 
 	// maxSparsePatternBytes covers info/sparse-checkout, which is a pattern
 	// list and legitimately large in a big monorepo. 8 MiB truncates only a
-	// file that is already pathological, and truncation degrades to the same
-	// "some patterns not applied" outcome an unreadable file already produces.
+	// file that is already pathological.
+	//
+	// A truncated pattern file is NOT the same outcome as an unreadable one and
+	// the two must not be conflated (#6969): unreadable lands on "not sparse"
+	// and indexes the repo in FULL, while a silently-truncated read used to
+	// leave the repo sparse with a partial pattern set, so files were dropped
+	// from the index with no error, no SkipEntry and no missing-entity signal.
+	// parseSparsePatternFile now reads the truncation signal and lands
+	// truncated on "not sparse" too.
 	maxSparsePatternBytes = 8 << 20
 )
 
@@ -78,11 +85,57 @@ func setGitMetaSkipOutput(w io.Writer) func() {
 // read failure as unknown" behaviour; the skip is reported here so that
 // behaviour stops being silent.
 func readGitMetaFile(path string, maxBytes int64) ([]byte, error) {
-	b, err := safeio.ReadFile(path, safeio.FollowSymlinks, maxBytes)
+	b, _, err := readGitMetaFileLimited(path, maxBytes)
+	return b, err
+}
+
+// readGitMetaFileLimited is readGitMetaFile plus the truncation signal.
+//
+// The two exist side by side on purpose. For this package's POINTER files —
+// HEAD, commondir, the .git gitdir-file, a loose ref — a truncated read is
+// already loud: each is one short line, every parser here demands a shape
+// ("ref: ", "gitdir: ", 40 hex bytes), and a 64 KiB prefix of something else
+// fails that shape and falls through to the same "unknown" the callers already
+// handle. Those callers keep readGitMetaFile and are deliberately unchanged.
+//
+// The sparse pattern file is the one LIST-shaped reader here, and a prefix of
+// a list is a valid-looking shorter list. That is the whole of #6969: it fails
+// silently and it fails toward EXCLUSION, the one direction nothing downstream
+// can notice.
+func readGitMetaFileLimited(path string, maxBytes int64) ([]byte, bool, error) {
+	b, truncated, err := safeio.ReadFileLimited(path, safeio.FollowSymlinks, maxBytes)
 	if err != nil {
 		reportGitMetaSkip(path, err)
 	}
-	return b, err
+	return b, truncated, err
+}
+
+// reportGitMetaTruncation announces a git metadata file that was read only in
+// part because it exceeded its byte cap.
+//
+// It is a SEPARATE report from reportGitMetaSkip and not a new branch inside
+// it, because the two carry different facts: a skip says the file was not read
+// at all and names the entry kind; this says the file was read and the tail is
+// missing. It shares the dedup map and the cap, so the combined output is
+// still bounded the way a report nobody scrolls past has to be.
+func reportGitMetaTruncation(path string, maxBytes int64) {
+	gitMetaSkipMu.Lock()
+	if gitMetaSkipSeen == nil {
+		gitMetaSkipSeen = map[string]bool{}
+	}
+	if gitMetaSkipSeen[path] || len(gitMetaSkipSeen) >= maxGitMetaSkipReports {
+		gitMetaSkipMu.Unlock()
+		return
+	}
+	gitMetaSkipSeen[path] = true
+	last := len(gitMetaSkipSeen) == maxGitMetaSkipReports
+	w := gitMetaSkipOut
+	gitMetaSkipMu.Unlock()
+
+	fmt.Fprintf(w, "grafel: %s exceeds %d bytes and was read only in part; treating this repo as NOT sparse so no file is silently excluded (#6969)\n", path, maxBytes)
+	if last {
+		fmt.Fprintf(w, "grafel: further git-metadata skips suppressed after %d\n", maxGitMetaSkipReports)
+	}
 }
 
 // reportGitMetaSkip says out loud that a git metadata file was refused for

--- a/internal/gitmeta/sparse.go
+++ b/internal/gitmeta/sparse.go
@@ -149,7 +149,9 @@ func ProbeRepo(repoPath string) SparseInfo {
 	//
 	// An existing-but-unreadable file lands on "not sparse" too, which is the
 	// over-inclusive direction — a superset, the same direction every other
-	// failure in this file chooses.
+	// failure in this file chooses. So does an OVERSIZED one, whose read is
+	// truncated: before #6969 that was the single input class landing the
+	// other way, staying sparse with a partial pattern set.
 	patterns, haveFile := parseSparsePatternFile(filepath.Join(gitDir, "info", "sparse-checkout"))
 	if !haveFile {
 		return SparseInfo{}
@@ -169,13 +171,40 @@ func ProbeRepo(repoPath string) SparseInfo {
 // states in git and must not be collapsed: an empty pattern file checks out
 // nothing, an absent one checks out everything (#6967 review). Callers that
 // only want the lines can ignore it; ProbeRepo cannot.
+//
+// It reports false for an ABSENT file, an UNREADABLE one, and an OVERSIZED one
+// whose read was truncated (#6969) — three inputs, one verdict, chosen so that
+// every way of failing to obtain the complete pattern set indexes the repo in
+// FULL rather than in part.
 func parseSparsePatternFile(path string) ([]string, bool) {
 	// readGitMetaFile, not os.Open: open(2) is what blocks on a FIFO, so
 	// scanning rather than slurping made no difference to #6416. The pattern
 	// file is name-chosen ("info/sparse-checkout" under the git dir) and is
 	// read before any walk, so no entry-type gate sits in front of it.
-	data, err := readGitMetaFile(path, maxSparsePatternBytes)
+	data, truncated, err := readGitMetaFileLimited(path, maxSparsePatternBytes)
 	if err != nil {
+		return nil, false
+	}
+	// A TRUNCATED pattern file is rejected WHOLESALE, not trimmed to its last
+	// intact line (#6969).
+	//
+	// Two distinct hazards live in a truncated read and only one of them is
+	// fixed by dropping the cut line:
+	//
+	//  1. Every pattern PAST the cut is gone — arbitrarily many, not one. The
+	//     surviving prefix is a valid-looking shorter list, so the repo stays
+	//     sparse with fewer includes and files vanish from the index with no
+	//     error and no SkipEntry. Dropping the cut line leaves this untouched.
+	//  2. The cut line itself is a pattern git never wrote. "!/src/deep/"
+	//     severed at the cap is "!/src", which does not fail to match — it
+	//     matches something WIDER than intended.
+	//
+	// So trimming addresses hazard 2 and leaves hazard 1, which is the one
+	// that silently shrinks the graph. Rejecting the file lands both on "not
+	// sparse", i.e. a FULL index — a superset, the same over-inclusive
+	// direction the absent and unreadable cases already choose above.
+	if truncated {
+		reportGitMetaTruncation(path, maxSparsePatternBytes)
 		return nil, false
 	}
 

--- a/internal/gitmeta/sparse_truncation_6969_test.go
+++ b/internal/gitmeta/sparse_truncation_6969_test.go
@@ -1,0 +1,259 @@
+// Truncation of the sparse-checkout pattern file (#6969).
+//
+// safeio.ReadFile caps a read and returns the PREFIX with a nil error. For
+// every other file this package reads that is loud — a 64 KiB prefix of HEAD
+// is not "ref: ..." and every parser rejects it. The sparse pattern file is
+// the one LIST-shaped reader, and a prefix of a list is a valid-looking
+// shorter list: the repo stayed sparse with fewer includes and files left the
+// index with no error, no SkipEntry and no missing-entity signal.
+//
+// It was also the only input class landing on the EXCLUSION side. #6967
+// settled the other two deliberately toward inclusion (absent → not sparse,
+// unreadable → not sparse); oversized went the other way.
+//
+// WHAT THESE TESTS OBSERVE. Not a counter and not "IsSparse is false" alone —
+// a NAMED FILE that the truncated pattern set would have dropped from the
+// index and that is now indexed. Two cut geometries are separate cases,
+// because the two hazards in the comment on parseSparsePatternFile are
+// different failures:
+//
+//   - a cut on a LINE BOUNDARY silently deletes every pattern after it;
+//   - a cut MID-LINE additionally leaves a pattern git never wrote, which
+//     matches something WIDER than intended rather than nothing.
+//
+// The pattern file here is git's own bytes with padding APPENDED. The config
+// is still written by real git, so #6964's rule ("never hand-write a config
+// value") holds where it is load-bearing — an over-cap pattern file is a shape
+// no git will ever produce, so it has to be constructed.
+//
+// Measured on macOS/APFS. Every case reports the git it ran on.
+package gitmeta_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/gitmeta"
+)
+
+// sparseCapBytes6969 is an INDEPENDENT LITERAL of maxSparsePatternBytes, not a
+// reference to it. A test that reads the production constant cannot detect the
+// constant being changed, and the whole point of the exactly-at-the-cap case
+// below is that the cap is a byte position the code must get right.
+// TestSparseCapConstantMatchesTheTestsLiteral (internal package) fails if the
+// two ever diverge, so a deliberate cap change updates this on purpose instead
+// of silently making these fixtures measure nothing.
+const sparseCapBytes6969 = 8 << 20
+
+// trNamed is a path that `git sparse-checkout set src` EXCLUDES and that a
+// whole-file read of the padded fixture would INCLUDE (the padding is followed
+// by a `/services/` pattern that only survives an untruncated read).
+const trNamed = "services/orders/h.go"
+
+// trInsideCone is inside the cone git actually set. Case B's corrupted pattern
+// (`!/src`) excludes it, so it is the path that names hazard 2.
+const trInsideCone = "src/a.go"
+
+// trSparseFile returns the path of the pattern file git wrote.
+func trSparseFile(t *testing.T, dir string) string {
+	t.Helper()
+	gitDir := strings.TrimSpace(rgRun(t, dir, "rev-parse", "--git-dir"))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(dir, gitDir)
+	}
+	p := filepath.Join(gitDir, "info", "sparse-checkout")
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("fixture premise broken: git wrote no %s: %v", p, err)
+	}
+	return p
+}
+
+// trSparseFixture builds a repo, makes it sparse with real git, and asserts
+// the PREMISE the whole file rests on: trNamed is excluded and trInsideCone is
+// included right now. Without that, every assertion below is satisfied by a
+// fixture that was never sparse in the first place.
+func trSparseFixture(t *testing.T) (dir string, patternFile string, gitWrote []byte) {
+	t.Helper()
+	dir = rgFixture(t)
+	si := probeAfterSparseSet(t, dir, "src")
+
+	if gitmeta.IsPathIncluded(si, trNamed) {
+		t.Fatalf("fixture premise broken: %s is INCLUDED by the cone git just set (patterns=%v) — nothing below can observe it being dropped", trNamed, si.Patterns)
+	}
+	if !gitmeta.IsPathIncluded(si, trInsideCone) {
+		t.Fatalf("fixture premise broken: %s is EXCLUDED by the cone git just set (patterns=%v)", trInsideCone, si.Patterns)
+	}
+
+	patternFile = trSparseFile(t, dir)
+	b, err := os.ReadFile(patternFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(b)) >= sparseCapBytes6969 {
+		t.Fatalf("fixture premise broken: git's own pattern file is already %d bytes, at or over the %d cap", len(b), sparseCapBytes6969)
+	}
+	t.Logf("%s | git wrote %d bytes of patterns: %q", rgVersion(t, dir), len(b), string(b))
+	return dir, patternFile, b
+}
+
+// trPadTo appends comment lines to base until the content is EXACTLY n bytes.
+// Comments are used for the filler so that the padding itself contributes no
+// pattern: everything these tests observe comes from the real patterns and
+// from the tail line, never from the filler.
+func trPadTo(t *testing.T, base []byte, n int) []byte {
+	t.Helper()
+	if len(base) > n {
+		t.Fatalf("cannot pad %d bytes down to %d", len(base), n)
+	}
+	const line = "# pad-6969 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+	out := make([]byte, 0, n)
+	out = append(out, base...)
+	for len(out)+len(line) <= n {
+		out = append(out, line...)
+	}
+	// One short comment closes the remainder exactly. "#" plus filler plus the
+	// newline needs at least 2 bytes; the loop above leaves fewer than
+	// len(line) so the remainder is small, and a 1-byte remainder is closed
+	// with a bare newline instead.
+	rem := n - len(out)
+	switch {
+	case rem == 0:
+	case rem == 1:
+		out = append(out, '\n')
+	default:
+		out = append(out, '#')
+		for len(out) < n-1 {
+			out = append(out, 'b')
+		}
+		out = append(out, '\n')
+	}
+	if len(out) != n {
+		t.Fatalf("padding produced %d bytes, want %d", len(out), n)
+	}
+	return out
+}
+
+// TestSparse_OversizedPatternFile_LineBoundaryCut_IndexesInFull is hazard 1:
+// the cut falls on a line boundary, so the truncated read is a syntactically
+// perfect but SHORTER pattern list. Nothing about it looks wrong, and the
+// patterns past the cut — here `/services/`, which is what puts trNamed back
+// in the index — are simply gone.
+func TestSparse_OversizedPatternFile_LineBoundaryCut_IndexesInFull(t *testing.T) {
+	dir, patternFile, gitWrote := trSparseFixture(t)
+
+	// Exactly cap bytes of git's patterns + comment filler, then the pattern
+	// that only an untruncated read ever sees.
+	content := trPadTo(t, gitWrote, sparseCapBytes6969)
+	content = append(content, "/services/\n"...)
+	if err := os.WriteFile(patternFile, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The cut is on a line boundary: byte sparseCapBytes6969-1 is the newline
+	// that ends the last filler line. Asserted, because "line boundary" is the
+	// axis that separates this case from the mid-line one and a fixture whose
+	// label outruns its content grades neither.
+	if got := content[sparseCapBytes6969-1]; got != '\n' {
+		t.Fatalf("fixture is not the line-boundary geometry: byte %d is %q, want a newline", sparseCapBytes6969-1, got)
+	}
+
+	si := gitmeta.ProbeRepo(dir)
+	if si.IsSparse {
+		t.Fatalf("an oversized pattern file left the repo SPARSE with a truncated pattern set: patterns=%v (%d of them) — every pattern past byte %d was dropped and the index silently shrank (#6969)",
+			si.Patterns, len(si.Patterns), sparseCapBytes6969)
+	}
+	if !gitmeta.IsPathIncluded(si, trNamed) {
+		t.Fatalf("%s is still EXCLUDED from the index after an oversized pattern file (patterns=%v). This is the artefact the fix is about: a named file that silently left the index (#6969). %s",
+			trNamed, si.Patterns, rgVersion(t, dir))
+	}
+	if !gitmeta.IsPathIncluded(si, trInsideCone) {
+		t.Fatalf("%s is EXCLUDED after an oversized pattern file (patterns=%v)", trInsideCone, si.Patterns)
+	}
+	if len(si.Patterns) != 0 {
+		t.Fatalf("a rejected pattern file must yield NO patterns, got %v", si.Patterns)
+	}
+}
+
+// TestSparse_OversizedPatternFile_MidLineCut_DropsTheCorruptedPattern is
+// hazard 2, and it is a DIFFERENT failure from the case above rather than a
+// variant of it. The cut lands inside `!/src/sub/` and leaves `!/src` — not a
+// pattern that fails to match, a pattern that matches MORE than the line git
+// would ever have written. The file is rejected wholesale, so that fragment
+// never reaches the matcher and trInsideCone stays in the index.
+func TestSparse_OversizedPatternFile_MidLineCut_DropsTheCorruptedPattern(t *testing.T) {
+	dir, patternFile, gitWrote := trSparseFixture(t)
+
+	const tail = "!/src/sub/\n"
+	const keep = len("!/src") // the fragment that survives the cut
+
+	content := trPadTo(t, gitWrote, sparseCapBytes6969-keep)
+	content = append(content, tail...)
+	if err := os.WriteFile(patternFile, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The geometry, asserted rather than asserted-by-label: the cut is inside
+	// the tail line, and the surviving fragment is exactly the corrupted
+	// pattern this case is named for.
+	if got := string(content[sparseCapBytes6969-keep : sparseCapBytes6969]); got != "!/src" {
+		t.Fatalf("fixture is not the mid-line geometry: the truncated tail is %q, want %q", got, "!/src")
+	}
+	if got := content[sparseCapBytes6969-1]; got == '\n' {
+		t.Fatalf("fixture is not a MID-LINE cut: byte %d is a newline, which is the other case's geometry", sparseCapBytes6969-1)
+	}
+
+	si := gitmeta.ProbeRepo(dir)
+	if si.IsSparse {
+		t.Fatalf("a mid-line-truncated pattern file left the repo SPARSE: patterns=%v (#6969)", si.Patterns)
+	}
+	for _, p := range si.Patterns {
+		if p == "!/src" {
+			t.Fatalf("the corrupted fragment %q reached the pattern set: patterns=%v", p, si.Patterns)
+		}
+	}
+	if !gitmeta.IsPathIncluded(si, trInsideCone) {
+		t.Fatalf("%s is EXCLUDED from the index by the corrupted fragment %q left behind by a mid-line cut (patterns=%v). %s",
+			trInsideCone, "!/src", si.Patterns, rgVersion(t, dir))
+	}
+	if !gitmeta.IsPathIncluded(si, trNamed) {
+		t.Fatalf("%s is still EXCLUDED after a mid-line-truncated pattern file (patterns=%v)", trNamed, si.Patterns)
+	}
+}
+
+// TestSparse_PatternFileExactlyAtTheCapStaysSparse is the counter-case that
+// makes the truncation signal load-bearing rather than a size threshold.
+//
+// A file whose size is EXACTLY the cap is complete: every byte of it was read.
+// Inferring truncation from len(b) == maxBytes — the obvious implementation —
+// would reject it, turn a perfectly good sparse repo into a full index, and
+// look identical to the correct code on every other input. So this asserts the
+// EXCLUSION direction survives at the boundary: trNamed must still be out.
+func TestSparse_PatternFileExactlyAtTheCapStaysSparse(t *testing.T) {
+	dir, patternFile, gitWrote := trSparseFixture(t)
+
+	content := trPadTo(t, gitWrote, sparseCapBytes6969)
+	if err := os.WriteFile(patternFile, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(patternFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() != sparseCapBytes6969 {
+		t.Fatalf("fixture premise broken: pattern file is %d bytes, want exactly %d", fi.Size(), sparseCapBytes6969)
+	}
+
+	si := gitmeta.ProbeRepo(dir)
+	if !si.IsSparse {
+		t.Fatalf("a pattern file of exactly %d bytes is COMPLETE, but the repo was reported not sparse — truncation is being inferred from the length instead of observed (#6969). %s",
+			sparseCapBytes6969, rgVersion(t, dir))
+	}
+	if gitmeta.IsPathIncluded(si, trNamed) {
+		t.Fatalf("%s is INCLUDED for a complete at-the-cap pattern file (patterns=%v): the sparse restriction was lost", trNamed, si.Patterns)
+	}
+	if !gitmeta.IsPathIncluded(si, trInsideCone) {
+		t.Fatalf("%s is EXCLUDED for a complete at-the-cap pattern file (patterns=%v)", trInsideCone, si.Patterns)
+	}
+}

--- a/internal/gitmeta/sparse_truncation_report_6969_test.go
+++ b/internal/gitmeta/sparse_truncation_report_6969_test.go
@@ -1,0 +1,100 @@
+// Internal-package half of the #6969 grading: the cap constant the external
+// fixtures hard-code, and the report line that stops the degradation being
+// silent.
+package gitmeta
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSparseCapConstantMatchesTheTestsLiteral ties the independent literal in
+// sparse_truncation_6969_test.go to the production constant.
+//
+// The external fixtures cannot import maxSparsePatternBytes and must not: a
+// fixture that reads the constant under test builds its file relative to
+// whatever the constant says, so a cap change can never fail it. This is the
+// one place the two are compared, and it fails loudly rather than letting the
+// byte-exact geometries over there quietly stop measuring the boundary.
+func TestSparseCapConstantMatchesTheTestsLiteral(t *testing.T) {
+	const literalUsedByTheExternalFixtures = 8 << 20
+	if maxSparsePatternBytes != literalUsedByTheExternalFixtures {
+		t.Fatalf("maxSparsePatternBytes = %d but sparse_truncation_6969_test.go builds its fixtures against %d; update sparseCapBytes6969 there",
+			maxSparsePatternBytes, literalUsedByTheExternalFixtures)
+	}
+}
+
+// TestParseSparsePatternFile_TruncatedIsReportedAndRejected covers the unit
+// directly, without a git repo, on the two facts ProbeRepo's callers cannot
+// see: the verdict is "no file" (so the repo indexes in full) and the reason
+// is printed.
+//
+// A truncated read that is merely handled is still a behaviour change with no
+// stated cause — #6338's shape. The line has to name the file and say which
+// way the decision fell, because "not sparse" on a repo the user made sparse
+// is otherwise indistinguishable from grafel ignoring their sparse-checkout.
+func TestParseSparsePatternFile_TruncatedIsReportedAndRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sparse-checkout")
+
+	body := bytes.Repeat([]byte("/src/\n"), (maxSparsePatternBytes/6)+64)
+	if int64(len(body)) <= maxSparsePatternBytes {
+		t.Fatalf("fixture premise broken: %d bytes does not exceed the %d cap", len(body), maxSparsePatternBytes)
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	restore := setGitMetaSkipOutput(&buf)
+	defer restore()
+
+	patterns, haveFile := parseSparsePatternFile(path)
+	if haveFile {
+		t.Fatalf("a truncated pattern file must read as NO file (so the repo indexes in full); got haveFile=true with %d patterns", len(patterns))
+	}
+	if patterns != nil {
+		t.Fatalf("a rejected pattern file must yield no patterns, got %v", patterns[:min(3, len(patterns))])
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, path) {
+		t.Fatalf("the truncation report names no file, so a user cannot act on it: %q", out)
+	}
+	if !strings.Contains(out, "NOT sparse") {
+		t.Fatalf("the truncation report does not say which way the decision fell: %q", out)
+	}
+	if !strings.Contains(out, "#6969") {
+		t.Fatalf("the truncation report carries no issue reference: %q", out)
+	}
+}
+
+// TestParseSparsePatternFile_CompleteFileIsNotReported is the other direction:
+// an ordinary pattern file must produce patterns and print NOTHING. A reporter
+// that fires on every healthy repo buries the signal it exists to carry, and
+// this package is entered on every whoami/ResolveCWD.
+func TestParseSparsePatternFile_CompleteFileIsNotReported(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sparse-checkout")
+	if err := os.WriteFile(path, []byte("/*\n!/*/\n/src/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	restore := setGitMetaSkipOutput(&buf)
+	defer restore()
+
+	patterns, haveFile := parseSparsePatternFile(path)
+	if !haveFile {
+		t.Fatal("a complete pattern file read as no file")
+	}
+	if len(patterns) != 3 {
+		t.Fatalf("patterns = %v, want the 3 lines written", patterns)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("a complete pattern file printed a report: %q", buf.String())
+	}
+}

--- a/internal/safeio/readfile_limited_6969_test.go
+++ b/internal/safeio/readfile_limited_6969_test.go
@@ -1,0 +1,139 @@
+// ReadFileLimited's truncation signal (#6969).
+//
+// ReadFile caps a read and returns the prefix with a NIL ERROR. For a caller
+// reading a config that costs a field; for a caller reading a LIST that
+// decides what gets indexed, a prefix is a different answer, not a smaller
+// one. The signal exists so that second kind of caller can tell.
+//
+// The boundary is the whole of it. Detecting truncation as
+// len(b) == maxBytes is wrong for a file whose size is EXACTLY the cap, so
+// these cases sit at cap-1, cap and cap+1 rather than at "small" and "huge".
+package safeio_test
+
+import (
+	"bytes"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/safeio"
+)
+
+func rlWrite(t *testing.T, n int) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(p, bytes.Repeat([]byte("x"), n), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestReadFileLimited_AtTheBoundary walks the three sizes around the cap. The
+// case table is written out as literals rather than derived from the cap, so a
+// change to how the boundary is computed cannot move the expectations with it.
+func TestReadFileLimited_AtTheBoundary(t *testing.T) {
+	const cap0 = 64
+
+	cases := []struct {
+		name          string
+		size          int
+		wantLen       int
+		wantTruncated bool
+	}{
+		{"one byte under the cap", 63, 63, false},
+		{"exactly the cap is COMPLETE", 64, 64, false},
+		{"one byte over the cap", 65, 64, true},
+		{"far over the cap", 4096, 64, true},
+		{"empty", 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := rlWrite(t, tc.size)
+			b, truncated, err := safeio.ReadFileLimited(p, safeio.FollowSymlinks, cap0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if truncated != tc.wantTruncated {
+				t.Fatalf("truncated = %v for a %d-byte file under a %d cap, want %v", truncated, tc.size, cap0, tc.wantTruncated)
+			}
+			if len(b) != tc.wantLen {
+				t.Fatalf("len = %d, want %d (the extra probe byte must never reach the caller)", len(b), tc.wantLen)
+			}
+			if want := bytes.Repeat([]byte("x"), tc.wantLen); !bytes.Equal(b, want) {
+				t.Fatalf("content mismatch: got %d bytes", len(b))
+			}
+		})
+	}
+}
+
+// TestReadFileLimited_UnlimitedNeverReportsTruncation — maxBytes <= 0 is the
+// "no cap" spelling, and a read with no cap has no cap to hit. The negative
+// case is included because a caller passing a negative by accident must not
+// get a silently empty read.
+func TestReadFileLimited_UnlimitedNeverReportsTruncation(t *testing.T) {
+	p := rlWrite(t, 5000)
+	for _, maxBytes := range []int64{0, -1} {
+		b, truncated, err := safeio.ReadFileLimited(p, safeio.FollowSymlinks, maxBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if truncated {
+			t.Fatalf("maxBytes=%d reported truncation", maxBytes)
+		}
+		if len(b) != 5000 {
+			t.Fatalf("maxBytes=%d read %d bytes, want the whole 5000-byte file", maxBytes, len(b))
+		}
+	}
+}
+
+// TestReadFileLimited_MaxInt64DoesNotOverflow — the implementation reads
+// maxBytes+1 to observe the extra byte. At math.MaxInt64 that addition wraps
+// negative, and io.LimitReader with a negative n reads ZERO bytes, so an
+// unguarded +1 turns the widest possible cap into an empty read: the exact
+// silent under-read this function exists to prevent.
+func TestReadFileLimited_MaxInt64DoesNotOverflow(t *testing.T) {
+	p := rlWrite(t, 5000)
+	b, truncated, err := safeio.ReadFileLimited(p, safeio.FollowSymlinks, math.MaxInt64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncated {
+		t.Fatal("a 5000-byte file reported truncated under a MaxInt64 cap")
+	}
+	if len(b) != 5000 {
+		t.Fatalf("read %d bytes under a MaxInt64 cap, want 5000 — the +1 overflowed", len(b))
+	}
+}
+
+// TestReadFileLimited_ErrorNeverClaimsTruncation — a read that failed has no
+// claim to make about how much of the file it saw, and a caller that treats
+// truncated as authoritative must not be handed a guess.
+func TestReadFileLimited_ErrorNeverClaimsTruncation(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "absent")
+	b, truncated, err := safeio.ReadFileLimited(p, safeio.FollowSymlinks, 8)
+	if err == nil {
+		t.Fatal("reading an absent file succeeded")
+	}
+	if truncated {
+		t.Fatal("a failed read reported truncated=true")
+	}
+	if b != nil {
+		t.Fatalf("a failed read returned %d bytes", len(b))
+	}
+}
+
+// TestReadFile_StillTruncatesSilently pins the deliberate NON-change. Every
+// other caller in the tree keeps ReadFile, and ReadFile's contract — a prefix
+// with a nil error — is what those callers were written against. If this ever
+// starts erroring, the change reached callers it was not supposed to reach.
+func TestReadFile_StillTruncatesSilently(t *testing.T) {
+	p := rlWrite(t, 100)
+	b, err := safeio.ReadFile(p, safeio.FollowSymlinks, 64)
+	if err != nil {
+		t.Fatalf("ReadFile now errors on a truncated read: %v — that is a behaviour change for every caller", err)
+	}
+	if len(b) != 64 {
+		t.Fatalf("ReadFile returned %d bytes under a 64 cap, want 64", len(b))
+	}
+}

--- a/internal/safeio/safeio.go
+++ b/internal/safeio/safeio.go
@@ -72,6 +72,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"sync"
 	"time"
@@ -253,16 +254,60 @@ func openWithDeadline(path string, open func(string) (*os.File, error), timeout 
 // ReadFile is the os.ReadFile replacement. maxBytes caps how much is read
 // (0 = unlimited); it exists because a character device never reaches EOF, so
 // "it will hit EOF eventually" is not a bound.
+//
+// A file over the cap comes back TRUNCATED with a nil error. That is the
+// documented contract and it is unchanged, because most callers of this
+// package are reading a config or manifest and a short read costs them a
+// field, not correctness. A caller for whom a truncated read is a DIFFERENT
+// answer rather than a smaller one must call ReadFileLimited instead — see
+// #6969, where a truncated git sparse-checkout pattern file silently narrowed
+// the index.
 func ReadFile(path string, policy SymlinkPolicy, maxBytes int64) ([]byte, error) {
+	b, _, err := ReadFileLimited(path, policy, maxBytes)
+	return b, err
+}
+
+// ReadFileLimited is ReadFile plus the one bit ReadFile throws away: whether
+// the cap was hit and bytes were dropped.
+//
+// WHY A SEPARATE RETURN AND NOT A LENGTH COMPARISON. The obvious test at a
+// call site — len(b) == maxBytes — is WRONG in the one direction that matters:
+// a file whose size is exactly the cap is complete, and reporting it truncated
+// makes the cap itself a behaviour boundary that no caller can see. So the
+// read asks for maxBytes+1 and truncation is the observation that a
+// (maxBytes+1)'th byte existed. Exactly-at-the-cap is therefore reported
+// COMPLETE, and the returned slice is capped at maxBytes either way, so the
+// extra byte is never handed to a caller.
+//
+// truncated is false whenever err is non-nil or maxBytes <= 0 (unlimited): an
+// unlimited read has no cap to hit, and a failed read has no claim to make
+// about how much of the file it saw.
+func ReadFileLimited(path string, policy SymlinkPolicy, maxBytes int64) (data []byte, truncated bool, err error) {
 	f, err := Open(path, policy)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer f.Close()
 
-	var r io.Reader = f
-	if maxBytes > 0 {
-		r = io.LimitReader(f, maxBytes)
+	if maxBytes <= 0 {
+		b, err := io.ReadAll(f)
+		return b, false, err
 	}
-	return io.ReadAll(r)
+
+	// maxBytes+1, guarded: math.MaxInt64+1 wraps NEGATIVE, and
+	// io.LimitReader with a negative n reads zero bytes — an overflow here
+	// would turn "unbounded cap" into "empty file", which is the silent
+	// under-read this function exists to make impossible.
+	probe := maxBytes
+	if probe < math.MaxInt64 {
+		probe++
+	}
+	b, err := io.ReadAll(io.LimitReader(f, probe))
+	if err != nil {
+		return b, false, err
+	}
+	if int64(len(b)) > maxBytes {
+		return b[:maxBytes], true, nil
+	}
+	return b, false, nil
 }


### PR DESCRIPTION
Closes #6969.

`safeio.ReadFile` is `io.LimitReader` + `io.ReadAll`: **a file over the cap comes back truncated with a nil error**. For every other file `internal/gitmeta` reads that is loud — HEAD, `commondir`, the `.git` gitdir-file and a loose ref are each one short line, every parser here demands a shape, and a 64 KiB prefix of something else fails that shape and falls through to the "unknown" the callers already handle.

`info/sparse-checkout` is the one **list**-shaped reader in the package, and a prefix of a list is a valid-looking shorter list. The repo stayed sparse with fewer includes and files left the index with **no error, no `SkipEntry`, no missing-entity signal** — just a smaller graph.

It was also the last of #6967's three input states landing the wrong way:

| input | before | after |
|---|---|---|
| absent pattern file | not sparse → full index | unchanged |
| unreadable pattern file | not sparse → full index | unchanged |
| **oversized pattern file** | **sparse with a partial pattern set → files silently excluded** | **not sparse → full index** |

## The shape, and why

`safeio.ReadFileLimited(path, policy, maxBytes) ([]byte, bool, error)` — a distinct function returning the one bit `ReadFile` throws away.

**Truncation is observed, not inferred.** The read asks for `maxBytes+1`; truncation is the observation that a `(maxBytes+1)`'th byte existed. The obvious alternative — `len(b) == maxBytes` at the call site — is wrong in the direction that matters: a file whose size is *exactly* the cap is complete, and rejecting it would turn a perfectly good sparse repo into a full index while looking identical to correct code on every other input. The extra byte is never handed to a caller; the slice is capped either way. `maxBytes+1` is guarded against overflow at `math.MaxInt64`, where the wrap goes negative and `io.LimitReader` with a negative `n` reads **zero** bytes — the exact silent under-read this function exists to prevent.

`truncated` is false whenever `err != nil` or `maxBytes <= 0`: an unlimited read has no cap to hit, and a failed read has no claim to make about how much of the file it saw.

### Wholesale rejection, not "drop the corrupted final pattern"

Stated explicitly because the two are different safety properties and only one is right. A truncated read carries **two** hazards:

1. Every pattern **past the cut** is gone — arbitrarily many, not one. The surviving prefix is a syntactically perfect shorter list, so the repo stays sparse with fewer includes and the index silently shrinks.
2. The **cut line itself** is a pattern git never wrote. `!/src/sub/` severed at the cap is `!/src` — not a pattern that fails to match, a pattern that matches **wider** than intended.

Trimming the final line addresses hazard 2 and leaves hazard 1 entirely — and hazard 1 is the one that drops files. Rejecting the file lands both on "not sparse", i.e. a **full index**: a superset, the same over-inclusive direction the absent and unreadable cases already chose. Graded as **M4** below, which is that rejected design implemented and run.

The rejection is **reported** (`reportGitMetaTruncation`, sharing `reportGitMetaSkip`'s dedup map and 8-line cap). "Not sparse" on a repo the user made sparse is otherwise indistinguishable from grafel ignoring their sparse-checkout — #6338's shape.

## Callers: what changed and what deliberately did not

`ReadFile` keeps its signature **and its contract** (a prefix, nil error), now delegating to `ReadFileLimited` and discarding the bit. So the answer is short: **one call site changed.**

- **Changed** — `internal/gitmeta` `parseSparsePatternFile`, via a new `readGitMetaFileLimited`.
- **Deliberately unchanged, same package** — `readGitMetaFile`'s four other call sites in `cache.go` (`commondir`, HEAD, the gitdir-file, `contentToken`'s loose ref), all under `maxGitPointerBytes = 64 KiB`. Each is one short line with a demanded shape; a 64 KiB prefix of anything else fails to parse and reaches the existing "unknown" path loudly.
- **Deliberately unchanged, elsewhere** — every other `safeio.ReadFile` / `ReadFileReported` caller: `internal/licenses`, `internal/extractors/golang/gomod`, `internal/extractors/yaml/helm`, `internal/extractors/javascript/aliases`, `internal/install/detect`, `internal/links/safe_source_read` (which documents inheriting truncation on purpose), `internal/daemon/walk/saferead`, `internal/engine`'s substrate/wrapper readers and `orm_queries_python_mongo_agg.go:1312`, and the ~20 `MaxConfigFileBytes` config readers across `internal/install`, `internal/mcp`, `internal/registry`, `internal/dashboard`, `internal/agents`, `internal/agentpatterns`, `internal/cli`, `internal/quality/fitness`, `internal/daemon/worktree`, `internal/daemon/watch`. For all of these a truncated read costs a *field*, not a *decision about what gets indexed*. `TestReadFile_StillTruncatesSilently` pins that non-change: if `ReadFile` ever starts erroring on a capped read, the change reached callers it was not meant to reach.

Is it reachable? **No — but state that precisely: this is an absence of counter-example, not a corpus measurement.** No repo I could produce comes near 8 MiB of sparse patterns, and cone mode writes a handful of lines. I did not enumerate a corpus and measure pattern-file sizes, so the honest claim is that nothing reachable to me exhibits it, not that nothing does. This closes a latent hole whose failure mode is invisible by construction, not a live defect — same conclusion the issue reached, now with the hole shut.

## Grading — a named file, not a counter

The claim is "an oversized pattern file no longer silently narrows the index", so the artefact is **a specific file that would have been excluded and now is not, by name**.

`internal/gitmeta/sparse_truncation_6969_test.go` (package `gitmeta_test`, real git):

- **Premise asserted first.** `trSparseFixture` drives `git sparse-checkout set src` and `t.Fatal`s unless `services/orders/h.go` is *excluded* and `src/a.go` is *included* right now. Without that every assertion below is satisfied by a fixture that was never sparse.
- **`..._LineBoundaryCut_IndexesInFull`** — hazard 1. git's own bytes padded to exactly the cap, then `/services/` appended past it. The cut lands on a newline (**asserted**, byte `cap-1`). Observed: `services/orders/h.go` is **in** the index, and `si.Patterns` is empty.
- **`..._MidLineCut_DropsTheCorruptedPattern`** — hazard 2, a *separate* case, not a variant. The cut lands inside `!/src/sub/` leaving exactly `!/src` (**asserted**, both that the fragment is `"!/src"` and that byte `cap-1` is *not* a newline, so the two geometries cannot collapse into one). Observed: `!/src` never reaches `si.Patterns`, and `src/a.go` is **in** the index.
- **`..._ExactlyAtTheCapStaysSparse`** — the counter-case that makes the signal load-bearing rather than a size threshold. A file of exactly `maxSparsePatternBytes` is complete: the repo must stay sparse and `services/orders/h.go` must stay **out**. This asserts the exclusion direction survives at the boundary.

The external file hard-codes `8 << 20` as an **independent literal** rather than importing the constant — a fixture built relative to the constant under test cannot detect that constant changing, and these geometries are byte-exact. `TestSparseCapConstantMatchesTheTestsLiteral` (internal package) is the single place the two are compared and fails loudly if they diverge.

`internal/gitmeta/sparse_truncation_report_6969_test.go` covers the unit directly: truncated → `haveFile=false`, no patterns, and a report line naming the file, saying which way the decision fell, and carrying the issue ref — plus the other direction, that a complete pattern file prints **nothing** (this package is entered on every `whoami`/`ResolveCWD`; a reporter that fires on healthy repos buries its own signal).

`internal/safeio/readfile_limited_6969_test.go` sits at `cap-1` / `cap` / `cap+1` rather than "small" and "huge", with the overflow, unlimited, error and non-change cases.

## Mutants — 6 scored, 6 DEAD

Every one in the **more permissive** direction. Each edit proved landed by an exact occurrence count with the hit line printed; green baseline immediately before each score; restore by `cp` from a SHA-256-verified backup, never `git checkout --` (the three production files were re-hashed to their pre-mutation digests after every round, and the final tree matches).

| # | mutant | verdict |
|---|---|---|
| M1 | `ReadFileLimited` returns `truncated=false` over the cap — the signal never fires | **DEAD** — `TestReadFileLimited_AtTheBoundary` + both oversized cases + the report test |
| M2 | the sparse path ignores `truncated` (`if false && truncated`) — the #6969 pre-state | **DEAD** — both oversized cases + the report test |
| M3 | truncation inferred as `len(b) >= maxBytes`, probe back to `maxBytes` — the ambiguous form the design rejects | **DEAD** — `AtTheBoundary` *and* `ExactlyAtTheCapStaysSparse`, which is the case that exists for it |
| M4 | **the rejected design**: trim the corrupted final line, keep the rest, stay sparse | **DEAD** — both oversized cases + the report test. Hazard 1 is what kills it |
| M5 | reject, but silently — the truncation report never fires | **DEAD** — the report test |
| M6 | `readGitMetaFileLimited` always answers `truncated=false` | **DEAD** — both oversized cases + the report test |

M3 and M4 are the two that matter: they are the two designs a reasonable person would have written instead, and each dies on the case written specifically to distinguish it.

## Verification

`go test -count=1` green on `./internal/safeio/`, `./internal/gitmeta/` and **`./cmd/grafel/`** (the whole-graph digest pin — 165s, and no diff-derived package set reaches it). `gofmt -l` and `go vet` clean on every touched package. `git status --porcelain` clean, no `MUTANT` text in the tree.

Measured on **macOS/APFS, git 2.50.1 (Apple Git-155)** — the real-git fixtures log the version they ran on into every failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861

