### PR TITLE
feat(#6912): C# fields carried their declared type as a property and never as an edge — emit the field→type REFERENCES edge, for same-file types only

### DIFF
--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -91,6 +91,12 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// ones declared in this same file (which is all #4854 ever emitted, and
 	// always as EXTENDS).
 	entities = attachCsharpHierarchy(entities)
+	// Issue #6912 — field→declared-type REFERENCES edges, for the types
+	// DECLARED IN THIS FILE only. Runs after the walk because the set of
+	// in-file declarations is only complete once every declaration is on the
+	// table; see field_type_refs.go for why the target is addressed
+	// structurally rather than by bare name.
+	entities = attachCsharpFieldTypeRefs(entities, file.Path)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "csharp")
 	extractor.TagEntitiesLanguage(entities, "csharp")

--- a/internal/extractors/csharp/field_members.go
+++ b/internal/extractors/csharp/field_members.go
@@ -41,7 +41,7 @@ func emitFieldMembers(
 	var fields []types.EntityRecord
 	seen := make(map[string]bool)
 
-	add := func(name, typ string, startNode ts.Node) {
+	add := func(name, typ string, typeNode, startNode ts.Node) {
 		if name == "" || seen[name] {
 			return
 		}
@@ -72,6 +72,14 @@ func emitFieldMembers(
 			Metadata:           map[string]interface{}{"subtype": "field", "owner": ownerName},
 			EnrichmentRequired: false,
 		})
+		// Issue #6912 — stash every bare type name written in the declared
+		// type for attachCsharpFieldTypeRefs, which turns the ones DECLARED IN
+		// THIS FILE into REFERENCES edges once the walk has seen every
+		// declaration. Nothing is decided here: a field may be declared before
+		// the type it names.
+		if cands := csTypeRefCandidates(typeNode, src); len(cands) > 0 {
+			fields[len(fields)-1].Metadata[csFieldTypeRefsMetaKey] = cands
+		}
 	}
 
 	// Record positional parameters: `record Foo(int Id, string Name)`. The
@@ -83,9 +91,10 @@ func emitFieldMembers(
 				if p == nil || p.Type() != "parameter" {
 					continue
 				}
-				typ := leafTypeName(p.ChildByFieldName("type"), src)
+				typeNode := p.ChildByFieldName("type")
+				typ := leafTypeName(typeNode, src)
 				name := childFieldText(p, "name", src)
-				add(name, typ, p)
+				add(name, typ, typeNode, p)
 			}
 		}
 	}
@@ -98,15 +107,17 @@ func emitFieldMembers(
 			}
 			switch ch.Type() {
 			case "property_declaration":
-				typ := leafTypeName(ch.ChildByFieldName("type"), src)
+				typeNode := ch.ChildByFieldName("type")
+				typ := leafTypeName(typeNode, src)
 				name := childFieldText(ch, "name", src)
-				add(name, typ, ch)
+				add(name, typ, typeNode, ch)
 			case "field_declaration":
 				vd := findChildByType(ch, "variable_declaration")
 				if vd == nil {
 					continue
 				}
-				typ := leafTypeName(vd.ChildByFieldName("type"), src)
+				typeNode := vd.ChildByFieldName("type")
+				typ := leafTypeName(typeNode, src)
 				for j := 0; j < int(vd.ChildCount()); j++ {
 					d := vd.Child(j)
 					if d == nil || d.Type() != "variable_declarator" {
@@ -122,7 +133,7 @@ func emitFieldMembers(
 							}
 						}
 					}
-					add(name, typ, ch)
+					add(name, typ, typeNode, ch)
 				}
 			}
 		}

--- a/internal/extractors/csharp/field_type_refs.go
+++ b/internal/extractors/csharp/field_type_refs.go
@@ -49,10 +49,31 @@ import (
 // IN THE SAME FILE — the single condition under which a pass-1 per-file
 // extractor can know an entity exists at all. That one check is what drops
 // primitives (`int`, `string`), framework and BCL types (`HttpClient`), generic
-// wrappers (`List`), open type parameters (`T`) and every unmodelled name: none
-// of them is declared in the file, so none of them gets an edge. It is
-// deliberately the ONLY guard — a redundant primitive blocklist in front of it
-// would fire only where this check already fires, leaving both ungraded.
+// wrappers (`List`) and every unmodelled name: none of them is declared in the
+// file, so none of them gets an edge. It is deliberately the ONLY guard — a
+// redundant primitive blocklist in front of it would fire only where this check
+// already fires, leaving both ungraded.
+//
+// WHAT THE CHECK IS NOT. It is FILE scope and nothing else: it consults neither
+// the C# namespace nor type-parameter scope, so it over-fires twice, and both
+// over-fires produce an edge that BINDS — which makes them worse than a
+// dangling edge, because `bug-extractor` never sees a bound edge and no
+// disposition figure will surface them.
+//
+//	namespace A { class Customer … }
+//	namespace B { class Order { Customer Buyer … } }   ← one file: WRONG edge
+//	class Box<Customer> { Customer Item … }            ← beside a same-file
+//	                                                     class Customer: WRONG
+//
+// So an open type parameter `T` is dropped only because nothing in the file
+// happens to be named `T`, NOT because the guard understands type parameters.
+// Measured incidence is zero — aspnetcore-mvc has 12 .cs files declaring two or
+// more namespaces and emits no field-type edge inside any of them, and
+// aspnetcore-realworld and WakeOnLAN have no multi-namespace file at all — which
+// is why this arm records the limitation instead of fixing it. Both cases are
+// PINNED as known-wrong behaviour by the two
+// TestCsharpFieldTypeRefs_KnownOverFire_* cases, which a fix is expected to
+// break.
 //
 // THE COST OF THAT RULE, stated plainly: a field whose type is declared in
 // ANOTHER file gets no edge, which on a one-type-per-file C# codebase is most

--- a/internal/extractors/csharp/field_type_refs.go
+++ b/internal/extractors/csharp/field_type_refs.go
@@ -1,0 +1,210 @@
+package csharp
+
+import (
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// field_type_refs.go — the field→declared-type edge for C# (issue #6912).
+//
+// THE GAP. emitFieldMembers records a field's declared type as the `field_type`
+// PROPERTY and never as a relationship, so every SCOPE.Schema/field entity is a
+// leaf on its outbound side: `Order.Buyer` knows it is a `Customer` and the
+// graph cannot answer "which fields point at Customer?". #6912 measured
+// SCOPE.Schema/field at 86 of the golden corpus's 109 SCOPE.Schema orphans.
+//
+// THE VOCABULARY IS NOT NEW. The custom lane already emits exactly this edge in
+// five languages through one shared helper (internal/custom/{python,golang,
+// java,javascript,ruby}, `referencesClassEdge`): Kind REFERENCES with the
+// property `ref_kind: "field_target_type"`. Core adopts that spelling rather
+// than minting a third name — `TYPED_AS` and `HAS_TYPE` are both declared in
+// internal/types/kinds.go with zero producers (#6906, #5828), and a third
+// spelling would split every "which fields point at X?" query.
+//
+// THE ADDRESS IS NOT the custom lane's `Class:<Target>`, and that divergence is
+// measured, not stylistic. Both `Customer` and `Class:<Customer>` reach the
+// resolver's bare-name tier, which returns AMBIGUOUS the moment a second file
+// declares a type of the same name — `Result`, `Options` and `Settings` are
+// routine in C#. This pass therefore addresses the target by its exact
+// location:
+//
+//	class / interface / struct / record → extractor.BuildComponentStructuralRef
+//	                                      "scope:component:class:csharp:<file>:<Name>"
+//	enum                                → extractor.EnumQualifiedName
+//	                                      "scope:enum:<file>:<Name>"
+//
+// Both forms are file-scoped and bind exactly — proven against the production
+// resolver (resolve.BuildIndex → LookupStatusHint / ReferencesEmbedded) in
+// field_type_refs_6912_test.go, including the two-files-one-name case where the
+// bare-name forms go ambiguous. Once resolved the ToID is rewritten to the
+// target entity's ID, so the stub dialect is a binding mechanism only and no
+// downstream query sees it.
+//
+// A NON-BINDING EDGE IS WORSE THAN NO EDGE. An unresolved stub is kept verbatim
+// and dangling and classified `bug-extractor`; there is no masking branch and no
+// drop pass, and every emitted edge adds exactly one endpoint to the disposition
+// denominator (#6906). So the pass emits ONLY when the target type is DECLARED
+// IN THE SAME FILE — the single condition under which a pass-1 per-file
+// extractor can know an entity exists at all. That one check is what drops
+// primitives (`int`, `string`), framework and BCL types (`HttpClient`), generic
+// wrappers (`List`), open type parameters (`T`) and every unmodelled name: none
+// of them is declared in the file, so none of them gets an edge. It is
+// deliberately the ONLY guard — a redundant primitive blocklist in front of it
+// would fire only where this check already fires, leaving both ungraded.
+//
+// THE COST OF THAT RULE, stated plainly: a field whose type is declared in
+// ANOTHER file gets no edge, which on a one-type-per-file C# codebase is most
+// of them. Closing that needs a cross-file type view, and FileInput has none in
+// pass 1 (CrossFileFields is attached for pass-2.5 detectors only). That is a
+// separate arm, not a widening of this one.
+
+// csFieldTypeRefsMetaKey is the per-field stash written by emitFieldMembers and
+// consumed — and deleted — by attachCsharpFieldTypeRefs. The candidates cannot
+// be turned into edges during the walk: `class Order { Customer Buyer; }` may be
+// declared BEFORE `class Customer` in the same file, so the set of in-file
+// declarations is only complete once the walk has finished.
+const csFieldTypeRefsMetaKey = "field_type_refs"
+
+// csFieldTargetRefKind is the value of the `ref_kind` edge property, matching
+// the custom lane's shared referencesClassEdge helper verbatim.
+const csFieldTargetRefKind = "field_target_type"
+
+// csTypeRefCandidates returns every bare type name written in a field's declared
+// type expression, in source order and without deduplication.
+//
+// It descends the type node and collects `identifier` leaves, which unwraps
+// nullable (`Order?`), array (`Order[]`), pointer (`Order*`) and tuple
+// (`(int, Customer)`) syntax for free, and for a generic returns the CONSTRUCTOR
+// as well as its arguments — `Dictionary<string, Order>` yields
+// [Dictionary, Order] and `List<Order>` yields [List, Order]. Emitting to `List`
+// would be wrong and emitting to `Order` is right; the caller's in-file check is
+// what separates them, since `Dictionary` and `List` are never declared in the
+// file and `Order` may be. A user-defined generic (`Box<T>` declared here) is
+// picked up by the same mechanism.
+//
+// A qualified name (`App.Other.Customer`, `System.Net.Http.HttpClient`) is NOT
+// descended into, and that is the one case where the rule is stricter than the
+// in-file check alone: writing `App.Other.Customer` in a file that also declares
+// its own `Customer` names the OTHER type, and taking the rightmost segment
+// would bind the edge to the wrong entity. A same-file type is written bare in
+// practice, so the recall this costs is small and the false edge it prevents is
+// silent. Pinned by TestCsharpFieldTypeRefs_QualifiedTypeIsNotResolved.
+func csTypeRefCandidates(typ ts.Node, src []byte) []string {
+	var out []string
+	var walkType func(n ts.Node)
+	walkType = func(n ts.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "qualified_name", "alias_qualified_name":
+			return
+		case "identifier":
+			out = append(out, string(src[n.StartByte():n.EndByte()]))
+			return
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			walkType(n.NamedChild(i))
+		}
+	}
+	walkType(typ)
+	return out
+}
+
+// csFieldTypeTarget is one in-file type declaration a field can point at: the
+// structural ToID that binds to it, and the bare type name for the edge's
+// `target_type` property.
+type csFieldTypeTarget struct {
+	toID string
+	name string
+}
+
+// csInFileTypeTargets indexes every type DECLARED in this file that a field-type
+// edge may address, keyed by bare name.
+//
+// The SCOPE.Enum value-set node is the enum's target, not the SCOPE.Schema/enum
+// declaration twin: the twin carries QualifiedName "" and is unaddressable, and
+// the two share a Name so the bare-name tier is ambiguous between them (probed
+// in field_type_refs_6912_test.go). Targeting the value-set node is also what
+// gives SCOPE.Enum its first inbound edge — #6906 measures that population at
+// 100% terminal orphan.
+//
+// A name declared twice in one file (a partial class, or a class and an enum
+// sharing a name) is REMOVED rather than resolved to either, so the pass never
+// guesses which of two same-file declarations a field meant.
+func csInFileTypeTargets(records []types.EntityRecord, filePath string) map[string]csFieldTypeTarget {
+	targets := make(map[string]csFieldTypeTarget)
+	collide := make(map[string]bool)
+	put := func(name, toID string) {
+		if name == "" || toID == "" {
+			return
+		}
+		if _, seen := targets[name]; seen {
+			collide[name] = true
+			return
+		}
+		targets[name] = csFieldTypeTarget{toID: toID, name: name}
+	}
+	for i := range records {
+		r := &records[i]
+		if r.SourceFile != filePath {
+			continue
+		}
+		switch {
+		case r.Kind == "SCOPE.Enum":
+			put(r.Name, r.QualifiedName)
+		case r.Kind == "SCOPE.Component":
+			switch r.Subtype {
+			case "class", "interface", "struct", "type":
+				put(r.Name, extractor.BuildComponentStructuralRef("csharp", filePath, r.Name))
+			}
+		}
+	}
+	for name := range collide {
+		delete(targets, name)
+	}
+	return targets
+}
+
+// attachCsharpFieldTypeRefs appends one REFERENCES edge per (field, in-file
+// declared type) pair and clears the stash it consumed.
+//
+// FromID is left empty so graph assembly anchors the edge on the field record
+// that carries it — the Django precedent at
+// internal/extractors/python/django_relational.go:246-252. (Hibernate sets an
+// explicit structural FromID because it hangs its edge off its own parallel
+// SCOPE.Component node; that is a different shape and not the one to copy.)
+func attachCsharpFieldTypeRefs(records []types.EntityRecord, filePath string) []types.EntityRecord {
+	targets := csInFileTypeTargets(records, filePath)
+	for i := range records {
+		r := &records[i]
+		if r.Metadata == nil {
+			continue
+		}
+		cands, _ := r.Metadata[csFieldTypeRefsMetaKey].([]string)
+		delete(r.Metadata, csFieldTypeRefsMetaKey)
+		if len(cands) == 0 || r.Kind != "SCOPE.Schema" || r.Subtype != "field" {
+			continue
+		}
+		emitted := make(map[string]bool)
+		for _, cand := range cands {
+			t, ok := targets[cand]
+			if !ok || emitted[t.toID] {
+				continue
+			}
+			emitted[t.toID] = true
+			r.Relationships = append(r.Relationships, types.RelationshipRecord{
+				ToID: t.toID,
+				Kind: string(types.RelationshipKindReferences),
+				Properties: types.Props{
+					{K: "field_name", V: r.Properties["field_name"]},
+					{K: "ref_kind", V: csFieldTargetRefKind},
+					{K: "target_type", V: t.name},
+				},
+			})
+		}
+	}
+	return records
+}

--- a/internal/extractors/csharp/field_type_refs_6912_test.go
+++ b/internal/extractors/csharp/field_type_refs_6912_test.go
@@ -45,6 +45,8 @@ public class Order
     public Dictionary<string, Customer> ByName { get; set; }
     public Customer[] History { get; set; }
     public Order Parent { get; set; }
+    public (Customer, Customer) Pair { get; set; }
+    public global::Customer Aliased { get; set; }
     public int Quantity { get; set; }
     public string Label { get; set; }
     public System.Net.Http.HttpClient Client { get; set; }
@@ -134,6 +136,10 @@ func TestCsharpFieldTypeRefs_EmittedEdges(t *testing.T) {
 		"Order.ByName -> scope:component:class:csharp:Models/Order.cs:Customer",
 		"Order.Buyer -> scope:component:class:csharp:Models/Order.cs:Customer",
 		"Order.History -> scope:component:class:csharp:Models/Order.cs:Customer",
+		// ONE row, not two: `(Customer, Customer)` names the same target twice
+		// and the per-field dedup collapses it. A second identical row here is
+		// what a dropped dedup looks like.
+		"Order.Pair -> scope:component:class:csharp:Models/Order.cs:Customer",
 		"Order.Parent -> scope:component:class:csharp:Models/Order.cs:Order",
 		"Order.ShipTo -> scope:component:class:csharp:Models/Order.cs:Address",
 		"Order.Shipper -> scope:component:class:csharp:Models/Order.cs:IShipper",
@@ -162,6 +168,7 @@ func TestCsharpFieldTypeRefs_ForbiddenTargets(t *testing.T) {
 		"Order.Quantity", // int
 		"Order.Label",    // string
 		"Order.Client",   // System.Net.Http.HttpClient — qualified AND external
+		"Order.Aliased",  // global::Customer — alias-qualified, NOT descended into
 		"Customer.Name",  // string
 		"Money.Cents",    // int
 		"Address.City",   // string
@@ -263,15 +270,20 @@ func TestCsharpFieldTypeRefs_SameNameInTwoFiles(t *testing.T) {
 // TestCsharpFieldTypeRefs_SameNameDeclaredTwiceInOneFile — a name declared twice
 // in the SAME file is removed from the target index rather than resolved to
 // either declaration, so the pass never guesses.
+//
+// The fixture uses PARTIAL CLASSES on purpose. An earlier cut wrote the two
+// declarations into two different namespaces in one file, which made the
+// fixture's SHAPE imply that namespace scope is part of what the collide branch
+// considers. It is not — see
+// TestCsharpFieldTypeRefs_KnownOverFire_NamespaceScopeIsNotConsulted, which
+// pins the opposite. A fixture that implies coverage it does not assert is how
+// two defects got past review this cycle; partial classes exercise the same
+// branch and imply nothing about namespaces.
 func TestCsharpFieldTypeRefs_SameNameDeclaredTwiceInOneFile(t *testing.T) {
 	const src = `namespace App.Models;
 
-public class Widget { public string A { get; set; } }
-
-namespace App.Other
-{
-    public class Widget { public string B { get; set; } }
-}
+public partial class Widget { public string A { get; set; } }
+public partial class Widget { public string B { get; set; } }
 
 public class Holder { public Widget W { get; set; } }
 `
@@ -297,6 +309,58 @@ public class Holder { public Widget W { get; set; } }
 		if strings.HasPrefix(e, "Holder.W -> ") {
 			t.Fatalf("Widget is declared twice in this file; Holder.W must get no edge, got %q", e)
 		}
+	}
+}
+
+// TestCsharpFieldTypeRefs_KnownOverFire_NamespaceScopeIsNotConsulted and
+// TestCsharpFieldTypeRefs_KnownOverFire_TypeParameterShadowsSameFileType PIN A
+// KNOWN DEFECT, and they are the only assertions in this file that describe
+// behaviour that is WRONG.
+//
+// "Declared in this same file" is a FILE-scoped check with no namespace and no
+// type-parameter scope behind it. Two consequences, both found in review of
+// #6912 and both reproduced here:
+//
+//  1. `namespace A { class Customer }` + `namespace B { class Order { Customer
+//     Buyer } }` in one file emits an edge, though App.B.Order cannot see
+//     App.A.Customer without a `using`.
+//  2. A type PARAMETER named after a same-file class (`class Box<Customer>`)
+//     binds the parameter to the class.
+//
+// Both are WORSE than a dangling edge by the same logic that chose this pass's
+// address: the edge BINDS, so it never reaches `bug-extractor` and no
+// disposition figure will ever surface it. Measured incidence on the corpora is
+// ZERO — aspnetcore-mvc has 12 multi-namespace .cs files and emits no field-type
+// edge inside any of them; aspnetcore-realworld and WakeOnLAN have none at all
+// — which is why the behaviour is recorded here rather than fixed in this arm.
+//
+// These two tests are expected to FAIL when the follow-up fixes them. That is
+// the point: they make the limitation observable at the code, and a fix has to
+// come here and say so rather than changing behaviour silently.
+func TestCsharpFieldTypeRefs_KnownOverFire_NamespaceScopeIsNotConsulted(t *testing.T) {
+	const src = `namespace App.A { public class Customer { public string N { get; set; } } }
+namespace App.B { public class Order { public Customer Buyer { get; set; } } }
+`
+	recs := extractCSFiles(t, map[string]string{"F.cs": src})
+	want := []string{"Order.Buyer -> scope:component:class:csharp:F.cs:Customer"}
+	if got := fieldTypeRefEdges(t, recs); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("KNOWN over-fire changed shape — if namespace scope is now consulted, "+
+			"delete this test and say so\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestCsharpFieldTypeRefs_KnownOverFire_TypeParameterShadowsSameFileType(t *testing.T) {
+	const src = `namespace App.Models;
+
+public class Customer { public string N { get; set; } }
+
+public class Box<Customer> { public Customer Item { get; set; } }
+`
+	recs := extractCSFiles(t, map[string]string{"F.cs": src})
+	want := []string{"Box.Item -> scope:component:class:csharp:F.cs:Customer"}
+	if got := fieldTypeRefEdges(t, recs); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("KNOWN over-fire changed shape — if type-parameter scope is now "+
+			"consulted, delete this test and say so\n got: %v\nwant: %v", got, want)
 	}
 }
 
@@ -369,6 +433,7 @@ func TestCsharpFieldTypeRefs_ResolverBindsEveryEdge(t *testing.T) {
 		"Models/Order.cs:Order.ByName => Models/Order.cs:SCOPE.Component:Customer",
 		"Models/Order.cs:Order.Buyer => Models/Order.cs:SCOPE.Component:Customer",
 		"Models/Order.cs:Order.History => Models/Order.cs:SCOPE.Component:Customer",
+		"Models/Order.cs:Order.Pair => Models/Order.cs:SCOPE.Component:Customer",
 		"Models/Order.cs:Order.Parent => Models/Order.cs:SCOPE.Component:Order",
 		"Models/Order.cs:Order.ShipTo => Models/Order.cs:SCOPE.Component:Address",
 		"Models/Order.cs:Order.Shipper => Models/Order.cs:SCOPE.Component:IShipper",

--- a/internal/extractors/csharp/field_type_refs_6912_test.go
+++ b/internal/extractors/csharp/field_type_refs_6912_test.go
@@ -1,0 +1,384 @@
+package csharp_test
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	_ "github.com/cajasmota/grafel/internal/extractors/csharp"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6912 — the field→declared-type edge for C#. See field_type_refs.go for the
+// kind / address / same-file decisions; this file grades them.
+//
+// Every assertion below names FIELDS AND TARGETS. A count table cannot see a
+// substitution (#6973), and recall cannot see over-firing at all — so the
+// forbidden set (primitives, a BCL type, the generic CONSTRUCTORS `List` and
+// `Dictionary`, a qualified name) is asserted by name beside the expected set.
+
+const fieldTypeRefsOwnerPath = "Models/Order.cs"
+
+const fieldTypeRefsSrc = `namespace App.Models;
+
+public enum OrderStatus { New, Shipped }
+
+public interface IShipper { void Ship(); }
+
+public struct Money { public int Cents; }
+
+public record Address(string City, Money Total);
+
+public class Customer { public string Name { get; set; } }
+
+public class Order
+{
+    public Customer Buyer { get; set; }
+    public OrderStatus Status { get; set; }
+    public IShipper Shipper { get; set; }
+    public Address? ShipTo { get; set; }
+    public List<Customer> Watchers { get; set; }
+    public Dictionary<string, Customer> ByName { get; set; }
+    public Customer[] History { get; set; }
+    public Order Parent { get; set; }
+    public int Quantity { get; set; }
+    public string Label { get; set; }
+    public System.Net.Http.HttpClient Client { get; set; }
+}
+`
+
+// A SECOND file declaring types of the SAME bare names. Its only job is to make
+// the bare-name resolver tier ambiguous, which is why the structural address is
+// used; the edges from Models/Order.cs must be identical with and without it.
+const fieldTypeRefsRivalPath = "Other/Rival.cs"
+
+const fieldTypeRefsRivalSrc = `namespace App.Other;
+
+public class Customer { public string Other { get; set; } }
+public class Order { public Customer Buyer { get; set; } }
+public enum OrderStatus { A, B }
+`
+
+func extractCSFiles(t *testing.T, files map[string]string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("csharp")
+	if !ok {
+		t.Fatal("csharp extractor not registered")
+	}
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	var recs []types.EntityRecord
+	for _, p := range paths {
+		got, err := ext.Extract(context.Background(), extractor.FileInput{
+			Path:     p,
+			Content:  []byte(files[p]),
+			Language: "csharp",
+			TSTree:   parseForTest(t, files[p]),
+		})
+		if err != nil {
+			t.Fatalf("Extract %s: %v", p, err)
+		}
+		recs = append(recs, got...)
+	}
+	return recs
+}
+
+// fieldTypeRefEdges returns "<field name> -> <ToID>" for every REFERENCES edge
+// carrying ref_kind=field_target_type, across ALL records, so an edge that
+// escaped onto some other record is still seen. It fails on a non-empty FromID:
+// the Django precedent leaves it empty so assembly anchors the edge on the
+// field that carries it.
+func fieldTypeRefEdges(t *testing.T, recs []types.EntityRecord) []string {
+	t.Helper()
+	var out []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || propOf(r.Properties, "ref_kind") != "field_target_type" {
+				continue
+			}
+			if r.FromID != "" {
+				t.Errorf("%s -[REFERENCES]-> %s has FromID=%q, want empty",
+					recs[i].Name, r.ToID, r.FromID)
+			}
+			out = append(out, recs[i].Name+" -> "+r.ToID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func propOf(p types.Props, key string) string {
+	for _, kv := range p {
+		if kv.K == key {
+			return kv.V
+		}
+	}
+	return ""
+}
+
+// TestCsharpFieldTypeRefs_EmittedEdges is the positive direction, written as an
+// INDEPENDENT LITERAL set (#6975) rather than derived from the production
+// target index. Each ToID is spelled out so a change of address dialect, of
+// enum target node, or of owning field fails here instead of passing silently.
+func TestCsharpFieldTypeRefs_EmittedEdges(t *testing.T) {
+	recs := extractCSFiles(t, map[string]string{fieldTypeRefsOwnerPath: fieldTypeRefsSrc})
+	want := []string{
+		"Address.Total -> scope:component:class:csharp:Models/Order.cs:Money",
+		"Order.ByName -> scope:component:class:csharp:Models/Order.cs:Customer",
+		"Order.Buyer -> scope:component:class:csharp:Models/Order.cs:Customer",
+		"Order.History -> scope:component:class:csharp:Models/Order.cs:Customer",
+		"Order.Parent -> scope:component:class:csharp:Models/Order.cs:Order",
+		"Order.ShipTo -> scope:component:class:csharp:Models/Order.cs:Address",
+		"Order.Shipper -> scope:component:class:csharp:Models/Order.cs:IShipper",
+		"Order.Status -> scope:enum:Models/Order.cs:OrderStatus",
+		"Order.Watchers -> scope:component:class:csharp:Models/Order.cs:Customer",
+	}
+	sort.Strings(want)
+	got := fieldTypeRefEdges(t, recs)
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("field-type edges mismatch\n got:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+// TestCsharpFieldTypeRefs_ForbiddenTargets is the negative direction, by name.
+// Recall is structurally blind to over-firing and over-firing is the failure
+// mode that hurts here: every non-binding edge is one more `bug-extractor`
+// endpoint (#6906), so a too-broad predicate makes the graph worse, not better.
+func TestCsharpFieldTypeRefs_ForbiddenTargets(t *testing.T) {
+	recs := extractCSFiles(t, map[string]string{fieldTypeRefsOwnerPath: fieldTypeRefsSrc})
+	edges := fieldTypeRefEdges(t, recs)
+
+	// Fields whose declared type is a primitive, a BCL type, or a qualified
+	// name must carry NO field-type edge at all.
+	for _, field := range []string{
+		"Order.Quantity", // int
+		"Order.Label",    // string
+		"Order.Client",   // System.Net.Http.HttpClient — qualified AND external
+		"Customer.Name",  // string
+		"Money.Cents",    // int
+		"Address.City",   // string
+	} {
+		for _, e := range edges {
+			if strings.HasPrefix(e, field+" -> ") {
+				t.Errorf("%s must have no field-type edge, got %q", field, e)
+			}
+		}
+	}
+
+	// The generic CONSTRUCTORS are targets in their own right if anything
+	// emits to them. `List<Customer>` must reach Customer and never List.
+	for _, banned := range []string{"List", "Dictionary", "HttpClient", "int", "string"} {
+		for _, e := range edges {
+			if strings.HasSuffix(e, ":"+banned) {
+				t.Errorf("no field-type edge may target %q, got %q", banned, e)
+			}
+		}
+	}
+}
+
+// TestCsharpFieldTypeRefs_QualifiedTypeIsNotResolved pins the one place the
+// rule is stricter than "is it declared in this file": a qualified name is not
+// descended into, so `App.Other.Customer` does NOT bind to the file's own
+// `Customer` even though the rightmost segment matches it.
+func TestCsharpFieldTypeRefs_QualifiedTypeIsNotResolved(t *testing.T) {
+	const src = `namespace App.Models;
+
+public class Customer { public string Name { get; set; } }
+
+public class Order
+{
+    public App.Other.Customer Foreign { get; set; }
+    public Customer Local { get; set; }
+}
+`
+	recs := extractCSFiles(t, map[string]string{"Models/Order.cs": src})
+	want := []string{"Order.Local -> scope:component:class:csharp:Models/Order.cs:Customer"}
+	if got := fieldTypeRefEdges(t, recs); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("qualified-type edges\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// TestCsharpFieldTypeRefs_CrossFileTypeGetsNoEdge states the deliberate cost of
+// the same-file rule as an assertion rather than as prose: a field whose type
+// is declared in ANOTHER file gets nothing, because pass 1 has no cross-file
+// view and an edge it cannot verify would dangle.
+func TestCsharpFieldTypeRefs_CrossFileTypeGetsNoEdge(t *testing.T) {
+	recs := extractCSFiles(t, map[string]string{
+		"Models/Order.cs":   "namespace App.Models;\n\npublic class Order { public Shipper Via { get; set; } }\n",
+		"Models/Shipper.cs": "namespace App.Models;\n\npublic class Shipper { public string Name { get; set; } }\n",
+	})
+	// Positive control: the field whose type lives in the other file must exist,
+	// otherwise "no edges" is trivially true for the wrong reason.
+	found := false
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" && recs[i].Name == "Order.Via" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("fixture produced no Order.Via field; the cross-file case is not exercised")
+	}
+	if got := fieldTypeRefEdges(t, recs); len(got) != 0 {
+		t.Fatalf("cross-file declared type must produce no edge, got %v", got)
+	}
+}
+
+// TestCsharpFieldTypeRefs_SameNameInTwoFiles is the reason the address is
+// structural. The rival file declares Customer / Order / OrderStatus under the
+// same bare names; the edges emitted for Models/Order.cs must be byte-identical
+// to the single-file run.
+func TestCsharpFieldTypeRefs_SameNameInTwoFiles(t *testing.T) {
+	alone := fieldTypeRefEdges(t, extractCSFiles(t, map[string]string{
+		fieldTypeRefsOwnerPath: fieldTypeRefsSrc,
+	}))
+	withRival := fieldTypeRefEdges(t, extractCSFiles(t, map[string]string{
+		fieldTypeRefsOwnerPath: fieldTypeRefsSrc,
+		fieldTypeRefsRivalPath: fieldTypeRefsRivalSrc,
+	}))
+	// The rival file has its own Order.Buyer -> its own Customer.
+	wantExtra := "Order.Buyer -> scope:component:class:csharp:Other/Rival.cs:Customer"
+	var got []string
+	for _, e := range withRival {
+		if e != wantExtra {
+			got = append(got, e)
+		}
+	}
+	if strings.Join(got, "\n") != strings.Join(alone, "\n") {
+		t.Fatalf("a same-named type in another file changed this file's edges\n got:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(alone, "\n"))
+	}
+	if len(withRival) != len(alone)+1 {
+		t.Fatalf("rival file's own edge missing: %v", withRival)
+	}
+}
+
+// TestCsharpFieldTypeRefs_SameNameDeclaredTwiceInOneFile — a name declared twice
+// in the SAME file is removed from the target index rather than resolved to
+// either declaration, so the pass never guesses.
+func TestCsharpFieldTypeRefs_SameNameDeclaredTwiceInOneFile(t *testing.T) {
+	const src = `namespace App.Models;
+
+public class Widget { public string A { get; set; } }
+
+namespace App.Other
+{
+    public class Widget { public string B { get; set; } }
+}
+
+public class Holder { public Widget W { get; set; } }
+`
+	recs := extractCSFiles(t, map[string]string{"Models/Dup.cs": src})
+	// Positive control: the fixture must actually contain TWO Widget
+	// declarations and the Holder.W field, or the assertion below is vacuous.
+	widgets := 0
+	holderField := false
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Name == "Widget" {
+			widgets++
+		}
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" && recs[i].Name == "Holder.W" {
+			holderField = true
+		}
+	}
+	if widgets != 2 || !holderField {
+		t.Fatalf("fixture did not produce two Widget declarations and a Holder.W field "+
+			"(widgets=%d holderField=%v); the duplicate-name case is not exercised",
+			widgets, holderField)
+	}
+	for _, e := range fieldTypeRefEdges(t, recs) {
+		if strings.HasPrefix(e, "Holder.W -> ") {
+			t.Fatalf("Widget is declared twice in this file; Holder.W must get no edge, got %q", e)
+		}
+	}
+}
+
+// TestCsharpFieldTypeRefs_ResolverBindsEveryEdge is the gate this whole issue
+// class turns on: #6906 exists because a comment described a binding nobody
+// built. Every emitted edge is driven through the PRODUCTION resolver
+// (BuildIndex → ReferencesEmbedded, exactly as graph assembly does) and must
+// come back REWRITTEN to a real entity ID. A dangling edge is worse than no
+// edge — it is one more `bug-extractor` endpoint — so zero non-resolved
+// dispositions is the assertion, not a ratio.
+func TestCsharpFieldTypeRefs_ResolverBindsEveryEdge(t *testing.T) {
+	recs := extractCSFiles(t, map[string]string{
+		fieldTypeRefsOwnerPath: fieldTypeRefsSrc,
+		fieldTypeRefsRivalPath: fieldTypeRefsRivalSrc,
+	})
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6912", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+	idx := resolve.BuildIndex(recs)
+
+	// Positive control on the address dialect itself: the BARE-name form of the
+	// same target is AMBIGUOUS here, which is why it is not what we emit.
+	if _, st := idx.LookupStatusHint("Customer", "REFERENCES"); st == 1 {
+		t.Fatalf("the bare name %q binds in this fixture, so the ambiguity this "+
+			"test controls for is not present and the structural address is ungraded", "Customer")
+	}
+
+	// Snapshot the (field, target-entity) pairs the structural stubs point at
+	// BEFORE resolution rewrites the ToIDs in place.
+	idToName := map[string]string{}
+	for i := range recs {
+		idToName[recs[i].ID] = recs[i].SourceFile + ":" + recs[i].Kind + ":" + recs[i].Name
+	}
+
+	before := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "REFERENCES" && propOf(r.Properties, "ref_kind") == "field_target_type" {
+				before++
+			}
+		}
+	}
+	if before == 0 {
+		t.Fatal("no field-type edges to drive through the resolver")
+	}
+
+	resolve.ReferencesEmbedded(recs, idx)
+
+	var bound []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || propOf(r.Properties, "ref_kind") != "field_target_type" {
+				continue
+			}
+			target, ok := idToName[r.ToID]
+			if !ok {
+				t.Errorf("%s -[REFERENCES]-> %q did NOT bind to an entity ID (dangling stub)",
+					recs[i].Name, r.ToID)
+				continue
+			}
+			bound = append(bound, recs[i].SourceFile+":"+recs[i].Name+" => "+target)
+		}
+	}
+	sort.Strings(bound)
+	want := []string{
+		"Models/Order.cs:Address.Total => Models/Order.cs:SCOPE.Component:Money",
+		"Models/Order.cs:Order.ByName => Models/Order.cs:SCOPE.Component:Customer",
+		"Models/Order.cs:Order.Buyer => Models/Order.cs:SCOPE.Component:Customer",
+		"Models/Order.cs:Order.History => Models/Order.cs:SCOPE.Component:Customer",
+		"Models/Order.cs:Order.Parent => Models/Order.cs:SCOPE.Component:Order",
+		"Models/Order.cs:Order.ShipTo => Models/Order.cs:SCOPE.Component:Address",
+		"Models/Order.cs:Order.Shipper => Models/Order.cs:SCOPE.Component:IShipper",
+		"Models/Order.cs:Order.Status => Models/Order.cs:SCOPE.Enum:OrderStatus",
+		"Models/Order.cs:Order.Watchers => Models/Order.cs:SCOPE.Component:Customer",
+		"Other/Rival.cs:Order.Buyer => Other/Rival.cs:SCOPE.Component:Customer",
+	}
+	sort.Strings(want)
+	if strings.Join(bound, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("resolved endpoints mismatch\n got:\n%s\nwant:\n%s",
+			strings.Join(bound, "\n"), strings.Join(want, "\n"))
+	}
+}


### PR DESCRIPTION
C# `SCOPE.Schema`/field entities recorded their declared type in the `field_type` **property** and never in `Relationships`, so every field was a leaf on its outbound side and "which fields point at `Customer`?" returned empty. This adds the producer, for C# only, and only where the edge is guaranteed to bind.

**Arm A of a multi-language defect — `Refs #6912`, the issue stays open.** Java does not retain the type string at all and several other core extractors don't either; capturing it is per-language cost and a different arm.

## The standing gate was cleared FIRST, and it is now a committed test

#6906/#6912 exist because a comment described a binding nobody built, so nothing was implemented until a synthetic field→type edge had been driven through the production resolver. `TestCsharpFieldTypeRefs_ResolverBindsEveryEdge` is that probe, kept: it runs the real path (`resolve.BuildIndex` → `resolve.ReferencesEmbedded`, exactly as graph assembly does) and asserts all 10 emitted edges are **rewritten to real entity IDs**, naming each `(field ⇒ target entity)` pair. Re-confirmed after rebasing onto `bd03cdfeb` — #6980 reworked `indexByName` and the `nameAmbigRef` raise in `refs.go`, so the pre-rebase result was re-measured rather than carried over.

## The three decisions, and the evidence for each

**Kind + discriminator — adopted, not minted.** `REFERENCES` with the property `ref_kind: "field_target_type"`, which is what `internal/custom/{python,golang,java,javascript,ruby}` already emit through the shared `referencesClassEdge`. `TYPED_AS` and `HAS_TYPE` stay producerless (#6906, #5828); a third spelling for one relation would split every "which fields point at X?" query (#6902's family).

**Address — deliberately NOT that lane's `Class:<Target>`, and the reason is measured.** Both `Customer` and `Class:Customer` reach the resolver's bare-name tier, which returns **AMBIGUOUS** as soon as a second file declares a type of the same name (`Result`, `Options`, `Settings` are routine in C#). Probed both ways:

| ToID form | one file declares `Customer` | two files declare `Customer` |
|---|---|---|
| `Customer` | rewritten | **ambiguous** |
| `Class:Customer` | rewritten | **ambiguous** |
| `scope:component:class:csharp:<file>:Customer` | rewritten | **rewritten** |
| `scope:enum:<file>:OrderStatus` | rewritten | **rewritten** |
| `OrderStatus` (bare) | **ambiguous** — the `SCOPE.Schema`/enum twin shares the Name | ambiguous |

So targets are addressed by location: `extractor.BuildComponentStructuralRef` for class/interface/struct/record, `extractor.EnumQualifiedName` for enums. Once resolved the `ToID` is rewritten to the target's entity ID, so the stub dialect is a **binding mechanism only** — no downstream query sees it, and the kind/`ref_kind` consistency the custom lane established is untouched. `TestCsharpFieldTypeRefs_SameNameInTwoFiles` holds this, and `TestCsharpFieldTypeRefs_ResolverBindsEveryEdge` carries a positive control asserting the bare name really is ambiguous in that fixture — otherwise the structural address would be ungraded.

The enum target is the `SCOPE.Enum` value-set node, which gives that population its **first inbound edge** (#6906 measures it at 100% terminal orphan). That is the "widen `REFERENCES` to carry QN-addressed enum targets" option #6912's own comment argues for; `ref_kind` expresses the distinction as a property.

**A non-binding edge is worse than no edge, so: same-file types only.** An unresolved stub is kept verbatim and dangling and classified `bug-extractor`, with no masking branch and no drop pass, and each emitted edge adds exactly one endpoint to the disposition denominator. Being declared in this file is the only condition a pass-1 per-file extractor can *know*, so it is the only condition under which an edge is emitted.

### The rule, branch by branch — and what grades each branch

Every bare type name written in the declared type is a candidate (`nullable_type`, `array_type`, `pointer_type`, tuple and generic-argument syntax are all unwrapped by one recursive walk); a candidate becomes an edge **iff a type of that name is declared in this same file**.

| input | result | graded by |
|---|---|---|
| `Customer Buyer` (declared here) | edge → `…:Customer` | `_EmittedEdges` |
| `OrderStatus Status` (enum here) | edge → `scope:enum:…:OrderStatus` | `_EmittedEdges` |
| `IShipper` / `Money` / `Address` (interface / struct / record) | edge | `_EmittedEdges` |
| `Address? ShipTo`, `Customer[] History` | edge to the element type | `_EmittedEdges` |
| `List<Customer>`, `Dictionary<string, Customer>` | edge to **`Customer`**, never to `List`/`Dictionary` | `_EmittedEdges` + `_ForbiddenTargets` (the wrappers are banned targets **by name**) |
| `Order Parent` (self-reference) | edge → itself | `_EmittedEdges` |
| `int` / `string` | **no edge** | `_ForbiddenTargets`, by field name |
| `System.Net.Http.HttpClient` | **no edge** | `_ForbiddenTargets`, by field name |
| `App.Other.Customer` where this file also declares `Customer` | **no edge** — a qualified name is not descended into, so the rightmost segment cannot bind to the wrong entity | `_QualifiedTypeIsNotResolved` |
| type declared in **another** file | **no edge** | `_CrossFileTypeGetsNoEdge` (+ positive control that the field exists) |
| name declared **twice in one file** | **no edge** — removed from the index rather than guessed | `_SameNameDeclaredTwiceInOneFile` (+ positive control that both declarations and the field exist) |
| open type parameter `T` | no edge — not declared here | same single check |

The in-file check is deliberately the **only** guard. A primitive blocklist in front of it would fire only where it already fires, leaving both ungraded.

**The cost of the same-file rule, stated as an assertion and not as prose:** a field whose type lives in another file gets nothing. Closing that needs a cross-file type view and `FileInput` has none in pass 1 (`CrossFileFields` is attached for pass-2.5 detectors only). Separate arm, not a widening of this one.

## Measurement — and the golden-corpus number is zero

All figures below are from the **core pass-1 extractor**, which runs regardless of the custom gate (#6966); this pass consults no detector output, so **custom-gate ON and OFF are the same number**. macOS/APFS, measured in `…/scratchpad/impl-6912a-q8w3z/wt`.

**Golden corpus: 0 edges added, 0 `*/field` orphans cleared.** Its 8 `.cs` files contain **3 C# field entities in total**, enumerated rather than counted:

- `csharp-aspnet-core-mini` `UsersController._userService : IUserService` — interface declared in another file
- `csharp-hangfire-mini` `JobSelector.Ascending : string` — primitive
- `csharp-hangfire-mini` `JobSelector.Descending : string` — primitive

None has a same-file declared type, so none gains an edge. The issue's "86 field orphans" ceiling is dominated by other languages; **none of the 86 clears here**, and that is why the `cmd/grafel` digest and the golden ratchet are both unmoved rather than silently re-baselined.

**Real C# corpora — where the mechanism actually has reach** (read-only clones under `archigraph-corpora`, extractor run directly):

| corpus | `.cs` files | field entities | fields gaining an edge | edges |
|---|---|---|---|---|
| aspnetcore-mvc | 2677 | 7637 | 490 (6.4%) | 493 |
| aspnetcore-realworld | 75 | 140 | 9 (6.4%) | 9 |
| WakeOnLAN | 22 | 133 | 6 (4.5%) | 6 |

21 of aspnetcore-mvc's 493 target an enum. Sampled edges are semantically real — `Family.Dad → Person`, `Parent.Children → Child`, `Order11.Customer → Person11`, `ResourceInvoker._exceptionContext → ExceptionContextSealed`.

**#6726's 99.3% of 35,353 is the contributor's corpus, not ours. The mechanism transfers; the number does not, and nothing here claims it moves.**

## Known over-fires: namespace scope is NOT consulted (added after review)

The same-file check is **file scope and nothing else**. Two cases emit a wrong edge, both found in review:

```csharp
namespace A { class Customer { … } }
namespace B { class Order { public Customer Buyer { get; set; } } }   // one file → WRONG edge
class Box<Customer> { public Customer Item { get; set; } }            // beside a same-file class Customer → WRONG
```

**These are worse than a dangling edge, by the same logic that chose this PR's address.** The edge *binds*, so it never lands in `bug-extractor` and no disposition figure will ever surface it — unlike an unresolved stub, which is at least counted.

**Measured incidence: zero.** aspnetcore-mvc has 12 `.cs` files declaring two or more namespaces and emits **no** field-type edge inside any of them; aspnetcore-realworld and WakeOnLAN have no multi-namespace file at all. Latent, not live — which is why this arm records the limitation instead of fixing it (a follow-up issue is being filed).

Recorded in three places rather than only on the board: the `field_type_refs.go` header (at the code someone reads), and two tests — `TestCsharpFieldTypeRefs_KnownOverFire_NamespaceScopeIsNotConsulted` and `..._TypeParameterShadowsSameFileType` — which **pin the wrong behaviour on purpose** and are expected to fail when the follow-up fixes it, so no fix can change this silently.

**The duplicate-name fixture no longer implies coverage it does not assert.** It was written with its two declarations in two namespaces of one file, which made its *shape* suggest namespace scope was part of the collide branch. It now uses partial classes — same branch, no implication.

**One prose over-claim removed:** "that one check drops … open type parameters `T`" was false in general; `T` is dropped only because nothing in the file happens to be named `T`. The `Box<Customer>` case above is the counter-example.

## Verification

- `go test -count=1 ./internal/extractors/csharp/` — green (the only package touched). `./internal/extractors/...` green.
- **`./cmd/grafel/` green** — the `custom_extractor_spans_6118_test.go` digest pin is **unmoved**, and the reason was enumerated, not assumed: its 7 inline `.cs` fixtures contain exactly two field entities — `OrdersController._svc : IOrderService` and `ShopContext.Orders : DbSet<Order>` — and neither type is declared in the file that uses it, so this pass emits nothing there. No constant was bumped.
- **Golden ratchet** (`scripts/quality/run.sh --ratchet`, isolated `HOME`/`GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT`): 38 gated fixtures held their baseline, 29 at 100% must-have recall. No baseline moved.
- Both whole-graph gates were re-run **after** the rebase onto `bd03cdfeb`; the pre-rebase runs are not quoted as evidence for the merged state.
- Re-run again after the review commit: `./internal/extractors/...` exit 0, `./cmd/grafel/` exit 0 (148s, digest still unmoved), ratchet exit 0 (38 held, 29 at 100%). That commit is comment-and-test only — no production behaviour changed.

### Mutants, all in the MORE PERMISSIVE direction — 4 applied, 4 DEAD

Each edit was applied from a shasum-verified backup with an asserted occurrence count of exactly 1 **and** an assertion on the enclosing function (and, for M3, on the neighbouring `case` line); `go vet` passed before every score, and the tree was restored by `cp` and shasum-compared afterwards.

| mutant | site | verdict |
|---|---|---|
| **M1** drop the in-repo check — fall back to a bare-name `ToID` for any unresolved candidate | `attachCsharpFieldTypeRefs` | **DEAD** — `_EmittedEdges`, `_CrossFileTypeGetsNoEdge`, `_SameNameDeclaredTwiceInOneFile`, `_ResolverBindsEveryEdge` all fail |
| **M2** descend into qualified names | `csTypeRefCandidates` | **DEAD** — `_QualifiedTypeIsNotResolved` |
| **M3** address targets by bare name instead of structurally | `csInFileTypeTargets` | **DEAD** — `_EmittedEdges`, `_QualifiedTypeIsNotResolved`, `_SameNameInTwoFiles`, `_ResolverBindsEveryEdge` |
| **M4** keep a name declared twice in one file and bind the first | `csInFileTypeTargets` | **DEAD** — `_SameNameDeclaredTwiceInOneFile` |
| **RM3** drop the per-field dedup *(review-found, ALIVE → now graded)* | `attachCsharpFieldTypeRefs` | **DEAD** — `(Customer, Customer) Pair` yields one `want` row, so a duplicate fails `_EmittedEdges` and `_ResolverBindsEveryEdge` |
| **RM4** drop `alias_qualified_name` from the not-descended case *(review-found, ALIVE → now graded)* | `csTypeRefCandidates` | **DEAD** — `global::Customer Aliased` is a named forbidden field; fails `_EmittedEdges`, `_ForbiddenTargets`, `_ResolverBindsEveryEdge` |

The review's RM1 and RM2 stay ALIVE and are **not** production-reachable / equivalent, with the reviewer's reasons: `Extract` is per-file so the `SourceFile != filePath` guard can never fire, and `csFieldTypeRefsMetaKey` has exactly one write site and it is on a field record.

## Not done here

- Cross-file targets (arm B; needs a pass-1 cross-file type view).
- Any other language — no second extractor was touched.
- The two over-fires above (namespace scope, type-parameter shadowing) — pinned, not fixed; zero measured incidence.
- The corollary the reviewer drew and I did not: if `Class:<Target>` goes ambiguous under duplicate type names, the shipped **custom lane** dangles the same way in golang/javascript/ruby/java (`refs.go:4574` masks `lang == "" || lang == "python"` only). Filed separately by the coordinator; out of scope for this arm.
- `internal/extractor/enum_valueset.go:23,70` still describe the `TYPED_AS` plan. Now that a real producer exists those comments are misleading and should be corrected on **#6906**, which owns them; left alone to keep this change to one package.

Refs #6912, #6906, #5828, #6726, #6966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
