### PR TITLE
fix(#6906): delete TYPED_AS and HAS_TYPE — two names for one edge #6984 already ships as REFERENCES/ref_kind=field_target_type, and a comment describing the producer that was never built

### DIFF
--- a/internal/extractor/enum_valueset.go
+++ b/internal/extractor/enum_valueset.go
@@ -22,11 +22,15 @@ import (
 //     value-for-value by a NestJS `enum Status { ACTIVE = 1, ARCHIVED = 2 }`.
 //   - "which fields are constrained to enum X?" — inbound REFERENCES edges
 //     carrying the property ref_kind="field_target_type", emitted from a field
-//     record to this node's QualifiedName. C# is the only language that emits
-//     them (internal/extractors/csharp/field_type_refs.go, #6984); in every
-//     other language a SCOPE.Enum node still has no inbound edge. No TYPED_AS
-//     edge exists: that kind was declared, never produced, and deleted by
-//     #6906 — see the RETIRED KINDS note in internal/types/kinds.go.
+//     record to this node's QualifiedName. Of the six
+//     ref_kind="field_target_type" producers, only C#'s
+//     (internal/extractors/csharp/field_type_refs.go, #6984) addresses its
+//     target by QualifiedName; the five in internal/custom/{python,golang,
+//     java,javascript,ruby} emit a `Class:<target>` stub instead, so C# is the
+//     only one that names a value-set node the way this helper spells it.
+//     No TYPED_AS edge exists: that kind was
+//     declared, never produced, and deleted by #6906 — see the RETIRED KINDS
+//     note in internal/types/kinds.go.
 //
 // Each language extractor detects the enum shape (Python Enum subclass, TS
 // `enum` / string-literal union, Java enum, Go iota const block, Ruby

--- a/internal/extractor/enum_valueset.go
+++ b/internal/extractor/enum_valueset.go
@@ -20,8 +20,13 @@ import (
 //     the full member list AND each member's literal value, so a Django
 //     Python `class Status(IntEnum): ACTIVE = 1; ARCHIVED = 2` is reproduced
 //     value-for-value by a NestJS `enum Status { ACTIVE = 1, ARCHIVED = 2 }`.
-//   - "which fields are constrained to enum X?" — the inbound TYPED_AS edges
-//     from fields/params declared with the enum type.
+//   - "which fields are constrained to enum X?" — inbound REFERENCES edges
+//     carrying the property ref_kind="field_target_type", emitted from a field
+//     record to this node's QualifiedName. C# is the only language that emits
+//     them (internal/extractors/csharp/field_type_refs.go, #6984); in every
+//     other language a SCOPE.Enum node still has no inbound edge. No TYPED_AS
+//     edge exists: that kind was declared, never produced, and deleted by
+//     #6906 — see the RETIRED KINDS note in internal/types/kinds.go.
 //
 // Each language extractor detects the enum shape (Python Enum subclass, TS
 // `enum` / string-literal union, Java enum, Go iota const block, Ruby
@@ -67,8 +72,14 @@ type constMember struct {
 //	scope:enum:<sourceFile>:<EnumName>
 //
 // File-scoped so distinct same-named enums in different files stay distinct.
-// This value is stored as the entity's QualifiedName, so a TYPED_AS edge whose
-// ToID equals it binds via the resolver's byQualifiedName exact-match tier.
+// This value is stored as the entity's QualifiedName (see EnumEntity below), so
+// an edge whose ToID equals it binds via the resolver's byQualifiedName
+// exact-match tier — the first probe in resolve.Index.LookupStatusHint, ahead
+// of the structural, kind and bare-name tiers. The one producer that uses it is
+// C#'s field→declared-type pass (csInFileTypeTargets in
+// internal/extractors/csharp/field_type_refs.go), which reads the SCOPE.Enum
+// record's QualifiedName directly and emits REFERENCES with
+// ref_kind="field_target_type".
 func EnumQualifiedName(sourceFile, enumName string) string {
 	return "scope:enum:" + sourceFile + ":" + enumName
 }

--- a/internal/extractors/csharp/field_type_refs.go
+++ b/internal/extractors/csharp/field_type_refs.go
@@ -19,9 +19,10 @@ import (
 // five languages through one shared helper (internal/custom/{python,golang,
 // java,javascript,ruby}, `referencesClassEdge`): Kind REFERENCES with the
 // property `ref_kind: "field_target_type"`. Core adopts that spelling rather
-// than minting a third name — `TYPED_AS` and `HAS_TYPE` are both declared in
-// internal/types/kinds.go with zero producers (#6906, #5828), and a third
-// spelling would split every "which fields point at X?" query.
+// than minting a third name — `TYPED_AS` and `HAS_TYPE` were both declared in
+// internal/types/kinds.go with zero producers (#6906, #5828) and were DELETED
+// by #6906 once this pass shipped; a third spelling would have split every
+// "which fields point at X?" query.
 //
 // THE ADDRESS IS NOT the custom lane's `Class:<Target>`, and that divergence is
 // measured, not stylistic. Both `Customer` and `Class:<Customer>` reach the

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -1236,10 +1236,6 @@ const (
 	// citizens via this edge kind.
 	RelationshipKindUnresolvedFetch RelationshipKind = "UNRESOLVED_FETCH"
 
-	// #1343: TypeScript type extraction edges.
-	//   HAS_TYPE     : entity → SCOPE.Schema  (e.g. a variable or field whose declared type is the target schema)
-	RelationshipKindHasType RelationshipKind = "HAS_TYPE"
-
 	// #1344: Post-rebuild rename / move / split detection.
 	// Emitted from a NEW entity to the OLD entity's ID after the indexer
 	// detects that a function, method, or class was renamed between rebuilds.
@@ -1794,18 +1790,6 @@ const (
 	// internal/engine/ws_channel_grouping.go.
 	RelationshipKindJoinsChannel RelationshipKind = "JOINS_CHANNEL"
 	RelationshipKindBroadcastsTo RelationshipKind = "BROADCASTS_TO"
-	// #3628 data-model: field/param → enum value-set edge. Emitted from a
-	// model field, struct field, or parameter whose declared type is a
-	// SCOPE.Enum value-set node, to that node. Lets the graph answer "which
-	// fields are constrained to enum X's values?" — the inbound side of the
-	// enum-parity contract. ToID is the SCOPE.Enum entity's QualifiedName so
-	// the resolver binds it via the byQualifiedName exact-match tier. Properties:
-	//   "enum"  : the bare enum type name.
-	//   "field" : the field/param name carrying the type (when known).
-	// Honest-partial: only statically-resolvable enum-typed declarations emit
-	// this edge; dynamic / computed types do not. See
-	// internal/extractor/enum_valueset.go.
-	RelationshipKindTypedAs RelationshipKind = "TYPED_AS"
 	// [sbom] DEPENDS_ON_PACKAGE points a manifest's project-anchor entity at a
 	// synthetic SCOPE.Package node (Name "package:<ecosystem>:<name>") it
 	// declares as an external dependency. Distinct from the file-scoped
@@ -1908,6 +1892,18 @@ const (
 	RelationshipKindDeploys RelationshipKind = "DEPLOYS"
 )
 
+// RETIRED KINDS — do not re-add. TYPED_AS (#6906) and HAS_TYPE (#5828) were
+// declared and registered here for months with zero producers and zero
+// consumers. Both named the same concept: a field / parameter → its declared
+// type. #6984 shipped that edge for C# as RelationshipKindReferences carrying
+// the property ref_kind="field_target_type" (internal/extractors/csharp/
+// field_type_refs.go), which is the spelling the custom lane had already
+// shipped in five languages via referencesClassEdge. A third name for one
+// concept is the defect #6451 was merged to remove for SCOPE.ExternalAPI, so
+// both constants were deleted rather than kept as reserved words. The deletion
+// is pinned by TestRetiredRelationshipKindsStayRetired in
+// kinds_retired_6906_test.go.
+//
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
 func AllRelationshipKinds() []RelationshipKind {
 	return []RelationshipKind{
@@ -1980,8 +1976,6 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindCloudEventFlows,
 		// #1217:
 		RelationshipKindUnresolvedFetch,
-		// #1343:
-		RelationshipKindHasType,
 		// #1344 rename detection:
 		RelationshipKindRenamedFrom,
 		// #1374 Django signal/admin connectivity:
@@ -2060,8 +2054,6 @@ func AllRelationshipKinds() []RelationshipKind {
 		// [realtime] WS room/channel grouping: JOINS_CHANNEL / BROADCASTS_TO.
 		RelationshipKindJoinsChannel,
 		RelationshipKindBroadcastsTo,
-		// #3628 data-model: field/param → enum value-set edge.
-		RelationshipKindTypedAs,
 		// #3834 (epic #3829) member-granularity inheritance edge:
 		RelationshipKindInherits,
 		// #4306 deterministic markdown doc ingestion (opt-in):

--- a/internal/types/kinds_retired_6906_test.go
+++ b/internal/types/kinds_retired_6906_test.go
@@ -1,6 +1,10 @@
 package types
 
-import "testing"
+import (
+	"os"
+	"strings"
+	"testing"
+)
 
 // Issue #6906 — TYPED_AS and HAS_TYPE are RETIRED. This guard fails if either
 // name comes back.
@@ -67,6 +71,57 @@ func TestRetiredRelationshipKindsStayRetired(t *testing.T) {
 		if IsValidRelationshipKind(retired) {
 			t.Errorf("IsValidRelationshipKind(%q) = true; the retired kind is back in the "+
 				"vocabulary (#6906/#5828)", retired)
+		}
+	}
+}
+
+// coverageJSPath is the public coverage page's hand-maintained kind roster.
+// Relative to this package directory, which is where `go test` runs.
+const coverageJSPath = "../../site/src/scripts/coverage.js"
+
+// TestRetiredRelationshipKindsAreGoneFromTheCoveragePage extends the retirement
+// to the one surface a Go-only enumeration cannot see.
+//
+// The first version of this PR grepped the UPPERCASE literals and the Go
+// constant names, and concluded "no dashboard or webui reference". It was
+// wrong: site/src/scripts/coverage.js listed "has_type" and "typed_as" in its
+// LOWERCASE display form, so the public page would have advertised two kinds
+// that no longer exist. A name has more than one spelling — constant,
+// string literal, lowercase display form — and an enumeration that covers one
+// spelling has not covered the name.
+//
+// This is deliberately a plain substring scan rather than a JS parse: the
+// spelling to catch IS the raw token, and a parser would add a way to be
+// silently wrong about a file that has no Go meaning.
+func TestRetiredRelationshipKindsAreGoneFromTheCoveragePage(t *testing.T) {
+	raw, err := os.ReadFile(coverageJSPath)
+	if err != nil {
+		t.Fatalf("read %s: %v (the coverage page is checked in; if it moved, "+
+			"repoint this guard rather than deleting it)", coverageJSPath, err)
+	}
+	page := string(raw)
+
+	// Non-vacuity: the scan must be looking at a file that really carries the
+	// lowercase roster, in the spelling the retired names would have used.
+	// Without this a moved, emptied or restructured file reads as "absent".
+	for _, control := range []string{`"references"`, `"inherits"`, `"contains"`} {
+		if !strings.Contains(page, control) {
+			t.Fatalf("control %s is absent from %s (%d bytes read); this scan is not looking at "+
+				"the relationship-kind roster and its absence checks are vacuous",
+				control, coverageJSPath, len(page))
+		}
+	}
+
+	for _, retired := range retired6906Kinds {
+		// The display form: lowercased, quoted as a roster item. The prose
+		// comment in that file names the retired kinds in UPPERCASE to explain
+		// why they are missing, which is why this matches the quoted lowercase
+		// token and not the bare name.
+		item := `"` + strings.ToLower(retired) + `"`
+		if strings.Contains(page, item) {
+			t.Errorf("%s still lists %s; %s was retired by #6906/#5828 and the public coverage "+
+				"page would advertise a kind grafel cannot emit",
+				coverageJSPath, item, retired)
 		}
 	}
 }

--- a/internal/types/kinds_retired_6906_test.go
+++ b/internal/types/kinds_retired_6906_test.go
@@ -1,0 +1,72 @@
+package types
+
+import "testing"
+
+// Issue #6906 — TYPED_AS and HAS_TYPE are RETIRED. This guard fails if either
+// name comes back.
+//
+// Both were declared in kinds.go and registered in AllRelationshipKinds() with
+// zero producers and zero consumers, and both named one concept: a field or
+// parameter → its declared type. #6984 shipped that edge for C# as
+// RelationshipKindReferences with the property ref_kind="field_target_type",
+// adopting the spelling the custom lane had already shipped in five languages.
+// Re-declaring either constant would put a third name on one concept.
+//
+// WHY THE LITERALS ARE WRITTEN OUT HERE. Every assertion below compares against
+// an INDEPENDENT string literal, never against AllRelationshipKinds() or any
+// other production value (#6975): a guard that ranges over the production slice
+// and asks whether it contains what the production slice contains cannot
+// observe a re-addition. "TYPED_AS" and "HAS_TYPE" appear in this file as
+// hard-coded strings for that reason, and must not be replaced by a reference
+// to a constant.
+var retired6906Kinds = []string{"TYPED_AS", "HAS_TYPE"}
+
+// TestRetiredRelationshipKindsStayRetired asserts the retirement on all three
+// surfaces a re-addition could use: the const declarations in kinds.go (read
+// from source, so a constant declared under ANY name is caught by its value),
+// the registered vocabulary, and the IsValidRelationshipKind predicate.
+func TestRetiredRelationshipKindsStayRetired(t *testing.T) {
+	declared := declaredRelationshipKindsFromSource(t)
+
+	// Non-vacuity, ahead of every absence check. A parse that read the wrong
+	// file, or read the right file and matched nothing, would let all three
+	// absence assertions below pass by examining nothing. Two independent
+	// literals must be PRESENT before any absence is believed.
+	if len(declared) == 0 {
+		t.Fatalf("no RelationshipKind constants parsed from %s; every absence check below "+
+			"would be vacuous", kindsSourceFile)
+	}
+	byValue := map[string]string{}
+	for _, d := range declared {
+		byValue[d.Value] = d.Name
+	}
+	for _, present := range []string{"CALLS", "REFERENCES"} {
+		if _, ok := byValue[present]; !ok {
+			t.Fatalf("control %q is not among the %d constants parsed from %s; the extraction is "+
+				"not reading the declarations and the absence checks are vacuous",
+				present, len(declared), kindsSourceFile)
+		}
+		if !IsValidRelationshipKind(present) {
+			t.Fatalf("control IsValidRelationshipKind(%q) = false; the predicate under test is "+
+				"not answering, so a false on a retired kind proves nothing", present)
+		}
+	}
+
+	for _, retired := range retired6906Kinds {
+		if name, ok := byValue[retired]; ok {
+			t.Errorf("%s declares %s = %q, but that kind was retired by #6906/#5828. The "+
+				"field→declared-type edge is REFERENCES with ref_kind=\"field_target_type\" "+
+				"(internal/extractors/csharp/field_type_refs.go, #6984); see the RETIRED KINDS "+
+				"note above AllRelationshipKinds.", kindsSourceFile, name, retired)
+		}
+		for _, k := range AllRelationshipKinds() {
+			if string(k) == retired {
+				t.Errorf("AllRelationshipKinds() registers the retired kind %q (#6906/#5828)", retired)
+			}
+		}
+		if IsValidRelationshipKind(retired) {
+			t.Errorf("IsValidRelationshipKind(%q) = true; the retired kind is back in the "+
+				"vocabulary (#6906/#5828)", retired)
+		}
+	}
+}

--- a/site/src/scripts/coverage.js
+++ b/site/src/scripts/coverage.js
@@ -8,10 +8,18 @@
 
   var INFRA = [["Platform / k8s",39],["Message brokers",22],["Observability",13],["Databases",12],["CI / CD",12],["Protocols",12],["Security",11],["Build systems",4]];
 
-  // Full authoritative kind lists, sourced from internal/types/kinds.go
-  // AllEntityKinds() (60) and AllRelationshipKinds() (106) — every kind grafel
-  // extractors are permitted to emit, grouped by category. Display forms strip
-  // the "SCOPE." prefix and lowercase to match the on-disk / MCP-rendered form.
+  // Display lists of the kinds grafel emits, grouped by category. Sourced from
+  // internal/types/kinds.go AllEntityKinds() / AllRelationshipKinds(), with the
+  // "SCOPE." prefix stripped and lowercased to match the on-disk / MCP-rendered
+  // form.
+  //
+  // HAND-MAINTAINED, and a SUBSET: nothing syncs these arrays with those
+  // accessors, and they have drifted behind them before. The counts that used
+  // to be quoted here described these arrays, not the accessors, so they are
+  // gone rather than restated — an unchecked number is how the drift went
+  // unnoticed. Add new kinds here by hand; the accessors remain the only
+  // authority. TYPED_AS and HAS_TYPE were removed by #6906 because both were
+  // deleted from the vocabulary.
   var ENT_GROUPS = [
     { label: "Code structure", items: ["operation","component","class","function","schema","variable","reference","constant","enum","constraint"] },
     { label: "Web & API", items: ["endpoint","route","http_endpoint_definition","http_endpoint_call","grpc_service","grpc_method","external_api","command","custom_validator"] },
@@ -23,7 +31,7 @@
     { label: "Docs, patterns & analysis", items: ["document","heading","code_block","scope_unknown","external","pattern","evolution","agent_pattern","markdown_document","section","design_decision"] }
   ];
   var REL_GROUPS = [
-    { label: "Structural", items: ["calls","imports","extends","implements","uses","uses_hook","contains","depends_on","references","has_props","has_type","typed_as","inherits"] },
+    { label: "Structural", items: ["calls","imports","extends","implements","uses","uses_hook","contains","depends_on","references","has_props","inherits"] },
     { label: "Web, routing & API", items: ["routes_to","serves","renders","returns","accepts_input","tagged_as","fetches","grpc_implements","grpc_handles","handles","handles_command","unresolved_fetch","navigates_to","validates","consumes_api"] },
     { label: "Data & persistence", items: ["accesses_table","reads_from","writes_to","queries","joins_collection","graph_relates","reads_field","writes_field","resolves_to","shares_data","shares_table_with","precedes","modifies_table","maps_to"] },
     { label: "Messaging & events", items: ["publishes_to","subscribes_to","transforms","batches","triggers","eventbridge_triggers","eventgrid_triggers","cloudevent_flows","captures"] },


### PR DESCRIPTION
Closes #6906. Refs #5828, #6912, #6984, #6757, #6451, #6726, #6975.

`TYPED_AS` and `HAS_TYPE` were both declared in `internal/types/kinds.go`, both registered in `AllRelationshipKinds()`, and both named the same concept: a field or parameter → its declared type. #6984 shipped that edge for C# as `REFERENCES` carrying `ref_kind: "field_target_type"` — the spelling the custom lane had already shipped in five languages via `referencesClassEdge`. So both kinds became **deliberately** producerless, which is worse than an oversight: nothing a reader of `kinds.go` could see distinguished "decided against" from "someone forgot", and three separate issues (#5828, #6906, #6912) were filed rediscovering the same gap.

**No producer is added here.** The decision against both kinds is already made.

## Outcome chosen: DELETE both, identically

Both constants and both `AllRelationshipKinds()` entries are gone. The alternative — keeping them marked "reserved" — was rejected because `TestAllRelationshipKinds_CoversEveryDeclaredConstant` (`internal/types/kinds_enum_completeness_6757_test.go:157-160`) already states the rule in as many words: *"There is no legitimate reason to declare a RelationshipKind and withhold it from the vocabulary: if a kind is to be retired, delete the constant."* A reserved marker would have to be either registered (still valid, still a third name a producer could pick up) or declared-and-unregistered (which that guard fails). Deletion is the only state the existing guards accept.

The decision is recorded in prose immediately above `AllRelationshipKinds()` as a **RETIRED KINDS** note, so the next person does not re-derive it, and pinned by a test so the note is not the only thing holding it.

## Step 1 — what removal would break, established BEFORE removing anything

Measured in the worktree at `.../scratchpad/impl-6906-k3p8w/wt`, branched from `origin/main` = `3c7d2c5ec`. macOS/APFS.

**The #6757 "no non-test caller" claim, re-verified on current `main` rather than inherited.** `grep -rn IsValidRelationshipKind` over the whole tree returns callers in **test files only**, plus its own definition (`kinds.go:2093`) and its call from `IsDeclaredRelationshipKind` (`derived_kinds.go:91`). `IsDeclaredRelationshipKind` in turn has **no non-test caller** either — only comments in `derived_kinds.go` and `graph/fbwriter/non_enum_kinds.go` reference it. So the predicate rejects nothing at runtime, and dropping two entries cannot drop an edge.

**Every consumer of the valid-kinds slice, enumerated.** `AllRelationshipKinds()` has exactly one non-test production consumer: `enumKindSet` in `internal/graph/fbwriter/non_enum_kinds.go:229-236`, the #6757 arm-C write-path counter. It reports how many written edges carry a kind *absent* from the enum. Removing two entries changes that report only if an edge of either kind is written — nothing produces one, so the counter is unaffected. Every other reference to the accessor in non-test code is a comment.

**"Zero producers" is pinned by a test, not by my grep** — the strongest evidence here, surfaced by review. `TestProducerRelationshipKindLiterals_AreValid` (via `internal/relkinds`) scans producer source for emitted kind literals and machine-checks them against the vocabulary. Review demonstrated it: unregistering a kind that *does* have a producer (`RelationshipKindSupervises`) goes red on that test. So a produced kind cannot be deleted silently, and the suite — not the author — is what certifies these two had no producer.

**Compile-time proof nothing referenced the constants:** `go build ./...` and `go vet ./...` both exit 0 across the whole module with both deleted.

### On-disk safety: deleting an enum member cannot renumber persisted kinds

Established at runtime by review, not by inference — and `go build`/`go vet` could not have supplied it, so it is recorded here as the load-bearing fact.

`internal/graph/schema/graph.fbs` declares **zero** `enum` types; `Entity.kind` and `Relationship.kind` are both `kind: string`. `fbwriter`'s `enumKindSet` is an in-memory `map[string]struct{}` from `sync.OnceValue`, never serialised, so it has no ordinal at all. Kinds persist **by name**.

Proven end-to-end: a `graph.fb` written from the **parent** tree with 112 relationships — one per parent `AllRelationshipKinds()` entry, including `HAS_TYPE` at index 54 and `TYPED_AS` at index 100 — read back with **this branch's** `fbreader.Open` + `IterateRelationships` gives an empty index+kind diff, exit 0. Every kind string survives byte-for-byte at every position, including the two deleted ones. Old graphs read correctly.

`types.KindVocabularyVersion` (#6779) is correctly not bumped: its rule is scoped to **entity** kinds, and with zero producers no stored graph can contain either edge anyway.

**`cmd/grafel` whole-graph digest and the golden ratchet: both held.** `go test -count=1 ./cmd/grafel/` → `ok, 152.0s`. `scripts/quality/run.sh --ratchet` → *"38 gated fixtures held their baseline (29 at 100% must-have recall)"*, exit 0. Nothing moved, so there is no delta to enumerate — consistent with the removal touching no producer.

### The enumeration was incomplete on its first pass — corrected

The first version of this body said "no rule YAML, no dashboard, MCP or webui reference". **That was false**, and review caught it. `site/src/scripts/coverage.js` listed `"has_type"` and `"typed_as"` in the public coverage page's kind roster, so the page would have advertised two kinds that no longer exist — the exact false advertisement #6906 was filed to end, shipping on this PR's own Cloudflare Pages deploy.

The miss has one cause worth naming: I grepped the **uppercase** literals and the Go constant names; the site uses the **lowercase display form**. A name has more than one spelling — constant, string literal, lowercase display, snake_case, serialised alias — and an enumeration that covers one spelling has not covered the name. Both items are removed, and a guard now scans that file so the next spelling-mismatch fails a test instead of a review.

The stale `(60)` / `(106)` counts in that file's comment are gone rather than restated. They were presented as the sizes of `AllEntityKinds()` / `AllRelationshipKinds()` but actually described the arrays themselves (the accessors return 94 and 110 on this branch), and an unchecked number is how the drift went unnoticed. The comment now says plainly that the arrays are hand-maintained and a subset, with the accessors as the only authority. Fixing the wider drift is out of scope for #6906.

**Complete surface list, after the correction:** the four Go files in this diff plus `site/src/scripts/coverage.js`. A case-insensitive `--binary-files=text` grep over the whole tree finds nothing else — no golden fixture, no `.json`/`.yaml`, no binary artefact, no reflection or string-keyed kind lookup.

## Step 3 — the comments, fact-checked sentence by sentence

`internal/extractor/enum_valueset.go` described a `TYPED_AS` binding whose producer half never existed. Rewritten to say what is true. Each claim and the file it was checked against:

| Claim now in the file | Verified against |
|---|---|
| the inbound edge is `REFERENCES` with `ref_kind="field_target_type"` | `internal/extractors/csharp/field_type_refs.go` — `Kind: string(types.RelationshipKindReferences)` and `{K: "ref_kind", V: csFieldTargetRefKind}` in `attachCsharpFieldTypeRefs`; `csFieldTargetRefKind = "field_target_type"` |
| of the six `field_target_type` producers, only C#'s addresses its target by QualifiedName | the other five: `custom/python/helpers.go:104` `pyClassRef`, `custom/golang/helpers.go:103` `goClassRef`, `custom/java/orm_helpers.go:52` `javaClassRef`, `custom/javascript/helpers.go:71` `"Class:" + targetClass`, `custom/ruby/helpers.go:89` `rbClassRef` — every one a `Class:<target>` stub |
| the producer reads the `SCOPE.Enum` record's `QualifiedName` directly | `csInFileTypeTargets`: `case r.Kind == "SCOPE.Enum": put(r.Name, r.QualifiedName)` |
| the QN binds via the `byQualifiedName` exact-match tier, ahead of the other tiers | `internal/resolve/refs.go` — the `idx.byQualifiedName[stub]` probe at `:2292`, at the top of `LookupStatusHint` (`:2268`) |
| `TYPED_AS` no longer exists | this diff |

Line numbers were deliberately **not** written into the new comments — the ones cited by the source issue had already rotted (`refs.go:2103` is no longer the probe on `3c7d2c5ec`). The comments name functions; the line numbers live here, in a PR that does not drift.

**One sentence was withdrawn on review.** The first version said *"in every other language a `SCOPE.Enum` node still has no inbound edge"* — an unqualified absolute over every language and every edge kind, which nothing observes and which I had not checked. It is replaced by the bounded claim in the table above (the six `field_target_type` producers, all five alternatives enumerated). Deleted rather than hedged: that sentence is the exact class of defect this PR is cleaning up.

**A newly-false comment was also fixed.** `internal/extractors/csharp/field_type_refs.go:22` said `TYPED_AS` and `HAS_TYPE` *"**are** both declared in internal/types/kinds.go"* — true when #6984 wrote it, false the moment this branch merges. The first version of this body called that line accurate; it is now past tense and names #6906 as where they went. A PR whose thesis is "a comment described a binding nobody built" must not leave a comment describing constants nobody declares.

**A comment-only diff has no mutant** — every mutation of a comment is equivalent by construction, so none was manufactured for that part. The table above is the verification instead.

## The guards, and proof they fire

`internal/types/kinds_retired_6906_test.go` holds two tests.

`TestRetiredRelationshipKindsStayRetired` fails if either name reappears on **all three Go surfaces** a re-addition could use: a const declaration in `kinds.go` (read from source via the existing AST walk, so a constant declared under *any* name is caught by its value), membership of `AllRelationshipKinds()`, and `IsValidRelationshipKind`.

`TestRetiredRelationshipKindsAreGoneFromTheCoveragePage` extends it to the surface a Go-only enumeration cannot see: a substring scan of `site/src/scripts/coverage.js` for the lowercase display forms. It is deliberately a raw substring scan, not a JS parse — the spelling to catch **is** the raw token, and a parser would add a way to be silently wrong about a file with no Go meaning.

Both compare against **independent string literals** (`retired6906Kinds = []string{"TYPED_AS", "HAS_TYPE"}`), never against the production slice — a guard that ranges over `AllRelationshipKinds()` and asks whether it contains what `AllRelationshipKinds()` contains cannot observe a re-addition (#6975). The file says so, so nobody "simplifies" it into a constant reference.

**Non-vacuity is asserted before any absence is believed**, on both. The AST guard requires a non-empty parse, two independent controls (`CALLS`, `REFERENCES`) **present** in it, and `IsValidRelationshipKind` **true** for both controls. The page guard requires three quoted controls (`"references"`, `"inherits"`, `"contains"`) present in the bytes it read, and treats a missing file as a hard failure rather than a skip.

**Proven to fire, five times, each mutant isolating one surface.** `gofmt`/`go vet` clean before each score, green baseline (`--- PASS`) immediately before, `-count=1`, occurrence count and enclosing scope asserted for every edit, and restore by `cp` from `shasum`-verified backups (`kinds.go` `10bdf67744…`, `coverage.js` `b6e8905eca…`, `kinds_retired_6906_test.go` `bfd1f648f5…`), never `git checkout`. All in the more-permissive direction:

| # | Mutant (permissive) | Edit landed | Result |
|---|---|---|---|
| M1 | re-declare `RelationshipKindTypedAs = "TYPED_AS"` **and** register it | 2 occurrences: `kinds.go:1893` in the `const` block, `:1912` inside `AllRelationshipKinds` | **DEAD** — all three assertions fired (declaration, registration, predicate) |
| M2 | declare `RelationshipKindHasType = "HAS_TYPE"`, do **not** register it | 1 occurrence, `kinds.go:1893`, in the `const` block | **DEAD** — the source-declaration assertion fired alone |
| M3 | register `RelationshipKind("TYPED_AS")` as a raw literal with **no** constant | 1 occurrence, `kinds.go:1911`, inside `AllRelationshipKinds` | **DEAD** — registration and predicate fired; the AST surface correctly did not |
| N5 | put `"typed_as"` back in the site roster | 1 occurrence, `coverage.js:34`, inside `REL_GROUPS`' "Structural" item array; `node --check` clean | **DEAD** — the page guard named the file and the item |
| N6 | point `coverageJSPath` at `site/astro.config.mjs` — a file that **exists and reads fine** | 1 occurrence, the `const coverageJSPath` declaration | **DEAD** — control `"references"` absent from 206 bytes read. This is the "reads the wrong file" no-op a count floor cannot catch |

M2/M3 are the pair that matters for the Go guard: each defeats one surface and is caught by another, so no assertion is carried by its neighbour. N5/N6 are the same pair for the page guard — one grades the content check, one grades the non-vacuity check.

Review scored four more (N1–N4) on the parent-vs-branch axis, including `N4` (reorder `AllRelationshipKinds()`) → **equivalent**, correctly so given that nothing persists an ordinal, and `N2` (re-add a kind *and* shrink the guard literal) → **ALIVE**, expected because it edits the pin itself. `N2` named the honest limit — the retirement rested on one string list with nothing cross-checking the non-Go surfaces — and `TestRetiredRelationshipKindsAreGoneFromTheCoveragePage` is the hardening it asked for.

## Verification

- `go test -count=1` on every touched package and its neighbours: `internal/types`, `internal/extractor`, `internal/graph/...` (incl. `fbwriter`), `internal/relkinds`, `internal/extractors/csharp` — 0 FAIL lines, exit 0.
- `go test -count=1 ./cmd/grafel/` — `ok 152.0s` (whole-graph digest pin).
- `scripts/quality/run.sh --ratchet` — 38 fixtures held, exit 0. No baseline constant was touched.
- `go build ./...`, `go vet ./...`, `gofmt -l internal/` — all clean, exit 0.
- `site/src/scripts/coverage.js` is a plain IIFE with no lint or test leg: no eslint/prettier config in `site/`, and no workflow in `.github/workflows/` builds it — only the Cloudflare Pages `astro build` does. Checked with `node --check` (exit 0) before and after every edit.
- Ran under `GRAFEL_HOME` / `GRAFEL_DAEMON_ROOT` pointed at a scratch directory; the real `~/.grafel` was not written.

`REFERENCES`, `ref_kind`, and everything #6984 shipped are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
