### PR TITLE
fix(#6988): GenericForeignKey's ct_field was read as a target model — 5 of the 21 wrong edges were BOUND, not dangling

### DIFF
--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -156,7 +156,13 @@ var (
 	// but it drops `TreeForeignKey(Category, ...)` with it — measured, not
 	// assumed: see TestIssue6988_RegexBoundaryRejected_WouldDropSubclasses.
 	// This regex extracts a target; it is NOT the constructor filter.
-	// `isDjangoRelationalField` is the sole guard on WHICH constructors get here.
+	// `isDjangoRelationalField` decides which constructors are PROCESSED — but it
+	// does not bound what this regex READS. The caller hands it a 400-char
+	// forward window (`fullRHS` below) that can span later lines, so a
+	// legitimate `ForeignKey` whose own argument this regex cannot parse
+	// (`models.ForeignKey(settings.AUTH_USER_MODEL, ...)`) can still match a
+	// string belonging to a constructor the gate REJECTED. That residue survives
+	// #6988 and is zero-incidence on the measured corpus; it is filed separately.
 	djangoModelRelTargetRe = regexp.MustCompile(
 		`(?:ForeignKey|OneToOneField|ManyToManyField)\s*\(\s*(?:to\s*=\s*)?(?:["']([^"']+)["']|([A-Z][A-Za-z0-9_]*))`)
 

--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -148,6 +148,15 @@ var (
 	// target model — string form ('app.Model' / 'self') or symbol form (Model).
 	// Group 1 = relation kind, group 2 = quoted target (if string form),
 	// group 3 = identifier target (if symbol form).
+	// NOTE (#6988): this alternation has NO left word boundary, and that is
+	// deliberate — it is what lets a third-party `*ForeignKey` SUBCLASS
+	// (django-mptt's `TreeForeignKey`, and the `ForeignKey` subclasses apps
+	// define) reach its target argument. A leading `\b` would also have closed
+	// #6988, by refusing to match the `ForeignKey(` inside `GenericForeignKey(`,
+	// but it drops `TreeForeignKey(Category, ...)` with it — measured, not
+	// assumed: see TestIssue6988_RegexBoundaryRejected_WouldDropSubclasses.
+	// This regex extracts a target; it is NOT the constructor filter.
+	// `isDjangoRelationalField` is the sole guard on WHICH constructors get here.
 	djangoModelRelTargetRe = regexp.MustCompile(
 		`(?:ForeignKey|OneToOneField|ManyToManyField)\s*\(\s*(?:to\s*=\s*)?(?:["']([^"']+)["']|([A-Z][A-Za-z0-9_]*))`)
 
@@ -898,12 +907,43 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	return out, nil
 }
 
+// djangoNonTargetRelCtors names field constructors that carry a relational
+// SUFFIX but whose first argument is NOT a model (issue #6988).
+// `GenericForeignKey(ct_field, fk_field)` takes the names of two sibling fields
+// on the same model, so treating argument 1 as a target model produced a wrong
+// edge — dangling when the sibling name matched no entity, and worse,
+// confidently BOUND to the sibling ForeignKey's Constraint node when it did
+// (#6369's wrong-node hazard).
+//
+// Keyed on the FINAL dotted segment, so `GenericForeignKey`,
+// `fields.GenericForeignKey` and `contenttypes.fields.GenericForeignKey` are all
+// covered. It is a deny-list rather than an exact-match allow-list on purpose:
+// third-party `*ForeignKey` SUBCLASSES (django-mptt's `TreeForeignKey`, and the
+// `ForeignKey` subclasses apps define) do take a model as argument 1, and an
+// allow-list would silently drop them. `GenericForeignKey` is the one such
+// constructor this list currently carries — the corpus surfaced no other, and a
+// new name goes here rather than into a re-broadened suffix rule.
+// `GenericRelation` is the adjacent case and is NOT listed: its argument IS a
+// model, but it wears neither suffix, so it has never been admitted here at all
+// (pinned by TestIssue6988_GenericRelationEmitsNoTargetEdge — admitting it is a
+// recall change, not this fix).
+var djangoNonTargetRelCtors = map[string]bool{
+	"GenericForeignKey": true,
+}
+
 // isDjangoRelationalField reports whether a field constructor RHS (the matched
 // `models.XField` head) is a relational field carrying a target-model argument.
 func isDjangoRelationalField(rhs string) bool {
-	return strings.HasSuffix(rhs, "ForeignKey") ||
-		strings.HasSuffix(rhs, "OneToOneField") ||
-		strings.HasSuffix(rhs, "ManyToManyField")
+	ctor := rhs
+	if dot := strings.LastIndexByte(ctor, '.'); dot >= 0 {
+		ctor = ctor[dot+1:]
+	}
+	if djangoNonTargetRelCtors[ctor] {
+		return false
+	}
+	return strings.HasSuffix(ctor, "ForeignKey") ||
+		strings.HasSuffix(ctor, "OneToOneField") ||
+		strings.HasSuffix(ctor, "ManyToManyField")
 }
 
 // djangoRelTarget extracts the bare target-model class name from a relational

--- a/internal/custom/python/django_gfk_6988_test.go
+++ b/internal/custom/python/django_gfk_6988_test.go
@@ -134,6 +134,26 @@ func TestIssue6988_RegexKeepsEveryTargetForm(t *testing.T) {
 	}
 }
 
+// TestIssue6988_RegexRejectsLowercaseInitialSymbol grades the symbol group's
+// UPPERCASE-INITIAL anchor — `([A-Z][A-Za-z0-9_]*)`. Nothing else observes it,
+// and widening it to `[A-Za-z]` is production-reachable: on the django corpus it
+// mints `LogEntry.user -> Class:settings` (from
+// `models.ForeignKey(settings.AUTH_USER_MODEL, ...)`, django/contrib/admin/models.py)
+// and `User.friends -> Class:auth`. A lowercase-initial identifier is a module or
+// package path, never a Django model name, so it must yield no target.
+func TestIssue6988_RegexRejectsLowercaseInitialSymbol(t *testing.T) {
+	cases := []string{
+		`    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)`,
+		`    friends = models.ManyToManyField(auth.User, blank=True)`,
+	}
+	for _, rhs := range cases {
+		if got := djangoRelTarget(rhs, "LogEntry"); got != "" {
+			t.Errorf("djangoRelTarget(%q) = %q, want \"\" — a lowercase-initial identifier is a "+
+				"module path, not a model; the symbol group must stay anchored to [A-Z] (#6988)", rhs, got)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // End-to-end, through the real Django extractor.
 // ---------------------------------------------------------------------------
@@ -235,6 +255,11 @@ func TestIssue6988_NamedGFKFieldEmitsNoTargetEdge(t *testing.T) {
 // `created_by_ct` — so they read as valid and a cardinality assertion is blind
 // to their removal by construction (#6973). This asserts the exact substitution
 // shape instead.
+//
+// Layer note: this is a PRE-RESOLUTION emission test, so what it pins is the
+// emitted edge shape. The "5 of 21 BIND to a sibling Constraint node" figure is
+// corpus-measured (gate ON), NOT observed here — this test does not run the
+// resolver and makes no claim about binding.
 func TestIssue6988_WrongButBoundEdgeShapeIsGone(t *testing.T) {
 	rels := djangoEdges6988(t, gfkSrc6988)
 

--- a/internal/custom/python/django_gfk_6988_test.go
+++ b/internal/custom/python/django_gfk_6988_test.go
@@ -1,0 +1,302 @@
+package python
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6988 — `GenericForeignKey(ct_field, fk_field)` names two SIBLING FIELDS
+// on the same model. Neither argument is a model. The Django model pass used to
+// treat argument 1 as a target model and emit a `field_target_type` REFERENCES
+// edge to `Class:<ct_field>`.
+//
+// Two compounding admits let it through, and EITHER ALONE closes the bug:
+//
+//	(1) `isDjangoRelationalField` gated on `strings.HasSuffix(rhs, "ForeignKey")`
+//	    and `GenericForeignKey` ends in `ForeignKey`.
+//	(2) `djangoModelRelTargetRe` has no LEFT word boundary, so the alternation's
+//	    `ForeignKey(` matches INSIDE `GenericForeignKey(`. (`GenericForeignKey`
+//	    is not in the alternation — the missing boundary is the whole story.)
+//
+// ONLY (1) was fixed. (2) was rejected on measured merit: the missing boundary
+// is also what lets third-party `*ForeignKey` SUBCLASSES (django-mptt's
+// `TreeForeignKey`) reach their target, and a `\b` drops those with it —
+// TestIssue6988_RegexBoundaryRejected_WouldDropSubclasses compiles the rejected
+// variant and shows both halves of that trade. Shipping one guard also keeps it
+// GRADED: two guards that only fire together grade neither.
+//
+// Scope note (#6966): these edges only ever existed with the custom Python lane
+// gate ON. Gate-OFF — the default — they were never produced, so the
+// user-facing incidence of the defect was zero.
+
+// ---------------------------------------------------------------------------
+// The shipped guard: the constructor gate.
+// ---------------------------------------------------------------------------
+
+// TestIssue6988_GateRejectsGenericForeignKey grades the `HasSuffix` gate
+// on its own. It never reaches the regex.
+func TestIssue6988_GateRejectsGenericForeignKey(t *testing.T) {
+	rejected := []string{
+		"GenericForeignKey",
+		"fields.GenericForeignKey",
+		"contenttypes.fields.GenericForeignKey",
+		"django.contrib.contenttypes.fields.GenericForeignKey",
+	}
+	for _, rhs := range rejected {
+		if isDjangoRelationalField(rhs) {
+			t.Errorf("isDjangoRelationalField(%q) = true, want false: "+
+				"GenericForeignKey's first argument is a sibling field name, not a model (#6988)", rhs)
+		}
+	}
+}
+
+// TestIssue6988_GateKeepsRelationalConstructors pins the ACCEPT side of
+// the same gate, member by member — a set needs an assertion per member. The
+// third-party `*ForeignKey` SUBCLASSES are deliberately still admitted: they do
+// take a model as argument 1, so a whole-suffix ban would be a recall loss.
+func TestIssue6988_GateKeepsRelationalConstructors(t *testing.T) {
+	accepted := []string{
+		"models.ForeignKey",
+		"ForeignKey",
+		"models.OneToOneField",
+		"models.ManyToManyField",
+		"mptt.models.TreeForeignKey", // django-mptt subclass: arg 1 IS a model
+	}
+	for _, rhs := range accepted {
+		if !isDjangoRelationalField(rhs) {
+			t.Errorf("isDjangoRelationalField(%q) = false, want true (#6988 must not narrow the legitimate set)", rhs)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The REJECTED alternative: a left word boundary on djangoModelRelTargetRe.
+// ---------------------------------------------------------------------------
+
+// TestIssue6988_RegexBoundaryRejected_WouldDropSubclasses is the evidence behind
+// closing #6988 at the GATE ONLY. The issue offered a second fix — add a left
+// word boundary to `djangoModelRelTargetRe` so the alternation stops matching
+// the `ForeignKey(` inside `GenericForeignKey(`. That does close the bug, but it
+// is not free: the missing boundary is ALSO what lets a third-party `*ForeignKey`
+// SUBCLASS reach its target argument, and `\b` drops those too. This test pins
+// the recall that the boundary would have cost, so the trade-off is observed
+// rather than argued.
+//
+// Shipping both guards was therefore rejected on merit, not on effort — and it
+// also avoids a masking pair: two guards that only fire together grade neither.
+// `isDjangoRelationalField` is the single graded guard.
+func TestIssue6988_RegexBoundaryRejected_WouldDropSubclasses(t *testing.T) {
+	const subclassRHS = `    node = TreeForeignKey(Category, on_delete=models.CASCADE)`
+
+	// What ships: the boundary-free regex resolves the subclass target.
+	if got := djangoRelTarget(subclassRHS, "Item"); got != "Category" {
+		t.Fatalf("djangoRelTarget(%q) = %q, want \"Category\" — the subclass recall this "+
+			"regex exists to preserve is gone (#6988)", subclassRHS, got)
+	}
+
+	// The rejected variant, compiled here so the claim is measured. It closes
+	// #6988 (no GFK target) AND drops TreeForeignKey (no subclass target).
+	withBoundary := regexp.MustCompile(
+		`\b` + djangoModelRelTargetRe.String())
+	if withBoundary.FindStringSubmatch(subclassRHS) != nil {
+		t.Error("the \\b variant still matched TreeForeignKey — the stated cost of the " +
+			"rejected fix is wrong and the decision in #6988 should be revisited")
+	}
+	const gfkRHS = `    content_object = GenericForeignKey("content_type", "object_id")`
+	if withBoundary.FindStringSubmatch(gfkRHS) != nil {
+		t.Error("the \\b variant did not close #6988 — the rejected fix was mischaracterised")
+	}
+}
+
+// TestIssue6988_RegexKeepsEveryTargetForm pins the shipped regex's ACCEPT set,
+// one assertion per form, so the target extractor cannot be narrowed silently.
+// It deliberately does NOT assert anything about GenericForeignKey: the regex is
+// not the guard, and asserting it here would grade the gate a second time
+// instead of grading this.
+func TestIssue6988_RegexKeepsEveryTargetForm(t *testing.T) {
+	cases := []struct{ rhs, owner, want string }{
+		{`    author = models.ForeignKey('catalog.Author', on_delete=models.CASCADE)`, "Book", "Author"},
+		{`    parent = models.ForeignKey('self', null=True, on_delete=models.CASCADE)`, "Node", "Node"},
+		{`    profile = models.OneToOneField(Profile, on_delete=models.CASCADE)`, "User", "Profile"},
+		{`    tags = models.ManyToManyField(to=Tag, blank=True)`, "Post", "Tag"},
+		{`    owner = models.ForeignKey(to='auth.User', on_delete=models.CASCADE)`, "Doc", "User"},
+		{`    node = TreeForeignKey(Category, on_delete=models.CASCADE)`, "Item", "Category"},
+	}
+	for _, c := range cases {
+		if got := djangoRelTarget(c.rhs, c.owner); got != c.want {
+			t.Errorf("djangoRelTarget(%q, %q) = %q, want %q (#6988 must not break a legitimate form)",
+				c.rhs, c.owner, got, c.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end, through the real Django extractor.
+// ---------------------------------------------------------------------------
+
+// djangoEdges6988 runs the registered python_django extractor over src and
+// returns every emitted relationship.
+func djangoEdges6988(t *testing.T, src string) []types.RelationshipRecord {
+	t.Helper()
+	ext, ok := extractor.Get("python_django")
+	if !ok {
+		t.Fatal("python_django extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: "models.py", Content: []byte(src), Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	var rels []types.RelationshipRecord
+	for _, e := range ents {
+		rels = append(rels, e.Relationships...)
+	}
+	return rels
+}
+
+func fieldTargetEdgesFrom6988(rels []types.RelationshipRecord, from string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, r := range rels {
+		if r.FromID != from || r.Kind != string(types.RelationshipKindReferences) {
+			continue
+		}
+		for _, p := range r.Properties {
+			if p.K == "ref_kind" && p.V == "field_target_type" {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+func hasEdge6988(rels []types.RelationshipRecord, from, to, kind string) bool {
+	for _, r := range rels {
+		if r.FromID == from && r.ToID == to && r.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// The named forbidden case from the issue: `tests/delete/models.py:279`,
+// verbatim, plus the sibling declarations that make it a real GFK.
+const gfkSrc6988 = `from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
+from django.db import models
+
+
+class GenericB1(models.Model):
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    object_id = models.PositiveIntegerField()
+    generic_delete_top = GenericForeignKey("content_type", "object_id")
+
+
+class Book(models.Model):
+    title = models.CharField(max_length=200)
+    created_by_ct = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    created_by_id = models.PositiveIntegerField()
+    created_by = GenericForeignKey("created_by_ct", "created_by_id")
+    tagged = GenericRelation(TaggedItem)
+`
+
+// TestIssue6988_NamedGFKFieldEmitsNoTargetEdge is the forbidden row. Recall
+// cannot detect over-firing; only a named negative catches a too-broad
+// predicate, and over-firing IS the defect. Asserted BY NAME on
+// `GenericB1.generic_delete_top`, and asserted as "no field_target_type edge AT
+// ALL" rather than "not to Class:content_type", so a re-broadened predicate
+// cannot pass by picking a different wrong target.
+func TestIssue6988_NamedGFKFieldEmitsNoTargetEdge(t *testing.T) {
+	rels := djangoEdges6988(t, gfkSrc6988)
+
+	if got := fieldTargetEdgesFrom6988(rels, "GenericB1.generic_delete_top"); len(got) != 0 {
+		t.Errorf("GenericB1.generic_delete_top emitted %d field_target_type edge(s), want 0; first ToID=%q (#6988)",
+			len(got), got[0].ToID)
+	}
+	// Positive control: the sibling REAL ForeignKey on the same class still
+	// resolves, so the negative above is not a vacuous "this file produced
+	// nothing" pass.
+	if !hasEdge6988(rels, "GenericB1.content_type", pyClassRef("ContentType"), string(types.RelationshipKindReferences)) {
+		t.Error("GenericB1.content_type -> Class:ContentType missing: the fix removed a LEGITIMATE edge (#6988)")
+	}
+	// The GFK field itself must still be a CONTAINS member of its model — the
+	// fix removes the wrong REFERENCES edge, not the field node.
+	if !hasEdge6988(rels, pyClassRef("GenericB1"), "GenericB1.generic_delete_top", string(types.RelationshipKindContains)) {
+		t.Error("GenericB1 CONTAINS generic_delete_top missing: the fix must drop only the target edge (#6988)")
+	}
+}
+
+// TestIssue6988_WrongButBoundEdgeShapeIsGone pins the FIVE bound edges measured
+// on the `django` corpus (gate ON) as a SHAPE, not as a count. Those edges bound
+// to the sibling ForeignKey field's Constraint node — `Book.created_by` ->
+// `created_by_ct` — so they read as valid and a cardinality assertion is blind
+// to their removal by construction (#6973). This asserts the exact substitution
+// shape instead.
+func TestIssue6988_WrongButBoundEdgeShapeIsGone(t *testing.T) {
+	rels := djangoEdges6988(t, gfkSrc6988)
+
+	if hasEdge6988(rels, "Book.created_by", pyClassRef("created_by_ct"), string(types.RelationshipKindReferences)) {
+		t.Error("Book.created_by -> Class:created_by_ct still emitted: the wrong-but-BOUND edge shape " +
+			"(#6369's wrong-node hazard) survives (#6988)")
+	}
+	if got := fieldTargetEdgesFrom6988(rels, "Book.created_by"); len(got) != 0 {
+		t.Errorf("Book.created_by emitted %d field_target_type edge(s), want 0; first ToID=%q (#6988)",
+			len(got), got[0].ToID)
+	}
+	// The sibling that MINTS the `created_by_ct` node keeps its own real edge.
+	if !hasEdge6988(rels, "Book.created_by_ct", pyClassRef("ContentType"), string(types.RelationshipKindReferences)) {
+		t.Error("Book.created_by_ct -> Class:ContentType missing (#6988)")
+	}
+}
+
+// TestIssue6988_GenericRelationEmitsNoTargetEdge pins the neighbour named in the
+// issue. `GenericRelation` fails the constructor gate (it ends in neither
+// suffix), so it emits no target edge — observed here rather than asserted in
+// prose. Adding it is a RECALL question (its argument IS a model), tracked
+// separately; this test pins today's behaviour so that change is a visible one.
+func TestIssue6988_GenericRelationEmitsNoTargetEdge(t *testing.T) {
+	rels := djangoEdges6988(t, gfkSrc6988)
+	if got := fieldTargetEdgesFrom6988(rels, "Book.tagged"); len(got) != 0 {
+		t.Errorf("Book.tagged (GenericRelation) emitted %d field_target_type edge(s), want 0; first ToID=%q (#6988)",
+			len(got), got[0].ToID)
+	}
+}
+
+// TestIssue6988_LegitimateRelationalFieldsSurvive walks the whole legitimate set
+// END TO END, one assertion per member: ForeignKey / OneToOneField /
+// ManyToManyField, in string form ('app.Model' and 'self'), symbol form and `to=`
+// kwarg form.
+func TestIssue6988_LegitimateRelationalFieldsSurvive(t *testing.T) {
+	const src = `from django.db import models
+
+
+class Book(models.Model):
+    author = models.ForeignKey('catalog.Author', on_delete=models.CASCADE)
+    sequel_to = models.ForeignKey('self', null=True, on_delete=models.CASCADE)
+    publisher = models.ForeignKey(Publisher, on_delete=models.PROTECT)
+    isbn_record = models.OneToOneField(ISBN, on_delete=models.CASCADE)
+    editor = models.OneToOneField(to='staff.Editor', on_delete=models.CASCADE)
+    tags = models.ManyToManyField(Tag, blank=True)
+    shelves = models.ManyToManyField(to='library.Shelf', blank=True)
+    category = TreeForeignKey(Category, on_delete=models.CASCADE)
+`
+	rels := djangoEdges6988(t, src)
+	want := map[string]string{
+		"Book.author":      "Author",    // ForeignKey, string 'app.Model'
+		"Book.sequel_to":   "Book",      // ForeignKey, string 'self' -> owner
+		"Book.publisher":   "Publisher", // ForeignKey, symbol
+		"Book.isbn_record": "ISBN",      // OneToOneField, symbol
+		"Book.editor":      "Editor",    // OneToOneField, to= kwarg string
+		"Book.tags":        "Tag",       // ManyToManyField, symbol
+		"Book.shelves":     "Shelf",     // ManyToManyField, to= kwarg string
+		"Book.category":    "Category",  // third-party *ForeignKey subclass
+	}
+	for from, target := range want {
+		if !hasEdge6988(rels, from, pyClassRef(target), string(types.RelationshipKindReferences)) {
+			t.Errorf("%s -> Class:%s missing — #6988 broke a legitimate relational field", from, target)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6988. Refs #6986, #6369, #6966, #6973.

## The defect

`GenericForeignKey("content_type", "object_id")` names two **sibling fields on the same model**. Neither argument is a model. `isDjangoRelationalField` (`internal/custom/python/django.go`) gated on `strings.HasSuffix(rhs, "ForeignKey")`, and `GenericForeignKey` ends in `ForeignKey`, so argument 1 was captured as a target model and a `field_target_type` `REFERENCES` edge was emitted to `Class:<ct_field>`.

**Gate state on every figure below (#6966): custom-Python-lane gate ON.** Gate-OFF — the default users run — these edges were never produced at all, so the user-facing incidence of this defect today is **zero**. The measured population is 21 GFK-sourced `field_target_type` edges on the `django` corpus: 16 dangle, **5 BIND** to the sibling `ForeignKey` field's `Constraint` node (`Book.created_by` → `created_by_ct`). Those 5 are #6369's wrong-node hazard live — confidently wrong and invisible, because nothing flags a bound edge.

## Which admit I closed, and why

The issue named two compounding admits, either of which alone closes the bug. **I closed only the gate.**

**Shipped — the constructor gate.** `isDjangoRelationalField` now strips the dotted prefix and rejects `GenericForeignKey` by final segment, so `GenericForeignKey`, `fields.GenericForeignKey` and `contenttypes.fields.GenericForeignKey` are all covered. It is a **deny-list, not an exact-match allow-list**, on purpose: third-party `*ForeignKey` **subclasses** (django-mptt's `TreeForeignKey`, and the `ForeignKey` subclasses apps define) *do* take a model as argument 1, and an allow-list would silently drop them. Pinned by `TestIssue6988_GateKeepsRelationalConstructors`.

**Rejected on measured merit — the left word boundary on `djangoModelRelTargetRe`.** I implemented it first. It closes #6988, and it also **breaks `TreeForeignKey(Category, ...)`**: the missing boundary is exactly what lets a `*ForeignKey` subclass reach its target argument, and `\b` refuses those with the same stroke. This was not an argument — the `\b` version turned `TestIssue6988_LegitimateRelationalFieldsSurvive` red on `Book.category → Class:Category`, an edge that **does** exist on `bd03cdfeb`. Independently reproduced end-to-end by the reviewer on the parent. The trade-off is now pinned in the suite: `TestIssue6988_RegexBoundaryRejected_WouldDropSubclasses` compiles the rejected variant and asserts **both** halves — that it would have closed #6988, and that it would have dropped the subclass. If that cost claim is ever wrong, that test fails and the decision gets revisited.

**This is a trade, not a clean win, and the scope of the claim is the measured corpus.** One guard is sufficient for **every form observed on the `django` corpus** — not in general. The two residues below would both have been closed by the second guard; it costs all `*ForeignKey` subclass recall to do it, which is why the trade went this way. Shipping one guard also keeps it **graded**: two guards that only fire together grade neither, and there is no masking pair here.

## Known residues — disclosed, zero-incidence today, filed as follow-up

Both are #6988's own shape and neither is fixed here. On the `django` corpus, gate ON, `field_target_type` edges whose target is snake_case (so cannot be a model class) went **18 on the parent → 0 on HEAD**, with 956 `field_target_type` edges total on both sides. Both residues are therefore **real hazards that the corpus does not currently exhibit**.

1. **A GFK subclass.** `class CTForeignKey(GenericForeignKey)` used as `content_object = CTForeignKey("content_type", "object_id")` still yields `Tag.content_object → Class:content_type`. That is the deny-list's open-endedness by construction — a new non-target constructor goes in the list.
2. **The 400-char forward scan.** `fullRHS := body[fIdx[0]:min(fIdx[0]+400, len(body))]` hands `djangoRelTarget` the *following lines* as well, so a legitimate `models.ForeignKey(settings.AUTH_USER_MODEL, ...)` whose own argument the regex cannot parse reads a *later* GFK's `ct_field` string instead: `Note.user → Class:content_type` survives on HEAD (and exists on the parent).

Residue 2 is why an earlier draft of the code comment — "`isDjangoRelationalField` is the sole guard on which constructors get here" — was **wrong and is now corrected in the source**. The gate decides which constructors are *processed*; it does not bound what the regex *reads*. That sentence was prose asserting what no test observes, in the PR that fixes an over-firing predicate, and it does not ship.

## Assertions

- **The negative, by name.** `TestIssue6988_NamedGFKFieldEmitsNoTargetEdge` uses the issue's ready-made case verbatim — `generic_delete_top = GenericForeignKey("content_type", "object_id")` from `tests/delete/models.py:279` — and asserts **zero `field_target_type` edges from `GenericB1.generic_delete_top`**, not merely "not to `Class:content_type`", so a re-broadened predicate cannot pass by picking a different wrong target. Recall cannot detect over-firing, and over-firing is the whole defect.
- **Two positive controls on the same fixture**, so the negative is not a vacuous "this file produced nothing" pass: the sibling real `ForeignKey` (`GenericB1.content_type → Class:ContentType`) still resolves, and the GFK field keeps its `CONTAINS` membership — the fix removes the wrong `REFERENCES` edge, **not the field node**.
- **The 5 wrong-but-BOUND edges as a SHAPE, not a count.** `TestIssue6988_WrongButBoundEdgeShapeIsGone` pins `Book.created_by → Class:created_by_ct` gone while `Book.created_by_ct → Class:ContentType` stays. Those edges are *bound*, so a cardinality assertion is blind to their removal by construction (#6973: +8 net `TESTS` while 7,221 edges were substituted). **Layer, stated in the docstring:** this is a pre-resolution emission test, so it pins the emitted shape. The "5 of 21 BIND to a `Constraint` node" figure is corpus-measured, **not** observed by this test, which never runs the resolver.
- **The legitimate set, one assertion per member** (`TestIssue6988_LegitimateRelationalFieldsSurvive`, end to end): `ForeignKey` string `'app.Model'`, `ForeignKey` string `'self'` → owner, `ForeignKey` symbol, `OneToOneField` symbol, `OneToOneField` `to=` kwarg, `ManyToManyField` symbol, `ManyToManyField` `to=` kwarg, plus the `TreeForeignKey` subclass.
- **The symbol group's uppercase-initial anchor** (`TestIssue6988_RegexRejectsLowercaseInitialSymbol`, added on review): `models.ForeignKey(settings.AUTH_USER_MODEL, ...)` and `models.ManyToManyField(auth.User, ...)` must yield **no** target. A lowercase-initial identifier is a module path, never a model name.
- **The neighbour.** `TestIssue6988_GenericRelationEmitsNoTargetEdge` pins today's `GenericRelation` behaviour: it wears neither relational suffix, so it has never been admitted here. Its argument *is* a model, so admitting it is a **recall** change, not this fix — pinning it now makes that a visible change rather than a silent one.

## Verification — macOS 15.6 / APFS / arm64

Measured in `…/scratchpad/impl-6988-z7v2n/wt`, a dedicated worktree off `bd03cdfeb`.

- **Red first.** Before the fix, `TestIssue6988_NamedGFKFieldEmitsNoTargetEdge` failed with `first ToID="Class:content_type"` and `TestIssue6988_WrongButBoundEdgeShapeIsGone` with `first ToID="Class:created_by_ct"` — the two shapes the issue predicted, reproduced exactly.
- `go test -count=1 ./internal/custom/python/` — **PASS** (exit 0), the only package touched.
- `go test -count=1 ./cmd/grafel/` — **PASS** (exit 0). Whole-graph digest pin; no diff-derived package set reaches it.
- `scripts/quality/run.sh --ratchet` — **exit 0**, 38 gated fixtures held their baseline (29 at 100% must-have recall). **No fixture moved, and none could**: `grep -rn "GenericForeignKey\|GenericRelation" internal/quality/golden/` returns nothing, so no golden fixture exercises this path. No baseline constant was touched. Gating therefore rests on the named forbidden row plus the corpus delta (18 → 0), independently re-derived by the reviewer.
- `gofmt -l internal/custom/python/` clean; `go vet` clean. All three suites re-run after the review changes.

## Mutants — permissive direction first

Green baseline immediately before each; `go vet` before each score; `-count=1` throughout; each edit proven with an exact occurrence count (`assert n==1`) and the enclosing function or the rewritten line printed after the edit; restored each time by `cp` from a shasum-verified backup, never `git checkout`.

| # | Mutation | Verdict | Killed by |
|---|---|---|---|
| A | Delete the deny-list check in `isDjangoRelationalField` — restore the bare suffix admit | **DEAD** | `GateRejectsGenericForeignKey`, `NamedGFKFieldEmitsNoTargetEdge`, `WrongButBoundEdgeShapeIsGone` |
| B | Key the deny-list on the full dotted `rhs` instead of the final segment — dotted `fields.GenericForeignKey` slips through | **DEAD** | `GateRejectsGenericForeignKey` |
| C | Apply the rejected fix: add `\b` to `djangoModelRelTargetRe` | **DEAD** | `RegexBoundaryRejected_WouldDropSubclasses`, `RegexKeepsEveryTargetForm`, `LegitimateRelationalFieldsSurvive` |
| D | Widen the symbol capture `([A-Z][A-Za-z0-9_]*)` → `([A-Za-z][A-Za-z0-9_]*)` (1 of the 9 sites of that pattern in the file; the other 8 verified untouched) | **DEAD** *(was ALIVE and ungraded — graded on review)* | `RegexRejectsLowercaseInitialSymbol` |
| E | Forward-scan window `+400` → `+4000` in `(*DjangoExtractor).Extract` | **ALIVE — equivalent on the `django` corpus** (956 `field_target_type` edges either way), not equivalent in principle. Ungraded on purpose: it is residue 2 above, filed as follow-up | — |
| F | `strings.LastIndexByte(ctor, '.')` → `strings.IndexByte` — `contenttypes.fields.GenericForeignKey` misses the deny-list | **DEAD** | `GateRejectsGenericForeignKey` |

A–C are mine; D–F are the reviewer's. C is the one that matters for the design decision: the choice *not* to add the boundary is itself graded, and the recall it would have cost is asserted rather than claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
