### PR TITLE
feat(#6912): protobuf fields carried their declared type only as a property and in the Signature — emit the field→type REFERENCES edge, same-file targets only

### DIFF
--- a/cmd/grafel/quality_subtype_assertion_6488_test.go
+++ b/cmd/grafel/quality_subtype_assertion_6488_test.go
@@ -100,7 +100,8 @@ func TestProtoEnumValueSubtypeIsGraded_6488(t *testing.T) {
 	// enum-value subtype flip was live and undetected — the fixture's size AT
 	// THAT TIME. #6518 has since added the per-file carrier entity and the
 	// file -> message CONTAINS row that carrier made gradeable, so the figures
-	// the assertion below demands are 19/19 and 17/17. The #6488 property is
+	// the assertion below demands are 19/19 and 18/18 (#6912 arm B added the
+	// eighteenth relationship row). The #6488 property is
 	// unchanged: absolute counts, re-derived here rather than read from
 	// baseline.json.
 	rep := quality.Evaluate(fix, doc)
@@ -115,9 +116,11 @@ func TestProtoEnumValueSubtypeIsGraded_6488(t *testing.T) {
 				r.SubtypeMismatch, r.GotSubtype, "enum_value")
 		}
 	}
-	// 19 since #6518 added the per-file SCOPE.Component carrier, and 17/17
-	// relationships since the file -> message CONTAINS row it made gradeable
-	// (see proto-mini/NOTICE.md, which asked for exactly that row).
+	// 19 since #6518 added the per-file SCOPE.Component carrier, and 18/18
+	// relationships since #6912 arm B added the field->declared-type row
+	// (User.profile -> Profile) on top of the file -> message CONTAINS row
+	// #6518 made gradeable (see proto-mini/NOTICE.md, which asked for that one).
+	// The entity count is unchanged: arm B adds an edge, not an entity.
 	if rep.EntityExpected != 19 || rep.EntityFound != 19 {
 		var missing []string
 		for _, r := range rep.EntityResults {
@@ -128,8 +131,8 @@ func TestProtoEnumValueSubtypeIsGraded_6488(t *testing.T) {
 		t.Errorf("proto-mini entities %d/%d want 19/19; missing: %v",
 			rep.EntityFound, rep.EntityExpected, missing)
 	}
-	if rep.RelExpected != 17 || rep.RelFound != 17 {
-		t.Errorf("proto-mini relationships %d/%d want 17/17", rep.RelFound, rep.RelExpected)
+	if rep.RelExpected != 18 || rep.RelFound != 18 {
+		t.Errorf("proto-mini relationships %d/%d want 18/18", rep.RelFound, rep.RelExpected)
 	}
 	if n := len(rep.ForbiddenHits); n != 0 {
 		t.Errorf("proto-mini forbidden hits = %d, want 0", n)

--- a/internal/extractors/proto/field_type_refs.go
+++ b/internal/extractors/proto/field_type_refs.go
@@ -119,28 +119,57 @@ const protoFieldTargetRefKind = "field_target_type"
 // integral or string scalar, so in practice only V ever yields a candidate — but
 // both are walked rather than assuming the spec, exactly as namedTypeRefs does.
 // `map<string, Order>` therefore yields [Order]: one candidate, not two, and not
-// a `map` target. All three branches are graded by
-// TestProtoFieldTypeRefs_MapValueIsTheTarget.
+// a `map` target — the `string` key is dropped by the scalar rule below, which
+// is load-bearing here and not decorative (see it). All branches are graded by
+// TestProtoFieldTypeRefs_MapValueIsTheTarget and, for the shadowed-scalar key,
+// by TestProtoFieldTypeRefs_ScalarShadowedByASameFileMessage.
 //
-// THERE IS NO SCALAR BLOCKLIST HERE, and its absence is the design, not an
-// omission. `string`, `int32` and the rest are the largest field population in
-// any .proto file and they must produce zero edges — but they already do,
-// because no .proto declares `message string`, so the in-file gate drops every
-// one of them. A protoScalars check in front of that gate would fire only where
-// the gate already fires, leaving BOTH ungraded (arm A refused the identical
-// blocklist for the identical reason). It was written and then removed after
-// mutation scoring made the masking explicit: deleting the check changed no
-// end-to-end behaviour on any fixture, which is what "redundant" means.
-// TestProtoFieldTypeRefs_EveryScalarProducesNoEdge enumerates the whole
-// production scalar set through Extract and asserts the observable consequence
-// rather than the mechanism.
+// Two rejections:
 //
-// (namedTypeRefs, the older message-anchored path, does keep a protoScalars
-// check. It is left alone: re-deciding it is not this arm's business, and
-// TestProtoScalars_MatchesTheSpecList pins that set against an independent
-// literal either way.)
+//   - A SCALAR (the full protoScalars set: double float int32 int64 uint32
+//     uint64 sint32 sint64 fixed32 fixed64 sfixed32 sfixed64 bool string bytes)
+//     yields nothing. This is the largest field population in any .proto file
+//     and the one that must produce zero edges.
 //
-// One rejection:
+//     THIS CHECK IS NOT REDUNDANT WITH THE IN-FILE GATE, and the first cut of
+//     this arm deleted it on the argument that it was. The argument was that no
+//     .proto declares `message string`, so the gate drops every scalar anyway
+//     and a blocklist in front of it would fire only where the gate already
+//     fires. **That is a corpus-relative zero, not a property of the pass**, and
+//     it is FALSE IN FACT — review of #6991 constructed the case:
+//
+//     message string { int32 v = 1; }
+//     enum bool { B_ZERO = 0; }
+//     message Holder { string name = 1; bool flag = 2; }
+//
+//     `message string` is in the file, so it IS in the gate's local set: without
+//     this check `Holder.name` gets an edge to it and the edge BINDS, so it
+//     never reaches `bug-extractor` and nothing surfaces it — the exact failure
+//     the qualified-name rule below exists to prevent. The file compiles under
+//     protoc at RC 0, and protoc's own descriptor binds `Holder.name` to
+//     TYPE_STRING with an EMPTY type_name: the grammar matches `string` in
+//     field-type position as a scalar before it ever considers a message type,
+//     so the shadowing message can never be the referent and the edge asserts
+//     something protoc says does not exist. `map<string, Order>` under that
+//     declaration gains a bogus second key edge on top of the right one.
+//
+//     Graded end to end, not at the unit, by
+//     TestProtoFieldTypeRefs_ScalarShadowedByASameFileMessage — because "an
+//     edge case that compiles under protoc" is what separates a live guard from
+//     a redundant one, and only a fixture containing the case can tell them
+//     apart. TestProtoFieldTypeRefs_EveryScalarProducesNoEdge enumerates the
+//     whole production scalar set separately, against an independent literal
+//     (#6975).
+//
+//     THE GENERAL LESSON, recorded here because it cost a review round: a
+//     mutant killed ONLY by its own unit test does not establish that a guard is
+//     redundant. It is equally consistent with the end-to-end population simply
+//     lacking the case — and telling those two apart requires CONSTRUCTING the
+//     case, which is the step that was skipped. (`namedTypeRefs`, the older
+//     message-anchored path, keeps its own protoScalars check; had this one
+//     stayed deleted the two anchors would have disagreed in the wrong
+//     direction, the field edge over-firing exactly where the message edge
+//     correctly stays silent.)
 //
 //   - A QUALIFIED name — anything containing a `.`, including the
 //     fully-qualified leading-dot form `.foo.bar.Order` — yields nothing, and is
@@ -162,7 +191,7 @@ func protoFieldTypeCandidates(ftype string) []string {
 	}
 	var out []string
 	for _, p := range parts {
-		if p == "" || strings.Contains(p, ".") {
+		if p == "" || protoScalars[p] || strings.Contains(p, ".") {
 			continue
 		}
 		out = append(out, p)

--- a/internal/extractors/proto/field_type_refs.go
+++ b/internal/extractors/proto/field_type_refs.go
@@ -1,0 +1,206 @@
+package proto
+
+import (
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// field_type_refs.go — the field→declared-type edge for protobuf (issue #6912,
+// arm B; arm A is internal/extractors/csharp/field_type_refs.go, #6984).
+//
+// THE GAP, AND HOW IT DIFFERS FROM C#. buildField records a proto field's
+// declared type as the `type` PROPERTY and in the Signature, and never as a
+// relationship, so every SCOPE.Schema/field entity this package emits is a leaf
+// on its outbound side. That is the #6912 population: #6726 measures
+// SCOPE.Schema at 99.3% orphan over their corpus, and protobuf is one of their
+// four languages.
+//
+// What protobuf already had, and what it did NOT have, is the whole design
+// question here. buildMessage already emits a REFERENCES edge per named field
+// type — but it hangs it off the MESSAGE (`message User` → `message Order`,
+// properties `type` / `via_field`). The message is therefore already wired; the
+// FIELD is not. "Which fields point at Order?" is answerable for C# after arm A
+// and was not answerable for protobuf, because the only edge that knew about
+// `Order` was anchored one level up and named its field in a property instead
+// of in its endpoints.
+//
+// So this pass adds a SECOND edge, from the field, rather than moving the
+// existing one. Moving it would break the message→message topology the .proto
+// dependency view is built on (#6419, #6422); duplicating the ANCHOR is the
+// point, not duplicating the information.
+//
+// VOCABULARY AND ADDRESS ARE ARM A'S, NOT NEW. Kind REFERENCES with the
+// property `ref_kind: "field_target_type"` — the spelling the custom lane's
+// shared `referencesClassEdge` helper has used in five languages, and the one
+// arm A adopted for core. `TYPED_AS` (#6906) and `HAS_TYPE` (#5828) are both
+// declared in internal/types/kinds.go with zero producers; a third spelling
+// would split every "which fields point at X?" query (#6902).
+//
+// The address is messageTypeRef — `scope:schema:message:proto:<file>:<Name>` —
+// which is this package's existing structural type address, already used by the
+// message→type edge, by the file→message CONTAINS edge (#6422) and by rpc
+// request/response types (#6359). It is FILE-SCOPED, so it does not go
+// AMBIGUOUS when a second .proto declares a same-named message — the failure
+// that #6986 measured at 91.6% dangling for the custom lane's `Class:<Name>`
+// form. Post-resolution the ToID is the target entity's ID, so no query sees
+// the dialect. Note the SCOPE.Enum arm of arm A has no analogue here: protobuf
+// enums are SCOPE.Schema/enum entities and take the SAME messageTypeRef
+// address, so there is one address dialect on this arm rather than two.
+//
+// A NON-BINDING EDGE IS WORSE THAN NO EDGE. An unresolved stub is kept verbatim
+// and dangling and classified `bug-extractor`, with no masking branch and no
+// drop pass, so every miss is a full hit and each emitted edge adds one
+// endpoint to the disposition denominator (#6906). The edge is therefore
+// emitted ONLY where the target is declared IN THE SAME FILE.
+//
+// THAT GATE IS NOT NEW EITHER, and reusing it is deliberate. #6357 already
+// installed dropUnresolvableTypeRefs, which runs in Extract after the walk and
+// removes every REFERENCES edge — on ANY entity — whose ToID is not a
+// message/enum declared in this file. Emitting the field edge into that same
+// address space means the same-file rule has ONE implementation and ONE
+// spelling for both anchors. A second private copy of the check inside this
+// file would fire only where that pass already fires, leaving both ungraded
+// (the redundant-guard trap arm A called out for its primitive blocklist).
+// The consequence is asserted end-to-end rather than described: see
+// TestProtoFieldTypeRefs_CrossFileTypeGetsNoEdge.
+//
+// WHAT THIS PASS IS NOT.
+//
+//   - It is FILE scope and nothing else. It does not consult the proto
+//     `package` declaration, and it cannot: one .proto file declares exactly one
+//     package, so there is no in-file namespace shadowing to get wrong. That is
+//     why arm A's namespace over-fire has no counterpart here.
+//   - It is DELIBERATELY STRICTER THAN THE MESSAGE-LEVEL EDGE on qualified
+//     names, and this is the one place the two anchors disagree. namedTypeRefs
+//     strips a qualifier to its trailing segment (`.foo.bar.Order` → `Order`),
+//     so if THIS file also happens to declare an unrelated `Order`, the
+//     message-level edge binds to the wrong entity — silently, because a bound
+//     edge never reaches `bug-extractor`. protoFieldTypeCandidates does not
+//     strip: any name carrying a `.` is skipped outright. A same-file type is
+//     written bare in practice, so the recall this costs is small and the false
+//     edge it prevents is invisible. Pinned in both directions by
+//     TestProtoFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName, which
+//     also pins that the message-level edge's behaviour is UNCHANGED by this
+//     arm. Widening the field edge is not the fix; narrowing namedTypeRefs is,
+//     and it belongs with the cross-file package index #6357 defers.
+//   - A NESTED message referenced as `Outer.Inner` therefore gets nothing from
+//     this pass, by the same rule. That is the honest floor, asserted by name
+//     rather than described.
+//   - It cannot reach an IMPORTED type at all, which for protobuf is the
+//     majority case: `import "common.proto"; ... Address address = 3;` gets no
+//     edge, because pass 1 sees one file and the import directives carry file
+//     paths, not package names (#6357). Closing that needs the cross-file proto
+//     package index, which is a separate arm.
+
+// protoFieldTargetRefKind is the value of the `ref_kind` edge property. It
+// matches arm A's csFieldTargetRefKind and the custom lane's referencesClassEdge
+// verbatim — the discriminator is what makes the edge queryable as a
+// field→declared-type edge across languages, so it must be one string.
+//
+// It is NOT the spelling the pre-existing message→type edge uses (`type` /
+// `via_field`). That edge is a different relation with a different anchor and is
+// left exactly as it was; re-spelling it would be a graph-wide change with no
+// bearing on #6912.
+const protoFieldTargetRefKind = "field_target_type"
+
+// protoFieldTypeCandidates returns the bare type names a field's declared type
+// may address, in source order and without deduplication.
+//
+// The input is the rendered type string from fieldTypeAndLabel /
+// mapFieldTypeAndLabel — the TYPE only. The proto label (`repeated`,
+// `optional`, `required`) is returned by those helpers as a SEPARATE value and
+// prepended only to the Signature, so `repeated Order orders = 3;` arrives here
+// as "Order" and never as "repeated Order". Pinned by
+// TestProtoFieldTypeRefs_LabelIsNeverTheTarget.
+//
+// map<K, V> IS UNWRAPPED, and the rule is: the wrapper is never a target and
+// each of K and V is considered independently. proto3 constrains a map key to an
+// integral or string scalar, so in practice only V ever yields a candidate — but
+// both are walked rather than assuming the spec, exactly as namedTypeRefs does.
+// `map<string, Order>` therefore yields [Order]: one candidate, not two, and not
+// a `map` target. All three branches are graded by
+// TestProtoFieldTypeRefs_MapValueIsTheTarget.
+//
+// THERE IS NO SCALAR BLOCKLIST HERE, and its absence is the design, not an
+// omission. `string`, `int32` and the rest are the largest field population in
+// any .proto file and they must produce zero edges — but they already do,
+// because no .proto declares `message string`, so the in-file gate drops every
+// one of them. A protoScalars check in front of that gate would fire only where
+// the gate already fires, leaving BOTH ungraded (arm A refused the identical
+// blocklist for the identical reason). It was written and then removed after
+// mutation scoring made the masking explicit: deleting the check changed no
+// end-to-end behaviour on any fixture, which is what "redundant" means.
+// TestProtoFieldTypeRefs_EveryScalarProducesNoEdge enumerates the whole
+// production scalar set through Extract and asserts the observable consequence
+// rather than the mechanism.
+//
+// (namedTypeRefs, the older message-anchored path, does keep a protoScalars
+// check. It is left alone: re-deciding it is not this arm's business, and
+// TestProtoScalars_MatchesTheSpecList pins that set against an independent
+// literal either way.)
+//
+// One rejection:
+//
+//   - A QUALIFIED name — anything containing a `.`, including the
+//     fully-qualified leading-dot form `.foo.bar.Order` — yields nothing, and is
+//     not stripped to its trailing segment. See the header block: this is where
+//     the field edge is deliberately narrower than the message edge.
+func protoFieldTypeCandidates(ftype string) []string {
+	ftype = strings.TrimSpace(ftype)
+	if ftype == "" {
+		return nil
+	}
+	var parts []string
+	if strings.HasPrefix(ftype, "map<") && strings.HasSuffix(ftype, ">") {
+		inner := ftype[len("map<") : len(ftype)-1]
+		for _, p := range strings.Split(inner, ",") {
+			parts = append(parts, strings.TrimSpace(p))
+		}
+	} else {
+		parts = append(parts, ftype)
+	}
+	var out []string
+	for _, p := range parts {
+		if p == "" || strings.Contains(p, ".") {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// protoFieldTypeRefs builds the field→declared-type REFERENCES edges carried by
+// ONE field entity, deduplicated by target.
+//
+// FromID is left empty so graph assembly anchors the edge on the field record
+// that carries it — the Django precedent at
+// internal/extractors/python/django_relational.go:246-252. (Hibernate sets an
+// explicit structural FromID because it hangs its edge off its own parallel
+// SCOPE.Component node; that is a different shape and not the one to copy —
+// #6912's own body was corrected on this point.)
+//
+// Every edge returned here is still provisional: dropUnresolvableTypeRefs
+// removes the ones whose target is not declared in this file. This function
+// deliberately does not pre-filter, so the same-file rule has one owner.
+func protoFieldTypeRefs(filePath, fname, ftype string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	emitted := make(map[string]bool)
+	for _, cand := range protoFieldTypeCandidates(ftype) {
+		toID := messageTypeRef(filePath, cand)
+		if emitted[toID] {
+			continue
+		}
+		emitted[toID] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: toID,
+			Kind: string(types.RelationshipKindReferences),
+			Properties: types.Props{
+				{K: "field_name", V: fname},
+				{K: "ref_kind", V: protoFieldTargetRefKind},
+				{K: "target_type", V: cand},
+			},
+		})
+	}
+	return out
+}

--- a/internal/extractors/proto/field_type_refs_6912_internal_test.go
+++ b/internal/extractors/proto/field_type_refs_6912_internal_test.go
@@ -26,10 +26,16 @@ import (
 // It is used twice: here, to pin the production set namedTypeRefs consults, and
 // in TestProtoFieldTypeRefs_EveryScalarProducesNoEdge below, to GENERATE one
 // field per scalar so the claim "scalars produce no edge" is asserted per
-// member instead of on a hand-picked representative. The #6912 arm B path has
-// no scalar blocklist of its own — see field_type_refs.go — so the generated
-// test grades the OBSERVABLE claim through Extract, which is the only place the
-// claim is true.
+// member instead of on a hand-picked representative. Adding a scalar to
+// protoScalars without adding it here fails TestProtoScalars_MatchesTheSpecList;
+// adding it here without adding it to protoScalars fails that test AND the
+// generated end-to-end case.
+//
+// Note what the generated fixture does NOT cover: it declares no message or
+// enum SHADOWING a scalar name, so it grades the scalar rule only where the
+// in-file gate would have covered for it anyway. The shadowed case is
+// TestProtoFieldTypeRefs_ScalarShadowedByASameFileMessage; the enumeration here
+// is over the scalar SET, not over the fixture space around it.
 var protoScalarLiteral = []string{
 	"bool",
 	"bytes",
@@ -70,9 +76,17 @@ func TestProtoScalars_MatchesTheSpecList(t *testing.T) {
 //
 // The map<> row set is the explicit answer to "what happens to map<K, V>":
 // the wrapper is NEVER a candidate and each of K and V is one, subject to the
-// same qualified-name rule. Note these are CANDIDATES, not edges — the in-file
-// gate runs afterwards, which is why a scalar component appears here and no
-// scalar field ever carries an edge (TestProtoFieldTypeRefs_EveryScalarProducesNoEdge).
+// same scalar and qualified-name rules.
+//
+// These rows are necessary and not sufficient. Two of the rules they cover are
+// masked end to end by the in-file gate on ordinary input — the qualified-name
+// pass-through and the empty-name guard — so this table is their only grader,
+// which is correct. The SCALAR rows are different: they are ALSO reachable
+// through Extract, and are graded there by
+// TestProtoFieldTypeRefs_ScalarShadowedByASameFileMessage. That distinction is
+// the review lesson from #6991 — "killed only by the unit table" is consistent
+// with a redundant guard AND with a fixture space that simply lacks the case,
+// and only constructing the case tells them apart.
 func TestProtoFieldTypeCandidates_Rules(t *testing.T) {
 	cases := []struct {
 		ftype string
@@ -82,14 +96,17 @@ func TestProtoFieldTypeCandidates_Rules(t *testing.T) {
 		{"Order", []string{"Order"}, "bare named type"},
 		{"", nil, "empty type string"},
 		{"  Order  ", []string{"Order"}, "surrounding whitespace"},
-		{"map<string, Order>", []string{"string", "Order"}, "the map WRAPPER is never a candidate; each component is one"},
-		{"map<int32, string>", []string{"int32", "string"}, "a map of scalars still yields its components HERE — the in-file gate is what drops them, not this function"},
+		{"map<string, Order>", []string{"Order"}, "the map WRAPPER is never a candidate; the scalar key is dropped by the scalar rule"},
+		{"map<int32, string>", nil, "a map of two scalars yields nothing"},
+		{"map<Key, Order>", []string{"Key", "Order"}, "a non-scalar key is considered by the same rule as the value"},
 		{"map<, >", nil, "degenerate map text yields nothing, not an empty-named target"},
 		{"demo.Profile", nil, "qualified name is NOT stripped to its trailing segment"},
 		{".demo.Profile", nil, "fully-qualified leading-dot form"},
 		{"Outer.Inner", nil, "nested message reference is a qualified name"},
-		{"map<string, demo.Profile>", []string{"string"}, "a qualified map value is rejected, the scalar key still surfaces"},
-		{"string", []string{"string"}, "NO scalar blocklist lives here: `string` is a candidate that the in-file gate then drops, because no .proto declares `message string`. See the header block."},
+		{"map<string, demo.Profile>", nil, "a qualified map value is rejected and the scalar key with it"},
+		{"string", nil, "scalar. NOT redundant with the in-file gate — see TestProtoFieldTypeRefs_ScalarShadowedByASameFileMessage, which reaches this branch through Extract on a file declaring `message string`"},
+		{"bool", nil, "scalar, and the enum-shadowing half of the same case"},
+		{"bytes", nil, "scalar"},
 		{"repeated", []string{"repeated"}, "the label is not filtered HERE — it never reaches here; see TestProtoFieldTypeRefs_LabelIsNeverTheTarget"},
 	}
 	for _, c := range cases {

--- a/internal/extractors/proto/field_type_refs_6912_internal_test.go
+++ b/internal/extractors/proto/field_type_refs_6912_internal_test.go
@@ -1,0 +1,217 @@
+package proto
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	tsproto "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/proto"
+	tsofficial "github.com/cajasmota/grafel/internal/treesitter/ts/official"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6912 arm B, internal half. Everything else about this arm is graded from
+// package proto_test through the real Extract; the two tests here need to see
+// unexported state and cannot move out.
+
+// protoScalarLiteral is an INDEPENDENT LITERAL of protobuf's scalar set,
+// transcribed from the protobuf language spec's scalar-value-types table rather
+// than derived from protoScalars (#6975: a table test that reads the production
+// collection it is grading can only ever agree with it).
+//
+// It is used twice: here, to pin the production set namedTypeRefs consults, and
+// in TestProtoFieldTypeRefs_EveryScalarProducesNoEdge below, to GENERATE one
+// field per scalar so the claim "scalars produce no edge" is asserted per
+// member instead of on a hand-picked representative. The #6912 arm B path has
+// no scalar blocklist of its own — see field_type_refs.go — so the generated
+// test grades the OBSERVABLE claim through Extract, which is the only place the
+// claim is true.
+var protoScalarLiteral = []string{
+	"bool",
+	"bytes",
+	"double",
+	"fixed32",
+	"fixed64",
+	"float",
+	"int32",
+	"int64",
+	"sfixed32",
+	"sfixed64",
+	"sint32",
+	"sint64",
+	"string",
+	"uint32",
+	"uint64",
+}
+
+func TestProtoScalars_MatchesTheSpecList(t *testing.T) {
+	got := make([]string, 0, len(protoScalars))
+	for k, v := range protoScalars {
+		if !v {
+			t.Errorf("protoScalars[%q] is false; a false entry is not a scalar and the map is used as a set", k)
+		}
+		got = append(got, k)
+	}
+	sort.Strings(got)
+	want := append([]string(nil), protoScalarLiteral...)
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("protoScalars drifted from the spec list\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// TestProtoFieldTypeCandidates_Rules grades the candidate rule branch by
+// branch, at the unit that owns it, so a change of behaviour is attributable
+// here as well as visible end-to-end.
+//
+// The map<> row set is the explicit answer to "what happens to map<K, V>":
+// the wrapper is NEVER a candidate and each of K and V is one, subject to the
+// same qualified-name rule. Note these are CANDIDATES, not edges — the in-file
+// gate runs afterwards, which is why a scalar component appears here and no
+// scalar field ever carries an edge (TestProtoFieldTypeRefs_EveryScalarProducesNoEdge).
+func TestProtoFieldTypeCandidates_Rules(t *testing.T) {
+	cases := []struct {
+		ftype string
+		want  []string
+		why   string
+	}{
+		{"Order", []string{"Order"}, "bare named type"},
+		{"", nil, "empty type string"},
+		{"  Order  ", []string{"Order"}, "surrounding whitespace"},
+		{"map<string, Order>", []string{"string", "Order"}, "the map WRAPPER is never a candidate; each component is one"},
+		{"map<int32, string>", []string{"int32", "string"}, "a map of scalars still yields its components HERE — the in-file gate is what drops them, not this function"},
+		{"map<, >", nil, "degenerate map text yields nothing, not an empty-named target"},
+		{"demo.Profile", nil, "qualified name is NOT stripped to its trailing segment"},
+		{".demo.Profile", nil, "fully-qualified leading-dot form"},
+		{"Outer.Inner", nil, "nested message reference is a qualified name"},
+		{"map<string, demo.Profile>", []string{"string"}, "a qualified map value is rejected, the scalar key still surfaces"},
+		{"string", []string{"string"}, "NO scalar blocklist lives here: `string` is a candidate that the in-file gate then drops, because no .proto declares `message string`. See the header block."},
+		{"repeated", []string{"repeated"}, "the label is not filtered HERE — it never reaches here; see TestProtoFieldTypeRefs_LabelIsNeverTheTarget"},
+	}
+	for _, c := range cases {
+		got := protoFieldTypeCandidates(c.ftype)
+		if strings.Join(got, ",") != strings.Join(c.want, ",") {
+			t.Errorf("protoFieldTypeCandidates(%q) = %v, want %v (%s)", c.ftype, got, c.want, c.why)
+		}
+	}
+}
+
+// extractInternal runs the registered protobuf extractor over one source. It
+// duplicates proto_test.go's helper because this file must live in package
+// proto to see protoScalars, and the external helper is not visible here.
+func extractInternal(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	parser, err := tsofficial.New().NewParser(tsproto.Language())
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	ext, ok := extractor.Get("protobuf")
+	if !ok {
+		t.Fatal("protobuf extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: path, Content: []byte(src), Language: "protobuf", TSTree: tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+// TestProtoFieldTypeRefs_EveryScalarProducesNoEdge is the biggest negative
+// direction on this arm, and it is ENUMERATED rather than sampled: the fixture
+// is GENERATED from protoScalarLiteral, one field per scalar, so the set cannot
+// grow a member that goes ungraded. Scalars are the dominant field population in
+// any real .proto file, and an edge for one of them would be a dangling
+// `bug-extractor` endpoint per occurrence (#6906).
+//
+// The message deliberately ALSO declares a same-file message and a field using
+// it, as a positive control: without it, "no field-type edges here" would pass
+// just as well for a pass that emits nothing at all.
+func TestProtoFieldTypeRefs_EveryScalarProducesNoEdge(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("syntax = \"proto3\";\n\nmessage Control { string x = 1; }\n\nmessage S {\n")
+	for i, s := range protoScalarLiteral {
+		fmt.Fprintf(&b, "  %s f_%s = %d;\n", s, s, i+1)
+	}
+	fmt.Fprintf(&b, "  Control control = %d;\n", len(protoScalarLiteral)+1)
+	b.WriteString("}\n")
+
+	ents := extractInternal(t, "s.proto", b.String())
+
+	// Positive control on the fixture: every scalar field entity must exist and
+	// carry the scalar as its declared type, or the assertion below is vacuous
+	// for a reason that has nothing to do with the edge rule.
+	byName := map[string]*types.EntityRecord{}
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Schema" && ents[i].Subtype == "field" {
+			byName[ents[i].Name] = &ents[i]
+		}
+	}
+	for _, s := range protoScalarLiteral {
+		f, ok := byName["S.f_"+s]
+		if !ok {
+			t.Fatalf("fixture produced no field entity S.f_%s; the %q case is not exercised", s, s)
+		}
+		if f.Properties["type"] != s {
+			t.Fatalf("S.f_%s declared type = %q, want %q", s, f.Properties["type"], s)
+		}
+		for _, r := range f.Relationships {
+			if r.Kind == "REFERENCES" {
+				t.Errorf("scalar field S.f_%s must carry no field-type edge, got -> %s", s, r.ToID)
+			}
+		}
+	}
+
+	// Positive control on the PASS: the non-scalar field in the same message
+	// must have got its edge, so "no edges for scalars" is not trivially true.
+	ctrl, ok := byName["S.control"]
+	if !ok {
+		t.Fatal("fixture produced no S.control field")
+	}
+	var ctrlTargets []string
+	for _, r := range ctrl.Relationships {
+		if r.Kind == "REFERENCES" {
+			ctrlTargets = append(ctrlTargets, r.ToID)
+		}
+	}
+	want := []string{"scope:schema:message:proto:s.proto:Control"}
+	if strings.Join(ctrlTargets, ",") != strings.Join(want, ",") {
+		t.Fatalf("positive control S.control edges = %v, want %v", ctrlTargets, want)
+	}
+}
+
+// TestProtoFieldTypeRefs_DedupesPerTarget grades the per-field dedupe. It is
+// tested at the unit and not end to end because the only type expression that
+// names one target twice — `map<Order, Order>` — is INVALID proto3 (a map key
+// must be an integral or string scalar), so no fixture can reach it through
+// Extract. Mutation scoring found the dedupe alive without this test; grading
+// it cost twelve lines, which is cheaper than arguing it cannot happen.
+//
+// Two edges to one target would double-count the field in every "which fields
+// point at Order?" answer and add a second endpoint to the disposition
+// denominator for one declaration.
+func TestProtoFieldTypeRefs_DedupesPerTarget(t *testing.T) {
+	got := protoFieldTypeRefs("m.proto", "both", "map<Order, Order>")
+	if len(got) != 1 {
+		t.Fatalf("map<Order, Order> produced %d edges, want 1 (deduped): %+v", len(got), got)
+	}
+	if got[0].ToID != "scope:schema:message:proto:m.proto:Order" {
+		t.Fatalf("ToID = %q", got[0].ToID)
+	}
+	// Positive control: two DIFFERENT targets must still produce two edges, so
+	// the assertion above is about dedupe and not about a pass that emits at
+	// most one edge per field.
+	if two := protoFieldTypeRefs("m.proto", "pair", "map<Key, Order>"); len(two) != 2 {
+		t.Fatalf("map<Key, Order> produced %d edges, want 2: %+v", len(two), two)
+	}
+}

--- a/internal/extractors/proto/field_type_refs_6912_test.go
+++ b/internal/extractors/proto/field_type_refs_6912_test.go
@@ -1,0 +1,501 @@
+package proto_test
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6912 arm B — the field→declared-type edge for protobuf. See
+// field_type_refs.go for the kind / address / same-file decisions; this file
+// grades them.
+//
+// Every assertion below names FIELDS AND TARGETS. A count cannot see a
+// substitution, and recall cannot see over-firing at all — and over-firing is
+// the failure mode that hurts here, because a dangling stub is kept verbatim
+// and counted as one more `bug-extractor` endpoint (#6906). So the forbidden
+// set — every scalar, an imported type, a qualified type, a nested-qualified
+// type, an undeclared type, the `map<>` wrapper and the proto labels — is
+// asserted BY NAME beside the expected set.
+//
+// The per-scalar enumeration lives in field_type_refs_6912_internal_test.go,
+// which generates one field per member of the production scalar set.
+
+const ftrOwnerPath = "svc/user.proto"
+
+// ftrOwnerSrc packs one case per branch of the rule. Read beside
+// TestProtoFieldTypeRefs_EmittedEdges and
+// TestProtoFieldTypeRefs_ForbiddenTargets, which grade the two directions of
+// the SAME fixture.
+const ftrOwnerSrc = `syntax = "proto3";
+
+package demo;
+
+import "common.proto";
+
+enum Role {
+  ROLE_UNKNOWN = 0;
+  ROLE_ADMIN = 1;
+}
+
+message Profile { string display_name = 1; }
+
+message Order { string id = 1; }
+
+message User {
+  string email = 1;
+  int32 age = 2;
+  Profile profile = 3;
+  Role role = 4;
+  repeated Order orders = 5;
+  optional Profile backup = 6;
+  map<string, Order> by_id = 7;
+  map<int32, string> tags = 8;
+  Address address = 9;
+  demo.Profile qualified = 10;
+  .demo.Profile fq = 11;
+  Missing gone = 12;
+  User parent = 13;
+  oneof choice {
+    Profile alt = 14;
+    string note = 15;
+  }
+}
+
+message Outer {
+  message Inner { string v = 1; }
+  Inner direct = 1;
+  Outer.Inner deep = 2;
+}
+`
+
+// ftrRivalPath / ftrRivalSrc declare messages under the SAME bare names in a
+// different file. Their only job is to prove the address is file-scoped: the
+// edges emitted for svc/user.proto must not change when they are present.
+const ftrRivalPath = "other/rival.proto"
+
+const ftrRivalSrc = `syntax = "proto3";
+
+package rival;
+
+message Profile { string other = 1; }
+
+message Order { string id = 1; }
+
+message User { Profile profile = 1; }
+`
+
+// ftrExtract runs the extractor over each file independently, exactly as pass 1
+// does, and concatenates the records.
+func ftrExtract(t *testing.T, files map[string]string) []types.EntityRecord {
+	t.Helper()
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	var out []types.EntityRecord
+	for _, p := range paths {
+		out = append(out, extract(t, p, files[p])...)
+	}
+	return out
+}
+
+// ftrEdges returns "<record name> -> <ToID>" for every REFERENCES edge carrying
+// ref_kind=field_target_type, across ALL records — so an edge that escaped onto
+// the message, the file entity or an enum is still seen rather than filtered
+// out of the picture. It fails on a non-empty FromID: the Django precedent
+// leaves it empty so assembly anchors the edge on the record that carries it.
+func ftrEdges(t *testing.T, recs []types.EntityRecord) []string {
+	t.Helper()
+	var out []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || ftrProp(r.Properties, "ref_kind") != "field_target_type" {
+				continue
+			}
+			if r.FromID != "" {
+				t.Errorf("%s -[REFERENCES]-> %s has FromID=%q, want empty",
+					recs[i].Name, r.ToID, r.FromID)
+			}
+			if recs[i].Kind != "SCOPE.Schema" || recs[i].Subtype != "field" {
+				t.Errorf("field-type edge escaped onto %s/%s %q; it must be carried by the FIELD",
+					recs[i].Kind, recs[i].Subtype, recs[i].Name)
+			}
+			out = append(out, recs[i].Name+" -> "+r.ToID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func ftrProp(p types.Props, key string) string {
+	for _, kv := range p {
+		if kv.K == key {
+			return kv.V
+		}
+	}
+	return ""
+}
+
+// TestProtoFieldTypeRefs_EmittedEdges is the positive direction, written as an
+// INDEPENDENT LITERAL set (#6975) rather than derived from the extractor's own
+// target index. Each ToID is spelled out, so a change of address dialect, of
+// target node, or of owning field fails here instead of passing silently.
+func TestProtoFieldTypeRefs_EmittedEdges(t *testing.T) {
+	recs := ftrExtract(t, map[string]string{ftrOwnerPath: ftrOwnerSrc})
+	want := []string{
+		// A field whose type is a nested message, written BARE, binds — the
+		// nested message is its own top-level-addressed entity.
+		"Outer.direct -> scope:schema:message:proto:svc/user.proto:Inner",
+		// oneof member: recovered by #6358 and edged like any other field.
+		"User.alt -> scope:schema:message:proto:svc/user.proto:Profile",
+		// `optional` label: the target is the TYPE, not the label.
+		"User.backup -> scope:schema:message:proto:svc/user.proto:Profile",
+		// map<string, Order>: ONE row. Not two, and never a `map` target.
+		"User.by_id -> scope:schema:message:proto:svc/user.proto:Order",
+		// `repeated` label: same as `optional` above.
+		"User.orders -> scope:schema:message:proto:svc/user.proto:Order",
+		// Self-reference.
+		"User.parent -> scope:schema:message:proto:svc/user.proto:User",
+		"User.profile -> scope:schema:message:proto:svc/user.proto:Profile",
+		// An in-file ENUM is a target, and takes the same address dialect as a
+		// message — protobuf enums are SCOPE.Schema/enum, so there is no second
+		// dialect here the way arm A needed one for SCOPE.Enum.
+		"User.role -> scope:schema:message:proto:svc/user.proto:Role",
+	}
+	sort.Strings(want)
+	got := ftrEdges(t, recs)
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("field-type edges mismatch\n got:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+// TestProtoFieldTypeRefs_ForbiddenTargets is the negative direction, by name.
+func TestProtoFieldTypeRefs_ForbiddenTargets(t *testing.T) {
+	recs := ftrExtract(t, map[string]string{ftrOwnerPath: ftrOwnerSrc})
+	edges := ftrEdges(t, recs)
+
+	// FIELDS that must carry no field-type edge at all, each for a stated
+	// reason. Scalars are enumerated over the whole production set in
+	// field_type_refs_6912_internal_test.go; the two here keep the reason
+	// visible in the fixture that also holds the positive rows.
+	for _, c := range []struct{ field, why string }{
+		{"User.email", "scalar (string)"},
+		{"User.age", "scalar (int32)"},
+		{"User.note", "scalar inside a oneof"},
+		{"User.tags", "map<int32, string> — both components are scalars"},
+		{"User.address", "IMPORTED type: Address is declared in common.proto, not here"},
+		{"User.qualified", "QUALIFIED name demo.Profile — not stripped to the same-file Profile"},
+		{"User.fq", "fully-qualified .demo.Profile"},
+		{"User.gone", "Missing is declared nowhere at all"},
+		{"Outer.deep", "Outer.Inner — a nested reference is a qualified name"},
+		{"Profile.display_name", "scalar"},
+		{"Order.id", "scalar"},
+		{"Inner.v", "scalar"},
+	} {
+		for _, e := range edges {
+			if strings.HasPrefix(e, c.field+" -> ") {
+				t.Errorf("%s must have no field-type edge (%s), got %q", c.field, c.why, e)
+			}
+		}
+	}
+
+	// TARGET NAMES that must never appear, whichever field reached them. The
+	// three proto labels are here because they are prepended to the SIGNATURE
+	// and a pass that read the signature instead of the type would target them.
+	for _, banned := range []string{
+		"map", "Address", "Missing", "demo", "string", "int32", "bytes",
+		"repeated", "optional", "required",
+	} {
+		for _, e := range edges {
+			if strings.HasSuffix(e, ":"+banned) {
+				t.Errorf("no field-type edge may target %q, got %q", banned, e)
+			}
+		}
+	}
+	// The map<> wrapper must not survive into a ToID in any spelling.
+	for _, e := range edges {
+		if strings.Contains(e, "map<") {
+			t.Errorf("the map<> wrapper reached a ToID: %q", e)
+		}
+	}
+}
+
+// TestProtoFieldTypeRefs_LabelIsNeverTheTarget isolates the label branch with a
+// positive control, so "no edge targets `repeated`" is not passing merely
+// because the fixture happens not to produce one.
+func TestProtoFieldTypeRefs_LabelIsNeverTheTarget(t *testing.T) {
+	const src = `syntax = "proto3";
+
+message Order { string id = 1; }
+
+message Bag {
+  repeated Order a = 1;
+  optional Order b = 2;
+  Order c = 3;
+}
+`
+	recs := ftrExtract(t, map[string]string{"b.proto": src})
+	// All three fields must reach the SAME target: the label changes nothing.
+	want := []string{
+		"Bag.a -> scope:schema:message:proto:b.proto:Order",
+		"Bag.b -> scope:schema:message:proto:b.proto:Order",
+		"Bag.c -> scope:schema:message:proto:b.proto:Order",
+	}
+	if got := ftrEdges(t, recs); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("label handling changed the target\n got:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+	// Positive control on the fixture: the labels really are on these fields,
+	// so the assertion above is about label HANDLING and not about a fixture
+	// that silently lost its labels.
+	labels := map[string]string{}
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" {
+			labels[recs[i].Name] = recs[i].Properties["label"]
+		}
+	}
+	if labels["Bag.a"] != "repeated" || labels["Bag.b"] != "optional" || labels["Bag.c"] != "" {
+		t.Fatalf("fixture labels = %v; the labelled cases are not exercised", labels)
+	}
+}
+
+// TestProtoFieldTypeRefs_MapValueIsTheTarget grades every branch of the map<>
+// rule stated in protoFieldTypeCandidates' doc, end to end.
+func TestProtoFieldTypeRefs_MapValueIsTheTarget(t *testing.T) {
+	const src = `syntax = "proto3";
+
+message Order { string id = 1; }
+
+message Bag {
+  map<string, Order> by_name = 1;
+  map<int32, string> scalars = 2;
+  map<string, Missing> unknown = 3;
+}
+`
+	recs := ftrExtract(t, map[string]string{"m.proto": src})
+	want := []string{"Bag.by_name -> scope:schema:message:proto:m.proto:Order"}
+	if got := ftrEdges(t, recs); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("map handling\n got:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+	// Positive control: all three map fields exist and carry a map<> type, so
+	// the two silent rows are silent for the right reason.
+	types_ := map[string]string{}
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" {
+			types_[recs[i].Name] = recs[i].Properties["type"]
+		}
+	}
+	for _, f := range []string{"Bag.by_name", "Bag.scalars", "Bag.unknown"} {
+		if !strings.HasPrefix(types_[f], "map<") {
+			t.Fatalf("%s declared type = %q, want a map<...>; the map case is not exercised",
+				f, types_[f])
+		}
+	}
+}
+
+// TestProtoFieldTypeRefs_CrossFileTypeGetsNoEdge states the deliberate cost of
+// the same-file rule as an assertion rather than as prose, and in doing so
+// grades the gate this arm REUSES (dropUnresolvableTypeRefs, #6357) for the new
+// anchor: an imported type is the majority case in real protobuf, and an edge
+// pass 1 cannot verify would dangle.
+func TestProtoFieldTypeRefs_CrossFileTypeGetsNoEdge(t *testing.T) {
+	recs := ftrExtract(t, map[string]string{
+		"svc/user.proto":   "syntax = \"proto3\";\n\nimport \"svc/common.proto\";\n\nmessage User { Address address = 1; }\n",
+		"svc/common.proto": "syntax = \"proto3\";\n\nmessage Address { string city = 1; }\n",
+	})
+	// Positive control: the field and the target message both exist, so "no
+	// edge" is not trivially true for the wrong reason.
+	var haveField, haveTarget bool
+	for i := range recs {
+		if recs[i].Name == "User.address" && recs[i].Subtype == "field" {
+			haveField = true
+		}
+		if recs[i].Name == "Address" && recs[i].Subtype == "message" {
+			haveTarget = true
+		}
+	}
+	if !haveField || !haveTarget {
+		t.Fatalf("fixture incomplete (field=%v target=%v); the cross-file case is not exercised",
+			haveField, haveTarget)
+	}
+	if got := ftrEdges(t, recs); len(got) != 0 {
+		t.Fatalf("a type declared in another file must produce no edge, got %v", got)
+	}
+}
+
+// TestProtoFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName pins the ONE
+// place the field edge is deliberately NARROWER than the message→type edge that
+// already existed, and pins that this arm did not change the older edge.
+//
+// namedTypeRefs strips `demo.Profile` to `Profile`, so the MESSAGE-level edge
+// binds to this file's own Profile even though the field names a type in
+// another package. protoFieldTypeCandidates does not strip, so the FIELD-level
+// edge is absent. The message row here is EXISTING behaviour recorded, not
+// endorsed: it is a silent mis-bind, and narrowing it belongs with the
+// cross-file package index #6357 defers.
+func TestProtoFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName(t *testing.T) {
+	const src = `syntax = "proto3";
+
+package demo;
+
+message Profile { string display_name = 1; }
+
+message Holder {
+  demo.Profile qualified = 1;
+  Profile local = 2;
+}
+`
+	recs := ftrExtract(t, map[string]string{"h.proto": src})
+
+	// The FIELD edge exists only for the bare-name field.
+	want := []string{"Holder.local -> scope:schema:message:proto:h.proto:Profile"}
+	if got := ftrEdges(t, recs); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("qualified-name field edges\n got: %v\nwant: %v", got, want)
+	}
+
+	// The pre-existing MESSAGE edge is unchanged: it still reaches Profile via
+	// the qualified field. If a later pass narrows namedTypeRefs, this row goes
+	// away and this test is where that shows up.
+	var viaFields []string
+	for i := range recs {
+		if recs[i].Name != "Holder" {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "REFERENCES" && ftrProp(r.Properties, "ref_kind") == "" {
+				viaFields = append(viaFields, ftrProp(r.Properties, "via_field")+" -> "+r.ToID)
+			}
+		}
+	}
+	sort.Strings(viaFields)
+	// One row: the message-level dedupe is per TARGET, so `qualified` (first in
+	// source order) mints it and `local` collapses into it.
+	wantMsg := []string{"qualified -> scope:schema:message:proto:h.proto:Profile"}
+	if strings.Join(viaFields, "\n") != strings.Join(wantMsg, "\n") {
+		t.Fatalf("this arm changed the pre-existing message→type edge\n got: %v\nwant: %v",
+			viaFields, wantMsg)
+	}
+}
+
+// TestProtoFieldTypeRefs_SameNameInAnotherFileChangesNothing is the reason the
+// address is structural and file-scoped rather than a bare name: a rival .proto
+// declaring Profile / Order / User must not perturb this file's edges.
+func TestProtoFieldTypeRefs_SameNameInAnotherFileChangesNothing(t *testing.T) {
+	alone := ftrEdges(t, ftrExtract(t, map[string]string{ftrOwnerPath: ftrOwnerSrc}))
+	withRival := ftrEdges(t, ftrExtract(t, map[string]string{
+		ftrOwnerPath: ftrOwnerSrc,
+		ftrRivalPath: ftrRivalSrc,
+	}))
+	const rivalOwn = "User.profile -> scope:schema:message:proto:other/rival.proto:Profile"
+	var got []string
+	seenRival := false
+	for _, e := range withRival {
+		if e == rivalOwn && !seenRival {
+			seenRival = true
+			continue
+		}
+		got = append(got, e)
+	}
+	if !seenRival {
+		t.Fatalf("the rival file's own edge is missing; the fixture is not exercising a rival: %v", withRival)
+	}
+	if strings.Join(got, "\n") != strings.Join(alone, "\n") {
+		t.Fatalf("a same-named message in another file changed this file's edges\n got:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(alone, "\n"))
+	}
+}
+
+// TestProtoFieldTypeRefs_ResolverBindsEveryEdge is the gate this whole issue
+// class turns on: #6906 exists because a comment described a binding nobody
+// built. Arm A established that the resolver binds a field→type REFERENCES edge
+// in general; this drives PROTOBUF entity kinds (SCOPE.Schema/message and
+// SCOPE.Schema/enum) and the PROTOBUF address dialect
+// (scope:schema:message:proto:...) through the production resolver
+// (BuildIndex → ReferencesEmbedded, exactly as graph assembly does) and asserts
+// every ToID comes back rewritten to a real entity ID.
+//
+// Zero dangling is the assertion, not a ratio: a dangling stub is kept verbatim
+// and is one more `bug-extractor` endpoint.
+func TestProtoFieldTypeRefs_ResolverBindsEveryEdge(t *testing.T) {
+	recs := ftrExtract(t, map[string]string{
+		ftrOwnerPath: ftrOwnerSrc,
+		ftrRivalPath: ftrRivalSrc,
+	})
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6912", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+	idx := resolve.BuildIndex(recs)
+
+	// Positive control on the address dialect: the BARE name of a target is
+	// AMBIGUOUS across these two files, which is exactly what the structural
+	// form exists to avoid. If it ever binds, the ambiguity this test controls
+	// for is absent and the address choice is ungraded.
+	if _, st := idx.LookupStatusHint("Profile", "REFERENCES"); st == 1 {
+		t.Fatal("the bare name \"Profile\" binds in this fixture, so the file-scoped " +
+			"address is ungraded here")
+	}
+
+	idToName := map[string]string{}
+	for i := range recs {
+		idToName[recs[i].ID] = recs[i].SourceFile + ":" + recs[i].Kind + "/" + recs[i].Subtype + ":" + recs[i].Name
+	}
+
+	before := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "REFERENCES" && ftrProp(r.Properties, "ref_kind") == "field_target_type" {
+				before++
+			}
+		}
+	}
+	if before == 0 {
+		t.Fatal("no field-type edges to drive through the resolver")
+	}
+
+	resolve.ReferencesEmbedded(recs, idx)
+
+	var bound []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || ftrProp(r.Properties, "ref_kind") != "field_target_type" {
+				continue
+			}
+			target, ok := idToName[r.ToID]
+			if !ok {
+				t.Errorf("%s -[REFERENCES]-> %q did NOT bind to an entity ID (dangling stub)",
+					recs[i].Name, r.ToID)
+				continue
+			}
+			bound = append(bound, recs[i].SourceFile+":"+recs[i].Name+" => "+target)
+		}
+	}
+	sort.Strings(bound)
+	want := []string{
+		"other/rival.proto:User.profile => other/rival.proto:SCOPE.Schema/message:Profile",
+		"svc/user.proto:Outer.direct => svc/user.proto:SCOPE.Schema/message:Inner",
+		"svc/user.proto:User.alt => svc/user.proto:SCOPE.Schema/message:Profile",
+		"svc/user.proto:User.backup => svc/user.proto:SCOPE.Schema/message:Profile",
+		"svc/user.proto:User.by_id => svc/user.proto:SCOPE.Schema/message:Order",
+		"svc/user.proto:User.orders => svc/user.proto:SCOPE.Schema/message:Order",
+		"svc/user.proto:User.parent => svc/user.proto:SCOPE.Schema/message:User",
+		"svc/user.proto:User.profile => svc/user.proto:SCOPE.Schema/message:Profile",
+		// The enum target, resolved to the SCOPE.Schema/enum record.
+		"svc/user.proto:User.role => svc/user.proto:SCOPE.Schema/enum:Role",
+	}
+	sort.Strings(want)
+	if strings.Join(bound, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("resolved endpoints mismatch\n got:\n%s\nwant:\n%s",
+			strings.Join(bound, "\n"), strings.Join(want, "\n"))
+	}
+}

--- a/internal/extractors/proto/field_type_refs_6912_test.go
+++ b/internal/extractors/proto/field_type_refs_6912_test.go
@@ -126,6 +126,27 @@ func ftrEdges(t *testing.T, recs []types.EntityRecord) []string {
 				t.Errorf("field-type edge escaped onto %s/%s %q; it must be carried by the FIELD",
 					recs[i].Kind, recs[i].Subtype, recs[i].Name)
 			}
+			// The two payload properties are checked on EVERY edge produced by
+			// EVERY test in this file, as invariants, because a value nothing
+			// reads is a value nothing grades: review of #6991 replaced each of
+			// them with a constant and the whole suite stayed green.
+			//
+			// `field_name` is the simple field name — the part of the record's
+			// dotted "<message>.<field>" Name after the dot — and `target_type`
+			// is the bare type the ToID addresses, i.e. the last ":"-separated
+			// segment of the structural ref. Both are cross-checks between the
+			// edge and its endpoints rather than restatements of one source,
+			// which is what makes a constant fail them. The exact literal
+			// spelling of a full property set is asserted separately by
+			// TestProtoFieldTypeRefs_EdgePropertiesAreSpelledOut.
+			if want := recs[i].Name[strings.LastIndex(recs[i].Name, ".")+1:]; ftrProp(r.Properties, "field_name") != want {
+				t.Errorf("%s -> %s: field_name = %q, want %q",
+					recs[i].Name, r.ToID, ftrProp(r.Properties, "field_name"), want)
+			}
+			if want := r.ToID[strings.LastIndex(r.ToID, ":")+1:]; ftrProp(r.Properties, "target_type") != want {
+				t.Errorf("%s -> %s: target_type = %q, want %q",
+					recs[i].Name, r.ToID, ftrProp(r.Properties, "target_type"), want)
+			}
 			out = append(out, recs[i].Name+" -> "+r.ToID)
 		}
 	}
@@ -497,5 +518,109 @@ func TestProtoFieldTypeRefs_ResolverBindsEveryEdge(t *testing.T) {
 	if strings.Join(bound, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("resolved endpoints mismatch\n got:\n%s\nwant:\n%s",
 			strings.Join(bound, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+// TestProtoFieldTypeRefs_EdgePropertiesAreSpelledOut asserts the FULL property
+// list of two named edges against an independent literal, so the payload the PR
+// claims is graded by spelling and not only by the invariants in ftrEdges.
+//
+// `User.by_id` is here because it is the one case where target_type is NOT the
+// field's declared type string: the declared type is "map<string, Order>" and
+// the target is `Order`.
+func TestProtoFieldTypeRefs_EdgePropertiesAreSpelledOut(t *testing.T) {
+	recs := ftrExtract(t, map[string]string{ftrOwnerPath: ftrOwnerSrc})
+	want := map[string][]string{
+		"User.profile": {"field_name=profile", "ref_kind=field_target_type", "target_type=Profile"},
+		"User.by_id":   {"field_name=by_id", "ref_kind=field_target_type", "target_type=Order"},
+	}
+	seen := map[string]bool{}
+	for i := range recs {
+		w, ok := want[recs[i].Name]
+		if !ok {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" {
+				continue
+			}
+			var got []string
+			for _, kv := range r.Properties {
+				got = append(got, kv.K+"="+kv.V)
+			}
+			if strings.Join(got, ",") != strings.Join(w, ",") {
+				t.Errorf("%s edge properties = %v, want %v", recs[i].Name, got, w)
+			}
+			seen[recs[i].Name] = true
+		}
+	}
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("no field-type edge found on %s; the fixture does not exercise it", name)
+		}
+	}
+}
+
+// TestProtoFieldTypeRefs_ScalarShadowedByASameFileMessage is the case that
+// proves the protoScalars check in protoFieldTypeCandidates is LIVE rather than
+// redundant with the in-file gate, and it exists because the first cut of this
+// arm deleted that check on the argument that it was redundant.
+//
+// The argument was "no .proto declares `message string`, so the gate drops
+// every scalar anyway". That is a corpus-relative zero. This file is legal
+// proto3 and compiles under protoc at RC 0, and protoc's descriptor binds
+// Holder.name to TYPE_STRING with an EMPTY type_name — the grammar matches
+// `string` in field-type position as a scalar before it ever considers a
+// message type, so the shadowing message can NEVER be the referent.
+//
+// Without the scalar check `message string` is in the gate's local set, so
+// Holder.name -> …:string survives AND BINDS: it never reaches `bug-extractor`
+// and no disposition figure surfaces it. The map row is the aggravation — the
+// key would mint a second, bogus edge beside the correct value edge.
+//
+// Deleting protoScalars from protoFieldTypeCandidates must turn this test red.
+func TestProtoFieldTypeRefs_ScalarShadowedByASameFileMessage(t *testing.T) {
+	const src = `syntax = "proto3";
+
+message string { int32 v = 1; }
+
+enum bool { B_ZERO = 0; }
+
+message Order { int32 id = 1; }
+
+message Holder {
+  string name = 1;
+  bool flag = 2;
+  map<string, Order> by_key = 3;
+  Order real = 4;
+}
+`
+	recs := ftrExtract(t, map[string]string{"shadow.proto": src})
+
+	// Positive control on the fixture: the shadowing declarations must actually
+	// have produced entities, or the gate's local set does not contain them and
+	// this test is green for a reason that has nothing to do with the check.
+	shadow := map[string]bool{}
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Schema" && (recs[i].Subtype == "message" || recs[i].Subtype == "enum") {
+			shadow[recs[i].Name] = true
+		}
+	}
+	if !shadow["string"] || !shadow["bool"] {
+		t.Fatalf("fixture produced no `message string` / `enum bool` entities (%v); "+
+			"the shadowing case is not exercised", shadow)
+	}
+
+	// Only the genuinely-named types are targets. The two scalar-typed fields
+	// and the map KEY produce nothing, though a same-file declaration of their
+	// name exists and the in-file gate alone would keep them.
+	want := []string{
+		"Holder.by_key -> scope:schema:message:proto:shadow.proto:Order",
+		"Holder.real -> scope:schema:message:proto:shadow.proto:Order",
+	}
+	got := ftrEdges(t, recs)
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("a scalar shadowed by a same-file declaration must still get NO edge\n got:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
 	}
 }

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -138,9 +138,17 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	return entities, nil
 }
 
-// dropUnresolvableTypeRefs removes every message→type REFERENCES edge whose
-// target message/enum is not defined in this same file, mutating entities in
-// place.
+// dropUnresolvableTypeRefs removes every type REFERENCES edge whose target
+// message/enum is not defined in this same file, mutating entities in place.
+//
+// It walks EVERY entity, not only messages, and that is now load-bearing rather
+// than incidental: since #6912 arm B it is the single implementation of the
+// same-file rule for BOTH type-edge anchors — the message→type edge this
+// function was written for, and the field→declared-type edge carried by each
+// SCOPE.Schema/field record (field_type_refs.go). Both address their target
+// through messageTypeRef, so one `local` set gates both. Do not add a second
+// copy of this check at either emit site: a redundant guard fires only where
+// this one already fires, which leaves both ungraded.
 //
 // #6357. namedTypeRefs strips the package qualifier from a field type, and
 // buildMessage then builds the structural ref against file.Path. For a field
@@ -638,7 +646,14 @@ func buildMessage(node ts.Node, file extractor.FileInput, fileRels *[]types.Rela
 			} else {
 				ftype, label = fieldTypeAndLabel(ch, file.Content)
 			}
-			fieldEnts = append(fieldEnts, buildField(file, name, fname, ftype, label, ch))
+			fieldEnt := buildField(file, name, fname, ftype, label, ch)
+			// #6912 arm B: the field→declared-type edge, anchored on the FIELD
+			// rather than on the message. Separate from the message→type edge
+			// below — different anchor, different ref_kind, both kept. See
+			// field_type_refs.go; dropUnresolvableTypeRefs enforces the
+			// same-file rule on both.
+			fieldEnt.Relationships = protoFieldTypeRefs(file.Path, fname, ftype)
+			fieldEnts = append(fieldEnts, fieldEnt)
 			rels = append(rels, types.RelationshipRecord{
 				ToID: fieldMemberRef(file.Path, name, fname),
 				Kind: "CONTAINS",

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -652,7 +652,11 @@ func buildMessage(node ts.Node, file extractor.FileInput, fileRels *[]types.Rela
 			// below — different anchor, different ref_kind, both kept. See
 			// field_type_refs.go; dropUnresolvableTypeRefs enforces the
 			// same-file rule on both.
-			fieldEnt.Relationships = protoFieldTypeRefs(file.Path, fname, ftype)
+			// APPEND, not assign: buildField sets no Relationships today, so
+			// either is correct now — but an assignment silently clobbers
+			// whatever a future buildField adds, and append costs nothing.
+			fieldEnt.Relationships = append(fieldEnt.Relationships,
+				protoFieldTypeRefs(file.Path, fname, ftype)...)
 			fieldEnts = append(fieldEnts, fieldEnt)
 			rels = append(rels, types.RelationshipRecord{
 				ToID: fieldMemberRef(file.Path, name, fname),

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -192,10 +192,10 @@
     "proto-mini": {
       "entity_found": 19,
       "entity_expected": 19,
-      "relationship_found": 17,
-      "relationship_expected": 17,
+      "relationship_found": 18,
+      "relationship_expected": 18,
       "entity_extracted_total": 31,
-      "relationship_extracted_total": 55
+      "relationship_extracted_total": 56
     },
     "python-django-mini": {
       "entity_found": 29,

--- a/internal/quality/golden/proto-mini/expected.json
+++ b/internal/quality/golden/proto-mini/expected.json
@@ -63,6 +63,11 @@
       "must_exist": true,
       "note": "message field type reference, same file, so it survives dropUnresolvableTypeRefs. Paired with forbidden row F1, which pins the cross-file field of the SAME message as producing NO edge." },
 
+    { "from_name": "User.profile", "from_kind": "SCOPE.Schema", "from_file": "user.proto",
+      "kind": "REFERENCES", "to_name": "Profile", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": true,
+      "note": "#6912 arm B — the field\u2192declared-type edge, anchored on the FIELD. It is NOT a duplicate of the row above: that edge is anchored on `message User` and names its field only in a `via_field` property, so \"which FIELDS point at Profile?\" was unanswerable for protobuf. The two are distinguished by ref_kind: this one carries ref_kind=field_target_type (the custom lane's and arm A's spelling), the message-level one carries type/via_field and no ref_kind. This row is the ONLY relationship this fixture gained from arm B \u2014 relationship_extracted_total moved 55 \u2192 56 and this edge is the whole of that delta, enumerated rather than absorbed into a bumped constant. Paired with forbidden row F5, which pins the cross-file field of the SAME message as producing no field-type edge." },
+
     { "from_name": "User", "from_kind": "SCOPE.Schema", "from_file": "user.proto",
       "kind": "CONTAINS", "to_name": "User.email", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
       "must_exist": true, "note": "message -> field, addressed through fieldMemberRef (SQL Format B style)." },
@@ -126,6 +131,11 @@
       "kind": "CONTAINS", "to_name": "User", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
       "must_exist": false,
       "note": "F2. The mirror image of #6422, and the reason the fixture needs the collision even though the file-anchored half is ungradeable (NOTICE.md). buildService addresses its rpc children through BuildOperationStructuralRef; the guard is that it does NOT use messageTypeRef. Switch that one call to messageTypeRef — the plausible over-correction of #6422, i.e. 'move everything into the schema address space' — and the service -> rpc edge binds to `message User` instead, this row hits, and the expected UserService -> User(SCOPE.Operation) row above goes red at the same time. Verified by mutation. Both halves of that pair fire only because message User and rpc User collide." },
+
+    { "from_name": "User.address", "from_kind": "SCOPE.Schema", "from_file": "user.proto",
+      "kind": "REFERENCES", "to_bare_name": "scope:schema:message:proto:user.proto:Address",
+      "must_exist": false,
+      "note": "F5, the FIELD-anchored twin of F1 and the negative direction of #6912 arm B. `Address address = 3;` names a message declared in common.proto, so the field entity User.address must carry NO field\u2192declared-type edge: the only address arm B can mint for it is user.proto:Address, a file with no Address, which resolve/refs.go would materialise as a phantom grey node and disposition as bug-extractor \u2014 a non-binding edge, which is worse than no edge. The guard is dropUnresolvableTypeRefs, which arm B REUSES rather than reimplementing (it walks every entity, not only messages); deleting that call from Extract fires F1 and F5 together. Recall cannot see over-firing, so this row is what grades the direction that hurts. As with F1, this does NOT bless the cross-file gap: when a proto package index makes the target resolve, delete this row and add an expected row with to_name/to_file. Do not suppress the edge to keep the fixture green." },
 
     { "from_name": "user.proto", "from_kind": "SCOPE.Component", "from_file": "user.proto",
       "kind": "CONTAINS", "to_name": "User", "to_kind": "SCOPE.Operation", "to_file": "user.proto",


### PR DESCRIPTION
Arm B of #6912 — the field→declared-type edge for **protobuf**. Arm A (C#) is #6984 (`a3e0e8e41`), the template this follows. One language; other languages remain, so `Refs`, not `Closes`.

## What the gap actually was here, and why it is not the same gap as C#

`buildField` records a proto field's declared type as the `type` PROPERTY and inside `Signature`, and never as a relationship — the #6912 shape, and the population #6726 measures at 99.3% orphan on their corpus (protobuf is one of their four languages).

But protobuf was **not** a language with no field-type edge at all. `buildMessage` already emits one REFERENCES edge per named field type — anchored on the **MESSAGE**, with the field named only in a `via_field` property:

```
message User -[REFERENCES {type: Profile, via_field: profile}]-> message Profile
```

So the message was wired and the `SCOPE.Schema`/`field` record was a leaf on its outbound side. *"Which fields point at `Profile`?"* — answerable for C# after arm A, and for protobuf answerable only by unpacking a property on an edge anchored one level up.

**This adds a second edge from the field rather than moving the existing one.** Moving it would break the message→message topology the .proto dependency view is built on (#6419, #6422). Duplicating the *anchor* is the point; the information is not duplicated, because the two edges are distinguished by `ref_kind` and answer different questions.

## Decisions, all inherited rather than re-litigated

| axis | choice | why |
|---|---|---|
| kind | `REFERENCES` | arm A + the custom lane's `referencesClassEdge`; `TYPED_AS` (#6906) and `HAS_TYPE` (#5828) are declared with zero producers, and a third spelling splits every "which fields point at X?" query (#6902) |
| property | `ref_kind: "field_target_type"` | verbatim from arm A and the five custom-lane languages. Plus `field_name` and `target_type`, as arm A — **both values asserted**, after review found them claimed here and read by nothing (R1/R2) |
| address | `messageTypeRef` → `scope:schema:message:proto:<file>:<Name>` | **not** `Class:<Name>`, whose bare-name tier #6986 measured at 91.6% dangling. This is already this package's type address (message→type, file→message #6422, rpc request/response #6359), it is file-scoped, and post-resolution the ToID is an entity ID so no query sees the dialect |
| anchor | `FromID` empty | the Django precedent (`python/django_relational.go:246-252`). Hibernate sets an explicit FromID because it hangs its edge off its own parallel node — a different shape, and #6912's body was corrected on exactly this |
| enum targets | same dialect | protobuf enums are `SCOPE.Schema`/`enum`, addressed by `messageTypeRef` like a message. Arm A needed a second dialect (`scope:enum:`) for `SCOPE.Enum`; this arm has **one** address form |

## The same-file rule is REUSED, not reimplemented

`dropUnresolvableTypeRefs` (#6357) already runs in `Extract` after the walk and removes every `REFERENCES` edge — **on any entity, it walks them all** — whose target is not a message/enum declared in this file. Emitting the field edge into the same address space means the same-file rule has one implementation and one spelling for both anchors. Its doc comment is updated to say the property is now load-bearing for two callers rather than incidental for one.

A second private copy of the check inside `field_type_refs.go` would fire only where that pass already fires, leaving both ungraded — the trap arm A called out for its primitive blocklist.

### A guard was deleted here on a false premise, and review caught it — the reasoning is worth keeping

The first cut of `protoFieldTypeCandidates` carried a `protoScalars` blocklist. Mutant M1 (delete it) was killed **only by the unit test written for it**: every end-to-end assertion stayed green. That was read as the redundant guard arm A refused — the in-file gate already drops every scalar, because no `.proto` declares `message string` — and the blocklist was deleted.

**The premise was false in fact, and review disproved it by constructing the case.** "No `.proto` declares `message string`" is a *corpus-relative zero*, not a property of the pass:

```proto
syntax = "proto3";
message string { int32 v = 1; }
enum bool { B_ZERO = 0; }
message Holder { string name = 1; bool flag = 2; map<string, Order> by_key = 3; }
```

`message string` **is** in the gate's local set, so without the blocklist `Holder.name -> …:string` survives **and binds** — it never reaches `bug-extractor` and no disposition figure surfaces it. That is exactly the failure this PR's own header calls out for `namedTypeRefs`' qualifier-stripping, reintroduced two paragraphs later.

The file is legal proto3 and protoc agrees with the graph's *silence*, not with its edge. Verified independently in this worktree (`grpcio-tools` in a scratch venv, `--descriptor_set_out`, **RC 0**):

```
Holder.name: type=TYPE_STRING type_name=''
Holder.flag: type=TYPE_BOOL   type_name=''
Holder.real: type=TYPE_MESSAGE type_name='.Order'
```

Empty `type_name` on the two shadowed fields: the grammar matches `string` in field-type position as a scalar before it ever considers a message type, so the shadowing declaration can never be the referent. `map<string, Order>` gained a bogus key edge beside the correct value edge, and because `namedTypeRefs` kept **its** scalar check, the two anchors disagreed in the wrong direction — the field edge over-firing exactly where the message edge correctly stayed silent.

**M1's verdict is therefore ALIVE and production-reachable, not redundant.** The guard is restored and is now graded **end to end** by `TestProtoFieldTypeRefs_ScalarShadowedByASameFileMessage` (with a positive control that the shadowing entities really exist, so the gate's local set really contains them), which answers the objection that killed it in the first place.

#### The general lesson, now in the code and not only here

**A mutant killed only by its own unit test does not establish that a guard is redundant.** It is equally consistent with the end-to-end fixture space simply *lacking the case*. Distinguishing the two requires **constructing the case** — the step that was skipped, and the whole cost of the review round.

Two other mutants in this PR have that same shape and are correctly left as-is: R3 (qualified-name pass-through) and R4 (the empty-name guard) are DEAD by the unit table and masked end to end, because `…:demo.Profile` and an empty-named target are genuinely not in `local`. The unit table is the right grader for those. The difference is that for the scalar rule the masking was *not* real, and only the constructed fixture could show it. `TestProtoFieldTypeCandidates_Rules` and `TestProtoFieldTypeRefs_EveryScalarProducesNoEdge` both carry notes saying which of the two situations each row is in.

## The rules, each stated and each graded

- **Scalars** → nothing. Enumerated, not sampled: `TestProtoFieldTypeRefs_EveryScalarProducesNoEdge` **generates** one field per member of `protoScalarLiteral`, asserts the field entity exists and carries that scalar as its type (positive control on the fixture), asserts no edge, and asserts a non-scalar field in the same message **did** get its edge (positive control on the pass). `TestProtoScalars_MatchesTheSpecList` pins the production `protoScalars` map against that independent literal (#6975), in both directions.
- **`map<K, V>`** → **the wrapper is never a target; each of K and V is a candidate, subject to the same qualified-name rule.** proto3 constrains a key to an integral/string scalar, so in practice only V ever survives; both are walked rather than assuming the spec. All three branches graded end to end by `TestProtoFieldTypeRefs_MapValueIsTheTarget` (`map<string, Order>` → exactly one row → `Order`; `map<int32, string>` → nothing; `map<string, Missing>` → nothing), with a positive control asserting all three fields really carry a `map<…>` type.
- **`repeated` / `optional` / `required`** never become the target. The label is a separate return value from `fieldTypeAndLabel` and is prepended only to `Signature`; this pass reads the type. `TestProtoFieldTypeRefs_LabelIsNeverTheTarget` asserts all three labelled/unlabelled forms reach the *same* target, with a positive control that the fixture's labels are actually present, and the three label strings are in the forbidden-target list.
- **Qualified and imported types** → nothing, **asserted by name**: `User.address` (imported from `common.proto`), `User.qualified` (`demo.Profile`), `User.fq` (`.demo.Profile`), `User.gone` (`Missing`, declared nowhere), `Outer.deep` (`Outer.Inner` — a nested reference is a qualified name).
- **In-file enums** are targets: `User.role → enum Role`.
- **oneof members** are edged like any other field (`User.alt → Profile`), so #6358's recovered population participates.

### The one place this arm is deliberately NARROWER than the existing edge

`namedTypeRefs` strips a qualifier to its trailing segment, so `demo.Profile` in a file that also declares its own `Profile` makes the **message-level** edge bind to the wrong entity — silently, because a bound edge never reaches `bug-extractor`. `protoFieldTypeCandidates` does not strip: any name carrying a `.` is rejected outright.

`TestProtoFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName` pins **both halves**: the field edge is absent, and the pre-existing message edge is byte-for-byte what it was. That second assertion is how a future narrowing of `namedTypeRefs` (which belongs with #6357's cross-file package index) is forced to come here and say so.

## Binding — for protobuf kinds and the protobuf address, not in general

Arm A established that the resolver binds a field→type `REFERENCES` edge at all. `TestProtoFieldTypeRefs_ResolverBindsEveryEdge` drives **protobuf** entity kinds (`SCOPE.Schema`/`message`, `SCOPE.Schema`/`enum`) and the **protobuf** dialect through the production resolver (`resolve.BuildIndex` → `resolve.ReferencesEmbedded`, exactly as assembly does) and asserts every ToID comes back rewritten to a real entity ID, named endpoint by named endpoint (9 rows). Zero dangling is the assertion, not a ratio.

It carries a positive control on the address choice itself: the **bare** name `Profile` must be AMBIGUOUS in the two-file fixture, or the file-scoped address is ungraded. `TestProtoFieldTypeRefs_SameNameInAnotherFileChangesNothing` asserts a rival `.proto` declaring `Profile`/`Order`/`User` leaves this file's edge set unchanged.

The golden run is an independent confirmation through the **real indexer** rather than the unit resolver: proto-mini scores 18/18 relationships with the new row **found**, and 0 forbidden hits.

## Numbers, and the gate on each

**Pass-1 only, gate-independent** — every figure below is this extractor's own output, measured by running the registered `protobuf` extractor over each file; no detector output is read, so no detector gate applies. macOS/APFS, worktree `…/scratchpad/impl-6912b-q9x4t/wt`, corpora read from `/Users/jorgecajas/Projects/archigraph-corpora` (read-only, not indexed).

| corpus | `.proto` files | field entities | fields gaining an edge | edges | dangling |
|---|---|---|---|---|---|
| etcd | 5 | 28 | 3 (10.7%) | 3 | 0 |
| apollo-server | 1 | 125 | 48 (38.4%) | 48 | 0 |
| grpc-go-examples | 3 | 4 | 0 | 0 | 0 |
| actix-examples | 1 | 2 | 0 | 0 | 0 |
| gin | 1 | 0 | 0 | 0 | 0 |
| **total** | **11** | **159** | **51 (32.1%)** | **51** | **0** |

Dangling was checked, not assumed: the probe asserted every emitted ToID is a same-file message/enum address.

etcd's 10.7% is the honest floor made visible — its field types are overwhelmingly `etcdserverpb.X` cross-file references, which is #6357's deferred package index, not a widening of this arm.

**Do not read #6726's 99.3% as moving.** That is their corpus, measured on v0.3.0; the mechanism transfers and the number does not. Also note #6599's `terminalLeafSubtypes` already routes `field` out of the orphan defect count on v0.3.1+, so the orphan-rate arithmetic that made this a P1 is separately in question (see the issue thread) — what this PR claims is the *edge*, which `internal/quality/analytics/scan.go` has no leaf exemption for.

**Golden corpus: +1 relationship, enumerated.** `relationship_extracted_total` for proto-mini moved **55 → 56**, and the whole of that delta is:

```
User.profile (SCOPE.Schema/field, user.proto)
  -[REFERENCES {ref_kind: field_target_type, target_type: Profile}]->
    scope:schema:message:proto:user.proto:Profile
```

Enumerated by extracting the two golden `.proto` files directly and listing every `ref_kind=field_target_type` edge — one row. `User.address` (cross-file) and every scalar field produce nothing, which is why the delta is 1 and not 4.

The baseline was **hand-edited for proto-mini only** (`relationship_found`/`_expected` 17→18, `relationship_extracted_total` 55→56; entity counts unchanged — this arm adds an edge, not an entity). A full `--update-baseline` regeneration was run first and **discarded**, and review proved that was right for a stronger reason than originally given. Two back-to-back regenerations — one at this branch's head, one at the untouched parent `a3e0e8e41` — differ **only** in proto-mini's `17/17 → 18/18` and `55 → 56`, so the committed hand-edit is byte-identical to a regeneration, and `proto-mini +1` is genuinely the only delta attributable to this change.

The other movement is **eight fixtures across four languages** — C# ×3, docker-compose, Python ×3, Razor — *not* "several C#", and every one is a `*_extracted_total` **ceiling**: no `_found`/`_expected` recall figure moved anywhere. They appear identically at the parent, so they are environmental. Crucially, `--ratchet` does **not** fail on a ceiling drop, so committing the regeneration would have been a **silent weakening** of eight ceilings rather than a visible failure.

expected.json gains **two** rows, so the fixture grades the arm in both directions:
- expected: `User.profile -REFERENCES-> Profile`, with a note stating it is not a duplicate of the message-anchored row and how the two are told apart.
- forbidden **F5**: `User.address -REFERENCES-> scope:schema:message:proto:user.proto:Address` — the field-anchored twin of F1, and the row that catches over-firing on the imported-type case. Like F1 it does **not** bless the cross-file gap: when a package index makes the target resolve, delete it and add an expected row.

## Verification

macOS 25.6.0 / APFS, in the worktree above.

- `go test -count=1 ./internal/extractors/proto/... ./internal/quality/... ./internal/resolve/...` — **green**
- `go test -count=1 ./cmd/grafel/` (155s) — **green**. Worth recording precisely: it was green *before* expected.json changed and red *after*, failing `TestProtoEnumValueSubtypeIsGraded_6488` on its **absolute** `17/17` pin (updated to `18/18`, comments updated to say why). So the whole-graph digest tests in `cmd/grafel` did **not** see the new edge — the ones under `worktree_seed_parity_test.go` are A/B parity digests, not absolute pins, so an unchanged result there is not evidence of an unchanged graph. The #6488 absolute count is what caught it. (Review confirmed and generalised this: `semanticDigest` is computed twice at runtime and compared to itself via `assertParity`, with no hardcoded digest literal anywhere in the file.)
- `scripts/quality/run.sh --ratchet` — **exit 0**, 38 gated fixtures held their baseline (29 at 100%). It failed first with `proto-mini: relationship_extracted_total GREW 55 -> 56`, which is the movement enumerated above.
- `gofmt -l internal/ cmd/` clean; `go vet` clean.
- `fieldEnt.Relationships` is an **append**, not an assignment (review, non-blocking): `buildField` sets none today so both are correct now, but an assignment silently clobbers whatever a future `buildField` adds.
- Corpus figures re-measured after restoring the guard: **unchanged** (159 fields, 51 edged, 32.1%, 0 dangling) — no corpus file shadows a scalar name, which is precisely why the corpus could not have found the bug.
- Run under `GRAFEL_HOME` / `GRAFEL_DAEMON_ROOT` pointed at scratch; the real `~/.grafel` was not written and no daemon was started, stopped or killed.

## Mutation score

Preferring the **more permissive** direction. Each edit was applied by a script asserting an **exact occurrence count of 1**, the enclosing function was named and the hit printed, `go vet` ran before every score, the baseline was green immediately before each, always `-count=1`, and each restore was `cp` from a shasum-verified backup (`git checkout` was never used).

| # | mutant (enclosing function) | verdict |
|---|---|---|
| M1 | delete the scalar blocklist (`protoFieldTypeCandidates`) | **ALIVE AND PRODUCTION-REACHABLE — input named.** Originally scored "redundant" on a false premise and the guard was deleted; review constructed `message string` / `enum bool` (protoc RC 0) and the edge survives and BINDS. Guard restored, and now **DEAD end to end** via `TestProtoFieldTypeRefs_ScalarShadowedByASameFileMessage` as well as the unit table. See above |
| M2 | make `dropUnresolvableTypeRefs` skip `field` records, i.e. drop the in-file check for this arm only | **DEAD** — 12 tests, including `TestProtoFieldTypeRefs_CrossFileTypeGetsNoEdge` and `_EveryScalarProducesNoEdge`, plus pre-existing `TestProto_NoRelationshipTargetsAPhantomNode` |
| M3 | do not unwrap `map<>`, target the wrapper (`protoFieldTypeCandidates`) | **DEAD** — `_MapValueIsTheTarget`, `_EmittedEdges`, `_ResolverBindsEveryEdge`, `_Rules` |
| M4 | read `Signature` instead of the type, so the label becomes part of it (`buildMessage`/`addMember`) | **DEAD** — 7 tests incl. `_LabelIsNeverTheTarget` |
| M5 | strip the qualifier to its trailing segment instead of rejecting it (`protoFieldTypeCandidates`) | **DEAD** — 5 tests incl. `_QualifiedTypeIsNotStrippedToASameFileName` and `_ForbiddenTargets` |
| M6 | anchor the edge on the message by setting a non-empty `FromID` (`protoFieldTypeRefs`) | **DEAD** — 6 tests, via `ftrEdges`' FromID and carrier-kind assertions |
| R1 | `field_name` property value → a constant (`protoFieldTypeRefs`) | **found DISTINGUISHABLE AND UNGRADED by review → now DEAD** (8 tests). Nothing read the value; the PR claimed it. `ftrEdges` now cross-checks it against the record's dotted Name on **every** edge in the file |
| R2 | `target_type` property value → a constant (`protoFieldTypeRefs`) | **found DISTINGUISHABLE AND UNGRADED by review → now DEAD** (8 tests). Cross-checked against the ToID's trailing segment, plus two full property lists asserted against an independent literal in `TestProtoFieldTypeRefs_EdgePropertiesAreSpelledOut` |
| R3 | weaken the qualified-name guard so a qualified name passes through unstripped | **DEAD by the unit table alone; masked end to end** — `…:demo.Profile` is genuinely not in `local`. Correctly left at the unit; noted rather than acted on, and the test says so |
| R4 | drop the `p == ""` guard (`protoFieldTypeCandidates`) | **DEAD by the unit table alone; masked end to end.** Reachable only through degenerate `map<, >` text. Same disposition as R3 |
| M7 | drop the per-field dedupe (`protoFieldTypeRefs`) | **ALIVE at first → graded, then DEAD.** The only expression naming one target twice is `map<Order, Order>`, which is invalid proto3 and so unreachable through `Extract`; rather than claim it cannot happen, it is graded at the unit in 12 lines by `TestProtoFieldTypeRefs_DedupesPerTarget`, which carries a `map<Key, Order>` positive control so it cannot pass for a pass that emits at most one edge per field |

## What this arm cannot do

In the code, in a header block, so it is read where the decision lives:

- **File scope only.** Unlike arm A there is no namespace over-fire to pin: one `.proto` declares exactly one package, so there is no in-file shadowing to get wrong.
- **No cross-file / imported targets at all**, which for real protobuf is the majority (etcd: 3 of 28). Needs #6357's package index; separate arm.
- **A nested message referenced as `Outer.Inner` gets nothing** (bare `Inner` does). Same qualified-name rule, asserted by name.

Refs #6912, #6726, #6906, #6984, #6986, #6357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
