### PR TITLE
fix(#6986): the Python custom lane's field->model edge was addressed by a name that could not bind — 863 edges on django, 39 bound, and re-addressing it silently stripped django_rel from 760 more

### DIFF
--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -505,7 +506,7 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 			if strings.HasSuffix(callee, "Serializer") && !strings.Contains(callee, ".") &&
 				callee != "Serializer" && callee != "ModelSerializer" {
 				serEnt.Relationships = append(serEnt.Relationships,
-					referencesClassEdge(className+"."+attr, callee, "drf", attr))
+					referencesClassEdge(file.Path, className+"."+attr, callee, "drf", attr))
 			}
 		}
 
@@ -715,9 +716,38 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 				continue
 			}
 			fullRHS := body[fIdx[0]:min(fIdx[0]+400, len(body))]
-			if target := djangoRelTarget(fullRHS, className); target != "" {
-				modelEnt.Relationships = append(modelEnt.Relationships,
-					referencesClassEdge(className+"."+attr, target, "django", attr))
+			if target, rawFKString, isSelf := djangoRelTargetDetail(fullRHS, className); target != "" {
+				rel := referencesClassEdge(file.Path, className+"."+attr, target, "django", attr)
+				// #6986 — carry the RELATION-SHAPE properties the core
+				// extractor's parallel edge carries. This is not decoration.
+				// internal/extractors/python/django_relational.go emits a
+				// REFERENCES edge from the SAME field entity to the SAME target,
+				// stamped `django_rel` / `self_ref` / `django_fk_string`. While
+				// this pass's ToID was the never-binding `Class:<Target>` the two
+				// edges could not collide, so both survived. Now that the
+				// structural ToID resolves to the same entity ID, graph assembly
+				// DEDUPES the pair and keeps exactly one property set — measured
+				// on django gate-ON: REFERENCES edges carrying `django_rel` fell
+				// 1018 → 258 when the address changed and these three properties
+				// were not carried across. Restoring them here is what makes the
+				// address change property-preserving rather than a silent
+				// substitution (#6973).
+				//
+				// The values mirror the core extractor's semantics EXACTLY:
+				// `django_rel` is the constructor's leaf name (ForeignKey /
+				// OneToOneField / ManyToManyField, and the *ForeignKey suffix
+				// forms isDjangoRelationalField admits); `self_ref` is true ONLY
+				// for the literal string target `'self'` — NOT for a symbol
+				// target that happens to name the enclosing class, which is
+				// parseTargetExpr's rule; `django_fk_string` is set only for the
+				// string form and carries the raw value BEFORE app_label
+				// stripping.
+				rel.Properties.Set("django_rel", djangoRelCtorLeaf(rhs))
+				rel.Properties.Set("self_ref", strconv.FormatBool(isSelf))
+				if rawFKString != "" {
+					rel.Properties.Set("django_fk_string", rawFKString)
+				}
+				modelEnt.Relationships = append(modelEnt.Relationships, rel)
 			}
 		}
 		out = append(out, modelEnt)
@@ -958,22 +988,50 @@ func isDjangoRelationalField(rhs string) bool {
 // form (`ForeignKey(Model, ...)` / `ForeignKey(to=Model, ...)`). For 'self' it
 // returns the enclosing model class so the edge self-references the owner.
 // Returns "" when no recognizable target is present (e.g. lazy callables).
-func djangoRelTarget(rhs, ownerClass string) string {
+// djangoRelCtorLeaf returns the leaf constructor name of a relational field's
+// RHS — `models.ForeignKey` → `ForeignKey`. Mirrors the leaf-stripping
+// isDjangoRelationalField already performs, so the `django_rel` property this
+// pass stamps carries the same vocabulary as the core extractor's
+// `djangoFieldTypes` key (#6986).
+func djangoRelCtorLeaf(rhs string) string {
+	ctor := rhs
+	if dot := strings.LastIndexByte(ctor, '.'); dot >= 0 {
+		ctor = ctor[dot+1:]
+	}
+	return ctor
+}
+
+// djangoRelTargetDetail is djangoRelTarget plus the two facts the `self_ref`
+// and `django_fk_string` edge properties need: whether the target was written
+// as the literal string `'self'`, and the raw string-literal value before the
+// app_label segment is stripped. Returns ("", "", false) exactly where
+// djangoRelTarget returns "".
+//
+// `isSelf` is deliberately NOT "the target resolves to the enclosing class":
+// `ForeignKey(Person)` written inside `class Person` returns isSelf=false, the
+// same as internal/extractors/python/django_relational.go's parseTargetExpr,
+// so the two producers cannot disagree on the property.
+func djangoRelTargetDetail(rhs, ownerClass string) (target, rawFKString string, isSelf bool) {
 	m := djangoModelRelTargetRe.FindStringSubmatch(rhs)
 	if m == nil {
-		return ""
+		return "", "", false
 	}
 	if m[1] != "" { // string form
 		raw := m[1]
 		if raw == "self" {
-			return ownerClass
+			return ownerClass, "self", true
 		}
 		if dot := strings.LastIndexByte(raw, '.'); dot >= 0 {
-			return raw[dot+1:] // strip app_label
+			return raw[dot+1:], raw, false
 		}
-		return raw
+		return raw, raw, false
 	}
-	return m[2] // symbol form
+	return m[2], "", false // symbol form
+}
+
+func djangoRelTarget(rhs, ownerClass string) string {
+	target, _, _ := djangoRelTargetDetail(rhs, ownerClass)
+	return target
 }
 
 // extractBalancedBrackets returns the content of a [...] list starting at openPos.

--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -982,17 +982,21 @@ func isDjangoRelationalField(rhs string) bool {
 		strings.HasSuffix(ctor, "ManyToManyField")
 }
 
-// djangoRelTarget extracts the bare target-model class name from a relational
-// field declaration's argument blob. Handles the string form
-// (`ForeignKey('app.Model', ...)` / `ForeignKey('self', ...)`) and the symbol
-// form (`ForeignKey(Model, ...)` / `ForeignKey(to=Model, ...)`). For 'self' it
-// returns the enclosing model class so the edge self-references the owner.
-// Returns "" when no recognizable target is present (e.g. lazy callables).
 // djangoRelCtorLeaf returns the leaf constructor name of a relational field's
 // RHS — `models.ForeignKey` → `ForeignKey`. Mirrors the leaf-stripping
-// isDjangoRelationalField already performs, so the `django_rel` property this
-// pass stamps carries the same vocabulary as the core extractor's
-// `djangoFieldTypes` key (#6986).
+// isDjangoRelationalField already performs.
+//
+// The resulting `django_rel` vocabulary is a strict SUPERSET of the core
+// extractor's, not the same set (#6986). Core gates on
+// `djangoRelationalFieldTypes`, an exact three-name allow-list; this lane gates
+// on `isDjangoRelationalField`, a `*ForeignKey` / `*OneToOneField` /
+// `*ManyToManyField` SUFFIX rule. So a third-party subclass such as
+// `TreeForeignKey` reaches here and is stamped `django_rel: TreeForeignKey`, a
+// value core never emits — because core emits no edge for that field at all.
+// That direction is a gain and is what keeps the property-preservation claim
+// safe: this lane can only ADD a `django_rel`-carrying edge where core had
+// none, never rename one core already produced. Pinned by
+// TestIssue6988_LegitimateRelationalFieldsSurvive's `Book.category` row.
 func djangoRelCtorLeaf(rhs string) string {
 	ctor := rhs
 	if dot := strings.LastIndexByte(ctor, '.'); dot >= 0 {
@@ -1029,6 +1033,12 @@ func djangoRelTargetDetail(rhs, ownerClass string) (target, rawFKString string, 
 	return m[2], "", false // symbol form
 }
 
+// djangoRelTarget extracts the bare target-model class name from a relational
+// field declaration's argument blob. Handles the string form
+// (`ForeignKey('app.Model', ...)` / `ForeignKey('self', ...)`) and the symbol
+// form (`ForeignKey(Model, ...)` / `ForeignKey(to=Model, ...)`). For 'self' it
+// returns the enclosing model class so the edge self-references the owner.
+// Returns "" when no recognizable target is present (e.g. lazy callables).
 func djangoRelTarget(rhs, ownerClass string) string {
 	target, _, _ := djangoRelTargetDetail(rhs, ownerClass)
 	return target

--- a/internal/custom/python/django_gfk_6988_test.go
+++ b/internal/custom/python/django_gfk_6988_test.go
@@ -194,6 +194,18 @@ func fieldTargetEdgesFrom6988(rels []types.RelationshipRecord, from string) []ty
 	return out
 }
 
+// fieldTargetRef6988 is the ToID a field_target_type edge carries for a target
+// declared in the fixture file these tests extract ("models.py"). #6986 moved
+// that address off the bare-name `Class:<Target>` stub (which never bound once
+// a second entity shared the name) and onto the structural
+// `scope:component:class:python:<file>:<Target>` form. The assertions below are
+// unchanged in INTENT — "this field emits a target edge pointing at <Target>" —
+// only the dialect the target is named in has moved. `pyClassRef` is still the
+// right helper for the CONTAINS FromID, which was never re-addressed.
+func fieldTargetRef6988(target string) string {
+	return extractor.BuildComponentStructuralRef("python", "models.py", target)
+}
+
 func hasEdge6988(rels []types.RelationshipRecord, from, to, kind string) bool {
 	for _, r := range rels {
 		if r.FromID == from && r.ToID == to && r.Kind == kind {
@@ -239,8 +251,8 @@ func TestIssue6988_NamedGFKFieldEmitsNoTargetEdge(t *testing.T) {
 	// Positive control: the sibling REAL ForeignKey on the same class still
 	// resolves, so the negative above is not a vacuous "this file produced
 	// nothing" pass.
-	if !hasEdge6988(rels, "GenericB1.content_type", pyClassRef("ContentType"), string(types.RelationshipKindReferences)) {
-		t.Error("GenericB1.content_type -> Class:ContentType missing: the fix removed a LEGITIMATE edge (#6988)")
+	if !hasEdge6988(rels, "GenericB1.content_type", fieldTargetRef6988("ContentType"), string(types.RelationshipKindReferences)) {
+		t.Error("GenericB1.content_type -> ContentType missing: the fix removed a LEGITIMATE edge (#6988)")
 	}
 	// The GFK field itself must still be a CONTAINS member of its model — the
 	// fix removes the wrong REFERENCES edge, not the field node.
@@ -263,8 +275,8 @@ func TestIssue6988_NamedGFKFieldEmitsNoTargetEdge(t *testing.T) {
 func TestIssue6988_WrongButBoundEdgeShapeIsGone(t *testing.T) {
 	rels := djangoEdges6988(t, gfkSrc6988)
 
-	if hasEdge6988(rels, "Book.created_by", pyClassRef("created_by_ct"), string(types.RelationshipKindReferences)) {
-		t.Error("Book.created_by -> Class:created_by_ct still emitted: the wrong-but-BOUND edge shape " +
+	if hasEdge6988(rels, "Book.created_by", fieldTargetRef6988("created_by_ct"), string(types.RelationshipKindReferences)) {
+		t.Error("Book.created_by -> created_by_ct still emitted: the wrong-but-BOUND edge shape " +
 			"(#6369's wrong-node hazard) survives (#6988)")
 	}
 	if got := fieldTargetEdgesFrom6988(rels, "Book.created_by"); len(got) != 0 {
@@ -272,8 +284,8 @@ func TestIssue6988_WrongButBoundEdgeShapeIsGone(t *testing.T) {
 			len(got), got[0].ToID)
 	}
 	// The sibling that MINTS the `created_by_ct` node keeps its own real edge.
-	if !hasEdge6988(rels, "Book.created_by_ct", pyClassRef("ContentType"), string(types.RelationshipKindReferences)) {
-		t.Error("Book.created_by_ct -> Class:ContentType missing (#6988)")
+	if !hasEdge6988(rels, "Book.created_by_ct", fieldTargetRef6988("ContentType"), string(types.RelationshipKindReferences)) {
+		t.Error("Book.created_by_ct -> ContentType missing (#6988)")
 	}
 }
 
@@ -320,8 +332,8 @@ class Book(models.Model):
 		"Book.category":    "Category",  // third-party *ForeignKey subclass
 	}
 	for from, target := range want {
-		if !hasEdge6988(rels, from, pyClassRef(target), string(types.RelationshipKindReferences)) {
-			t.Errorf("%s -> Class:%s missing — #6988 broke a legitimate relational field", from, target)
+		if !hasEdge6988(rels, from, fieldTargetRef6988(target), string(types.RelationshipKindReferences)) {
+			t.Errorf("%s -> %s missing — #6988 broke a legitimate relational field", from, target)
 		}
 	}
 }

--- a/internal/custom/python/field_target_address_6986_test.go
+++ b/internal/custom/python/field_target_address_6986_test.go
@@ -1,0 +1,301 @@
+package python_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	extreg "github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+
+	_ "github.com/cajasmota/grafel/internal/custom/python"
+	_ "github.com/cajasmota/grafel/internal/extractors/python"
+)
+
+// field_target_address_6986_test.go — the Python custom lane's field→declared-
+// type address (issue #6986).
+//
+// MEASURED PREMISE, gate-ON (`WithCustomExtractors(true)`; the custom lane is
+// OFF by default, so user-facing incidence today is zero — #6966). On the
+// `django` corpus repo at 64ffa3d22: 863 `ref_kind: field_target_type` edges,
+// 39 bound (4.5%). Re-addressed from `Class:<Target>` to
+// `scope:component:class:python:<consumer file>:<Target>`: 949 edges, 886 bound
+// (93.4%), zero previously-bound key lost, zero bound to a file that does not
+// declare the name.
+//
+// The address is built from the CONSUMER's file, not the target's — which a
+// per-file pass-1 extractor cannot know. That is the dialect the resolver
+// already speaks for Python: internal/resolve/refs.go lookupStructural resolves
+// this shape same-file via lookupLocationKind and then, for `component` scope
+// with lang=="python" only, cross-file via lookupUniqueRealComponentByName.
+
+const modelsPath6986 = "shop/models.py"
+
+// twoFilesSrc6986 is the shape the whole issue turns on: a target model name
+// declared in TWO files. `Class:Customer` goes AMBIGUOUS here and dangles; the
+// file-scoped structural address binds to the RIGHT one.
+const ownerSrc6986 = `from django.db import models
+
+
+class Customer(models.Model):
+    name = models.CharField(max_length=100)
+
+
+class Order(models.Model):
+    buyer = models.ForeignKey(Customer, on_delete=models.CASCADE)
+    watchers = models.ManyToManyField('self', blank=True)
+`
+
+const rivalPath6986 = "billing/models.py"
+
+const rivalSrc6986 = `from django.db import models
+
+
+class Customer(models.Model):
+    vat_id = models.CharField(max_length=32)
+`
+
+func mergedFor6986(t *testing.T, files map[string]string) []types.EntityRecord {
+	t.Helper()
+	var all []types.EntityRecord
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		file := extreg.FileInput{Path: p, Language: "python", Content: []byte(files[p])}
+		base, ok := extreg.Get("python")
+		if !ok {
+			t.Fatal("base python extractor not registered")
+		}
+		baseEnts, err := base.Extract(context.Background(), file)
+		if err != nil {
+			t.Fatalf("base extract %s: %v", p, err)
+		}
+		customEnts, errs := extractors.RunCustomExtractors(context.Background(), file)
+		for _, e := range errs {
+			t.Fatalf("custom extract %s: %v", p, e)
+		}
+		all = append(all, extractors.MergeWithCustom(baseEnts, customEnts)...)
+	}
+	for i := range all {
+		if all[i].Name == "" {
+			continue
+		}
+		all[i].ID = graph.EntityID("issue6986", all[i].Kind, all[i].Name, all[i].SourceFile)
+	}
+	return all
+}
+
+func fieldTargetEdges6986(ents []types.EntityRecord) []struct {
+	Owner types.EntityRecord
+	Rel   types.RelationshipRecord
+} {
+	var out []struct {
+		Owner types.EntityRecord
+		Rel   types.RelationshipRecord
+	}
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind != string(types.RelationshipKindReferences) {
+				continue
+			}
+			for _, p := range r.Properties {
+				if p.K == "ref_kind" && p.V == "field_target_type" {
+					out = append(out, struct {
+						Owner types.EntityRecord
+						Rel   types.RelationshipRecord
+					}{ents[i], r})
+				}
+			}
+		}
+	}
+	return out
+}
+
+func propOf6986(props types.Props, k string) string {
+	for _, p := range props {
+		if p.K == k {
+			return p.V
+		}
+	}
+	return ""
+}
+
+// TestPythonFieldTargetType_BindsWhenTheNameIsDeclaredInTwoFiles is the
+// mechanism. `Customer` is declared in shop/models.py AND billing/models.py, so
+// the bare-name tier is ambiguous — the positive control asserts that first, or
+// the structural address would be ungraded. The edge must then bind, and bind
+// to the SHOP declaration.
+func TestPythonFieldTargetType_BindsWhenTheNameIsDeclaredInTwoFiles(t *testing.T) {
+	ents := mergedFor6986(t, map[string]string{
+		modelsPath6986: ownerSrc6986,
+		rivalPath6986:  rivalSrc6986,
+	})
+	idx := resolve.BuildIndex(ents)
+
+	// Positive control on the dialect itself: the OLD address is ambiguous here.
+	if id, ok := idx.Lookup("Class:Customer"); ok && id != "" {
+		t.Fatalf("Class:Customer binds in this fixture (%q), so the ambiguity this test "+
+			"controls for is absent and the structural address is ungraded", id)
+	}
+
+	byID := map[string]types.EntityRecord{}
+	for i := range ents {
+		byID[ents[i].ID] = ents[i]
+	}
+	edges := fieldTargetEdges6986(ents)
+	if len(edges) == 0 {
+		t.Fatal("no field_target_type edges emitted")
+	}
+	var buyer *types.RelationshipRecord
+	for i := range edges {
+		if edges[i].Rel.FromID == "Order.buyer" {
+			buyer = &edges[i].Rel
+		}
+	}
+	if buyer == nil {
+		t.Fatal("Order.buyer emitted no field_target_type edge")
+	}
+	want := extreg.BuildComponentStructuralRef("python", modelsPath6986, "Customer")
+	if buyer.ToID != want {
+		t.Fatalf("Order.buyer ToID = %q, want %q", buyer.ToID, want)
+	}
+
+	resolve.ReferencesEmbedded(ents, idx)
+	for _, e := range fieldTargetEdges6986(ents) {
+		if e.Rel.FromID != "Order.buyer" {
+			continue
+		}
+		target, ok := byID[e.Rel.ToID]
+		if !ok {
+			t.Fatalf("Order.buyer -> %q did NOT bind (dangling stub)", e.Rel.ToID)
+		}
+		if target.Name != "Customer" || target.SourceFile != modelsPath6986 {
+			t.Fatalf("Order.buyer bound to %s@%s, want Customer@%s — #6369's wrong-node hazard",
+				target.Name, target.SourceFile, modelsPath6986)
+		}
+	}
+}
+
+// TestPythonFieldTargetType_NeverBindsToANonDeclaringFile is the OTHER
+// direction, asserted BY NAME. Recall cannot detect over-firing. `Customer` is
+// declared in shop/models.py and billing/models.py and NOWHERE ELSE, so no
+// field_target_type edge in this fixture may bind to an entity in any other
+// file — and specifically not to billing/models.py's `Customer` from a
+// shop/models.py field.
+func TestPythonFieldTargetType_NeverBindsToANonDeclaringFile(t *testing.T) {
+	ents := mergedFor6986(t, map[string]string{
+		modelsPath6986: ownerSrc6986,
+		rivalPath6986:  rivalSrc6986,
+	})
+	declares := map[string]map[string]bool{
+		"Customer": {modelsPath6986: true, rivalPath6986: true},
+		"Order":    {modelsPath6986: true},
+	}
+	byID := map[string]types.EntityRecord{}
+	for i := range ents {
+		byID[ents[i].ID] = ents[i]
+	}
+	idx := resolve.BuildIndex(ents)
+	resolve.ReferencesEmbedded(ents, idx)
+
+	checked := 0
+	for _, e := range fieldTargetEdges6986(ents) {
+		target, ok := byID[e.Rel.ToID]
+		if !ok {
+			continue // dangling is not the over-fire direction
+		}
+		files, known := declares[target.Name]
+		if !known {
+			t.Errorf("%s bound to %q@%s — a name nothing in this fixture declares",
+				e.Rel.FromID, target.Name, target.SourceFile)
+			continue
+		}
+		if !files[target.SourceFile] {
+			t.Errorf("%s bound to %q@%s, a file that does NOT declare that name",
+				e.Rel.FromID, target.Name, target.SourceFile)
+		}
+		// Nothing in shop/models.py may reach billing's Customer.
+		if e.Rel.FromID == "Order.buyer" && target.SourceFile == rivalPath6986 {
+			t.Errorf("Order.buyer (shop/models.py) bound to the billing/models.py Customer")
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Fatal("no bound field_target_type edge to check: this negative is vacuous")
+	}
+}
+
+// TestPythonFieldTargetType_CarriesTheRelationShapeProperties is the control on
+// A′'s reason for existing. Once the structural ToID resolves to the SAME
+// entity ID the core extractor's parallel edge points at, graph assembly
+// dedupes the pair and keeps ONE property set — measured on django gate-ON,
+// REFERENCES edges carrying `django_rel` fell 1018 → 258 when the custom edge
+// did not carry them. So the custom edge must carry `django_rel` / `self_ref`
+// (and `django_fk_string` for the string form) itself.
+//
+// Asserted per NAMED edge, not as a count: a count cannot see a substitution
+// (#6973).
+func TestPythonFieldTargetType_CarriesTheRelationShapeProperties(t *testing.T) {
+	ents := mergedFor6986(t, map[string]string{modelsPath6986: ownerSrc6986})
+	want := map[string]struct{ rel, self, fkString string }{
+		"Order.buyer":    {"ForeignKey", "false", ""},
+		"Order.watchers": {"ManyToManyField", "true", "self"},
+	}
+	seen := map[string]bool{}
+	for _, e := range fieldTargetEdges6986(ents) {
+		w, ok := want[e.Rel.FromID]
+		if !ok {
+			continue
+		}
+		seen[e.Rel.FromID] = true
+		if got := propOf6986(e.Rel.Properties, "django_rel"); got != w.rel {
+			t.Errorf("%s django_rel = %q, want %q", e.Rel.FromID, got, w.rel)
+		}
+		if got := propOf6986(e.Rel.Properties, "self_ref"); got != w.self {
+			t.Errorf("%s self_ref = %q, want %q", e.Rel.FromID, got, w.self)
+		}
+		if got := propOf6986(e.Rel.Properties, "django_fk_string"); got != w.fkString {
+			t.Errorf("%s django_fk_string = %q, want %q", e.Rel.FromID, got, w.fkString)
+		}
+	}
+	for k := range want {
+		if !seen[k] {
+			t.Errorf("%s emitted no field_target_type edge — the property assertion above is vacuous", k)
+		}
+	}
+}
+
+// TestPythonFieldTargetType_SelfRefIsTheStringFormOnly pins the ONE place the
+// two producers could silently disagree. `self_ref` is true for the literal
+// string target `'self'` and FALSE for a symbol target that happens to name the
+// enclosing class — parseTargetExpr's rule in
+// internal/extractors/python/django_relational.go. A permissive reading ("the
+// target resolves to the owner") would flip `Node.parent` to true here.
+func TestPythonFieldTargetType_SelfRefIsTheStringFormOnly(t *testing.T) {
+	const src = `from django.db import models
+
+
+class Node(models.Model):
+    parent = models.ForeignKey(Node, null=True, on_delete=models.CASCADE)
+    sibling = models.ForeignKey('self', null=True, on_delete=models.CASCADE)
+`
+	ents := mergedFor6986(t, map[string]string{modelsPath6986: src})
+	got := map[string]string{}
+	for _, e := range fieldTargetEdges6986(ents) {
+		got[e.Rel.FromID] = propOf6986(e.Rel.Properties, "self_ref")
+	}
+	if got["Node.parent"] != "false" {
+		t.Errorf("Node.parent self_ref = %q, want \"false\" — a SYMBOL target naming the "+
+			"enclosing class is not a self-reference (parseTargetExpr's rule)", got["Node.parent"])
+	}
+	if got["Node.sibling"] != "true" {
+		t.Errorf("Node.sibling self_ref = %q, want \"true\" — the literal string 'self' IS one",
+			got["Node.sibling"])
+	}
+}

--- a/internal/custom/python/field_target_address_6986_test.go
+++ b/internal/custom/python/field_target_address_6986_test.go
@@ -3,6 +3,7 @@ package python_test
 import (
 	"context"
 	"sort"
+	"strings"
 	"testing"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -117,6 +118,17 @@ func fieldTargetEdges6986(ents []types.EntityRecord) []struct {
 	return out
 }
 
+// edgeKey6986 identifies a field_target_type edge in a way that SURVIVES
+// resolution. `resolve.ReferencesEmbedded` rewrites FromID in place once the
+// source endpoint binds, so matching a post-resolution edge on
+// `FromID == "Order.buyer"` silently matches NOTHING and every assertion under
+// it passes vacuously — which is exactly what the first draft of this file did.
+// The `field_name` property and the owning entity's Name are both untouched by
+// resolution, so the pair is a stable key.
+func edgeKey6986(owner types.EntityRecord, r types.RelationshipRecord) string {
+	return owner.Name + "." + propOf6986(r.Properties, "field_name")
+}
+
 func propOf6986(props types.Props, k string) string {
 	for _, p := range props {
 		if p.K == k {
@@ -167,10 +179,12 @@ func TestPythonFieldTargetType_BindsWhenTheNameIsDeclaredInTwoFiles(t *testing.T
 	}
 
 	resolve.ReferencesEmbedded(ents, idx)
+	checked := 0
 	for _, e := range fieldTargetEdges6986(ents) {
-		if e.Rel.FromID != "Order.buyer" {
+		if edgeKey6986(e.Owner, e.Rel) != "Order.buyer" {
 			continue
 		}
+		checked++
 		target, ok := byID[e.Rel.ToID]
 		if !ok {
 			t.Fatalf("Order.buyer -> %q did NOT bind (dangling stub)", e.Rel.ToID)
@@ -179,6 +193,9 @@ func TestPythonFieldTargetType_BindsWhenTheNameIsDeclaredInTwoFiles(t *testing.T
 			t.Fatalf("Order.buyer bound to %s@%s, want Customer@%s — #6369's wrong-node hazard",
 				target.Name, target.SourceFile, modelsPath6986)
 		}
+	}
+	if checked == 0 {
+		t.Fatal("no Order.buyer edge survived to the post-resolution check: this half is vacuous")
 	}
 }
 
@@ -221,7 +238,7 @@ func TestPythonFieldTargetType_NeverBindsToANonDeclaringFile(t *testing.T) {
 				e.Rel.FromID, target.Name, target.SourceFile)
 		}
 		// Nothing in shop/models.py may reach billing's Customer.
-		if e.Rel.FromID == "Order.buyer" && target.SourceFile == rivalPath6986 {
+		if edgeKey6986(e.Owner, e.Rel) == "Order.buyer" && target.SourceFile == rivalPath6986 {
 			t.Errorf("Order.buyer (shop/models.py) bound to the billing/models.py Customer")
 		}
 		checked++
@@ -249,19 +266,20 @@ func TestPythonFieldTargetType_CarriesTheRelationShapeProperties(t *testing.T) {
 	}
 	seen := map[string]bool{}
 	for _, e := range fieldTargetEdges6986(ents) {
-		w, ok := want[e.Rel.FromID]
+		key := edgeKey6986(e.Owner, e.Rel)
+		w, ok := want[key]
 		if !ok {
 			continue
 		}
-		seen[e.Rel.FromID] = true
+		seen[key] = true
 		if got := propOf6986(e.Rel.Properties, "django_rel"); got != w.rel {
-			t.Errorf("%s django_rel = %q, want %q", e.Rel.FromID, got, w.rel)
+			t.Errorf("%s django_rel = %q, want %q", key, got, w.rel)
 		}
 		if got := propOf6986(e.Rel.Properties, "self_ref"); got != w.self {
-			t.Errorf("%s self_ref = %q, want %q", e.Rel.FromID, got, w.self)
+			t.Errorf("%s self_ref = %q, want %q", key, got, w.self)
 		}
 		if got := propOf6986(e.Rel.Properties, "django_fk_string"); got != w.fkString {
-			t.Errorf("%s django_fk_string = %q, want %q", e.Rel.FromID, got, w.fkString)
+			t.Errorf("%s django_fk_string = %q, want %q", key, got, w.fkString)
 		}
 	}
 	for k := range want {
@@ -288,7 +306,7 @@ class Node(models.Model):
 	ents := mergedFor6986(t, map[string]string{modelsPath6986: src})
 	got := map[string]string{}
 	for _, e := range fieldTargetEdges6986(ents) {
-		got[e.Rel.FromID] = propOf6986(e.Rel.Properties, "self_ref")
+		got[edgeKey6986(e.Owner, e.Rel)] = propOf6986(e.Rel.Properties, "self_ref")
 	}
 	if got["Node.parent"] != "false" {
 		t.Errorf("Node.parent self_ref = %q, want \"false\" — a SYMBOL target naming the "+
@@ -298,4 +316,246 @@ class Node(models.Model):
 		t.Errorf("Node.sibling self_ref = %q, want \"true\" — the literal string 'self' IS one",
 			got["Node.sibling"])
 	}
+}
+
+// ---------------------------------------------------------------------------
+// The CROSS-FILE tier — the entire difference between this arm and #6984/#6991.
+// ---------------------------------------------------------------------------
+
+// TestPythonFieldTargetType_CrossFileTier_BindsUniqueRefusesAmbiguous grades the
+// tier this pass newly depends on and that nothing in this package graded
+// before: `lookupUniqueRealComponentByName`, reached when the CONSUMER's file
+// declares nothing by that name.
+//
+// Why the existing negative does not cover it: in
+// TestPythonFieldTargetType_NeverBindsToANonDeclaringFile the consumer file
+// declares `Customer` itself, so the same-file `lookupLocationKind` tier
+// resolves FIRST and the cross-file tier never fires. The two claims — "never
+// binds to a non-declaring file" and "never binds a cross-file AMBIGUOUS name"
+// — are different, and only the first was asserted. A mutant that makes
+// lookupUniqueRealComponentByName accept an ambiguous name leaves this package
+// GREEN without this case (scored on review as M3).
+//
+// Here `orders/models.py` declares NEITHER target, so every edge must travel
+// the cross-file tier. All three outcomes are asserted together, because
+// asserting only the bind would leave the refusal — the direction that matters
+// for #6369 — ungraded, and asserting only the refusal could pass vacuously on
+// a tier that binds nothing at all.
+func TestPythonFieldTargetType_CrossFileTier_BindsUniqueRefusesAmbiguous(t *testing.T) {
+	const consumerPath = "orders/models.py"
+	files := map[string]string{
+		// Consumer: declares Order and nothing else. Ambiguous target,
+		// unique target and absent target, side by side.
+		consumerPath: `from django.db import models
+
+
+class Order(models.Model):
+    buyer = models.ForeignKey(Customer, on_delete=models.CASCADE)
+    carrier = models.ForeignKey(Vendor, on_delete=models.CASCADE)
+    coupon = models.ForeignKey(Ghost, on_delete=models.CASCADE)
+`,
+		// AMBIGUOUS: Customer declared in two other files.
+		"shop/models.py": `from django.db import models
+
+
+class Customer(models.Model):
+    name = models.CharField(max_length=100)
+`,
+		"billing/models.py": `from django.db import models
+
+
+class Customer(models.Model):
+    vat_id = models.CharField(max_length=32)
+`,
+		// UNIQUE: Vendor declared in exactly one other file.
+		"vendors/models.py": `from django.db import models
+
+
+class Vendor(models.Model):
+    code = models.CharField(max_length=8)
+`,
+		// Ghost is declared nowhere at all.
+	}
+	ents := mergedFor6986(t, files)
+	byID := map[string]types.EntityRecord{}
+	for i := range ents {
+		byID[ents[i].ID] = ents[i]
+	}
+
+	// Preconditions, or the three outcomes below are not the outcomes named.
+	declCount := map[string]int{}
+	for i := range ents {
+		if ents[i].SourceFile == consumerPath {
+			continue
+		}
+		switch ents[i].Name {
+		case "Customer", "Vendor":
+			if ents[i].Kind == "SCOPE.Component" || ents[i].Kind == "SCOPE.Schema" {
+				declCount[ents[i].Name+"@"+ents[i].SourceFile] = 1
+			}
+		}
+	}
+	custFiles, vendFiles := 0, 0
+	for k := range declCount {
+		if strings.HasPrefix(k, "Customer@") {
+			custFiles++
+		}
+		if strings.HasPrefix(k, "Vendor@") {
+			vendFiles++
+		}
+	}
+	if custFiles < 2 {
+		t.Fatalf("fixture precondition: Customer must be declared outside %s in >=2 files, got %d — "+
+			"the ambiguity this test grades is not present", consumerPath, custFiles)
+	}
+	if vendFiles != 1 {
+		t.Fatalf("fixture precondition: Vendor must be declared outside %s in exactly 1 file, got %d",
+			consumerPath, vendFiles)
+	}
+
+	idx := resolve.BuildIndex(ents)
+	resolve.ReferencesEmbedded(ents, idx)
+
+	got := map[string]types.RelationshipRecord{}
+	for _, e := range fieldTargetEdges6986(ents) {
+		got[edgeKey6986(e.Owner, e.Rel)] = e.Rel
+	}
+	for _, from := range []string{"Order.buyer", "Order.carrier", "Order.coupon"} {
+		if _, ok := got[from]; !ok {
+			t.Fatalf("%s emitted no field_target_type edge — every assertion below would be vacuous", from)
+		}
+	}
+
+	// AMBIGUOUS -> must DANGLE. Refusing to guess is the #6369 direction.
+	if target, bound := byID[got["Order.buyer"].ToID]; bound {
+		t.Errorf("Order.buyer bound to %s@%s, want DANGLING: `Customer` is declared in two files "+
+			"and %s declares neither, so the cross-file tier must refuse rather than pick one",
+			target.Name, target.SourceFile, consumerPath)
+	}
+
+	// UNIQUE -> must BIND, and to the one declaring file.
+	target, bound := byID[got["Order.carrier"].ToID]
+	if !bound {
+		t.Errorf("Order.carrier did NOT bind (ToID %q): `Vendor` has exactly one declaration, which is "+
+			"the case the python cross-file tier exists to serve — this is the recall #6984 could not have",
+			got["Order.carrier"].ToID)
+	} else if target.Name != "Vendor" || target.SourceFile != "vendors/models.py" {
+		t.Errorf("Order.carrier bound to %s@%s, want Vendor@vendors/models.py",
+			target.Name, target.SourceFile)
+	}
+
+	// ABSENT -> must DANGLE.
+	if target, bound := byID[got["Order.coupon"].ToID]; bound {
+		t.Errorf("Order.coupon bound to %s@%s, want DANGLING: `Ghost` is declared nowhere in the fixture",
+			target.Name, target.SourceFile)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// KNOWN-WRONG, pinned deliberately. A fix to #6990 is EXPECTED to break this.
+// ---------------------------------------------------------------------------
+
+// TestPythonFieldTargetType_KnownWrong_6990_OverReadBindsToTheNextFieldsTarget
+// pins a wrong BOUND edge that this address change creates, and that the PR
+// body originally denied existed.
+//
+// #6990's mechanism: `djangoModelRelTargetRe` has no left word boundary and the
+// producer hands it a 400-char `fullRHS` window. For
+// `user = models.ForeignKey(settings.AUTH_USER_MODEL, …)` the dotted target is
+// correctly REJECTED by the `[A-Z]` symbol alternative — and the window then
+// runs on into the NEXT field's `ForeignKey(ContentType`, capturing that. The
+// field's target_type becomes a class it does not reference.
+//
+// Under the old `Class:<Target>` address that wrong edge could not bind, so it
+// surfaced as one more dangling stub. Under the structural address it binds
+// whenever the wrong name has a unique in-tree declaration — which is exactly
+// #6369's hazard, a confident wrong edge that no dangling count can see.
+//
+// THIS IS NOT COVERED BY THE OVER-FIRE CONTROLS IN THIS FILE, and that is the
+// point of pinning it separately: `NeverBindsToANonDeclaringFile` and the
+// corpus "0 bound to a non-declaring file" figure both grade the FILE the
+// resolver picked. Here the file is right — `ContentType` really is declared
+// there. The wrongness is in the NAME the extractor chose, a dimension neither
+// control observes.
+//
+// On the django corpus this particular edge stays dangling, but for a reason
+// that lives elsewhere: the `ext:django:` external-synthesis pass intercepts
+// first. The guarantee is that pass's, not this address's. Fixing #6990 (either
+// anchoring the regex or bounding the window at the field's own call) should
+// make this test fail with `Class:` / no edge at all — delete it then.
+func TestPythonFieldTargetType_KnownWrong_6990_OverReadBindsToTheNextFieldsTarget(t *testing.T) {
+	files := map[string]string{
+		"admin/models.py": `from django.conf import settings
+from django.db import models
+
+
+class LogEntry(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+`,
+		"contenttypes/models.py": `from django.db import models
+
+
+class ContentType(models.Model):
+    app_label = models.CharField(max_length=100)
+`,
+	}
+	ents := mergedFor6986(t, files)
+	byID := map[string]types.EntityRecord{}
+	for i := range ents {
+		byID[ents[i].ID] = ents[i]
+	}
+
+	// Control on the premise, through the production path: the SAME field with
+	// no sibling behind it emits NO edge at all. So the capture below is the
+	// 400-char window running on into the next field, not the symbol
+	// alternative accepting `settings.AUTH_USER_MODEL`.
+	lone := mergedFor6986(t, map[string]string{
+		"admin/models.py": `from django.conf import settings
+from django.db import models
+
+
+class LogEntry(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+`,
+	})
+	for _, e := range fieldTargetEdges6986(lone) {
+		if edgeKey6986(e.Owner, e.Rel) == "LogEntry.user" {
+			t.Fatalf("LogEntry.user emits a target edge (%q) with NO sibling field behind it — this "+
+				"test's premise (the window over-reads into the NEXT field) is not what is happening",
+				propOf6986(e.Rel.Properties, "target_type"))
+		}
+	}
+
+	idx := resolve.BuildIndex(ents)
+	resolve.ReferencesEmbedded(ents, idx)
+
+	var userEdge *types.RelationshipRecord
+	for _, e := range fieldTargetEdges6986(ents) {
+		if edgeKey6986(e.Owner, e.Rel) == "LogEntry.user" {
+			r := e.Rel
+			userEdge = &r
+		}
+	}
+	if userEdge == nil {
+		t.Skip("LogEntry.user emits no target edge — #6990 appears fixed; delete this known-wrong pin")
+	}
+	if got := propOf6986(userEdge.Properties, "target_type"); got != "ContentType" {
+		t.Fatalf("LogEntry.user target_type = %q, want \"ContentType\" — #6990's over-read shape has "+
+			"changed and this pin no longer describes it", got)
+	}
+	target, bound := byID[userEdge.ToID]
+	if !bound {
+		t.Fatalf("LogEntry.user did NOT bind (ToID %q). If #6990 or the address changed so this "+
+			"wrong edge can no longer bind, that is an improvement — delete this known-wrong pin",
+			userEdge.ToID)
+	}
+	if target.Name != "ContentType" || target.SourceFile != "contenttypes/models.py" {
+		t.Fatalf("LogEntry.user bound to %s@%s, want the known-wrong ContentType@contenttypes/models.py",
+			target.Name, target.SourceFile)
+	}
+	t.Logf("KNOWN WRONG (#6990, pinned by #6986): LogEntry.user -[REFERENCES field_target_type]-> "+
+		"%s@%s. The field references settings.AUTH_USER_MODEL; the 400-char window captured the "+
+		"NEXT field's target. Dangling under the old address, BOUND under this one.",
+		target.Name, target.SourceFile)
 }

--- a/internal/custom/python/helpers.go
+++ b/internal/custom/python/helpers.go
@@ -123,8 +123,23 @@ func containsFieldEdge(ownerClass, memberName, fieldName, framework string) type
 //
 // So this pass is NOT same-file-only the way the C# port (#6984) had to be:
 // a cross-file target still binds when its declaration is globally unique, and
-// an ambiguous or absent target still dangles — never more edges than before,
-// and never a guessed one.
+// an ambiguous or absent target still dangles.
+//
+// EDGE COUNT: the producer emits the SAME NUMBER OF RECORDS as before — one per
+// relational field, unchanged — but the GRAPH gains edges, measured 863 -> 949
+// on django gate-ON. The 86 are not new references: a field whose own entity is
+// an unresolved stub (`Person.friends` exists in four files) used to collapse
+// with its namesakes because their `Class:<Target>` ToIDs were byte-identical,
+// and a file-qualified ToID no longer collapses. So "never more edges" is FALSE
+// under the graph reading and must not be written here; what holds is "never a
+// new reference, and never a guessed one".
+//
+// NEVER A GUESSED ONE is an assertion, not a claim:
+// TestPythonFieldTargetType_NeverBindsToANonDeclaringFile requires that no bound
+// field_target_type edge points at an entity in a file that does not declare
+// that name, and names the case it must refuse — a `shop/models.py` field may
+// not reach the `billing/models.py` `Customer`. Recall cannot detect
+// over-firing, so that forbidden row is the only thing grading this direction.
 func referencesClassEdge(filePath, memberName, targetClass, framework, fieldName string) types.RelationshipRecord {
 	return types.RelationshipRecord{
 		FromID: memberName,

--- a/internal/custom/python/helpers.go
+++ b/internal/custom/python/helpers.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -95,13 +96,39 @@ func containsFieldEdge(ownerClass, memberName, fieldName, framework string) type
 // type is the field's only outbound semantic edge; without it the related model /
 // nested serializer rings.
 //
-// FromID is the field entity's qualified Name (`<owner>.<field>`); ToID is the
-// `Class:<target>` stub the resolver binds to the real class entity (same-file
-// or symbol-table wide). The edge is hung off the field entity by the caller.
-func referencesClassEdge(memberName, targetClass, framework, fieldName string) types.RelationshipRecord {
+// FromID is the field entity's qualified Name (`<owner>.<field>`).
+//
+// ToID is the STRUCTURAL address
+// `scope:component:class:python:<declaring_file>:<Target>`, not the
+// `Class:<Target>` bare-name stub this helper shipped until #6986. Measured
+// reason, gate-ON on the 16-repo corpus: 917 `field_target_type` edges, 840
+// (91.6%) DANGLING, essentially all Python (django 880 edges / 836 dangling).
+// `Class:<Target>` reaches the resolver's bare-name tier, which returns
+// AMBIGUOUS the moment two entities share the name — and on Django that is the
+// ordinary case twice over: a second app declaring `Author`, and, for a
+// UNIQUELY declared model, grafel's own untwinned rule-pack `Model` node
+// sitting beside the tree-sitter class anchor (#6981). Only ~54% of the loss is
+// duplicate names; the other ~40% is a unique class made ambiguous by grafel.
+//
+// The address is deliberately built from the CONSUMER's file — the file this
+// per-file extractor is reading — and NOT from the target's file, which a
+// pass-1 extractor cannot know. That is not a compromise: it is the Python
+// dialect the resolver already speaks. internal/resolve/refs.go's
+// lookupStructural resolves `scope:component:class:python:<file>:<Name>` in two
+// tiers — same-file `lookupLocationKind`, then, for `component` scope with
+// lang=="python" only, `lookupUniqueRealComponentByName`, which binds when
+// exactly one entity in the whole graph declares the name. The Python
+// hierarchy extractor has emitted EXTENDS targets in exactly this shape, with
+// exactly this consumer's-file convention, since the flask-realworld wave.
+//
+// So this pass is NOT same-file-only the way the C# port (#6984) had to be:
+// a cross-file target still binds when its declaration is globally unique, and
+// an ambiguous or absent target still dangles — never more edges than before,
+// and never a guessed one.
+func referencesClassEdge(filePath, memberName, targetClass, framework, fieldName string) types.RelationshipRecord {
 	return types.RelationshipRecord{
 		FromID: memberName,
-		ToID:   pyClassRef(targetClass),
+		ToID:   extractor.BuildComponentStructuralRef("python", filePath, targetClass),
 		Kind:   string(types.RelationshipKindReferences),
 		Properties: types.Props{
 			{K: "field_name", V: fieldName},

--- a/internal/custom/python/issue4366_livedrepro_test.go
+++ b/internal/custom/python/issue4366_livedrepro_test.go
@@ -153,11 +153,18 @@ func TestIssue4366_DjangoModelFields_AreMembers(t *testing.T) {
 	// Relational fields carry a REFERENCES edge to the target model. contract.py
 	// has `group = models.ForeignKey(Group, ...)` and
 	// `recipients = models.ManyToManyField("User", ...)`.
-	if !hasReferencesTo(ents, "Class:Group") {
-		t.Errorf("expected REFERENCES edge to Class:Group (ForeignKey target)")
+	//
+	// #6986 moved the target address from the bare-name `Class:<Target>` stub to
+	// the structural `scope:component:class:python:<file>:<Target>` form. What
+	// this pins is unchanged — BOTH relational fields still emit a target edge,
+	// and each still names the same target model — only the dialect moved.
+	groupRef := extreg.BuildComponentStructuralRef("python", "core/models/contract.py", "Group")
+	userRef := extreg.BuildComponentStructuralRef("python", "core/models/contract.py", "User")
+	if !hasReferencesTo(ents, groupRef) {
+		t.Errorf("expected REFERENCES edge to %s (ForeignKey target)", groupRef)
 	}
-	if !hasReferencesTo(ents, "Class:User") {
-		t.Errorf("expected REFERENCES edge to Class:User (ManyToManyField string target)")
+	if !hasReferencesTo(ents, userRef) {
+		t.Errorf("expected REFERENCES edge to %s (ManyToManyField string target)", userRef)
 	}
 }
 
@@ -173,13 +180,51 @@ func TestIssue4366_SQLAlchemyFields_AreMembers(t *testing.T) {
 		t.Errorf("SQLAlchemy model has %d/%d orphan field entities (want 0)", orphans, total)
 	}
 
-	// Relationship target must carry a resolving REFERENCES edge.
-	idx := resolve.BuildIndex(ents)
-	if _, ok := idx.Lookup("Class:Order"); !ok {
-		t.Errorf("Class:Order did not resolve in symbol table")
+	// Relationship target must carry a RESOLVING REFERENCES edge. That is the
+	// property this has always pinned — the old form asserted it by looking the
+	// `Class:Order` stub up in the symbol table. #6986 re-addressed the edge to
+	// `scope:component:class:python:<file>:<Target>`, which the bare-name
+	// `Index.Lookup` tier does not serve, so the same property is now pinned one
+	// layer lower and more strictly: drive the REAL production path
+	// (BuildIndex → ReferencesEmbedded) and require the emitted edge's ToID to
+	// come back REWRITTEN to a real entity ID. Weaker would be to drop the
+	// resolution half and keep only "an edge exists"; this keeps both.
+	orderRef := extreg.BuildComponentStructuralRef("python", "app/models/orders.py", "Order")
+	customerRef := extreg.BuildComponentStructuralRef("python", "app/models/orders.py", "Customer")
+	if !hasReferencesTo(ents, orderRef) && !hasReferencesTo(ents, customerRef) {
+		t.Errorf("expected a REFERENCES edge to a related SQLAlchemy model (%s / %s)", orderRef, customerRef)
 	}
-	if !hasReferencesTo(ents, "Class:Order") && !hasReferencesTo(ents, "Class:Customer") {
-		t.Errorf("expected a REFERENCES edge to a related SQLAlchemy model")
+	ids := map[string]bool{}
+	for i := range ents {
+		ids[ents[i].ID] = true
+	}
+	idx := resolve.BuildIndex(ents)
+	resolve.ReferencesEmbedded(ents, idx)
+	boundTargets := 0
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind != string(types.RelationshipKindReferences) {
+				continue
+			}
+			isFieldTarget := false
+			for _, p := range r.Properties {
+				if p.K == "ref_kind" && p.V == "field_target_type" {
+					isFieldTarget = true
+				}
+			}
+			if !isFieldTarget {
+				continue
+			}
+			if !ids[r.ToID] {
+				t.Errorf("%s -[REFERENCES]-> %q did NOT bind to an entity ID (dangling stub)",
+					ents[i].Name, r.ToID)
+				continue
+			}
+			boundTargets++
+		}
+	}
+	if boundTargets == 0 {
+		t.Error("no field_target_type edge bound: the resolution half of this assertion is vacuous")
 	}
 }
 

--- a/internal/custom/python/orm_relationships.go
+++ b/internal/custom/python/orm_relationships.go
@@ -113,7 +113,7 @@ func (e *PeeweeRelExtractor) Extract(ctx context.Context, file extractor.FileInp
 			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
 			// Issue #4366 — relation field → target model REFERENCES.
 			relEnt.Relationships = append(relEnt.Relationships,
-				referencesClassEdge(className+"."+attr, target, "peewee", attr))
+				referencesClassEdge(file.Path, className+"."+attr, target, "peewee", attr))
 			out = append(out, relEnt)
 		}
 
@@ -131,7 +131,7 @@ func (e *PeeweeRelExtractor) Extract(ctx context.Context, file extractor.FileInp
 			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
 			// Issue #4366 — relation field → target model REFERENCES.
 			relEnt.Relationships = append(relEnt.Relationships,
-				referencesClassEdge(className+"."+attr, target, "peewee", attr))
+				referencesClassEdge(file.Path, className+"."+attr, target, "peewee", attr))
 			out = append(out, relEnt)
 		}
 	}
@@ -231,7 +231,7 @@ func (e *PonyRelExtractor) Extract(ctx context.Context, file extractor.FileInput
 			}
 			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
 			relEnt.Relationships = append(relEnt.Relationships,
-				referencesClassEdge(className+"."+attr, target, "pony", attr))
+				referencesClassEdge(file.Path, className+"."+attr, target, "pony", attr))
 			out = append(out, relEnt)
 		}
 	}
@@ -325,7 +325,7 @@ func (e *BeanieRelExtractor) Extract(ctx context.Context, file extractor.FileInp
 			}
 			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
 			relEnt.Relationships = append(relEnt.Relationships,
-				referencesClassEdge(className+"."+attr, target, "beanie", attr))
+				referencesClassEdge(file.Path, className+"."+attr, target, "beanie", attr))
 			out = append(out, relEnt)
 		}
 
@@ -342,7 +342,7 @@ func (e *BeanieRelExtractor) Extract(ctx context.Context, file extractor.FileInp
 			}
 			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
 			relEnt.Relationships = append(relEnt.Relationships,
-				referencesClassEdge(className+"."+attr, target, "beanie", attr))
+				referencesClassEdge(file.Path, className+"."+attr, target, "beanie", attr))
 			out = append(out, relEnt)
 		}
 	}
@@ -455,7 +455,7 @@ func (e *MongoEngineRelExtractor) Extract(ctx context.Context, file extractor.Fi
 				}
 				relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
 				relEnt.Relationships = append(relEnt.Relationships,
-					referencesClassEdge(className+"."+attr, ormRelTargetLeaf(target), "mongoengine", attr))
+					referencesClassEdge(file.Path, className+"."+attr, ormRelTargetLeaf(target), "mongoengine", attr))
 				out = append(out, relEnt)
 			}
 		}
@@ -558,7 +558,7 @@ func (e *TortoiseRelExtractor) Extract(ctx context.Context, file extractor.FileI
 			}
 			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
 			relEnt.Relationships = append(relEnt.Relationships,
-				referencesClassEdge(className+"."+attr, ormRelTargetLeaf(target), "tortoise", attr))
+				referencesClassEdge(file.Path, className+"."+attr, ormRelTargetLeaf(target), "tortoise", attr))
 			out = append(out, relEnt)
 		}
 
@@ -580,7 +580,7 @@ func (e *TortoiseRelExtractor) Extract(ctx context.Context, file extractor.FileI
 			}
 			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
 			relEnt.Relationships = append(relEnt.Relationships,
-				referencesClassEdge(className+"."+attr, ormRelTargetLeaf(target), "tortoise", attr))
+				referencesClassEdge(file.Path, className+"."+attr, ormRelTargetLeaf(target), "tortoise", attr))
 			out = append(out, relEnt)
 		}
 
@@ -597,7 +597,7 @@ func (e *TortoiseRelExtractor) Extract(ctx context.Context, file extractor.FileI
 			}
 			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
 			relEnt.Relationships = append(relEnt.Relationships,
-				referencesClassEdge(className+"."+attr, ormRelTargetLeaf(target), "tortoise", attr))
+				referencesClassEdge(file.Path, className+"."+attr, ormRelTargetLeaf(target), "tortoise", attr))
 			out = append(out, relEnt)
 		}
 
@@ -614,7 +614,7 @@ func (e *TortoiseRelExtractor) Extract(ctx context.Context, file extractor.FileI
 			}
 			relEnt := entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props)
 			relEnt.Relationships = append(relEnt.Relationships,
-				referencesClassEdge(className+"."+attr, ormRelTargetLeaf(target), "tortoise", attr))
+				referencesClassEdge(file.Path, className+"."+attr, ormRelTargetLeaf(target), "tortoise", attr))
 			out = append(out, relEnt)
 		}
 	}

--- a/internal/custom/python/sqlalchemy.go
+++ b/internal/custom/python/sqlalchemy.go
@@ -198,7 +198,7 @@ func (e *SQLAlchemyExtractor) Extract(ctx context.Context, file extractor.FileIn
 			out[modelIdx].Relationships = append(out[modelIdx].Relationships,
 				containsFieldEdge(className, className+"."+relAttr, relAttr, "sqlalchemy"))
 			out[modelIdx].Relationships = append(out[modelIdx].Relationships,
-				referencesClassEdge(className+"."+relAttr, targetModel, "sqlalchemy", relAttr))
+				referencesClassEdge(file.Path, className+"."+relAttr, targetModel, "sqlalchemy", relAttr))
 
 			// GRAPH_RELATES model↔model edge with cardinality. SQLAlchemy
 			// relationship() default is a collection (one_to_many); uselist=False


### PR DESCRIPTION
## Gate state, first

**Everything below is gate-ON** (`WithCustomExtractors(true)`, the in-process entry point `grafel quality` uses). The custom lane is **OFF by default** (#6966), so **user-facing incidence on a default `grafel index` today is ZERO** — none of these edges are produced at all. That caps the urgency; it does not make the address correct.

Measured in `/private/tmp/.../scratchpad/impl-6986a-k7m3q/wt` at `64ffa3d22`, on the `django` corpus repo copied to scratch (`/Users/jorgecajas/Projects/archigraph-corpora` untouched). macOS/APFS, Apple Silicon, `GOMAXPROCS=3`, `nice -n 10`, isolated `GRAFEL_HOME` / `GRAFEL_DAEMON_ROOT`.

## Part 1 — the three questions the arm was gated on

**1. Can the Python producer build a structural address? YES, and more cheaply than the C# arm.** Every `referencesClassEdge` call site has `file.Path`, and it does not need the target's file: the Python dialect addresses by the **consumer's** file. `internal/resolve/refs.go` `lookupStructural` resolves `scope:component:class:python:<file>:<Name>` in two tiers — same-file `lookupLocationKind`, then, for `component` scope with `lang=="python"` **only**, cross-file `lookupUniqueRealComponentByName`. The Python hierarchy extractor has emitted EXTENDS targets in exactly this shape with exactly this convention since the flask-realworld wave, and the Django class anchor already carries `ref: scope:component:class:python:tests/admin_views/models.py:ReferencedByParent` as a property.

**2. Same-file is not the constraint here.** Because of that cross-file tier, this pass is **not** same-file-only the way #6984 had to be. Measured: `dup` (≥2 declaring files) 439 newly bound, `uniq-same` 305, `uniq-other` 3.

**3. The untwinned-`Model` subset binds — measured, not assumed.** 724 of 747 newly-bound edges bind to the untwinned rule-pack `Model` node (the resolver's real-tier-first preference), 20 to `SCOPE.Component`; same file, same line, same qualified name. `ParentWithFK.fk → ReferencedByParent` and `B3.restrict → R` both bind.

## The result

| | before | after |
|---|---|---|
| `field_target_type` edges | 863 | 949 |
| bound | **39 (4.5%)** | **886 (93.4%)** |
| bound `(field, file, target)` keys | 39 | 802 |
| **keys that LOST a binding** | — | **0** |
| **bound to a file that does NOT declare the name** | — | **0** |

The +86 edges are edges whose *FROM* endpoint is itself an unresolved stub (`Person.friends` exists in four files): they previously collapsed into one because their `Class:` ToIDs were byte-identical, and now stay distinct. Key set is 863 before and after; `onlyBefore` = `onlyAfter` = 0.

8 edges were **upgraded**, not substituted: `Request.profile`, `SessionEvent.session`, `ColorfulItem.colors`, `SimulationRun.start`/`.end`, `Thing.color`, `Product.image`, `FooImage.my_image` moved from a synthesised `SCOPE.External` node with no source file to the real in-tree model.

## The part that would have shipped as a silent substitution

`internal/extractors/python/django_relational.go:246` already emits a REFERENCES edge **from the same field entity to the same target**, addressed `scope:component:ref:python:<file>:<Name>` and stamped `django_rel` / `self_ref` / `django_fk_string`. On django, **766 field entities carry both edges; the core edge binds 708 times while the custom edge binds 8.**

While the custom ToID never bound, the two edges could not collide. Once it binds, graph assembly **dedupes the pair and keeps exactly one property set** — and it keeps the custom one. Measured on a full re-index of the naive change:

```
REFERENCES edges carrying django_rel:   1018  ->  258      (-760)
```

`GRAPH_RELATES` (922) was unaffected, so the model↔model cardinality survived — but the **field-level** relation type and self-reference flag vanished from 760 edges, invisibly to any recall count. That is the #6973 class.

So the producer now stamps those three properties itself, mirroring `parseTargetExpr`'s semantics exactly. Re-measured on a third full index:

```
REFERENCES edges carrying django_rel:   1018  ->  1207
django_rel (from,to) PAIR SET:  before 1018, after 1207, LOST 0
REFERENCES self_ref:            1018  ->  1207
django_fk_string:                169  ->   210
```

**The count does not come back to exactly 1018, and it should not.** 1018 counted only the edges the *core* producer emitted. The custom lane emits a relational-field edge for 97 django fields the core pass produces nothing for, plus the 86 previously-collapsed ones; those now carry `django_rel` too. The load-bearing control is the **set** control — every `(from, to)` pair that carried `django_rel` before still carries it, `LOST 0` — which a count could not have shown. Named example, asserted in the suite: `Order.watchers = models.ManyToManyField('self')` carries `django_rel=ManyToManyField`, `self_ref=true`, `django_fk_string=self`; `Order.buyer = models.ForeignKey(Customer)` carries `django_rel=ForeignKey`, `self_ref=false`, no `django_fk_string`.

**Vocabulary correction.** An earlier version of the `djangoRelCtorLeaf` comment said `django_rel` "carries the same vocabulary as the core extractor's `djangoFieldTypes` key". It does not, and the difference is a **gain**: core gates on `djangoRelationalFieldTypes`, an exact three-name allow-list, while this lane gates on `isDjangoRelationalField`, a `*ForeignKey`/`*OneToOneField`/`*ManyToManyField` **suffix** rule. `TreeForeignKey` reaches this lane and is stamped `django_rel: TreeForeignKey`, a value core never emits — because core emits no edge for that field at all. That direction is what keeps the pair-set claim safe: this lane can only ADD a `django_rel`-carrying edge where core had none, never rename one core already produced. The comment now says that, and `TestIssue6988_LegitimateRelationalFieldsSurvive`'s `Book.category` row pins it.

**Semantic agreement, verified per form** (reviewer's check, stronger than the corpus set-diff): core `parseTargetExpr` and custom `djangoRelTargetDetail` produce identical `django_rel` / `self_ref` / `django_fk_string` on `ForeignKey('auth.User')`, `ForeignKey('Customer')` and `OneToOneField(Customer)`. **The app-labelled string form `'auth.User'` is not covered by my suite and it agrees** — that is the case that would have silently broken `ResolveDjangoStringFKRefs`, and its agreement is what makes the `LOST 0` pair-set result safe rather than lucky.

Full relationship-profile diff, before → after, is exactly the intended edges and nothing else:

```
+847  REFERENCES INFERRED_FROM_MODEL_FIELD_TARGET  bound
-761  REFERENCES INFERRED_FROM_MODEL_FIELD_TARGET  dangling
-708  REFERENCES (core django_rel)                 bound      (absorbed by the dedupe)
 -52  REFERENCES (core django_rel)                 dangling   (absorbed)
  -1  SCOPE.External/function entity + its CONTAINS (an edge that now binds in-tree)
```
**On the +86 — legitimate on the TO side, with a caveat that belongs in #6726's arithmetic.** The reviewer named the population in `archigraph-corpora/django`: `class Person(models.Model)` with `friends = models.ManyToManyField("self")` is declared in **four distinct apps** (`tests/test_runner/models.py:4`, `tests/m2m_recursive/models.py:22`, `tests/queries/models.py:690`, `tests/m2m_signals/models.py:24`). Four declarations, four relationships — four edges is right, not inflation. **But the FromID is the bare `Person.friends`, identical across all four files and still unresolved**, so the graph gains four outbound edges hanging off **one** collapsed source node. That is pre-existing FROM-side under-resolution, not something this PR introduces, and it means "+86 distinct edges" is only half true: **86 distinct targets, from fewer distinct sources.**

They are not new references. A field whose own entity is an unresolved stub (`Person.friends` exists in four files) used to collapse with its namesakes because their `Class:<Target>` ToIDs were byte-identical; a file-qualified ToID no longer collapses. The producer emits the **same number of records** — one per relational field. The `referencesClassEdge` doc comment originally read "never more edges than before", which is true of records and false of the graph; it now states the measured version and names the test behind "never a guessed one".

(`RENAMED_FROM` also moves between runs — a git-history pass sensitive to the state dir, not to this change; the same noise appears on a repo where no `field_target_type` edge changed at all.)

## Both directions are asserted, and the negative is by name

- `TestPythonFieldTargetType_BindsWhenTheNameIsDeclaredInTwoFiles` — `Customer` declared in `shop/models.py` AND `billing/models.py`. A **positive control** first asserts the bare `Class:Customer` form is ambiguous in the fixture, or the structural address would be ungraded. Then `Order.buyer` must bind, and bind to **shop's** Customer.
- `TestPythonFieldTargetType_NeverBindsToANonDeclaringFile` — the over-fire direction, named: no bound `field_target_type` edge may point at an entity in a file that does not declare that name, and specifically `Order.buyer` may not reach `billing/models.py`'s `Customer`. Guarded against vacuity (`checked == 0` fails).
- `TestPythonFieldTargetType_SelfRefIsTheStringFormOnly` — `self_ref` is true for the literal `'self'` and **false** for a symbol target naming the enclosing class, which is `parseTargetExpr`'s rule. A permissive reading flips `Node.parent`.
- **`TestPythonFieldTargetType_CrossFileTier_BindsUniqueRefusesAmbiguous` (new)** — the cross-file tier is the entire difference between this arm and #6984/#6991, and nothing in this package graded it: `NeverBindsToANonDeclaringFile`'s consumer declares `Customer` itself, so the same-file tier resolves first and the cross-file tier never fires. The new fixture's consumer (`orders/models.py`) declares **neither** target, and all three outcomes are asserted together — ambiguous (`Customer` in two other files) must **DANGLE**, unique (`Vendor` in one) must **BIND to that file**, absent (`Ghost`) must **DANGLE** — with fixture preconditions checked first so the ambiguity cannot silently disappear, and per-edge existence checked so no branch passes vacuously.

**A vacuity bug in my own first draft, found while writing that test and fixed here.** `resolve.ReferencesEmbedded` rewrites `FromID` in place once the source endpoint binds, so every post-resolution `e.Rel.FromID == "Order.buyer"` match in the original file matched **nothing** and the assertions under it passed vacuously. All matching now goes through `edgeKey6986`, built from the owning entity's `Name` plus the `field_name` property — both untouched by resolution — and each such loop carries an explicit `checked == 0` failure. This affected the binding half of `BindsWhenTheNameIsDeclaredInTwoFiles` and the `Order.buyer`-specific clause of `NeverBindsToANonDeclaringFile`.

## The 5 updated tests — what each was pinning, and why the new assertion pins the same thing

None was weakened; each asserted `pyClassRef(X)`, i.e. **the old address literal**, as the way of saying "this edge exists and points at X".

| test | what it pinned | new assertion |
|---|---|---|
| `TestIssue6988_NamedGFKFieldEmitsNoTargetEdge` | its forbidden row is `len(edges) != 0` and is **untouched**; only the *positive control* (`GenericB1.content_type` still emits a real edge to `ContentType`) named the address | same edge, addressed via `fieldTargetRef6988("ContentType")` |
| `TestIssue6988_WrongButBoundEdgeShapeIsGone` | the wrong-but-bound shape `Book.created_by → created_by_ct` must NOT be emitted, and the sibling `Book.created_by_ct → ContentType` must survive | both, re-addressed. The forbidden shape is still asserted as *this exact ToID absent* **and** as *zero `field_target_type` edges from that field* |
| `TestIssue6988_LegitimateRelationalFieldsSurvive` | all 8 legitimate forms (FK/O2O/M2M × string/`'self'`/symbol/`to=`/third-party subclass) still emit an edge naming the right target | same 8 rows, same targets, structural ToID |
| `TestIssue4366_DjangoModelFields_AreMembers` | both relational fields emit a target edge naming `Group` and `User` | same two, structural ToID |
| `TestIssue4366_SQLAlchemyFields_AreMembers` | (a) an edge to a related model exists **and** (b) its address RESOLVES — asserted by looking `Class:Order` up in the symbol table | (a) unchanged. (b) is now pinned **one layer lower and more strictly**: drive the real production path (`BuildIndex` → `ReferencesEmbedded`) and require the emitted ToID to come back rewritten to a real entity ID, with a `boundTargets == 0` vacuity guard. Dropping (b) would have been the weakening; it is kept |

`pyClassRef` is untouched and still correct for the CONTAINS FromID, which was never re-addressed.

## Mutants

Both scored with `-count=1` off a green baseline, edit proven applied by exact occurrence count **inside the named function**, restored by `cp` from a shasum-verified backup.

- **M1 — permissive `self_ref`** (`return m[2], "", m[2] == ownerClass` in `djangoRelTargetDetail`, 1 occurrence, inside `djangoRelTargetDetail`): **DEAD** — `TestPythonFieldTargetType_SelfRefIsTheStringFormOnly`.
- **M2 — file segment dropped from the address** (`BuildComponentStructuralRef("python", "", targetClass)`, 1 occurrence, inside `referencesClassEdge`): **DEAD** — 7 tests, including `TestPythonFieldTargetType_NeverBindsToANonDeclaringFile`. That is the interesting kill: a fileless address falls through to the cross-file unique tier, which is precisely the over-fire the negative test exists to catch.
- **M3 (reviewer's) — the cross-file tier accepts an ambiguous name** (`continue` on collision in `lookupUniqueRealComponentByName`, refs.go, 1 occurrence, inside that function): was **ALIVE in this package** — the tier this PR routes 847 edges through was graded only by `internal/resolve` helper-equivalence tests. `TestPythonFieldTargetType_CrossFileTier_BindsUniqueRefusesAmbiguous` now kills it: re-scored after adding the test, `./internal/custom/python/` goes **RED on that test alone**. Restored by `cp` from a shasum-verified backup (`786d695b…` both ways), zero `MUTANT` text remaining, green after.
- **CK-1 (reviewer's, posted on this PR)** — **DEAD**, and worth reading for *which* tests killed it: **three of the six are the #6988 GFK tests**, written for an unrelated defect. They caught a corrupted language segment because they assert **resolved targets** rather than emitted strings, so a broken address breaks them even though nothing about GFKs changed. That is evidence the address is graded more broadly than by the tests added for it here.

### Correction carried from review

The ambiguous-name case was called unasserted during review; it is not. `TestPythonFieldTargetType_BindsWhenTheNameIsDeclaredInTwoFiles` covers it and asserts it **binds** — which is the correct expectation, because the consumer's file declares `Customer` too and the same-file `lookupLocationKind` tier resolves before the cross-file one. The genuinely-ambiguous direction (the consumer's file does NOT declare the name and two other files do) is the one that must dangle, and it is `TestPythonFieldTargetType_NeverBindsToANonDeclaringFile` that forbids guessing there.

## Gates

- `go test -count=1 ./internal/custom/python/` — ok
- `go test -count=1 ./internal/resolve/` — ok
- `go test -count=1 ./cmd/grafel/` — **PASS, 153.5s, 0 failures**, re-run on the final head under a FRESH isolated `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`. Two earlier attempts on this box wedged in `TestRebuild_MarksTheGroupForeground` → `internal/gitmeta.runGitReal`, on a `git status` subprocess that hung and left a `(git)` process behind (goroutine dump captured). That is environmental — a stale state dir or a concurrent Go test run reproduces it — not this change: filtered to non-comment lines, `git diff` of the non-test source since the previously green run is **empty**.
- `scripts/quality/run.sh --ratchet` — **OK, 38 gated fixtures held their baseline (29 at 100% must-have recall)**. **No fixture moved**, so no baseline was regenerated and no hand-edit was needed; `git status` shows no `internal/quality/**` change.

Second-repo control: `django-realworld` — 3 DRF `field_target_type` edges, bound before and after, same targets.

## Two things this deliberately does NOT fix

- **`LogEntry.user` is a live instance of #6990, and this PR CAN turn it into a bound wrong edge. My earlier claim that it could not was false of the mechanism.** `user = models.ForeignKey(settings.AUTH_USER_MODEL, …)` at `django/contrib/admin/models.py:63` emits a target of `ContentType`: the 400-char `fullRHS` window reads past the dotted `settings.X` (which the regex's `[A-Z]` symbol alternative correctly rejects) into the **next** field's `ForeignKey(ContentType`.

  Minimal repro, now pinned as `TestPythonFieldTargetType_KnownWrong_6990_OverReadBindsToTheNextFieldsTarget`:

  ```
  parent address (Class:ContentType):   LogEntry.user  DANGLING
  A′     address (structural):          LogEntry.user  BOUND -> ContentType@contenttypes/models.py
  ```

  A dangling wrong edge promoted to a **bound** wrong edge is #6369's hazard, and it is worse than a dangle because nothing flags it. Three things must be said plainly:

  1. **On django it stays dangling, but the guarantee is not this address's.** Re-measured under A′ (fresh index, gate-ON): the ToID is `ext:django:ContentType` and it is **DANGLING** — the external-synthesis pass intercepts first. `class ContentType(models.Model)` is declared **exactly once** in the corpus (`django/contrib/contenttypes/models.py:134`), so absent that interception the cross-file unique tier *would* bind it.
  2. **My over-fire controls cannot detect this class.** Both "0 bound to a non-declaring file" and `NeverBindsToANonDeclaringFile` grade the **file** the resolver picked. Here the file is right — `ContentType` really is declared there. The wrongness is in the **name the extractor chose**, a dimension neither control observes.
  3. **A′ enlarges the population that could exhibit it**, from 39 bound edges to 886 — more than twenty-fold.

  **Re-measured #6990 corpus incidence under A′** (the original zero-incidence figure was taken against the old, never-binding address and no longer describes the shipped graph): of 949 `field_target_type` edges, the over-read population — custom target disagreeing with the core producer's target for the same field — is **1**, `LogEntry.user`, and it is dangling. So bound-wrong incidence on django under A′ is **0**, population **1**. The wrong *name* is #6990's defect, not this PR's; the promotion path is this PR's and is now pinned. Deleting that test is the expected consequence of fixing #6990.
- **The duplicate-producer question.** 765 of 863 of these edges duplicate a core edge that already binds. Reconciling the two producers — stamping `ref_kind: field_target_type` on the core edge and dropping the custom Django duplicate — is the better end state and is being filed separately; it does not replace this change, because 97 django fields have no core twin and the seven non-Django Python ORM frameworks (SQLAlchemy, peewee, pony, beanie, mongoengine, tortoise, DRF) have no core producer at all.

`Refs #6986` rather than `Closes` — four languages (golang, javascript, ruby, java) still ship `Class:<Name>`, and `internal/resolve/refs.go:4574`'s Python disposition guard is untouched: 86.5% of what it routes `dynamic` is the ORM-queries family it was written for, so it must not be narrowed on this evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
