### PR TITLE
fix(#6985): an oversized file was dropped from the graph with no name and no reason — the loss is exclusion, and the comment that said otherwise caused a phantom issue

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -2904,6 +2904,10 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	trk.Done(len(files), doc.Stats.Entities)
 
 	dur := time.Since(start)
+	// #6985 — close the oversized-file report before the aggregate line, so a
+	// user who saw eight names also learns how many more there were. Prints
+	// nothing unless the cap actually hid something.
+	i.classifier.ReportOversizedSummary()
 	fmt.Fprintf(os.Stderr,
 		"grafel: processed=%d extracted=%d skipped=%d failed=%d "+
 			"entities=%d relationships=%d "+

--- a/cmd/grafel/oversized_report_6985_test.go
+++ b/cmd/grafel/oversized_report_6985_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #6985 — the oversized-file report and its end-of-index total, observed on
+// the PRODUCTION index path rather than in a classifier unit test.
+//
+// This test exists because the summary call is one line of wiring in
+// Indexer.Run: deleting it left every classifier-package test green, so
+// nothing graded whether a user actually gets the total. The named lines are
+// asserted here too, for the same reason — they are emitted from inside the
+// worker pool, which no unit test exercises.
+//
+// NOTE: this test swaps the process-global os.Stderr handle and therefore MUST
+// NOT call t.Parallel(), for the reason spelled out on
+// TestExternalSynthesis_VerboseCounter.
+func TestOversizedFilesAreNamedAndTotalledByTheIndexer_6985(t *testing.T) {
+	repo := t.TempDir()
+
+	// One indexable file so the run has real work, plus enough oversized ones
+	// to overflow the report's cap.
+	if err := os.WriteFile(filepath.Join(repo, "app.js"),
+		[]byte("export function handler(req, res) { return res.send('ok'); }\n"), 0o644); err != nil {
+		t.Fatalf("write app.js: %v", err)
+	}
+	const oversizedCount = 9
+	padding := strings.Repeat("x", 1<<20) // one byte of prelude puts it over 1 MiB
+	for i := range oversizedCount {
+		name := fmt.Sprintf("bundle_%d.js", i)
+		body := fmt.Sprintf("// %s\n/*%s*/\n", name, padding)
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		if st, err := os.Stat(filepath.Join(repo, name)); err != nil || st.Size() <= 1<<20 {
+			t.Fatalf("fixture degenerate: %s is %v bytes (err %v), want > 1 MiB", name, st.Size(), err)
+		}
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var buf []byte
+		tmp := make([]byte, 4096)
+		for {
+			n, err := r.Read(tmp)
+			if n > 0 {
+				buf = append(buf, tmp[:n]...)
+			}
+			if err != nil {
+				break
+			}
+		}
+		done <- string(buf)
+	}()
+
+	idx := newTestIndexer(t, "oversized_repo", nil, "")
+	_, runErr := idx.Run(context.Background(), repo)
+
+	os.Stderr = origStderr
+	w.Close()
+	got := <-done
+	if runErr != nil {
+		t.Fatalf("Run: %v\nstderr:\n%s", runErr, got)
+	}
+
+	// Exactly the cap's worth of files is named…
+	named := 0
+	for i := range oversizedCount {
+		if strings.Contains(got, fmt.Sprintf("bundle_%d.js is ", i)) {
+			named++
+		}
+	}
+	if named != 8 {
+		t.Errorf("indexer named %d oversized files, want 8 (the cap); stderr:\n%s", named, got)
+	}
+	if !strings.Contains(got, "was NOT indexed") {
+		t.Errorf("no oversized-skip line on the production path; stderr:\n%s", got)
+	}
+	// …and the end-of-index line says how many it did not name. Without the
+	// ReportOversizedSummary call in Run this is the assertion that fails.
+	if !strings.Contains(got, "1 further oversized-file skips were not named") {
+		t.Errorf("no end-of-index total for the suppressed oversized files; stderr:\n%s", got)
+	}
+	if !strings.Contains(got, "9 over the 1048576-byte limit in total") {
+		t.Errorf("the total does not say how many files were over the limit; stderr:\n%s", got)
+	}
+}

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -168,8 +168,13 @@ func (c *Classifier) classifyWithSizeInner(filePath string, sizeBytes int64) Cla
 		return ClassifyResult{Skip: true, SkipReason: "empty_path"}
 	}
 
-	// Size check first — cheapest guard.
+	// Size check first — cheapest guard. The skip is announced (#6985): an
+	// oversized file mints no entity and appears nowhere in graph.json, and
+	// before the report the only trace of it was the aggregate `skipped=N`.
+	// See oversized_report.go for why the report lives here and why the
+	// UnsupportedTally is not the surface for it.
 	if sizeBytes > maxIndexableBytes {
+		reportOversizedSkip(filePath, sizeBytes)
 		return ClassifyResult{Skip: true, SkipReason: "too_large"}
 	}
 

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -53,6 +53,10 @@ type ClassifyResult struct {
 type Classifier struct {
 	// tracer is the OTel tracer used for classify spans.
 	tracer trace.Tracer
+
+	// oversized carries this classifier's oversized-skip report state. It is
+	// per-Classifier, i.e. per index, on purpose — see oversized_report.go.
+	oversized oversizedReporter
 }
 
 // New constructs a Classifier.
@@ -174,7 +178,7 @@ func (c *Classifier) classifyWithSizeInner(filePath string, sizeBytes int64) Cla
 	// See oversized_report.go for why the report lives here and why the
 	// UnsupportedTally is not the surface for it.
 	if sizeBytes > maxIndexableBytes {
-		reportOversizedSkip(filePath, sizeBytes)
+		c.oversized.report(filePath, sizeBytes)
 		return ClassifyResult{Skip: true, SkipReason: "too_large"}
 	}
 

--- a/internal/classifier/oversized_report.go
+++ b/internal/classifier/oversized_report.go
@@ -25,71 +25,136 @@ import (
 // report counts, which is a different report about a different fact. This is a
 // separate surface for a separate disposition.
 //
-// WHY HERE rather than at the extraction entry points. Three call sites
-// classify with a size (cmd/grafel/index.go, internal/daemon/extract's
-// coordinator and subproc). Reporting at each of them is the shape that let
-// eleven copies of one read diverge in #6823; classifyWithSizeInner is the
-// single place "too_large" is minted, so guarding it there is by construction.
+// WHY HERE rather than at the consuming call sites. Within this package
+// "too_large" is minted in exactly one place, classifyWithSizeInner, while
+// FOUR call sites consume it: cmd/grafel/index.go, internal/daemon/extract's
+// coordinator and subproc, and internal/extractors/incremental.go:1003 on the
+// daemon's watcher-driven incremental path. (internal/secrets declares its own
+// unrelated SkipTooLarge constant; that is a different subsystem and not this
+// mint point.) Reporting at each consumer is the shape that let eleven copies
+// of one read diverge in #6823; guarding the mint point is by construction.
+//
+// WHY THE STATE IS PER-CLASSIFIER. It was process-global in the first cut of
+// this file, and that made the report go permanently and globally silent after
+// the first eight oversized files: the second index in the same process — a
+// different repo included — printed nothing at all, not even the suppression
+// line, so a user who fixed nothing and re-ran saw a clean report. internal/
+// gitmeta can hold process-global state because its inputs are read once per
+// process; this code re-enters per index AND per daemon incremental reindex.
+// Every construction site (cmd/grafel/index.go:808,
+// internal/daemon/extract/coordinator.go:662, subproc.go:105,
+// internal/extractors/incremental.go:886) calls classifier.New per run, so
+// hanging the state off the Classifier makes the lifetime per-index with no
+// reset call for a caller to forget.
 
-// oversized* back the always-on report below. Shape taken from
-// internal/gitmeta's reportGitMetaSkip / reportGitMetaTruncation: a dedup map
-// plus a cap, so the output stays bounded.
-var (
-	oversizedMu   sync.Mutex
-	oversizedSeen map[string]bool
-	oversizedOut  io.Writer = os.Stderr
-)
-
-// maxOversizedReports caps the report the way maxGitMetaSkipReports caps its
-// own: a warning long enough to scroll past reports nothing.
+// maxOversizedReports caps the NAMED lines, the way maxGitMetaSkipReports caps
+// internal/gitmeta's: a warning long enough to scroll past reports nothing.
 //
 // The cap is load-bearing here rather than a backstop. The population is
 // exactly a repo full of vendored bundles — of the ten oversized files with a
 // recognised language across grafel's 60 corpora, eight are compiled/vendored
 // JS and nine of the ten are in a single repo — so a line per file is the
-// output shape this report has to avoid. A bounded list plus the existing
-// `skipped=N` aggregate is what a reader can act on.
+// output shape this report has to avoid.
 const maxOversizedReports = 8
 
-// setOversizedReportOutput redirects the report for tests and returns a
-// restore func. Test-only helper.
-func setOversizedReportOutput(w io.Writer) func() {
-	oversizedMu.Lock()
-	prev := oversizedOut
-	oversizedOut = w
-	oversizedSeen = nil
-	oversizedMu.Unlock()
-	return func() {
-		oversizedMu.Lock()
-		oversizedOut = prev
-		oversizedSeen = nil
-		oversizedMu.Unlock()
-	}
+// oversizedReporter is one index's worth of oversized-skip reporting state.
+//
+// The mutex is not decoration: ClassifyWithSize runs inside the indexer's
+// worker pool (cmd/grafel/index.go), so an unguarded map write here is a
+// concurrent map write — a Go runtime fatal, not a warning.
+type oversizedReporter struct {
+	mu sync.Mutex
+	// seen holds the paths already NAMED, and is capped at
+	// maxOversizedReports so its memory is O(cap) rather than O(oversized
+	// files in the repo).
+	seen map[string]bool
+	// suppressed counts the skips that were not named because the cap was
+	// already full. It is what lets the end-of-index line say how much was
+	// cut: "8 of 40" and "8 of 9" are indistinguishable without it.
+	suppressed int
+	// out is nil in production and is os.Stderr then; tests redirect it.
+	out io.Writer
 }
 
-// reportOversizedSkip names a file that was dropped for exceeding the size
-// gate, and says what the consequence is.
+// writer resolves the destination. Callers hold r.mu.
+func (r *oversizedReporter) writer() io.Writer {
+	if r.out == nil {
+		return os.Stderr
+	}
+	return r.out
+}
+
+// setOversizedReportOutput redirects one classifier's report. Test-only
+// helper: production never sets it, so the zero value writes to stderr.
+func setOversizedReportOutput(c *Classifier, w io.Writer) {
+	c.oversized.mu.Lock()
+	c.oversized.out = w
+	c.oversized.mu.Unlock()
+}
+
+// report names a file that was dropped for exceeding the size gate, and says
+// what the consequence is.
 //
 // It reports and returns; it does not change the ClassifyResult, so the
 // `skipped=N` aggregate still counts a named file exactly once, as a skip. The
-// dedup map is keyed on the file path, so two distinct oversized files are two
+// dedup is keyed on the file path, so two distinct oversized files are two
 // lines and the same file classified twice is one.
-func reportOversizedSkip(filePath string, sizeBytes int64) {
-	oversizedMu.Lock()
-	if oversizedSeen == nil {
-		oversizedSeen = map[string]bool{}
+func (r *oversizedReporter) report(filePath string, sizeBytes int64) {
+	r.mu.Lock()
+	if r.seen == nil {
+		r.seen = map[string]bool{}
 	}
-	if oversizedSeen[filePath] || len(oversizedSeen) >= maxOversizedReports {
-		oversizedMu.Unlock()
+	if r.seen[filePath] {
+		r.mu.Unlock()
 		return
 	}
-	oversizedSeen[filePath] = true
-	last := len(oversizedSeen) == maxOversizedReports
-	w := oversizedOut
-	oversizedMu.Unlock()
+	if len(r.seen) >= maxOversizedReports {
+		// Past the cap the path is not remembered, so a repeat of an unnamed
+		// file counts twice. On the index path each file is classified once,
+		// and the alternative is an unbounded map keyed by a population this
+		// report exists because it can be large.
+		r.suppressed++
+		r.mu.Unlock()
+		return
+	}
+	r.seen[filePath] = true
+	last := len(r.seen) == maxOversizedReports
+	w := r.writer()
+	r.mu.Unlock()
 
 	fmt.Fprintf(w, "grafel: %s is %d bytes, over the %d-byte limit, and was NOT indexed — it mints no entity and appears nowhere in the graph (#6985)\n", filePath, sizeBytes, maxIndexableBytes)
 	if last {
-		fmt.Fprintf(w, "grafel: further oversized-file skips suppressed after %d\n", maxOversizedReports)
+		fmt.Fprintf(w, "grafel: further oversized-file skips are not named; the total is reported at the end of the index\n")
 	}
+}
+
+// summary closes the report with the count the cap hid.
+//
+// Nothing is printed when nothing was suppressed: the named lines already say
+// everything in that case, and "0 further" is a zero row.
+func (r *oversizedReporter) summary() {
+	r.mu.Lock()
+	hidden := r.suppressed
+	named := len(r.seen)
+	w := r.writer()
+	r.mu.Unlock()
+
+	if hidden == 0 {
+		return
+	}
+	fmt.Fprintf(w, "grafel: %d further oversized-file skips were not named (%d named, %d over the %d-byte limit in total) (#6985)\n",
+		hidden, named, named+hidden, maxIndexableBytes)
+}
+
+// ReportOversizedSummary prints the end-of-index line for the oversized files
+// the cap did not name, and prints nothing when the cap was never reached.
+//
+// It is exported and called from ONE place — cmd/grafel/index.go, immediately
+// before the `processed=… skipped=…` summary — because that is the surface a
+// user reads after an index. The daemon's extract coordinator, subproc and
+// incremental paths deliberately do not call it: they print no run summary at
+// all, so a trailing count there would land nowhere. Their named lines are
+// unaffected.
+func (c *Classifier) ReportOversizedSummary() {
+	c.oversized.summary()
 }

--- a/internal/classifier/oversized_report.go
+++ b/internal/classifier/oversized_report.go
@@ -1,0 +1,95 @@
+package classifier
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+)
+
+// oversized_report.go — the user-visible surface for a file dropped by the
+// size gate (#6985).
+//
+// WHY IT EXISTS. classifyWithSizeInner turns any file over maxIndexableBytes
+// into Skip=true / SkipReason="too_large", and that file then mints no entity
+// and appears nowhere in graph.json. Before this report the only trace a user
+// could read after an index was the aggregate `skipped=N` in the run summary:
+// no reason, no filename. The reason was not thrown away entirely —
+// classifier.go attaches classifier.skip_reason as an OTel span attribute on
+// both Classify and ClassifyWithSize — but that requires tracing to be
+// enabled and is not something a user reads after an index.
+//
+// WHY NOT THE UnsupportedTally. That tally aggregates unsupported-LANGUAGE
+// skips by extension, and its Observe deliberately ignores oversized files
+// (unsupported.go). Widening it would change what the unsupported-extension
+// report counts, which is a different report about a different fact. This is a
+// separate surface for a separate disposition.
+//
+// WHY HERE rather than at the extraction entry points. Three call sites
+// classify with a size (cmd/grafel/index.go, internal/daemon/extract's
+// coordinator and subproc). Reporting at each of them is the shape that let
+// eleven copies of one read diverge in #6823; classifyWithSizeInner is the
+// single place "too_large" is minted, so guarding it there is by construction.
+
+// oversized* back the always-on report below. Shape taken from
+// internal/gitmeta's reportGitMetaSkip / reportGitMetaTruncation: a dedup map
+// plus a cap, so the output stays bounded.
+var (
+	oversizedMu   sync.Mutex
+	oversizedSeen map[string]bool
+	oversizedOut  io.Writer = os.Stderr
+)
+
+// maxOversizedReports caps the report the way maxGitMetaSkipReports caps its
+// own: a warning long enough to scroll past reports nothing.
+//
+// The cap is load-bearing here rather than a backstop. The population is
+// exactly a repo full of vendored bundles — of the ten oversized files with a
+// recognised language across grafel's 60 corpora, eight are compiled/vendored
+// JS and nine of the ten are in a single repo — so a line per file is the
+// output shape this report has to avoid. A bounded list plus the existing
+// `skipped=N` aggregate is what a reader can act on.
+const maxOversizedReports = 8
+
+// setOversizedReportOutput redirects the report for tests and returns a
+// restore func. Test-only helper.
+func setOversizedReportOutput(w io.Writer) func() {
+	oversizedMu.Lock()
+	prev := oversizedOut
+	oversizedOut = w
+	oversizedSeen = nil
+	oversizedMu.Unlock()
+	return func() {
+		oversizedMu.Lock()
+		oversizedOut = prev
+		oversizedSeen = nil
+		oversizedMu.Unlock()
+	}
+}
+
+// reportOversizedSkip names a file that was dropped for exceeding the size
+// gate, and says what the consequence is.
+//
+// It reports and returns; it does not change the ClassifyResult, so the
+// `skipped=N` aggregate still counts a named file exactly once, as a skip. The
+// dedup map is keyed on the file path, so two distinct oversized files are two
+// lines and the same file classified twice is one.
+func reportOversizedSkip(filePath string, sizeBytes int64) {
+	oversizedMu.Lock()
+	if oversizedSeen == nil {
+		oversizedSeen = map[string]bool{}
+	}
+	if oversizedSeen[filePath] || len(oversizedSeen) >= maxOversizedReports {
+		oversizedMu.Unlock()
+		return
+	}
+	oversizedSeen[filePath] = true
+	last := len(oversizedSeen) == maxOversizedReports
+	w := oversizedOut
+	oversizedMu.Unlock()
+
+	fmt.Fprintf(w, "grafel: %s is %d bytes, over the %d-byte limit, and was NOT indexed — it mints no entity and appears nowhere in the graph (#6985)\n", filePath, sizeBytes, maxIndexableBytes)
+	if last {
+		fmt.Fprintf(w, "grafel: further oversized-file skips suppressed after %d\n", maxOversizedReports)
+	}
+}

--- a/internal/classifier/oversized_report_6985_internal_test.go
+++ b/internal/classifier/oversized_report_6985_internal_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -13,33 +15,30 @@ import (
 // user-visible report that names it.
 //
 // Every assertion below observes the EMITTED REPORT (the artefact a user
-// reads), never a counter the classifier keeps about itself. The tests share
-// package-level state (the dedup map and the output writer), so none of them
-// calls t.Parallel.
+// reads), never a counter the classifier keeps about itself. The report state
+// is per-Classifier, so each test constructs its own and there is no shared
+// state to reset — a fresh Classifier IS the starting state.
 
 // oversizedBytes is comfortably over the gate; the exact value is asserted in
 // the report line, so it doubles as the "the size is named" fixture.
 const oversizedBytes = maxIndexableBytes + 1024
 
-// captureOversizedReport runs fn with the report redirected and returns
-// everything it wrote.
-func captureOversizedReport(t *testing.T, fn func(c *Classifier)) string {
-	t.Helper()
-	var buf bytes.Buffer
-	restore := setOversizedReportOutput(&buf)
-	defer restore()
-	fn(New(nil))
-	return buf.String()
+// newReportingClassifier returns a classifier whose report is captured.
+func newReportingClassifier(w io.Writer) *Classifier {
+	c := New(nil)
+	setOversizedReportOutput(c, w)
+	return c
 }
 
 // The report names the file, its size and the limit — not just "a file was
 // skipped".
 func TestOversizedSkipReportNamesTheFile(t *testing.T) {
-	var res ClassifyResult
-	out := captureOversizedReport(t, func(c *Classifier) {
-		res = c.ClassifyWithSize(context.Background(), "packages/next/src/compiled/webpack/bundle5.js", oversizedBytes)
-	})
+	var buf bytes.Buffer
+	c := newReportingClassifier(&buf)
 
+	res := c.ClassifyWithSize(context.Background(), "packages/next/src/compiled/webpack/bundle5.js", oversizedBytes)
+
+	out := buf.String()
 	if !strings.Contains(out, "packages/next/src/compiled/webpack/bundle5.js") {
 		t.Errorf("report does not name the oversized file; got %q", out)
 	}
@@ -60,13 +59,14 @@ func TestOversizedSkipReportNamesTheFile(t *testing.T) {
 // A file exactly at the limit is indexed and must produce no report at all —
 // otherwise the report fires for files that were never dropped.
 func TestOversizedReportSilentAtAndUnderTheLimit(t *testing.T) {
-	var atLimit, underLimit ClassifyResult
-	out := captureOversizedReport(t, func(c *Classifier) {
-		atLimit = c.ClassifyWithSize(context.Background(), "src/at_limit.js", maxIndexableBytes)
-		underLimit = c.ClassifyWithSize(context.Background(), "src/under_limit.js", 1024)
-	})
+	var buf bytes.Buffer
+	c := newReportingClassifier(&buf)
 
-	if out != "" {
+	atLimit := c.ClassifyWithSize(context.Background(), "src/at_limit.js", maxIndexableBytes)
+	underLimit := c.ClassifyWithSize(context.Background(), "src/under_limit.js", 1024)
+	c.ReportOversizedSummary()
+
+	if out := buf.String(); out != "" {
 		t.Errorf("report fired for a file that was not dropped for size: %q", out)
 	}
 	if atLimit.Skip || underLimit.Skip {
@@ -79,11 +79,13 @@ func TestOversizedReportSilentAtAndUnderTheLimit(t *testing.T) {
 // path; a map that suppresses the second file reports a repo of bundles as one
 // bundle.
 func TestOversizedReportNamesEachDistinctFile(t *testing.T) {
-	out := captureOversizedReport(t, func(c *Classifier) {
-		c.ClassifyWithSize(context.Background(), "a/first_bundle.js", oversizedBytes)
-		c.ClassifyWithSize(context.Background(), "b/second_bundle.js", oversizedBytes)
-	})
+	var buf bytes.Buffer
+	c := newReportingClassifier(&buf)
 
+	c.ClassifyWithSize(context.Background(), "a/first_bundle.js", oversizedBytes)
+	c.ClassifyWithSize(context.Background(), "b/second_bundle.js", oversizedBytes)
+
+	out := buf.String()
 	for _, want := range []string{"a/first_bundle.js", "b/second_bundle.js"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("report omits distinct oversized file %q; got %q", want, out)
@@ -95,12 +97,13 @@ func TestOversizedReportNamesEachDistinctFile(t *testing.T) {
 // skip, so the `skipped=N` aggregate keeps counting every skip and a named
 // file is not double-counted or dropped from the count.
 func TestOversizedReportDedupsRepeatsWithoutChangingTheSkip(t *testing.T) {
-	var first, second ClassifyResult
-	out := captureOversizedReport(t, func(c *Classifier) {
-		first = c.ClassifyWithSize(context.Background(), "a/bundle.js", oversizedBytes)
-		second = c.ClassifyWithSize(context.Background(), "a/bundle.js", oversizedBytes)
-	})
+	var buf bytes.Buffer
+	c := newReportingClassifier(&buf)
 
+	first := c.ClassifyWithSize(context.Background(), "a/bundle.js", oversizedBytes)
+	second := c.ClassifyWithSize(context.Background(), "a/bundle.js", oversizedBytes)
+
+	out := buf.String()
 	if got := strings.Count(out, "a/bundle.js"); got != 1 {
 		t.Errorf("same path reported %d times, want 1; got %q", got, out)
 	}
@@ -112,16 +115,23 @@ func TestOversizedReportDedupsRepeatsWithoutChangingTheSkip(t *testing.T) {
 	}
 }
 
-// The output is bounded. maxOversizedReports files are named, the next is not,
-// and the suppression line says so.
+// The output is bounded: maxOversizedReports files are named, the next is not,
+// the "not named" notice appears EXACTLY ONCE (printing it per suppressed file
+// makes the output unbounded again, which is the whole point of the cap), and
+// the total line count is exactly the cap plus that one notice.
 func TestOversizedReportIsCapped(t *testing.T) {
-	total := maxOversizedReports + 1
-	out := captureOversizedReport(t, func(c *Classifier) {
-		for i := range total {
-			c.ClassifyWithSize(context.Background(), fmt.Sprintf("vendor/bundle_%d.js", i), oversizedBytes)
-		}
-	})
+	var buf bytes.Buffer
+	c := newReportingClassifier(&buf)
+	if buf.Len() != 0 {
+		t.Fatalf("fixture degenerate: a fresh classifier already emitted %q", buf.String())
+	}
 
+	total := maxOversizedReports + 1
+	for i := range total {
+		c.ClassifyWithSize(context.Background(), fmt.Sprintf("vendor/bundle_%d.js", i), oversizedBytes)
+	}
+
+	out := buf.String()
 	for i := range maxOversizedReports {
 		want := fmt.Sprintf("vendor/bundle_%d.js", i)
 		if !strings.Contains(out, want) {
@@ -132,8 +142,143 @@ func TestOversizedReportIsCapped(t *testing.T) {
 	if strings.Contains(out, beyond) {
 		t.Errorf("file %q past the cap was reported; got %q", beyond, out)
 	}
-	if !strings.Contains(out, fmt.Sprintf("suppressed after %d", maxOversizedReports)) {
-		t.Errorf("no suppression line once the cap was reached; got %q", out)
+	if got := strings.Count(out, "further oversized-file skips are not named"); got != 1 {
+		t.Errorf("the cap notice was printed %d times, want exactly 1; got %q", got, out)
+	}
+	if got := strings.Count(out, "grafel:"); got != maxOversizedReports+1 {
+		t.Errorf("emitted %d lines, want %d (%d named + 1 notice); got %q",
+			got, maxOversizedReports+1, maxOversizedReports, out)
+	}
+}
+
+// The end-of-index summary says HOW MUCH the cap hid: "8 of 40" must not read
+// like "8 of 9".
+func TestOversizedSummaryCountsWhatTheCapHid(t *testing.T) {
+	var buf bytes.Buffer
+	c := newReportingClassifier(&buf)
+
+	const total = 40
+	for i := range total {
+		c.ClassifyWithSize(context.Background(), fmt.Sprintf("vendor/bundle_%d.js", i), oversizedBytes)
+	}
+	beforeSummary := buf.String()
+	c.ReportOversizedSummary()
+	summary := strings.TrimPrefix(buf.String(), beforeSummary)
+
+	hidden := total - maxOversizedReports
+	for _, want := range []string{
+		fmt.Sprintf("%d further oversized-file skips were not named", hidden),
+		fmt.Sprintf("%d named", maxOversizedReports),
+		fmt.Sprintf("%d over the %d-byte limit in total", total, maxIndexableBytes),
+	} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("summary omits %q; got %q", want, summary)
+		}
+	}
+	if got := strings.Count(summary, "grafel:"); got != 1 {
+		t.Errorf("summary emitted %d lines, want exactly 1; got %q", got, summary)
+	}
+}
+
+// Nothing was hidden → no summary line. A "0 further" row is the zero row the
+// rest of this package's reporting refuses to print.
+func TestOversizedSummarySilentWhenNothingWasSuppressed(t *testing.T) {
+	var buf bytes.Buffer
+	c := newReportingClassifier(&buf)
+
+	c.ClassifyWithSize(context.Background(), "vendor/only_bundle.js", oversizedBytes)
+	named := buf.String()
+	c.ReportOversizedSummary()
+
+	if got := strings.TrimPrefix(buf.String(), named); got != "" {
+		t.Errorf("summary printed with nothing suppressed: %q", got)
+	}
+	if !strings.Contains(named, "vendor/only_bundle.js") {
+		t.Fatalf("fixture degenerate: the one oversized file was not named; got %q", named)
+	}
+}
+
+// THE LIFETIME. A second index in the same process must report again — even
+// after a first index saturated the cap, and even for a repo whose paths were
+// never seen. The first cut of this file kept the state process-global, so the
+// second run printed NOTHING AT ALL: a user who fixed nothing and re-ran saw a
+// clean report.
+//
+// One writer across both passes, and no reset between them, because production
+// has no reset to call.
+func TestOversizedReportIsPerIndexNotPerProcess(t *testing.T) {
+	var buf bytes.Buffer
+
+	firstIndex := newReportingClassifier(&buf)
+	for i := range maxOversizedReports {
+		firstIndex.ClassifyWithSize(context.Background(), fmt.Sprintf("repo-a/bundle_%d.js", i), oversizedBytes)
+	}
+	firstIndex.ReportOversizedSummary()
+	firstOut := buf.String()
+	if !strings.Contains(firstOut, "repo-a/bundle_0.js") {
+		t.Fatalf("fixture degenerate: the first index reported nothing; got %q", firstOut)
+	}
+
+	secondIndex := newReportingClassifier(&buf)
+	secondIndex.ClassifyWithSize(context.Background(), "repo-b/other_bundle.js", oversizedBytes)
+	secondIndex.ClassifyWithSize(context.Background(), "repo-a/bundle_0.js", oversizedBytes)
+	secondOut := strings.TrimPrefix(buf.String(), firstOut)
+
+	if !strings.Contains(secondOut, "repo-b/other_bundle.js") {
+		t.Errorf("a second index reported nothing for a path never seen before; got %q", secondOut)
+	}
+	if !strings.Contains(secondOut, "repo-a/bundle_0.js") {
+		t.Errorf("a re-indexed file was silent on the second index; got %q", secondOut)
+	}
+}
+
+// lockingWriter serialises the writes themselves, so a failure below is the
+// reporter's own race and not the buffer's.
+type lockingWriter struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *lockingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *lockingWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+// THE MUTEX. ClassifyWithSize runs inside the indexer's worker pool, so the
+// reporter's map is written concurrently. Unguarded that is a concurrent map
+// write — a Go runtime fatal, not a warning — and under -race it is a reported
+// data race. Both are failures; the dedup assertion below is the third.
+func TestOversizedReportIsSafeUnderConcurrentClassification(t *testing.T) {
+	w := &lockingWriter{}
+	c := newReportingClassifier(w)
+
+	paths := []string{"vendor/a.js", "vendor/b.js", "vendor/c.js", "vendor/d.js"}
+	var wg sync.WaitGroup
+	for i := range 32 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			c.ClassifyWithSize(context.Background(), paths[i%len(paths)], oversizedBytes)
+		}(i)
+	}
+	wg.Wait()
+	c.ReportOversizedSummary()
+
+	out := w.String()
+	for _, p := range paths {
+		if got := strings.Count(out, p); got != 1 {
+			t.Errorf("path %q named %d times under concurrency, want exactly 1; got %q", p, got, out)
+		}
+	}
+	if got := strings.Count(out, "grafel:"); got != len(paths) {
+		t.Errorf("emitted %d lines under concurrency, want %d; got %q", got, len(paths), out)
 	}
 }
 
@@ -144,9 +289,7 @@ func TestOversizedReportIsCapped(t *testing.T) {
 // the limit is skipped as too_large and must not appear, and neither must an
 // oversized recognised-language file.
 func TestOversizedSkipLeavesUnsupportedTallyUnchanged(t *testing.T) {
-	c := New(nil)
-	restore := setOversizedReportOutput(&bytes.Buffer{})
-	defer restore()
+	c := newReportingClassifier(&bytes.Buffer{})
 
 	tally := NewUnsupportedTally()
 	observe := func(p string, size int64) {
@@ -172,9 +315,7 @@ func TestOversizedSkipLeavesUnsupportedTallyUnchanged(t *testing.T) {
 // an unsupported-language skip — the report is additive to the classification,
 // not a re-routing of it.
 func TestOversizedSkipReasonIsUnchangedForAnUnsupportedLanguageExtension(t *testing.T) {
-	c := New(nil)
-	restore := setOversizedReportOutput(&bytes.Buffer{})
-	defer restore()
+	c := newReportingClassifier(&bytes.Buffer{})
 
 	res := c.ClassifyWithSize(context.Background(), "legacy/Huge.pas", oversizedBytes)
 	if res.SkipReason != "too_large" {

--- a/internal/classifier/oversized_report_6985_internal_test.go
+++ b/internal/classifier/oversized_report_6985_internal_test.go
@@ -1,0 +1,186 @@
+package classifier
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// #6985 — an oversized file is dropped from the graph; these pin the
+// user-visible report that names it.
+//
+// Every assertion below observes the EMITTED REPORT (the artefact a user
+// reads), never a counter the classifier keeps about itself. The tests share
+// package-level state (the dedup map and the output writer), so none of them
+// calls t.Parallel.
+
+// oversizedBytes is comfortably over the gate; the exact value is asserted in
+// the report line, so it doubles as the "the size is named" fixture.
+const oversizedBytes = maxIndexableBytes + 1024
+
+// captureOversizedReport runs fn with the report redirected and returns
+// everything it wrote.
+func captureOversizedReport(t *testing.T, fn func(c *Classifier)) string {
+	t.Helper()
+	var buf bytes.Buffer
+	restore := setOversizedReportOutput(&buf)
+	defer restore()
+	fn(New(nil))
+	return buf.String()
+}
+
+// The report names the file, its size and the limit — not just "a file was
+// skipped".
+func TestOversizedSkipReportNamesTheFile(t *testing.T) {
+	var res ClassifyResult
+	out := captureOversizedReport(t, func(c *Classifier) {
+		res = c.ClassifyWithSize(context.Background(), "packages/next/src/compiled/webpack/bundle5.js", oversizedBytes)
+	})
+
+	if !strings.Contains(out, "packages/next/src/compiled/webpack/bundle5.js") {
+		t.Errorf("report does not name the oversized file; got %q", out)
+	}
+	if !strings.Contains(out, fmt.Sprintf("%d bytes", oversizedBytes)) {
+		t.Errorf("report does not carry the file's size %d; got %q", oversizedBytes, out)
+	}
+	if !strings.Contains(out, fmt.Sprintf("%d-byte limit", maxIndexableBytes)) {
+		t.Errorf("report does not carry the limit %d; got %q", maxIndexableBytes, out)
+	}
+	if !strings.Contains(out, "NOT indexed") {
+		t.Errorf("report does not state the consequence; got %q", out)
+	}
+	if !res.Skip || res.SkipReason != "too_large" {
+		t.Errorf("classification changed: got Skip=%v reason=%q, want true/too_large", res.Skip, res.SkipReason)
+	}
+}
+
+// A file exactly at the limit is indexed and must produce no report at all —
+// otherwise the report fires for files that were never dropped.
+func TestOversizedReportSilentAtAndUnderTheLimit(t *testing.T) {
+	var atLimit, underLimit ClassifyResult
+	out := captureOversizedReport(t, func(c *Classifier) {
+		atLimit = c.ClassifyWithSize(context.Background(), "src/at_limit.js", maxIndexableBytes)
+		underLimit = c.ClassifyWithSize(context.Background(), "src/under_limit.js", 1024)
+	})
+
+	if out != "" {
+		t.Errorf("report fired for a file that was not dropped for size: %q", out)
+	}
+	if atLimit.Skip || underLimit.Skip {
+		t.Fatalf("fixture degenerate: at-limit skip=%v under-limit skip=%v, want both indexed",
+			atLimit.Skip, underLimit.Skip)
+	}
+}
+
+// Two DISTINCT oversized files are two lines. The dedup map must key on the
+// path; a map that suppresses the second file reports a repo of bundles as one
+// bundle.
+func TestOversizedReportNamesEachDistinctFile(t *testing.T) {
+	out := captureOversizedReport(t, func(c *Classifier) {
+		c.ClassifyWithSize(context.Background(), "a/first_bundle.js", oversizedBytes)
+		c.ClassifyWithSize(context.Background(), "b/second_bundle.js", oversizedBytes)
+	})
+
+	for _, want := range []string{"a/first_bundle.js", "b/second_bundle.js"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report omits distinct oversized file %q; got %q", want, out)
+		}
+	}
+}
+
+// The same path classified twice is one line — but BOTH calls still return a
+// skip, so the `skipped=N` aggregate keeps counting every skip and a named
+// file is not double-counted or dropped from the count.
+func TestOversizedReportDedupsRepeatsWithoutChangingTheSkip(t *testing.T) {
+	var first, second ClassifyResult
+	out := captureOversizedReport(t, func(c *Classifier) {
+		first = c.ClassifyWithSize(context.Background(), "a/bundle.js", oversizedBytes)
+		second = c.ClassifyWithSize(context.Background(), "a/bundle.js", oversizedBytes)
+	})
+
+	if got := strings.Count(out, "a/bundle.js"); got != 1 {
+		t.Errorf("same path reported %d times, want 1; got %q", got, out)
+	}
+	if !first.Skip || !second.Skip {
+		t.Errorf("a repeated classification stopped being a skip: first=%v second=%v", first.Skip, second.Skip)
+	}
+	if first.SkipReason != "too_large" || second.SkipReason != "too_large" {
+		t.Errorf("skip reason changed: %q / %q", first.SkipReason, second.SkipReason)
+	}
+}
+
+// The output is bounded. maxOversizedReports files are named, the next is not,
+// and the suppression line says so.
+func TestOversizedReportIsCapped(t *testing.T) {
+	total := maxOversizedReports + 1
+	out := captureOversizedReport(t, func(c *Classifier) {
+		for i := range total {
+			c.ClassifyWithSize(context.Background(), fmt.Sprintf("vendor/bundle_%d.js", i), oversizedBytes)
+		}
+	})
+
+	for i := range maxOversizedReports {
+		want := fmt.Sprintf("vendor/bundle_%d.js", i)
+		if !strings.Contains(out, want) {
+			t.Errorf("file %q under the cap was not reported; got %q", want, out)
+		}
+	}
+	beyond := fmt.Sprintf("vendor/bundle_%d.js", maxOversizedReports)
+	if strings.Contains(out, beyond) {
+		t.Errorf("file %q past the cap was reported; got %q", beyond, out)
+	}
+	if !strings.Contains(out, fmt.Sprintf("suppressed after %d", maxOversizedReports)) {
+		t.Errorf("no suppression line once the cap was reached; got %q", out)
+	}
+}
+
+// The UnsupportedTally must count exactly what it counted before #6985.
+//
+// `.pas` is in unsupportedLanguageNames, so an UNDER-limit .pas file is the
+// positive control that the tally still works at all; the same .pas file over
+// the limit is skipped as too_large and must not appear, and neither must an
+// oversized recognised-language file.
+func TestOversizedSkipLeavesUnsupportedTallyUnchanged(t *testing.T) {
+	c := New(nil)
+	restore := setOversizedReportOutput(&bytes.Buffer{})
+	defer restore()
+
+	tally := NewUnsupportedTally()
+	observe := func(p string, size int64) {
+		tally.Observe(p, c.ClassifyWithSize(context.Background(), p, size))
+	}
+
+	observe("legacy/Report.pas", 4096)
+	control := tally.Counts()
+	if !reflect.DeepEqual(control, map[string]int{".pas": 1}) {
+		t.Fatalf("fixture degenerate: control tally is %v, want {.pas:1}", control)
+	}
+
+	observe("legacy/Huge.pas", oversizedBytes)
+	observe("vendor/bundle.js", oversizedBytes)
+	observe("assets/data.json", oversizedBytes)
+
+	if got := tally.Counts(); !reflect.DeepEqual(got, control) {
+		t.Errorf("oversized files changed the unsupported-extension report: got %v, want %v", got, control)
+	}
+}
+
+// The oversized skip is still classified as too_large and never re-labelled as
+// an unsupported-language skip — the report is additive to the classification,
+// not a re-routing of it.
+func TestOversizedSkipReasonIsUnchangedForAnUnsupportedLanguageExtension(t *testing.T) {
+	c := New(nil)
+	restore := setOversizedReportOutput(&bytes.Buffer{})
+	defer restore()
+
+	res := c.ClassifyWithSize(context.Background(), "legacy/Huge.pas", oversizedBytes)
+	if res.SkipReason != "too_large" {
+		t.Errorf("oversized .pas skip reason is %q, want too_large", res.SkipReason)
+	}
+	if res.Language != "" {
+		t.Errorf("oversized skip now carries a language %q; the size gate runs before language detection", res.Language)
+	}
+}

--- a/internal/links/safe_source_read.go
+++ b/internal/links/safe_source_read.go
@@ -50,10 +50,12 @@ import (
 //
 // classifier.maxIndexableBytes (internal/classifier/classifier.go:27) is the
 // SAME 1 MiB, and classifyWithSizeInner (:172) skips any file over it with
-// SkipReason="too_large" before any language is detected. All three extraction
-// entry points gate on that result — cmd/grafel/index.go:3987,
-// internal/daemon/extract/coordinator.go:673 and subproc.go:277 each
-// ClassifyWithSize then `if cr.Skip || cr.Language == "" { continue }` — so an
+// SkipReason="too_large" before any language is detected. All FOUR
+// ClassifyWithSize consumers gate on that result — cmd/grafel/index.go:3987,
+// internal/daemon/extract/coordinator.go:673, subproc.go:277 and
+// internal/extractors/incremental.go:1003 (the daemon's watcher-driven
+// incremental path) each ClassifyWithSize then
+// `if cr.Skip || cr.Language == "" { continue }` — so on the NORMAL path an
 // oversized file mints no entity, and every pass in this package iterates a
 // file set built from entity SourceFile. The classifier is the gate that
 // actually decides; maxSourceFileBytes is defence in depth behind it, kept at
@@ -62,17 +64,30 @@ import (
 // So THE LOSS IS EXCLUSION, NOT TRUNCATION: a file over 1 MiB is absent from
 // the graph whole, not parsed short. That is a real capability loss (#6450
 // recorded it on the engine path) and it is now reported by name — see
-// reportOversizedSkip in internal/classifier/oversized_report.go. The trade is
+// oversizedReporter.report in internal/classifier/oversized_report.go. The trade is
 // accepted because a bound is not optional — safeio needs one, a character
 // device never reaches EOF — and because base-URL constants, import lines and
 // handler bodies live in small modules; a source file over 1 MiB is generated
 // or minified, not hand-written.
 //
-// THE ONE RESIDUAL IS TOCTOU, and it is uncharacterised. The classifier
-// decides on a size taken at index time; group-link re-opens the file later by
-// path. A file that grows past 1 MiB in that window was admitted by the gate
-// and IS truncated here, silently. Nobody has measured how often that happens
-// and nothing above covers it.
+// TWO RESIDUALS SURVIVE THAT ARGUMENT, and "normal path" above is doing real
+// work. Neither is covered by the exclusion reasoning, and a comment claiming
+// ONE residual was itself a #6983-class error:
+//
+//   - A STAT FAILURE. All three index sites initialise size = int64(-1) and
+//     leave it there when os.Stat fails (cmd/grafel/index.go:3980,
+//     internal/daemon/extract/coordinator.go:669, subproc.go:273). -1 is not
+//     greater than maxIndexableBytes, so an oversized file whose stat failed
+//     PASSES the gate, mints an entity, reaches readSourceFile and is
+//     genuinely truncated here — silently, with no oversized-file report,
+//     and with no concurrency required. Deterministic and in-tree.
+//   - TOCTOU. The classifier decides on a size taken at index time; group-link
+//     re-opens the file later by path. A file that grows past 1 MiB in that
+//     window was admitted by the gate and IS truncated here.
+//
+// Neither has been characterised: nobody has measured how often a stat fails
+// on a file that is also oversized, nor how often a file grows across the
+// bound mid-index.
 const maxSourceFileBytes int64 = 1 << 20
 
 // stringScanMaxFileBytes bounds the string-literal scan instead. That pass

--- a/internal/links/safe_source_read.go
+++ b/internal/links/safe_source_read.go
@@ -41,15 +41,38 @@ import (
 // at 1 MiB, the other at something else — would be a new instance of the bug
 // being fixed, not a fix for it.
 //
-// The cost is real and is inherited whole. safeio.ReadFile TRUNCATES at the
-// bound (io.LimitReader) rather than failing, so a declaring file larger than
-// 1 MiB is parsed from its first megabyte only: a constant declared past that
-// point is silently not found, with no telemetry. #6450 recorded exactly that
-// as a permanent capability loss on the engine path. This path now shares it.
-// The trade is accepted because a bound is not optional — safeio needs one, a
-// character device never reaches EOF — and because base-URL constants,
-// import lines and handler bodies live in small modules; a source file over
-// 1 MiB is generated or minified, not hand-written.
+// WHAT THE BOUND ACTUALLY COSTS, corrected (#6985). safeio.ReadFile does
+// TRUNCATE at the bound rather than failing — it is ReadFileLimited with the
+// truncation bool dropped — so read in isolation this file looks like it
+// parses an oversized declaring file from its first megabyte only. It does
+// not, and an earlier version of this comment saying so is what caused #6983
+// to be filed against a hazard that cannot occur:
+//
+// classifier.maxIndexableBytes (internal/classifier/classifier.go:27) is the
+// SAME 1 MiB, and classifyWithSizeInner (:172) skips any file over it with
+// SkipReason="too_large" before any language is detected. All three extraction
+// entry points gate on that result — cmd/grafel/index.go:3987,
+// internal/daemon/extract/coordinator.go:673 and subproc.go:277 each
+// ClassifyWithSize then `if cr.Skip || cr.Language == "" { continue }` — so an
+// oversized file mints no entity, and every pass in this package iterates a
+// file set built from entity SourceFile. The classifier is the gate that
+// actually decides; maxSourceFileBytes is defence in depth behind it, kept at
+// the same value for the divergence reason above.
+//
+// So THE LOSS IS EXCLUSION, NOT TRUNCATION: a file over 1 MiB is absent from
+// the graph whole, not parsed short. That is a real capability loss (#6450
+// recorded it on the engine path) and it is now reported by name — see
+// reportOversizedSkip in internal/classifier/oversized_report.go. The trade is
+// accepted because a bound is not optional — safeio needs one, a character
+// device never reaches EOF — and because base-URL constants, import lines and
+// handler bodies live in small modules; a source file over 1 MiB is generated
+// or minified, not hand-written.
+//
+// THE ONE RESIDUAL IS TOCTOU, and it is uncharacterised. The classifier
+// decides on a size taken at index time; group-link re-opens the file later by
+// path. A file that grows past 1 MiB in that window was admitted by the gate
+// and IS truncated here, silently. Nobody has measured how often that happens
+// and nothing above covers it.
 const maxSourceFileBytes int64 = 1 << 20
 
 // stringScanMaxFileBytes bounds the string-literal scan instead. That pass


### PR DESCRIPTION
Closes #6985.

Two deliverables on one axis: the oversized file gets a bounded, user-visible report, and the comment that made #6983 look like a live defect is rewritten to say what is true.

Branched from `bd03cdfeb`. Everything below was run in the worktree at `/private/tmp/claude-501/-Users-jorgecajas-Projects-archigraph/c0fefed4-0195-4c81-9a94-07a7145710a4/scratchpad/impl-6985-k4m7p/wt` (macOS Darwin 25.6 / APFS), never in the main checkout.

**`3e266c957` → `d86b5fba6` answers the REQUEST-CHANGES review; every item was confirmed and taken.** Summary of what changed is at the bottom.

## Part 1 — the report

`internal/classifier/oversized_report.go`: an `oversizedReporter` (mutex, `seen` map capped at `maxOversizedReports = 8`, a `suppressed` counter, an optional writer) hangs off the `Classifier`, and `classifyWithSizeInner`'s size gate calls `c.oversized.report(...)`. The `ClassifyResult` is byte-identical to before.

```
grafel: <path> is <n> bytes, over the 1048576-byte limit, and was NOT indexed — it mints no entity and appears nowhere in the graph (#6985)
grafel: further oversized-file skips are not named; the total is reported at the end of the index   # once, on the 8th
grafel: 32 further oversized-file skips were not named (8 named, 40 over the 1048576-byte limit in total) (#6985)
```

**Which surface, and why.** stderr, always on, dedup + cap, shaped after `internal/gitmeta`'s `reportGitMetaSkip` / `reportGitMetaTruncation` (`internal/gitmeta/saferead.go:121,157`). Bounded output is the requirement: the population is a repo full of vendored bundles (8 of the 10 recognised-language oversized files across the corpora are compiled/vendored JS, 9 of 10 in one repo — **quoted from #6983's measurement, not re-measured here**), so a line per file is the shape to avoid.

**Lifetime: per-Classifier, i.e. per index.** The first cut kept the state process-global, and the reviewer measured the consequence: run 2 in the same process printed **nothing at all**, for a different repo too, not even the suppression notice — a user who fixed nothing and re-ran saw a clean report, which is worse than no report. `gitmeta` is not a precedent for that: its inputs are read once per process, while this code re-enters per index **and** per daemon incremental reindex (`internal/extractors/incremental.go:1003`). Every construction site (`cmd/grafel/index.go:808`, `internal/daemon/extract/coordinator.go:662`, `subproc.go:105`, `internal/extractors/incremental.go:886`) calls `classifier.New` per run, so per-Classifier state gets the right lifetime **with no reset call for a caller to forget** — chosen over an exported `ResetOversizedReport()` for exactly that reason.

**Why at the mint point.** Within this package `"too_large"` is minted only in `classifyWithSizeInner`, while **four** call sites consume it (the four above). Reporting at each consumer is the shape that let eleven copies of one read diverge in #6823. (Scoped as the reviewer asked: `internal/secrets/secrets.go:410` declares its own unrelated `SkipTooLarge`; the claim is package-local, not repo-wide.)

**The cap now carries a count.** `ReportOversizedSummary` prints the hidden total and is called from **one** place — `Indexer.Run`, immediately before the `processed=… skipped=…` line — because that is the surface a user reads after an index. The daemon's coordinator/subproc/incremental paths print no run summary at all, so a trailing count there would land nowhere; their named lines are unaffected. Nothing is printed when nothing was suppressed. Cost stated in the source: past the cap a path is not remembered, so a repeated unnamed file would count twice; on the index path each file is classified once, and the alternative is an unbounded map keyed by exactly the population this report exists because it can be large.

**`UnsupportedTally` is untouched** — no line of `internal/classifier/unsupported.go` changed. **`skipped=N` still reconciles** — the report is additive and returns.

### Tests — all observe the emitted report

`internal/classifier/oversized_report_6985_internal_test.go` (each test builds its own `Classifier`, so a fresh instance *is* the starting state — the previous version's order-coupling on a shared map is gone):

| test | asserts |
|---|---|
| `…ReportNamesTheFile` | the line carries the **path**, size, limit, consequence |
| `…SilentAtAndUnderTheLimit` | 1 MiB exactly and 1 KiB → **no output**, both indexed |
| `…NamesEachDistinctFile` | two distinct paths → two named lines |
| `…DedupsRepeatsWithoutChangingTheSkip` | one path twice → one line, two skips |
| `…IsCapped` | 9 files → 8 named, 9th absent, the notice **exactly once**, and total lines **== cap + 1** |
| `…SummaryCountsWhatTheCapHid` | 40 files → one summary line naming 32 hidden / 8 named / 40 total |
| `…SummarySilentWhenNothingWasSuppressed` | cap never reached → no summary line |
| `…IsPerIndexNotPerProcess` | two classifiers, **one writer, no reset** → the second index names a never-seen path *and* a re-indexed one |
| `…IsSafeUnderConcurrentClassification` | 32 goroutines over 4 paths, locking writer → each named exactly once, 4 lines total (run under `-race`) |
| `…LeavesUnsupportedTallyUnchanged` | `.pas` control `{".pas":1}`; three oversized files leave `Counts()` `DeepEqual` to it |
| `…SkipReasonIsUnchangedFor…` | oversized `.pas` is still `too_large`, `Language == ""` |

`cmd/grafel/oversized_report_6985_test.go` is new and observes the **production index path**: a temp repo with 9 oversized `.js` files run through `Indexer.Run` with `os.Stderr` captured, asserting 8 named files plus `1 further oversized-file skips were not named` and `9 over the 1048576-byte limit in total`.

### Mutants — 13 applied, 13 DEAD

Each applied with an asserted exact pre-edit occurrence count, post-edit counts printed, and the enclosing function named; `go vet` exit 0 for every one; scored `-count=1`; restored by `cp` from `shasum`-verified backups, never `git checkout`. The reviewer's four ungraded seams are N1/N2/N8/N13 below.

| # | mutation (enclosing func) | result |
|---|---|---|
| M1 | delete the report call (`classifyWithSizeInner`) | **DEAD** — 8 tests |
| M2 | line without the filename (`report`) | **DEAD** — 7 tests |
| M3 | constant dedup key, distinct files suppressed (`report`, 7 anchors) | **DEAD** — 5 tests |
| M4 | `maxOversizedReports = 0` (file scope) | **DEAD** — 7 tests |
| M5 | report before the size gate (`classifyWithSizeInner`) | **DEAD** — `…SilentAtAndUnderTheLimit` |
| M6 | widen `UnsupportedTally.Observe` to fold in `too_large` (`Observe`) | **DEAD** — the new non-change test **and** the pre-existing `TestUnsupportedTally_OtherSkipReasonsNotCounted/too-large` |
| M7 | cap boundary `>=` → `>` (`report`) | **DEAD** — 2 tests |
| **N1** | print the notice **once per suppressed file** (`report`; notice sites 1→2) | **DEAD** — `…IsCapped` (line-count assertion) |
| **N2** | **delete the mutex entirely** (`report`, `summary`, `setOversizedReportOutput`; locks 2→0, unlocks 4→0, field and `sync` import removed) | **DEAD under `-race`** — 4 DATA RACE reports + `…IsSafeUnderConcurrentClassification`. **Honest caveat: WITHOUT `-race` it survived 5/5 runs** — the concurrent-map-write fatal is scheduling-dependent. The kill's premise is `-race`, and `.github/workflows/test.yml:404-408` runs `-race` only on a tag push, a dispatch with `race=true`, or the **`ci:full` label** — so this PR wants that label (which is also what runs the macOS leg). |
| **N8** | share `seen`/`suppressed` process-wide again — the reviewed defect (`report`, `summary`; `r.seen` 7→0) | **DEAD** — `…IsPerIndexNotPerProcess` + 4 others |
| N9 | `summary` returns unconditionally (`summary`) | **DEAD** — `…SummaryCountsWhatTheCapHid` |
| N10 | `summary` prints a zero row (`summary`) | **DEAD** — 3 tests |
| N11 | summary reports `named+hidden` where it should report `hidden` (`summary`) | **DEAD** — `…SummaryCountsWhatTheCapHid` |
| N12 | ignore the writer seam, always stderr (`writer`) | **DEAD** — 8 tests |
| **N13** | delete `i.classifier.ReportOversizedSummary()` (`Indexer.Run`) | **ALIVE before the new cmd/grafel test** (whole `./cmd/grafel/` suite green, 152s) → **DEAD after it**. That is why the end-to-end test was written rather than priced. |

N3/N4 from the review (the two mutually-masking `oversizedSeen = nil` resets) **no longer exist**: per-Classifier state has no global to reset, so there is no compound guard left to grade part by part.

## Part 2 — the `safe_source_read.go` comment

Rewritten, and **a comment-only diff has no mutant — every mutation of it is equivalent by construction — so each sentence was fact-checked against source instead.** Verified, with locations:

- `safeio.ReadFile` truncates: it is `ReadFileLimited` minus the bool — `internal/safeio/safeio.go:265-268`, `:309-311`. The stale *"with no telemetry"* clause is gone (`ReadFileLimited` exists at `:285`).
- `classifier.maxIndexableBytes` is `1 * 1024 * 1024` (`internal/classifier/classifier.go:27`), the same value as `maxSourceFileBytes` (`internal/links/safe_source_read.go`) and `substrateMaxFileBytes` (`internal/engine/http_endpoint_substrate_fold.go:92`). **None of the three constants is changed here.**
- The deciding gate: `classifier.go:172-174`, before language detection.
- **Four** `ClassifyWithSize` consumers, not three — the review caught the undercount, and #6983 had listed the fourth: `cmd/grafel/index.go:3987`, `coordinator.go:673`, `subproc.go:277`, `internal/extractors/incremental.go:1003`.
- **Two residuals, not one.** Alongside TOCTOU, all three index sites initialise `size := int64(-1)` and leave it there when `os.Stat` fails (`cmd/grafel/index.go:3980`, `coordinator.go:669`, `subproc.go:273`); `-1 > maxIndexableBytes` is false, so an oversized file whose stat fails passes the gate, mints an entity, reaches `readSourceFile` and **is** truncated — deterministic, no concurrency needed, no report. The comment now says the exclusion argument holds **on the normal path** and names both residuals as uncharacterised. Writing "THE ONE RESIDUAL" was the same defect class the rewrite exists to remove.
- The per-pass claim ("every pass here iterates a file set built from entity `SourceFile`") is still **carried over from #6983's enumeration, not independently re-derived** — not a second confirmation.

## Verification

Custom-gate state (#6966): **gate-OFF** for every figure — `go test` and `scripts/quality/run.sh --ratchet` neither enter `WithCustomExtractors`.

- `go vet ./internal/classifier/ ./internal/links/ ./cmd/grafel/` — exit 0; `gofmt -l` on the touched dirs — empty.
- `go test -count=1 ./internal/classifier/ ./internal/links/ ./cmd/grafel/ ./internal/cli/ ./internal/daemon/extract/` — **exit 0**, all five `ok` (`cmd/grafel` 149s, whole-graph digest pin).
- `go test -count=1 -race ./internal/classifier/ ./internal/links/` — **exit 0**.
- `scripts/quality/run.sh --ratchet` (isolated `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`) — **exit 0**: *"quality ratchet OK — 38 gated fixtures held their baseline (29 at 100% must-have recall)"*. No fixture moved; no baseline constant touched.

**What I did NOT measure:** no corpus index — the population figures are quoted from #6983. Neither residual is characterised: I did not measure how often a stat fails on an oversized file, nor the TOCTOU window. I did not measure daemon behaviour end-to-end; the per-index lifetime claim rests on the four `classifier.New` construction sites plus the unit test above, not on a running daemon.

## What changed after the review (`3e266c957` → `d86b5fba6`)

| review item | disposition |
|---|---|
| (a) process-global dedup+cap goes permanently, globally silent | **fixed** — state is per-Classifier; pinned by `…IsPerIndexNotPerProcess` (and N8) |
| (b) `"the single place too_large is minted"` is package-local, not repo-wide | **scoped** in the source comment |
| (c) the cap never says how much it hid | **fixed** — `ReportOversizedSummary` + the `cmd/grafel` end-to-end test |
| (d1) "all three extraction entry points" — there are four | **fixed** in both comments |
| (d2) "THE ONE RESIDUAL IS TOCTOU" — the `size = -1` stat bypass is a second | **fixed**; named as a residual with its three sites |
| N1 suppression line ungraded | **graded** — DEAD |
| N2 mutex ungraded, ALIVE even under `-race` | **graded** — DEAD under `-race` (see the caveat in the table; wants the `ci:full` label) |
| N3/N4 mutually-masking resets | **dissolved** — no global state, no resets |
| the `reflect.DeepEqual` tally assertion passes #6975 | unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
