### PR TITLE
fix(#6978): 26 custom-extractor path gates can never fire — the enumeration, and a guard that fails when a 27th appears

### DIFF
--- a/internal/custom/csharp/blazor.go
+++ b/internal/custom/csharp/blazor.go
@@ -260,14 +260,27 @@ func (e *blazorExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	// below are further restricted to `.razor`, and only the two code rules
 	// (methods, [Parameter]) run over code-behind.
 	// #6978 — isRazorMarkup is UNREACHABLE, so the markup rules below have
-	// never run on any file. `.razor` classifies as language "razor", which
-	// has no entry in customPrefixForLanguage, so no custom_csharp_* extractor
-	// is ever dispatched for a `.razor` file (internal/extractors/
-	// custom_dispatch.go). Only the `.razor.cs` code-behind arm is live, and
-	// that is the arm #6975 measured. Kept and listed in
-	// TestCustomExtractorGatesAreReachable6978 rather than deleted: routing
-	// "razor" to custom_csharp_ is what would make these rules run, and this
-	// is where that change lands.
+	// never run on any file, and could not have before #6975 either. This
+	// EXTENDS point 2 above rather than restating it: there is a THIRD gate,
+	// earlier than both of the two named there. Dispatch itself is keyed on
+	// language — RunCustomExtractors selects via CustomExtractorsFor, and
+	// "razor" has no entry in customPrefixForLanguage
+	// (internal/extractors/custom_dispatch.go) — so a `.razor` file is never
+	// handed to a custom_csharp_* extractor in the first place, on ANY of the
+	// three dispatch paths.
+	//
+	// SO ROUTING ALONE WOULD NOT MAKE THESE RULES RUN. Point 2 above is right
+	// and this comment does not contradict it: reaching the markup rules needs
+	// all three, in order — (1) an entry routing "razor" to `custom_csharp_`;
+	// (2) the `file.Language != "csharp"` check above widened, which
+	// TestBlazorLanguageGuardRejectsNonCSharp6975 pins deliberately; and (3) a
+	// razor tree-sitter grammar, for the two dispatch paths that also require
+	// file.TSTree != nil (cmd/grafel/index.go, incremental.go — the daemon
+	// subprocess path has no such guard).
+	//
+	// Kept, not deleted, and listed in
+	// TestCustomExtractorGatesAreReachable6978 so it cannot be mistaken for a
+	// working `.razor` gate; that test fails if a NEW unreachable gate appears.
 	isRazorMarkup := strings.HasSuffix(file.Path, ".razor")
 	isRazorCodeBehind := strings.HasSuffix(file.Path, ".razor.cs")
 	if !isRazorMarkup && !isRazorCodeBehind {

--- a/internal/custom/csharp/blazor.go
+++ b/internal/custom/csharp/blazor.go
@@ -259,6 +259,15 @@ func (e *blazorExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	// generic type argument, not a component reference. So the markup rules
 	// below are further restricted to `.razor`, and only the two code rules
 	// (methods, [Parameter]) run over code-behind.
+	// #6978 — isRazorMarkup is UNREACHABLE, so the markup rules below have
+	// never run on any file. `.razor` classifies as language "razor", which
+	// has no entry in customPrefixForLanguage, so no custom_csharp_* extractor
+	// is ever dispatched for a `.razor` file (internal/extractors/
+	// custom_dispatch.go). Only the `.razor.cs` code-behind arm is live, and
+	// that is the arm #6975 measured. Kept and listed in
+	// TestCustomExtractorGatesAreReachable6978 rather than deleted: routing
+	// "razor" to custom_csharp_ is what would make these rules run, and this
+	// is where that change lands.
 	isRazorMarkup := strings.HasSuffix(file.Path, ".razor")
 	isRazorCodeBehind := strings.HasSuffix(file.Path, ".razor.cs")
 	if !isRazorMarkup && !isRazorCodeBehind {

--- a/internal/custom/csharp/blazor_deep.go
+++ b/internal/custom/csharp/blazor_deep.go
@@ -176,6 +176,19 @@ func (e *blazorDeepExtractor) Extract(ctx context.Context, file extractor.FileIn
 	}
 
 	src := string(file.Content)
+	// #6978 — THE `.razor` DISJUNCT IS UNREACHABLE, and kept deliberately.
+	// `.razor` classifies as language "razor" (internal/classifier), and
+	// "razor" has no entry in customPrefixForLanguage
+	// (internal/extractors/custom_dispatch.go), so CustomExtractorsFor never
+	// returns a custom_csharp_* extractor for such a file. No `.razor` file
+	// reaches this function on ANY dispatch path — that is a routing fact, not
+	// a corpus observation. (A razor grammar would also be needed for the two
+	// paths that additionally require file.TSTree != nil.)
+	//
+	// It is NOT deleted: the suffix pair names the Blazor file family, and the
+	// day razor is routed here this is the line that must already be right.
+	// TestCustomExtractorGatesAreReachable6978 lists it, so it cannot be
+	// mistaken for a working `.razor` gate — and it fails if a NEW one appears.
 	isRazor := strings.HasSuffix(file.Path, ".razor") ||
 		strings.HasSuffix(file.Path, ".razor.cs")
 	var entities []types.EntityRecord

--- a/internal/custom/csharp/blazor_deep.go
+++ b/internal/custom/csharp/blazor_deep.go
@@ -177,18 +177,28 @@ func (e *blazorDeepExtractor) Extract(ctx context.Context, file extractor.FileIn
 
 	src := string(file.Content)
 	// #6978 — THE `.razor` DISJUNCT IS UNREACHABLE, and kept deliberately.
-	// `.razor` classifies as language "razor" (internal/classifier), and
-	// "razor" has no entry in customPrefixForLanguage
-	// (internal/extractors/custom_dispatch.go), so CustomExtractorsFor never
-	// returns a custom_csharp_* extractor for such a file. No `.razor` file
-	// reaches this function on ANY dispatch path — that is a routing fact, not
-	// a corpus observation. (A razor grammar would also be needed for the two
-	// paths that additionally require file.TSTree != nil.)
+	// Three independent gates stop a `.razor` file, and ALL THREE would have
+	// to change for this arm to matter:
 	//
-	// It is NOT deleted: the suffix pair names the Blazor file family, and the
-	// day razor is routed here this is the line that must already be right.
-	// TestCustomExtractorGatesAreReachable6978 lists it, so it cannot be
-	// mistaken for a working `.razor` gate — and it fails if a NEW one appears.
+	//  1. Dispatch is keyed on language. RunCustomExtractors selects via
+	//     CustomExtractorsFor, and "razor" has no entry in
+	//     customPrefixForLanguage (internal/extractors/custom_dispatch.go), so
+	//     no custom_csharp_* extractor is offered the file at all — on any of
+	//     the three dispatch paths.
+	//  2. The `file.Language != "csharp"` check 5 lines above rejects it a
+	//     second time. That check is live and load-bearing, pinned by
+	//     TestBlazorLanguageGuardRejectsNonCSharp6975, so ROUTING ALONE IS NOT
+	//     ENOUGH — the guard would have to be widened too.
+	//  3. There is no razor tree-sitter grammar, so file.TSTree is nil and the
+	//     in-proc (cmd/grafel/index.go) and incremental (incremental.go) paths
+	//     skip custom extractors entirely. The daemon subprocess path
+	//     (subproc.go) carries no such guard, so this one is path-specific.
+	//
+	// None of that is a corpus observation; it is how routing is wired. The
+	// arm is NOT deleted because the suffix pair is what names the Blazor file
+	// family (blazor.go uses the same pair), and
+	// TestCustomExtractorGatesAreReachable6978 lists it so it cannot be
+	// mistaken for a working `.razor` gate.
 	isRazor := strings.HasSuffix(file.Path, ".razor") ||
 		strings.HasSuffix(file.Path, ".razor.cs")
 	var entities []types.EntityRecord

--- a/internal/extractors/custom_gate_reachability_6978_test.go
+++ b/internal/extractors/custom_gate_reachability_6978_test.go
@@ -29,15 +29,27 @@ package extractors_test
 // WHY A GUARD RATHER THAN A FIX. The sites below are NOT one defect. Some are
 // unreachable code beside a live path (blazor_deep's `.razor` arm); some are a
 // whole capability that has never run (rust's diesel/sqlx `.sql` migration
-// parsing). Deleting them uniformly would throw away the second kind. This
-// test freezes the population so a NEW one cannot be written in silence.
+// parsing, php's Symfony `services.yaml` DI graph, the whole Vue/Svelte/Nuxt
+// family). Deleting them uniformly would throw away the second kind. This test
+// freezes the population so a NEW one cannot be written in silence.
+//
+// POLARITY: FAIL-CLOSED. The scan applies NO filter to the gate's subject
+// expression. Every extension-shaped literal compared against anything is a
+// candidate, and every candidate the reachability predicate calls unreachable
+// must appear in one of the two hand-written lists below — as a real gate, or
+// as a literal that is matched against file CONTENT rather than a path. An
+// unreachable candidate in neither list FAILS. The first version of this test
+// filtered candidates by a marker list of subject NAMES ("path", "rel", "ext",
+// …) and silently dropped every gate whose subject was called `low`, `lower`
+// or `fp` — that is the hand-picked-enumeration failure this derivation exists
+// to avoid, so the filter is gone rather than extended.
 
 import (
 	"go/ast"
 	"go/parser"
-	"go/printer"
 	"go/token"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -51,6 +63,14 @@ import (
 // customGateRoot is the tree scanned. Relative to this package's directory,
 // which is where `go test` runs.
 const customGateRoot = "../custom"
+
+// registryImportPath is the package whose Register() calls name a package's
+// dispatch keys. The scan resolves the LOCAL name of this import per file
+// rather than matching the identifier `extractor`: internal/custom/javascript
+// (34 registrations) and internal/custom/java (7) import it as `extreg`, and an
+// identifier-matching scan silently found zero keys for both — which the
+// empty-key branch then read as "out of scope", exempting two whole packages.
+const registryImportPath = "github.com/cajasmota/grafel/internal/extractor"
 
 // knownUnreachableGates is the frozen population of extension gates that
 // cannot fire, as `<pkg>/<file>|<enclosing func>|<literal>`.
@@ -75,11 +95,35 @@ var knownUnreachableGates = []string{
 	"cpp/unreal_extractor.go|Extract|.Build.cs",
 	// `.razor` classifies as "razor" (classifier.go), and "razor" has no
 	// custom prefix. `.razor.cs` classifies as "csharp" and IS live, so both
-	// extractors still run — over code-behind only. In blazor.go this means
-	// the MARKUP rule set, which is further restricted to isRazorMarkup, has
-	// never run on any file.
+	// extractors still run — over code-behind only.
 	"csharp/blazor.go|Extract|.razor",
 	"csharp/blazor_deep.go|Extract|.razor",
+	// Vue SFCs classify as language "vue", which has no custom prefix, so no
+	// custom_js_* extractor can see one. All four are DISJUNCTS, not whole
+	// gates — checked at each site rather than assumed: vue.go and svelte.go
+	// both read `lang != "typescript" && lang != "javascript" && !vueFile`, so
+	// the ts/js arm keeps each extractor live; nuxt's `.server.vue`/
+	// `.client.vue` sit beside live `.server.ts`/`.client.ts`/`.js` arms, and
+	// its `.vue` feeds isPagesFile only, beside a live isServerAPI path. What
+	// is unreachable is SFC-specific extraction (the `<template>` half), not
+	// the extractors.
+	"javascript/vue.go|isVueFile|.vue",
+	"javascript/nuxt.go|Extract|.vue",
+	"javascript/nuxt.go|Extract|.server.vue",
+	"javascript/nuxt.go|Extract|.client.vue",
+	// `.svelte` classifies as "svelte", also without a custom prefix. Same
+	// disjunct shape as vue.go.
+	"javascript/svelte.go|Extract|.svelte",
+	// The java pattern adapter (patterns_dispatch.go) registers
+	// `custom_java_patterns`, so only `.java` files reach these functions —
+	// and the adapter stamps ctx.Language "java" literally, so the
+	// `ctx.Language != "java"` guard rejects anything else a second time.
+	// `.routes` classifies as "scala" (routing to custom_scala_) and `.xml` as
+	// nothing. Both are disjuncts: each falls through to a live source-marker
+	// path when false, so the extractors still work on `.java`.
+	"java/play_routes.go|isPlayRoutesFile|.routes",
+	"java/struts_routes.go|ExtractStruts|.xml",
+	"java/struts_routes.go|extractStrutsRequestValidation|.xml",
 	// SQLDelight `.sq`/`.sqm` are classified as nothing, so no FileInput with
 	// that path ever exists. The kotlin-language arm of both gates is live.
 	"kotlin/orm_query.go|Extract|.sq",
@@ -102,14 +146,43 @@ var knownUnreachableGates = []string{
 	"nim/ormin_orm.go|Extract|.sql",
 	"rust/diesel.go|Extract|.sql",
 	"rust/sqlx_rbatis.go|isSqlxMigrationFile|.sql",
+	// `.yaml`/`.yml` classify as "yaml", which has no custom prefix. di_graph
+	// has NO language guard, so routing alone decides it: the whole Symfony
+	// `services.yaml` DI alias→implementation branch is latent capability,
+	// exercised only by its own unit test. Subject is `lower`, which is why
+	// the first version of this scan could not see it.
+	"php/di_graph.go|Extract|.yaml",
+	"php/di_graph.go|Extract|.yml",
+	// Behat `.feature` files classify as nothing. Written as a slice compare
+	// (`file.Path[len(file.Path)-8:] == ".feature"`) rather than a HasSuffix
+	// call, which is why the scan also inspects equality comparisons.
+	"php/test_data.go|Extract|.feature",
 }
 
-// liveGateControls are gates in the SAME files that the scan must find and
-// must NOT report as dead. This is the positive control for the "read the
-// wrong file / matched nothing" no-op: if the scan is pointed at a tree that
-// parses fine but contains no gates, or its matcher stops recognising gate
-// shapes, these disappear and the test fails on them rather than passing
-// vacuously on an empty dead set.
+// knownContentMatchLiterals are extension-shaped literals that are NOT file
+// gates: they are matched against file CONTENT (a source line, an identifier
+// fragment, a config value), so "unreachable as an extension" says nothing
+// about them. Same id shape, same hand-written discipline, same both-direction
+// set equality — an entry here is an explicit claim that the site is not a
+// path gate, and a reviewer can check it in one line.
+//
+// This list exists because the scan deliberately applies no subject filter: a
+// filter that dropped these would also drop real gates, as the first version
+// of this test did. Adjudicating them by hand is the price of fail-closed.
+var knownContentMatchLiterals = []string{
+	// Both are matched against `receiver` — an identifier parsed out of the
+	// SOURCE (`step.run(...)`, `inngest.createFunction(...)`) — not against a
+	// path. Extension-shaped by coincidence.
+	"javascript/inngest.go|Extract|.inngest",
+	"javascript/inngest.go|inngestStepReceiverAttributed|.step",
+}
+
+// liveGateControls are gates that the scan must find and must NOT report as
+// dead. This is the positive control for the "read the wrong file / matched
+// nothing" no-op: if the scan is pointed at a tree that parses fine but
+// contains no gates, or its matcher stops recognising gate shapes, these
+// disappear and the test fails on them rather than passing vacuously on an
+// empty dead set.
 var liveGateControls = []string{
 	"csharp/blazor.go|Extract|.razor.cs",
 	"csharp/blazor_deep.go|Extract|.razor.cs",
@@ -118,8 +191,8 @@ var liveGateControls = []string{
 }
 
 // minGateLiterals / minFilesParsed are floors on the scan's raw work. They
-// catch only the crudest no-op (read nothing), which is why the two set
-// assertions above carry the real weight.
+// catch only the crudest no-op (read nothing), which is why the set assertions
+// above carry the real weight.
 const (
 	minGateLiterals = 25
 	minFilesParsed  = 300
@@ -133,19 +206,30 @@ type gateSite struct {
 }
 
 // scanCustomGates walks internal/custom/** and returns every extension-shaped
-// literal tested against a path-shaped expression, split into unreachable and
-// reachable, plus the number of non-test files parsed.
-func scanCustomGates(t *testing.T) (dead, live []gateSite, filesParsed int) {
+// literal compared against something, split into unreachable and reachable,
+// plus the number of non-test files parsed and the packages whose Register
+// keys came back empty.
+func scanCustomGates(t *testing.T) (dead, live []gateSite, filesParsed int, keylessDirs []string) {
 	t.Helper()
 
 	keysByDir := map[string][]string{}
+	dirsSeen := map[string]bool{}
 	var all []gateSite
 
 	err := filepath.Walk(customGateRoot, func(p string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() || !strings.HasSuffix(p, ".go") || strings.HasSuffix(p, "_test.go") {
+		if info.IsDir() {
+			// testdata/ holds Go SOURCE FIXTURES, not packages: they register
+			// nothing, and judging them would make every scan report a keyless
+			// package. `go build` ignores them for the same reason.
+			if info.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(p, ".go") || strings.HasSuffix(p, "_test.go") {
 			return nil
 		}
 		filesParsed++
@@ -168,61 +252,139 @@ func scanCustomGates(t *testing.T) (dead, live []gateSite, filesParsed int) {
 			}
 			return "<file-scope>"
 		}
-		rel := filepath.ToSlash(strings.TrimPrefix(p, customGateRoot+string(filepath.Separator)))
+		// SLASH FIRST, THEN STRIP. filepath.Walk yields OS-separator paths, so
+		// on Windows `p` is `..\custom\csharp\blazor.go` while
+		// customGateRoot is "../custom" — stripping a forward-slash prefix off
+		// a backslash path is a silent NO-OP, every key keeps a `../custom/`
+		// prefix the hand-written lists do not have, and BOTH directions of
+		// the set comparison fail at once. That is exactly how this test went
+		// red on the default windows-latest leg while green on macOS and
+		// Linux. The in-tree convention (internal/resolve normalizePath) is
+		// that paths are slash-form inside the program and only converted back
+		// at the OS-disk boundary; keyFor asserts it rather than trusting it.
+		rel := keyFor(t, p)
 		dir := filepath.Dir(p)
+		dirsSeen[dir] = true
+		regName := localImportName(f, registryImportPath)
+		strName := localImportName(f, "strings")
 
+		// String constants/variables bound to a literal ANYWHERE in this file,
+		// so `const razorSuffix = ".razor"` + HasSuffix(fp, razorSuffix) is
+		// seen. Resolution is single-file and single-assignment: an ident bound
+		// more than once, or bound to anything but a literal, is dropped rather
+		// than guessed at.
+		bindings := map[string]*ast.BasicLit{}
+		bound := map[string]int{}
 		ast.Inspect(f, func(n ast.Node) bool {
-			ce, ok := n.(*ast.CallExpr)
-			if !ok || len(ce.Args) == 0 {
-				return true
-			}
-			se, ok := ce.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			pkg, _ := se.X.(*ast.Ident)
-			if pkg == nil {
-				return true
-			}
-			// extractor.Register("<key>", …) — the package's dispatch keys.
-			if pkg.Name == "extractor" && se.Sel.Name == "Register" {
-				if bl, ok := ce.Args[0].(*ast.BasicLit); ok && bl.Kind == token.STRING {
-					if s, uerr := strconv.Unquote(bl.Value); uerr == nil {
-						keysByDir[dir] = append(keysByDir[dir], s)
+			switch d := n.(type) {
+			case *ast.ValueSpec:
+				for i, nm := range d.Names {
+					bound[nm.Name]++
+					if i < len(d.Values) {
+						if bl, ok := d.Values[i].(*ast.BasicLit); ok && bl.Kind == token.STRING {
+							bindings[nm.Name] = bl
+						}
 					}
 				}
-				return true
-			}
-			if pkg.Name != "strings" {
-				return true
-			}
-			switch se.Sel.Name {
-			case "HasSuffix", "EqualFold":
-			default:
-				return true
-			}
-			var subj strings.Builder
-			if perr := printer.Fprint(&subj, fset, ce.Args[0]); perr != nil {
-				t.Fatalf("print subject in %s: %v", p, perr)
-			}
-			if !pathShaped(subj.String()) {
-				return true
-			}
-			for _, a := range ce.Args[1:] {
-				bl, ok := a.(*ast.BasicLit)
-				if !ok || bl.Kind != token.STRING {
-					continue
+			case *ast.AssignStmt:
+				if d.Tok != token.DEFINE && d.Tok != token.ASSIGN {
+					return true
 				}
-				s, uerr := strconv.Unquote(bl.Value)
-				if uerr != nil || !extensionShaped(s) {
-					continue
+				for i, lhs := range d.Lhs {
+					id, ok := lhs.(*ast.Ident)
+					if !ok {
+						continue
+					}
+					bound[id.Name]++
+					if i < len(d.Rhs) {
+						if bl, ok := d.Rhs[i].(*ast.BasicLit); ok && bl.Kind == token.STRING {
+							bindings[id.Name] = bl
+						}
+					}
 				}
-				all = append(all, gateSite{
-					id:   rel + "|" + enclosing(bl.Pos()) + "|" + s,
-					lit:  s,
-					file: p,
-					line: fset.Position(bl.Pos()).Line,
-				})
+			}
+			return true
+		})
+		// resolve returns the literal an expression denotes: itself when it is
+		// one, or its unique single-literal binding when it is an identifier.
+		resolve := func(e ast.Expr) *ast.BasicLit {
+			switch v := e.(type) {
+			case *ast.BasicLit:
+				return v
+			case *ast.Ident:
+				if bound[v.Name] == 1 {
+					return bindings[v.Name]
+				}
+			}
+			return nil
+		}
+
+		record := func(bl *ast.BasicLit) {
+			if bl.Kind != token.STRING {
+				return
+			}
+			s, uerr := strconv.Unquote(bl.Value)
+			if uerr != nil || !extensionShaped(s) {
+				return
+			}
+			all = append(all, gateSite{
+				id:   rel + "|" + enclosing(bl.Pos()) + "|" + s,
+				lit:  s,
+				file: p,
+				line: fset.Position(bl.Pos()).Line,
+			})
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch v := n.(type) {
+			case *ast.CallExpr:
+				se, ok := v.Fun.(*ast.SelectorExpr)
+				if !ok || len(v.Args) == 0 {
+					return true
+				}
+				pkg, _ := se.X.(*ast.Ident)
+				if pkg == nil {
+					return true
+				}
+				// <registry>.Register("<key>", …) — the package's dispatch keys.
+				if regName != "" && pkg.Name == regName && se.Sel.Name == "Register" {
+					if bl, ok := v.Args[0].(*ast.BasicLit); ok && bl.Kind == token.STRING {
+						if s, uerr := strconv.Unquote(bl.Value); uerr == nil {
+							keysByDir[dir] = append(keysByDir[dir], s)
+						}
+					}
+					return true
+				}
+				if strName == "" || pkg.Name != strName {
+					return true
+				}
+				switch se.Sel.Name {
+				case "HasSuffix", "EqualFold":
+					for _, a := range v.Args {
+						if bl := resolve(a); bl != nil {
+							record(bl)
+						}
+					}
+				}
+			case *ast.BinaryExpr:
+				// `file.Path[len(file.Path)-8:] == ".feature"` and friends.
+				if v.Op != token.EQL && v.Op != token.NEQ {
+					return true
+				}
+				lb, rb := resolve(v.X), resolve(v.Y)
+				lok, rok := lb != nil, rb != nil
+				if lok && !rok {
+					record(lb)
+				}
+				if rok && !lok {
+					record(rb)
+				}
+			case *ast.CaseClause:
+				for _, e := range v.List {
+					if bl := resolve(e); bl != nil {
+						record(bl)
+					}
+				}
 			}
 			return true
 		})
@@ -232,6 +394,13 @@ func scanCustomGates(t *testing.T) (dead, live []gateSite, filesParsed int) {
 		t.Fatalf("walk %s: %v", customGateRoot, err)
 	}
 
+	for d := range dirsSeen {
+		if len(keysByDir[d]) == 0 {
+			keylessDirs = append(keylessDirs, filepath.ToSlash(d))
+		}
+	}
+	sort.Strings(keylessDirs)
+
 	for _, s := range all {
 		if gateIsReachable(s, keysByDir[filepath.Dir(s.file)]) {
 			live = append(live, s)
@@ -239,25 +408,101 @@ func scanCustomGates(t *testing.T) (dead, live []gateSite, filesParsed int) {
 			dead = append(dead, s)
 		}
 	}
-	return dead, live, filesParsed
+	return dead, live, filesParsed, keylessDirs
 }
 
-// pathShaped reports whether a HasSuffix/EqualFold subject is plausibly a file
-// path rather than file CONTENT. Gates read `file.Path`, a `path`/`rel`/`base`
-// local, or a lowercased copy of one; content checks read `src`/`line`.
-func pathShaped(subj string) bool {
-	for _, m := range []string{"Path", "path", "rel", "Rel", "base", "Base", "file", "File", "name", "Name", "ext", "Ext"} {
-		if strings.Contains(subj, m) {
-			return true
+// gateKey converts a walked path into the slash-form, root-relative key the
+// hand-written lists are written in. It is a pure function so the Windows
+// breakage can be pinned FROM ANY PLATFORM (see
+// TestGateKeyNormalisesWindowsPaths6978) — filepath.ToSlash is a no-op on
+// Unix, so a test built on it could not have caught this from the macOS or
+// Linux legs, which is precisely how the bug reached CI.
+//
+// The backslash replacement is unconditional rather than OS-dependent: a
+// backslash inside internal/custom/** would be a path separator on the only
+// platform that produces one, and no file in that tree has one in its name.
+func gateKey(walked string) (key string, problem string) {
+	slashed := strings.ReplaceAll(walked, "\\", "/")
+	prefix := strings.ReplaceAll(customGateRoot, "\\", "/") + "/"
+	key = strings.TrimPrefix(slashed, prefix)
+	switch {
+	case strings.ContainsRune(key, '\\'):
+		return key, "contains a backslash — it was not converted to slash form, so it can never match the hand-written lists"
+	case key == slashed:
+		return key, "still carries the " + customGateRoot + " prefix — the strip was a no-op"
+	}
+	return key, ""
+}
+
+// keyFor is gateKey with the failure wired to the test. Asserting the
+// normalisation rather than only the outcome is the point: a key that merely
+// happens to line up on the platform the author ran is one refactor away from
+// silently reverting.
+func keyFor(t *testing.T, walked string) string {
+	t.Helper()
+	key, problem := gateKey(walked)
+	if problem != "" {
+		t.Fatalf("key %q (from %q) %s", key, walked, problem)
+	}
+	return key
+}
+
+// TestGateKeyNormalisesWindowsPaths6978 pins the normalisation itself. The
+// windows-latest leg reported EVERY gate as new-unreachable and ALL FOUR
+// live-gate controls as not-found, because filepath.Walk yields
+// `..\custom\csharp\blazor.go` there and the prefix strip was written in
+// forward slashes — so it silently did nothing and both directions of the set
+// comparison failed at once.
+func TestGateKeyNormalisesWindowsPaths6978(t *testing.T) {
+	for _, tc := range []struct{ walked, want string }{
+		{"../custom/csharp/blazor.go", "csharp/blazor.go"},
+		{"..\\custom\\csharp\\blazor.go", "csharp/blazor.go"},
+		{"..\\custom\\javascript\\nuxt.go", "javascript/nuxt.go"},
+	} {
+		got, problem := gateKey(tc.walked)
+		if problem != "" {
+			t.Errorf("gateKey(%q) rejected its own input: %s", tc.walked, problem)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("gateKey(%q) = %q, want %q — a key that keeps an OS separator or a root prefix matches nothing in either direction", tc.walked, got, tc.want)
 		}
 	}
-	return false
+	// A path outside the root must be REPORTED, not silently passed through.
+	if _, problem := gateKey("../engine/foo.go"); problem == "" {
+		t.Error("gateKey accepted a path outside customGateRoot without reporting the no-op strip")
+	}
+}
+
+// localImportName returns the identifier a file refers to importPath by, or ""
+// when the file does not import it. Handles an explicit alias (`extreg "…"`),
+// the implicit package name, and a dot import (reported as "" — no selector
+// exists to match, and no file in this tree uses one).
+func localImportName(f *ast.File, importPath string) string {
+	for _, im := range f.Imports {
+		p, err := strconv.Unquote(im.Path.Value)
+		if err != nil || p != importPath {
+			continue
+		}
+		if im.Name != nil {
+			if im.Name.Name == "." || im.Name.Name == "_" {
+				return ""
+			}
+			return im.Name.Name
+		}
+		// No alias: the local name is the package's own name, which for every
+		// import in this tree is the final path segment.
+		return path.Base(p)
+	}
+	return ""
 }
 
 // extensionShaped reports whether a literal looks like a file extension rather
-// than a method-call or expression fragment (".route", ".Adapt<", ".cache.").
-// Extensions are a leading dot plus letters/digits, optionally compound
-// (".razor.cs", ".Build.cs").
+// than an expression fragment (".Adapt<", ".cache.", ".Handle("). Extensions
+// are a leading dot plus letters/digits, optionally compound (".razor.cs",
+// ".server.vue"). Method-name fragments like ".route" pass this test too —
+// they are adjudicated by hand into knownContentMatchLiterals rather than
+// filtered out by a heuristic on the subject expression.
 func extensionShaped(s string) bool {
 	if len(s) < 2 || s[0] != '.' {
 		return false
@@ -277,8 +522,8 @@ func extensionShaped(s string) bool {
 // extension decides it; CustomExtractorsFor is the real dispatch predicate.
 func gateIsReachable(s gateSite, dirKeys []string) bool {
 	if len(dirKeys) == 0 {
-		// A package registering nothing is out of this test's scope.
-		return true
+		// Reported separately as a scanner failure, not silently excused.
+		return false
 	}
 	lang := classifier.LanguageForExtension(s.lit)
 	if lang == "" {
@@ -305,7 +550,12 @@ func gateIsReachable(s gateSite, dirKeys []string) bool {
 
 func ids(sites []gateSite) []string {
 	out := make([]string, 0, len(sites))
+	seen := map[string]bool{}
 	for _, s := range sites {
+		if seen[s.id] {
+			continue
+		}
+		seen[s.id] = true
 		out = append(out, s.id)
 	}
 	sort.Strings(out)
@@ -315,16 +565,43 @@ func ids(sites []gateSite) []string {
 // TestCustomExtractorGatesAreReachable6978 fails when a NEW unreachable
 // extension gate appears in internal/custom/**, and when a listed one is
 // repaired or removed without updating the list.
+//
+// WHAT IT CANNOT SEE — stated because a guard presented as complete is a trap,
+// and each of these was scored ALIVE rather than assumed. The scan is
+// syntactic. It reaches a string literal in a strings.HasSuffix/EqualFold
+// call, an equality comparison, or a switch case, and it resolves an
+// identifier bound exactly once to a literal in the SAME FILE. It does NOT
+// see:
+//
+//   - a suffix built by concatenation (`"." + ext`) or returned by a function;
+//   - an identifier bound in another file of the package, or imported;
+//   - an identifier assigned more than once (deliberately dropped, not
+//     guessed);
+//   - `strings.Contains`, `HasPrefix`, a regexp, or a path-SEGMENT test — the
+//     lua `strings.Contains(ext, "nginx")` disjunct is exactly this shape, and
+//     it happens to be live;
+//   - a gate in a helper package outside internal/custom/**.
+//
+// Those remain writable in silence. What this test does guarantee is that the
+// shapes which produced all 26 known instances cannot grow a 27th without a
+// failure, and that no package is exempt from being asked.
 func TestCustomExtractorGatesAreReachable6978(t *testing.T) {
-	dead, live, filesParsed := scanCustomGates(t)
+	dead, live, filesParsed, keylessDirs := scanCustomGates(t)
 
 	if filesParsed < minFilesParsed {
 		t.Fatalf("scan parsed %d non-test files under %s, want >= %d — the walk read (almost) nothing",
 			filesParsed, customGateRoot, minFilesParsed)
 	}
 	if n := len(dead) + len(live); n < minGateLiterals {
-		t.Fatalf("scan found %d extension gate literals, want >= %d — the matcher recognised (almost) nothing",
+		t.Fatalf("scan found %d extension literals, want >= %d — the matcher recognised (almost) nothing",
 			n, minGateLiterals)
+	}
+	// Every internal/custom/<lang> package registers at least one extractor.
+	// A package that yields zero keys is a SCANNER bug (a registry import the
+	// alias resolution missed), never a real state of the tree — and left
+	// unreported it exempts that package from the whole test.
+	for _, d := range keylessDirs {
+		t.Errorf("package %s yielded zero extractor.Register keys — the scan cannot judge reachability there, so the package is silently exempt. This is a scanner bug (an unresolved registry import alias?), not a property of the tree.", d)
 	}
 
 	// Positive control: the scan must see, and correctly classify as LIVE,
@@ -341,25 +618,27 @@ func TestCustomExtractorGatesAreReachable6978(t *testing.T) {
 	}
 
 	got := ids(dead)
-	want := append([]string(nil), knownUnreachableGates...)
-	sort.Strings(want)
+	adjudicated := map[string]string{}
+	for _, w := range knownUnreachableGates {
+		adjudicated[w] = "gate"
+	}
+	for _, w := range knownContentMatchLiterals {
+		if adjudicated[w] != "" {
+			t.Errorf("%q is listed BOTH as an unreachable gate and as a content match — it can only be one", w)
+		}
+		adjudicated[w] = "content"
+	}
 
 	gotSet := map[string]bool{}
 	for _, g := range got {
 		gotSet[g] = true
-	}
-	wantSet := map[string]bool{}
-	for _, w := range want {
-		wantSet[w] = true
-	}
-	for _, g := range got {
-		if !wantSet[g] {
-			t.Errorf("NEW unreachable gate %q: no file matching this suffix can reach an extractor registered in that package, so the gate selects nothing, forever, in silence. Either route the language in customPrefixForLanguage (internal/extractors/custom_dispatch.go) or drop the gate — see #6978.", g)
+		if adjudicated[g] == "" {
+			t.Errorf("UNADJUDICATED unreachable literal %q: no file matching this suffix can reach an extractor registered in that package. If it is a file gate, it selects nothing, forever, in silence — route the language in customPrefixForLanguage (internal/extractors/custom_dispatch.go), or drop the gate, or list it in knownUnreachableGates. If it is matched against file CONTENT rather than a path, list it in knownContentMatchLiterals. See #6978.", g)
 		}
 	}
-	for _, w := range want {
+	for w, kind := range adjudicated {
 		if !gotSet[w] {
-			t.Errorf("listed unreachable gate %q is no longer detected as unreachable — if it was repaired or deleted, delete its line from knownUnreachableGates; if the SCAN stopped seeing it, that is the bug.", w)
+			t.Errorf("listed %s %q is no longer detected as unreachable — if it was repaired or deleted, delete its line from the list; if the SCAN stopped seeing it, that is the bug.", kind, w)
 		}
 	}
 }

--- a/internal/extractors/custom_gate_reachability_6978_test.go
+++ b/internal/extractors/custom_gate_reachability_6978_test.go
@@ -1,0 +1,365 @@
+package extractors_test
+
+// #6978 — a path gate inside a custom extractor can be UNREACHABLE BY
+// CONSTRUCTION, and when it is, it produces silence rather than an error.
+//
+// THE MECHANISM. RunCustomExtractors (custom_dispatch.go) is the ONLY
+// dispatcher that ever selects a prefixed custom-extractor key: ordinary
+// dispatch is an exact-key extractor.Get(file.Language) lookup
+// (registry.go:95), which can never match "custom_csharp_blazor". And
+// RunCustomExtractors selects purely on file.Language, via
+// CustomExtractorsFor. So a file reaches the extractors of package P if and
+// only if the classifier's language for that file maps — through
+// customPrefixForLanguage / extraCustomPrefixesForLanguage — to a registry
+// prefix one of P's keys carries.
+//
+// A gate that tests a file SUFFIX therefore selects nothing, forever, when the
+// classifier's language for that suffix routes somewhere else (or nowhere).
+// `strings.HasSuffix(file.Path, ".razor")` inside internal/custom/csharp is the
+// canonical case: `.razor` classifies as language "razor", "razor" has no
+// custom prefix, so no custom_csharp_* extractor can ever see such a file.
+//
+// The argument is CONSTRUCTIVE, not corpus-derived: it is a statement about
+// language routing, so it holds for every repo and every dispatch path. It is
+// deliberately independent of the `file.TSTree != nil` guard that the in-proc
+// (cmd/grafel/index.go:4179) and incremental (incremental.go:1126) paths carry
+// and the daemon subprocess path (subproc.go:364) does not — language routing
+// alone already decides these sites, in all three paths.
+//
+// WHY A GUARD RATHER THAN A FIX. The sites below are NOT one defect. Some are
+// unreachable code beside a live path (blazor_deep's `.razor` arm); some are a
+// whole capability that has never run (rust's diesel/sqlx `.sql` migration
+// parsing). Deleting them uniformly would throw away the second kind. This
+// test freezes the population so a NEW one cannot be written in silence.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/classifier"
+	"github.com/cajasmota/grafel/internal/extractors"
+)
+
+// customGateRoot is the tree scanned. Relative to this package's directory,
+// which is where `go test` runs.
+const customGateRoot = "../custom"
+
+// knownUnreachableGates is the frozen population of extension gates that
+// cannot fire, as `<pkg>/<file>|<enclosing func>|<literal>`.
+//
+// IT IS A HAND-WRITTEN LITERAL, deliberately not derived from the scan it
+// grades (#6975): a list built from the thing under test cannot detect an
+// addition to that thing. Set equality is asserted in BOTH directions, so
+// deleting or repairing a site requires deleting its line here too.
+//
+// Line numbers are omitted on purpose — they rot on every edit above the site,
+// and a guard that has to be re-baselined for unrelated edits gets re-baselined
+// without being read.
+var knownUnreachableGates = []string{
+	// `.xml` is classified as nothing at all, and `file.Language == "xml"`
+	// beside it names a language the classifier never emits. The `isCPP` arm
+	// of the same gate is live; only the XML alternative is dead.
+	"cpp/ros_extractor.go|Extract|.xml",
+	// `.Build.cs` classifies as "csharp", which routes to custom_csharp_ —
+	// not to custom_cpp_, where this extractor lives. The `file.Language ==
+	// "csharp"` disjunct beside it is dead for the same reason, so the whole
+	// isCSharp alternative is unreachable; isCPP is live.
+	"cpp/unreal_extractor.go|Extract|.Build.cs",
+	// `.razor` classifies as "razor" (classifier.go), and "razor" has no
+	// custom prefix. `.razor.cs` classifies as "csharp" and IS live, so both
+	// extractors still run — over code-behind only. In blazor.go this means
+	// the MARKUP rule set, which is further restricted to isRazorMarkup, has
+	// never run on any file.
+	"csharp/blazor.go|Extract|.razor",
+	"csharp/blazor_deep.go|Extract|.razor",
+	// SQLDelight `.sq`/`.sqm` are classified as nothing, so no FileInput with
+	// that path ever exists. The kotlin-language arm of both gates is live.
+	"kotlin/orm_query.go|Extract|.sq",
+	"kotlin/orm_query.go|Extract|.sqm",
+	"kotlin/orm_schema.go|isSQLDelightFile|.sq",
+	"kotlin/orm_schema.go|isSQLDelightFile|.sqm",
+	// `.moon` (MoonScript) is classified as nothing. `.conf` likewise, except
+	// the single basename `nginx.conf`, which classifies as language "nginx" —
+	// also without a custom prefix. The `strings.Contains(ext, "nginx")`
+	// disjunct beside these is NOT dead: it fires for a `.lua` file under an
+	// nginx/ directory.
+	"lua/middleware.go|Extract|.moon",
+	"lua/middleware.go|Extract|.conf",
+	"lua/routing.go|Extract|.moon",
+	"lua/routing.go|Extract|.conf",
+	// `.sql` classifies as "sql", which customPrefixForLanguage routes to
+	// custom_js_ ONLY. These three sites are whole branches, not disjuncts:
+	// ormin's SQL-DSL half, diesel's migration parser and sqlx's migration
+	// parser have never run outside their own unit tests.
+	"nim/ormin_orm.go|Extract|.sql",
+	"rust/diesel.go|Extract|.sql",
+	"rust/sqlx_rbatis.go|isSqlxMigrationFile|.sql",
+}
+
+// liveGateControls are gates in the SAME files that the scan must find and
+// must NOT report as dead. This is the positive control for the "read the
+// wrong file / matched nothing" no-op: if the scan is pointed at a tree that
+// parses fine but contains no gates, or its matcher stops recognising gate
+// shapes, these disappear and the test fails on them rather than passing
+// vacuously on an empty dead set.
+var liveGateControls = []string{
+	"csharp/blazor.go|Extract|.razor.cs",
+	"csharp/blazor_deep.go|Extract|.razor.cs",
+	"lua/middleware.go|Extract|.lua",
+	"lua/routing.go|Extract|.lua",
+}
+
+// minGateLiterals / minFilesParsed are floors on the scan's raw work. They
+// catch only the crudest no-op (read nothing), which is why the two set
+// assertions above carry the real weight.
+const (
+	minGateLiterals = 25
+	minFilesParsed  = 300
+)
+
+type gateSite struct {
+	id   string // "<pkg>/<file>|<func>|<literal>"
+	lit  string
+	file string
+	line int
+}
+
+// scanCustomGates walks internal/custom/** and returns every extension-shaped
+// literal tested against a path-shaped expression, split into unreachable and
+// reachable, plus the number of non-test files parsed.
+func scanCustomGates(t *testing.T) (dead, live []gateSite, filesParsed int) {
+	t.Helper()
+
+	keysByDir := map[string][]string{}
+	var all []gateSite
+
+	err := filepath.Walk(customGateRoot, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(p, ".go") || strings.HasSuffix(p, "_test.go") {
+			return nil
+		}
+		filesParsed++
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, p, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", p, perr)
+		}
+		var funcs []*ast.FuncDecl
+		for _, d := range f.Decls {
+			if fd, ok := d.(*ast.FuncDecl); ok {
+				funcs = append(funcs, fd)
+			}
+		}
+		enclosing := func(pos token.Pos) string {
+			for _, fd := range funcs {
+				if pos >= fd.Pos() && pos <= fd.End() {
+					return fd.Name.Name
+				}
+			}
+			return "<file-scope>"
+		}
+		rel := filepath.ToSlash(strings.TrimPrefix(p, customGateRoot+string(filepath.Separator)))
+		dir := filepath.Dir(p)
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			ce, ok := n.(*ast.CallExpr)
+			if !ok || len(ce.Args) == 0 {
+				return true
+			}
+			se, ok := ce.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, _ := se.X.(*ast.Ident)
+			if pkg == nil {
+				return true
+			}
+			// extractor.Register("<key>", …) — the package's dispatch keys.
+			if pkg.Name == "extractor" && se.Sel.Name == "Register" {
+				if bl, ok := ce.Args[0].(*ast.BasicLit); ok && bl.Kind == token.STRING {
+					if s, uerr := strconv.Unquote(bl.Value); uerr == nil {
+						keysByDir[dir] = append(keysByDir[dir], s)
+					}
+				}
+				return true
+			}
+			if pkg.Name != "strings" {
+				return true
+			}
+			switch se.Sel.Name {
+			case "HasSuffix", "EqualFold":
+			default:
+				return true
+			}
+			var subj strings.Builder
+			if perr := printer.Fprint(&subj, fset, ce.Args[0]); perr != nil {
+				t.Fatalf("print subject in %s: %v", p, perr)
+			}
+			if !pathShaped(subj.String()) {
+				return true
+			}
+			for _, a := range ce.Args[1:] {
+				bl, ok := a.(*ast.BasicLit)
+				if !ok || bl.Kind != token.STRING {
+					continue
+				}
+				s, uerr := strconv.Unquote(bl.Value)
+				if uerr != nil || !extensionShaped(s) {
+					continue
+				}
+				all = append(all, gateSite{
+					id:   rel + "|" + enclosing(bl.Pos()) + "|" + s,
+					lit:  s,
+					file: p,
+					line: fset.Position(bl.Pos()).Line,
+				})
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", customGateRoot, err)
+	}
+
+	for _, s := range all {
+		if gateIsReachable(s, keysByDir[filepath.Dir(s.file)]) {
+			live = append(live, s)
+		} else {
+			dead = append(dead, s)
+		}
+	}
+	return dead, live, filesParsed
+}
+
+// pathShaped reports whether a HasSuffix/EqualFold subject is plausibly a file
+// path rather than file CONTENT. Gates read `file.Path`, a `path`/`rel`/`base`
+// local, or a lowercased copy of one; content checks read `src`/`line`.
+func pathShaped(subj string) bool {
+	for _, m := range []string{"Path", "path", "rel", "Rel", "base", "Base", "file", "File", "name", "Name", "ext", "Ext"} {
+		if strings.Contains(subj, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// extensionShaped reports whether a literal looks like a file extension rather
+// than a method-call or expression fragment (".route", ".Adapt<", ".cache.").
+// Extensions are a leading dot plus letters/digits, optionally compound
+// (".razor.cs", ".Build.cs").
+func extensionShaped(s string) bool {
+	if len(s) < 2 || s[0] != '.' {
+		return false
+	}
+	for _, r := range s[1:] {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.':
+		default:
+			return false
+		}
+	}
+	return !strings.HasSuffix(s, ".")
+}
+
+// gateIsReachable reports whether any file matching the literal could reach an
+// extractor registered in the same package. The classifier's language for the
+// extension decides it; CustomExtractorsFor is the real dispatch predicate.
+func gateIsReachable(s gateSite, dirKeys []string) bool {
+	if len(dirKeys) == 0 {
+		// A package registering nothing is out of this test's scope.
+		return true
+	}
+	lang := classifier.LanguageForExtension(s.lit)
+	if lang == "" {
+		// Compound suffix: the classifier keys on the final extension, so
+		// ".razor.cs" is decided by ".cs".
+		if i := strings.LastIndex(s.lit, "."); i > 0 {
+			lang = classifier.LanguageForExtension(s.lit[i:])
+		}
+	}
+	if lang == "" {
+		return false // classified as nothing: no FileInput ever carries it
+	}
+	reachable := map[string]bool{}
+	for _, e := range extractors.CustomExtractorsFor(lang) {
+		reachable[e.Language()] = true
+	}
+	for _, k := range dirKeys {
+		if reachable[k] {
+			return true
+		}
+	}
+	return false
+}
+
+func ids(sites []gateSite) []string {
+	out := make([]string, 0, len(sites))
+	for _, s := range sites {
+		out = append(out, s.id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestCustomExtractorGatesAreReachable6978 fails when a NEW unreachable
+// extension gate appears in internal/custom/**, and when a listed one is
+// repaired or removed without updating the list.
+func TestCustomExtractorGatesAreReachable6978(t *testing.T) {
+	dead, live, filesParsed := scanCustomGates(t)
+
+	if filesParsed < minFilesParsed {
+		t.Fatalf("scan parsed %d non-test files under %s, want >= %d — the walk read (almost) nothing",
+			filesParsed, customGateRoot, minFilesParsed)
+	}
+	if n := len(dead) + len(live); n < minGateLiterals {
+		t.Fatalf("scan found %d extension gate literals, want >= %d — the matcher recognised (almost) nothing",
+			n, minGateLiterals)
+	}
+
+	// Positive control: the scan must see, and correctly classify as LIVE,
+	// gates that are known to fire. Without this a scan pointed at a tree with
+	// no gates in it reports an empty dead set and passes.
+	liveSet := map[string]bool{}
+	for _, id := range ids(live) {
+		liveSet[id] = true
+	}
+	for _, want := range liveGateControls {
+		if !liveSet[want] {
+			t.Errorf("live-gate control %q was not found as a REACHABLE gate — the scan is looking at the wrong files, or its matcher no longer recognises this gate shape", want)
+		}
+	}
+
+	got := ids(dead)
+	want := append([]string(nil), knownUnreachableGates...)
+	sort.Strings(want)
+
+	gotSet := map[string]bool{}
+	for _, g := range got {
+		gotSet[g] = true
+	}
+	wantSet := map[string]bool{}
+	for _, w := range want {
+		wantSet[w] = true
+	}
+	for _, g := range got {
+		if !wantSet[g] {
+			t.Errorf("NEW unreachable gate %q: no file matching this suffix can reach an extractor registered in that package, so the gate selects nothing, forever, in silence. Either route the language in customPrefixForLanguage (internal/extractors/custom_dispatch.go) or drop the gate — see #6978.", g)
+		}
+	}
+	for _, w := range want {
+		if !gotSet[w] {
+			t.Errorf("listed unreachable gate %q is no longer detected as unreachable — if it was repaired or deleted, delete its line from knownUnreachableGates; if the SCAN stopped seeing it, that is the bug.", w)
+		}
+	}
+}

--- a/internal/extractors/custom_gate_reachability_6978_test.go
+++ b/internal/extractors/custom_gate_reachability_6978_test.go
@@ -203,6 +203,11 @@ type gateSite struct {
 	lit  string
 	file string
 	line int
+	// subjectIsPath reports whether the expression the literal is compared
+	// AGAINST derives from the file's path. This is what tells a gate from a
+	// content match, and it is asserted rather than taken from the list —
+	// see the adjudication check in the test.
+	subjectIsPath bool
 }
 
 // scanCustomGates walks internal/custom/** and returns every extension-shaped
@@ -305,6 +310,122 @@ func scanCustomGates(t *testing.T) (dead, live []gateSite, filesParsed int, keyl
 			}
 			return true
 		})
+		// PATH TAINT. The same single-assignment bindings, kept as expressions
+		// rather than literals, plus the parameters that receive a
+		// path-derived argument at a call site IN THIS FILE. Every helper this
+		// matters for (isVueFile, isPlayRoutesFile, isSqlxMigrationFile) is
+		// called from the same file as its declaration; a cross-file caller is
+		// not followed, and the effect of missing one is a LOUD failure on the
+		// gate list, never a silent pass — see subjectVerdicts.
+		// A MAY-analysis, so an identifier assigned more than once keeps ALL
+		// its right-hand sides and is tainted if ANY of them is path-derived.
+		// (Literal resolution above is a MUST-analysis and drops such an
+		// identifier — the two questions want opposite polarities.) The
+		// bindings are file-scoped, so a name as ordinary as `fp` is bound in
+		// several functions at once; requiring a single binding here reported
+		// two genuine gates as content matches.
+		exprBind := map[string][]ast.Expr{}
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch d := n.(type) {
+			case *ast.ValueSpec:
+				for i, nm := range d.Names {
+					if i < len(d.Values) {
+						exprBind[nm.Name] = append(exprBind[nm.Name], d.Values[i])
+					}
+				}
+			case *ast.AssignStmt:
+				if len(d.Lhs) != len(d.Rhs) {
+					return true
+				}
+				for i, lhs := range d.Lhs {
+					if id, ok := lhs.(*ast.Ident); ok {
+						exprBind[id.Name] = append(exprBind[id.Name], d.Rhs[i])
+					}
+				}
+			}
+			return true
+		})
+		taintedParam := map[string]bool{}
+		var isPathExpr func(ast.Expr, map[ast.Expr]bool) bool
+		isPathExpr = func(e ast.Expr, seen map[ast.Expr]bool) bool {
+			if e == nil || seen[e] {
+				return false
+			}
+			seen[e] = true
+			switch v := e.(type) {
+			case *ast.SelectorExpr:
+				// file.Path / ctx.FilePath — the only two path sources a
+				// FileInput or a PatternContext offers.
+				if v.Sel.Name == "Path" || v.Sel.Name == "FilePath" {
+					return true
+				}
+				return isPathExpr(v.X, seen)
+			case *ast.Ident:
+				if taintedParam[v.Name] {
+					return true
+				}
+				for _, b := range exprBind[v.Name] {
+					if isPathExpr(b, seen) {
+						return true
+					}
+				}
+			case *ast.CallExpr:
+				// strings.ToLower(p), filepath.ToSlash(p), filepath.Base(p) …
+				// a wrapper is path-derived when any argument is.
+				for _, a := range v.Args {
+					if isPathExpr(a, seen) {
+						return true
+					}
+				}
+			case *ast.SliceExpr:
+				return isPathExpr(v.X, seen)
+			case *ast.IndexExpr:
+				return isPathExpr(v.X, seen)
+			case *ast.ParenExpr:
+				return isPathExpr(v.X, seen)
+			case *ast.BinaryExpr:
+				return isPathExpr(v.X, seen) || isPathExpr(v.Y, seen)
+			}
+			return false
+		}
+		// Fixpoint: a tainted argument taints the parameter, which can taint a
+		// binding, which can taint another argument. Three passes settle every
+		// chain in this tree; the loop stops early when nothing changes.
+		for pass := 0; pass < 3; pass++ {
+			changed := false
+			ast.Inspect(f, func(n ast.Node) bool {
+				ce, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				id, ok := ce.Fun.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				for _, fd := range funcs {
+					if fd.Name.Name != id.Name || fd.Type.Params == nil {
+						continue
+					}
+					pos := 0
+					for _, fl := range fd.Type.Params.List {
+						for _, nm := range fl.Names {
+							if pos < len(ce.Args) && !taintedParam[nm.Name] &&
+								isPathExpr(ce.Args[pos], map[ast.Expr]bool{}) {
+								taintedParam[nm.Name] = true
+								changed = true
+							}
+							pos++
+						}
+					}
+				}
+				return true
+			})
+			if !changed {
+				break
+			}
+		}
+		pathSubject := func(e ast.Expr) bool { return isPathExpr(e, map[ast.Expr]bool{}) }
+
 		// resolve returns the literal an expression denotes: itself when it is
 		// one, or its unique single-literal binding when it is an identifier.
 		resolve := func(e ast.Expr) *ast.BasicLit {
@@ -319,7 +440,7 @@ func scanCustomGates(t *testing.T) (dead, live []gateSite, filesParsed int, keyl
 			return nil
 		}
 
-		record := func(bl *ast.BasicLit) {
+		record := func(bl *ast.BasicLit, subject ast.Expr) {
 			if bl.Kind != token.STRING {
 				return
 			}
@@ -328,10 +449,11 @@ func scanCustomGates(t *testing.T) (dead, live []gateSite, filesParsed int, keyl
 				return
 			}
 			all = append(all, gateSite{
-				id:   rel + "|" + enclosing(bl.Pos()) + "|" + s,
-				lit:  s,
-				file: p,
-				line: fset.Position(bl.Pos()).Line,
+				id:            rel + "|" + enclosing(bl.Pos()) + "|" + s,
+				lit:           s,
+				file:          p,
+				line:          fset.Position(bl.Pos()).Line,
+				subjectIsPath: pathSubject(subject),
 			})
 		}
 
@@ -360,10 +482,21 @@ func scanCustomGates(t *testing.T) (dead, live []gateSite, filesParsed int, keyl
 				}
 				switch se.Sel.Name {
 				case "HasSuffix", "EqualFold":
-					for _, a := range v.Args {
-						if bl := resolve(a); bl != nil {
-							record(bl)
+					// The subject is the OTHER operand: HasSuffix(subject,
+					// lit) and EqualFold in either order.
+					for i, a := range v.Args {
+						bl := resolve(a)
+						if bl == nil {
+							continue
 						}
+						var subject ast.Expr
+						for j, o := range v.Args {
+							if j != i {
+								subject = o
+								break
+							}
+						}
+						record(bl, subject)
 					}
 				}
 			case *ast.BinaryExpr:
@@ -374,15 +507,25 @@ func scanCustomGates(t *testing.T) (dead, live []gateSite, filesParsed int, keyl
 				lb, rb := resolve(v.X), resolve(v.Y)
 				lok, rok := lb != nil, rb != nil
 				if lok && !rok {
-					record(lb)
+					record(lb, v.Y)
 				}
 				if rok && !lok {
-					record(rb)
+					record(rb, v.X)
 				}
-			case *ast.CaseClause:
-				for _, e := range v.List {
-					if bl := resolve(e); bl != nil {
-						record(bl)
+			case *ast.SwitchStmt:
+				// Handled at the switch, not the case, so the tag — which is
+				// the subject — is in scope. A tagless `switch { case … }`
+				// carries its comparisons inside the case expressions and is
+				// picked up by the branches above.
+				for _, st := range v.Body.List {
+					cc, ok := st.(*ast.CaseClause)
+					if !ok {
+						continue
+					}
+					for _, e := range cc.List {
+						if bl := resolve(e); bl != nil {
+							record(bl, v.Tag)
+						}
 					}
 				}
 			}
@@ -548,6 +691,17 @@ func gateIsReachable(s gateSite, dirKeys []string) bool {
 	return false
 }
 
+// subjectVerdicts aggregates, per id, whether ANY site behind that id compares
+// its literal against a path-derived expression. A gate must have one; a
+// content match must not.
+func subjectVerdicts(sites []gateSite) map[string]bool {
+	out := map[string]bool{}
+	for _, s := range sites {
+		out[s.id] = out[s.id] || s.subjectIsPath
+	}
+	return out
+}
+
 func ids(sites []gateSite) []string {
 	out := make([]string, 0, len(sites))
 	seen := map[string]bool{}
@@ -627,6 +781,39 @@ func TestCustomExtractorGatesAreReachable6978(t *testing.T) {
 			t.Errorf("%q is listed BOTH as an unreachable gate and as a content match — it can only be one", w)
 		}
 		adjudicated[w] = "content"
+	}
+
+	// THE ADJUDICATION IS CHECKED AGAINST A PROPERTY, NOT TAKEN ON TRUST.
+	// Membership alone cannot tell the two lists apart: `adjudicated[g] != ""`
+	// is satisfied identically by either, so moving a genuine dead gate into
+	// knownContentMatchLiterals used to pass — and the failure message above
+	// invites exactly that edit by offering both lists without a way to
+	// choose. The lists mean different things (`gate` = a defect or latent
+	// capability someone must look at; `content` = a false positive to
+	// ignore), so a misfile does not mislabel a finding, it RETIRES it. The
+	// scan already knows the subject expression — that is how the two content
+	// entries were identified as matching against a parsed `receiver` rather
+	// than a path — so the difference is asserted here.
+	//
+	// Direction of error: a path-derived subject the taint analysis fails to
+	// recognise makes the GATE list fail loudly (a listed gate reported as
+	// having a non-path subject). It cannot turn into a silent pass.
+	subjectPath := subjectVerdicts(dead)
+	for _, w := range knownUnreachableGates {
+		if _, seen := subjectPath[w]; !seen {
+			continue // reported by the reverse-direction check below
+		}
+		if !subjectPath[w] {
+			t.Errorf("%q is listed as an unreachable GATE but its literal is not compared against a path-derived expression. Either it is a content match in the wrong list (move it to knownContentMatchLiterals), or the path taint failed to follow the subject — which is a scanner bug.", w)
+		}
+	}
+	for _, w := range knownContentMatchLiterals {
+		if _, seen := subjectPath[w]; !seen {
+			continue
+		}
+		if subjectPath[w] {
+			t.Errorf("%q is listed as a CONTENT MATCH but its literal IS compared against a path-derived expression, so it is a file gate. Listing a real gate here retires a live finding into the ignore bucket, which is the failure this whole test exists to prevent. Move it to knownUnreachableGates.", w)
+		}
 	}
 
 	gotSet := map[string]bool{}


### PR DESCRIPTION
#6978 asked for **the enumeration** — one dead gate is a curiosity; the class is the finding. Derived from the classifier and the dispatch map, **not hand-listed**: the population is **26 unreachable gate literals across 15 files in 8 language packages**, plus 2 extension-shaped literals adjudicated as content matches.

> **Revised after review** ([review](https://github.com/cajasmota/grafel/pull/6995#issuecomment-review), REQUEST-CHANGES). The first revision said 15. It was **under-inclusive in two independent ways**, both real, and its two new comments asserted something the suite already contradicted. All of it is fixed below, and **every number in this body was re-measured against the current scanner, not carried over.**

Measured in `.../scratchpad/impl-6978-q9x4v/wt`, macOS/APFS, on `2d6c82ba8`.

## The criterion is LANGUAGE ROUTING, not `TSTree`

The issue's chain routes through `TSTree == nil`. That is true but **not the load-bearing step** — the reviewer verified all three call sites independently and reached the same conclusion:

- `internal/daemon/extract/subproc.go:364` calls `RunCustomExtractors` with **no `TSTree != nil` guard** (the per-file loop simply continues when `parser.Parse` errors). Only the in-proc (`cmd/grafel/index.go:4179`) and incremental (`incremental.go:1126`) paths carry it.
- Conversely `.sql` **has** a grammar, so `TSTree` is non-nil, and three `.sql` gates are dead anyway.

The step that actually decides it: `RunCustomExtractors` is the **only** dispatcher that selects a prefixed custom key (ordinary dispatch is an exact-key `Get(file.Language)` at `registry.go:95`, which cannot match `custom_csharp_blazor`), and it selects **purely on `file.Language`** via `CustomExtractorsFor`. So:

> A suffix gate in package `P` is unreachable **iff** the classifier's language for that suffix does not route to a prefix any of `P`'s registered keys carries.

Path-independent, repo-independent, **constructive**. **No corpus number appears in this PR.** The one zero I state is labelled as corpus-relative.

## What the review changed

| | was | now |
|---|---|---|
| **H1** — `extractor.Register` matched the **identifier** `extractor` | `internal/custom/javascript` (34 registrations) and `internal/custom/java` (7) import it as `extreg` ⇒ zero keys ⇒ `gateIsReachable` returned `true` for an empty key set. **Two whole packages silently exempt** | the scan resolves the import **alias** per file, and a scanned package yielding **zero keys is a FAILURE**, not an excused skip. Every `internal/custom/<lang>` package registers something, so zero is only ever a scanner bug |
| **H2** — `pathShaped()` was a marker list of subject NAMES | dropped every gate whose subject was `low` / `lower` / `fp`; `php/di_graph.go` was invisible **inside a package the scan covered** | the subject filter is **deleted, not extended**. It was the same hand-picked-enumeration failure the derivation exists to avoid |
| **Polarity** | a candidate the filter dropped disappeared silently | **fail-closed**: every extension-shaped literal is a candidate, and every unreachable one must be adjudicated by hand into `knownUnreachableGates` **or** `knownContentMatchLiterals`. Unlisted ⇒ FAIL |
| **Shapes seen** | `strings.HasSuffix`/`EqualFold` only | + equality comparisons (which is how `php/test_data.go`'s `.feature` slice compare surfaces), + `switch` cases, + an identifier bound exactly once to a literal in the same file |
| **Population** | 15 | **26 gates + 2 content matches** |
| **blazor comments** | "routing `razor` to `custom_csharp_` is what would make these rules run" | **false, and contradicted `blazor.go`'s own comment 20 lines above.** Corrected — see below |
| **"The near-miss landed halfway"** | a heading | **dropped.** See "blazor is latent capability" |
| **Windows** | `test (windows-latest)` RED on `acc936aa3` | fixed and pinned — see below |

## The Windows failure, and why it belongs in this PR

`test (windows-latest)` was red on the first revision, and the failure was the **guard**, not the code it guards. `filepath.Walk` yields `..\custom\csharp\blazor.go` on Windows; the prefix strip was written in forward slashes, so it was a **silent no-op**, every key kept a `../custom/` prefix the hand-written lists do not have, and **both directions of the set comparison failed at once** — every gate reported as new, all four live-gate controls reported as missing.

Two things beyond making it pass:

1. **The normalisation is asserted, not just the outcome.** `gateKey` is a pure function; it reports a key that still contains a backslash, and a strip that did nothing. A key that merely lines up on the author's platform is one refactor from reverting.
2. **It is pinned from any platform.** `filepath.ToSlash` is a **no-op on Unix**, so a test built on it could not have caught this from the macOS or Linux legs — which is exactly how the bug reached CI. `gateKey` replaces backslashes unconditionally, and `TestGateKeyNormalisesWindowsPaths6978` feeds it a literal `..\custom\csharp\blazor.go`. **Scored: reverting `gateKey` to the pre-fix `ToSlash`-then-strip makes that test RED on macOS** (W1 below).

Worth recording rather than fixing quietly: this PR is *about* gates that select nothing because of a path-shaped assumption, and it shipped one. That is evidence the class is easy to fall into, not an aside. No `ci:full` was added — the Windows leg runs by default and caught it.

## The enumeration — 26 sites

| site | literal | whole gate or one disjunct? | why unreachable | anything else break if removed? |
|---|---|---|---|---|
| `cpp/ros_extractor.go` `Extract` | `.xml` | **whole alternative** (`isXML`); `isCPP` live | `.xml` classifies as **nothing**; `file.Language == "xml"` beside it names a language the classifier never emits | no — ROS `package.xml` manifests are simply not parsed |
| `cpp/unreal_extractor.go` `Extract` | `.Build.cs` | **whole alternative** (`isCSharp`); `isCPP` live | `.cs` → `csharp` → `custom_csharp_`, not `custom_cpp_` | no |
| `csharp/blazor.go` `Extract` | `.razor` | **one disjunct** — but it gates the entire markup rule set | `.razor` → language `razor`, no custom prefix | no; `.razor.cs` keeps the two code rules alive |
| `csharp/blazor_deep.go` `Extract` | `.razor` | **one disjunct** | same | no |
| `javascript/vue.go` `isVueFile` | `.vue` | **one disjunct** | `.vue` → language `vue`, no custom prefix | no — `lang != "typescript" && lang != "javascript" && !vueFile` keeps the ts/js arm live |
| `javascript/svelte.go` `Extract` | `.svelte` | **one disjunct** | `.svelte` → `svelte`, no prefix | no — identical shape to vue.go |
| `javascript/nuxt.go` `Extract` | `.vue`, `.server.vue`, `.client.vue` | **three disjuncts** | same | no — `.server.ts`/`.client.ts`/`.js` arms are live, and `.vue` only feeds `isPagesFile` beside a live `isServerAPI` |
| `java/play_routes.go` `isPlayRoutesFile` | `.routes` | **one disjunct** | `.routes` → `scala` → `custom_scala_`; this is `custom_java_patterns` | no — falls through to a live source-marker path |
| `java/struts_routes.go` `ExtractStruts`, `extractStrutsRequestValidation` | `.xml` ×2 | **one disjunct / one branch** | `.xml` classifies as nothing; and the adapter stamps `ctx.Language` `"java"` literally, so `ctx.Language != "java"` rejects it a second time | no |
| `kotlin/orm_query.go` `Extract` | `.sq`, `.sqm` | **one disjunct** (`isSq`) | SQLDelight extensions classify as **nothing** | no; the `language == "kotlin"` arm is live |
| `kotlin/orm_schema.go` `isSQLDelightFile` | `.sq`, `.sqm` | **first branch** | same | no; the kotlin-import branch is live |
| `lua/middleware.go`, `lua/routing.go` `Extract` | `.moon`, `.conf` ×2 each | **two disjuncts each** | `.moon` classifies as nothing; `.conf` too, except basename `nginx.conf` → language `nginx`, also without a prefix | no — and `strings.Contains(ext, "nginx")` beside them is **live**: it fires for a `.lua` file under `nginx/` |
| `nim/ormin_orm.go` `Extract` | `.sql` | **whole branch** | `.sql` → `sql` → `custom_js_` **only** | removing it deletes ormin's SQL-DSL half outright |
| `rust/diesel.go` `Extract` | `.sql` | **whole branch** | same | removing it deletes `extractSQLMigration` outright |
| `rust/sqlx_rbatis.go` `isSqlxMigrationFile` | `.sql` | **whole predicate** — always `false` in production | same | same |
| `php/di_graph.go` `Extract` | `.yaml`, `.yml` | **whole branch** | `.yaml` → `yaml`, no custom prefix; `di_graph.go` has **no language guard**, so routing alone decides it | removing it deletes the Symfony `services.yaml` DI alias→implementation `BINDS` edges outright |
| `php/test_data.go` `Extract` | `.feature` | **whole predicate** | `.feature` classifies as nothing | removing it deletes Behat feature-file handling |

Adjudicated as **content matches**, not gates: `javascript/inngest.go`'s `.inngest` and `.step`, both matched against a `receiver` identifier parsed out of the source. Extension-shaped by coincidence.

**The distinction the issue asked for**, and I checked it at each site rather than inheriting it — the review's summary called `vue.go`/`svelte.go` whole gates; they are disjuncts beside a live ts/js arm, and the difference is exactly the bug-vs-tidy-up line:

- **19 are unreachable code beside a working path** — a tidy-up. What is unreachable in the Vue/Svelte/Nuxt case is SFC-specific extraction (the `<template>` half), not the extractors.
- **5 are latent capability** — diesel/sqlx migration parsing, ormin's SQL DSL, php's Symfony DI graph, php's Behat handling: written, unit-tested, and never run on a real index. Each of the five is exercised **only** by a direct-call unit test, which is what creates the impression of coverage.

A blanket "delete unreachable gates" rule would destroy the second group. **This PR deletes nothing.**

**One zero, labelled.** `.razor.cs` is claimed live by routing (`.cs` → `csharp` → `custom_csharp_`), not by a corpus hit — #6975 measured **zero** `.razor.cs` files across `archigraph-corpora`. That is a corpus-relative zero and says nothing about reachability.

## blazor is latent capability, not a regression #6977 introduced

The first revision's heading "the near-miss landed halfway" is **dropped**. Pre-#6977 `blazor.go` had no file gate, so its markup rules ran over every `.cs` file; #6977 measured the five `@`-directive rules at **zero** matches in `.cs`, and the component-tag rule's `.cs` output as false positives. No `.razor` file has ever reached either extractor on any path. So **nothing that ever produced a true positive was lost** — #6977 removed measured false positives and left a capability that could not fire before it either. The "avoided" record stands.

## What would have to become true — all three conditions, not one

Both new comments originally said routing would be enough. **It would not**, and `blazor.go`'s own pre-existing comment ~20 lines above already said so — the new comment contradicted it in the same function, which is this PR's own defect class written into its fix. Corrected at both sites and here:

- **`.razor`** needs **three** changes, in order: (1) an entry routing `"razor"` to `custom_csharp_` in `customPrefixForLanguage`; (2) the `file.Language != "csharp"` guard widened — it rejects the file a second time and is **deliberately pinned** by `TestBlazorLanguageGuardRejectsNonCSharp6975`; (3) a razor tree-sitter grammar, for the two dispatch paths that also require `TSTree != nil`. Routing alone would light up nothing.
- **`.sql` → rust/nim** needs **prefix routing only**: `sql` has a grammar and those extractors have no language guard on that branch. Cheapest of the set, and the one with real output behind it.
- **`.vue` / `.svelte`** need a prefix entry for `vue`/`svelte`, plus the ts/js language checks widened at each site — same two-part shape as razor, minus the grammar (they would still need one for the two `TSTree` paths).
- **`.yaml` → php** needs prefix routing only — `di_graph.go` has no language guard at all.
- **`.sq` / `.sqm` / `.moon` / `.xml` / `.feature`** need a **classifier** entry first; they name no language today.

Follow-ups are filed rather than bundled: #6996 (`.sql` routing) and #6997 (the three dispatch sites disagree on the `TSTree` guard). Routing changes graph output for whole ecosystems and is a measured decision, not a side effect of an enumeration PR.

## The guard

`internal/extractors/custom_gate_reachability_6978_test.go`. AST-scans `internal/custom/**`, resolves each file's registry import **alias** to read that package's `Register` keys, and asks the **real dispatch predicate** — `classifier.LanguageForExtension` + `extractors.CustomExtractorsFor` — whether any file matching each literal could reach any of them.

Both lists are **hand-written literals** keyed `pkg/file.go|func|literal`, per #6975: not derived from the scan they grade, no line numbers (they rot), set equality **in both directions**, so repairing a site requires deleting its line.

**Two design choices worth stating, because the cheaper version of each was available and wrong:**

- **The `pathShaped` name allowlist was deleted, not extended.** Adding `low`/`lower`/`fp` to it would have made the reviewer's M2 pass while leaving the mechanism — a hand-picked list of subject names, silently dropping whatever it did not anticipate — which is the exact failure the derivation exists to avoid. Deleting it made the scan fail-closed instead.
- **A zero-key package is a FAILURE, not an excused skip.** That branch is what hid `javascript` and `java`: an empty key set read as "out of scope" and returned reachable. Turning it into an assertion closed the hole at the precise point that concealed it — and it is the check most likely to be silently inert, so it is scored (**N5**, 21 keyless-package failures; and the reviewer's K1 independently confirmed it fires and names the package).

### The adjudication is checked against a property, not taken on trust

The reviewer's **CM-1** moved a genuine dead gate — `csharp/blazor.go|Extract|.razor` — out of `knownUnreachableGates` and into `knownContentMatchLiterals`, and the test **passed**. `adjudicated[g] != ""` is satisfied identically by either list; the duplicate check catches an entry in *both*, the reverse-direction check catches one in *neither*, and nothing checked an entry was in the **right** one.

It is reachable in the only sense that matters for a guard: **the failure message invites the edit** — it names both lists and gives no way to choose — and someone facing a red build picks one. The misfile is not cosmetic: `gate` means *a defect or latent capability someone should look at*, `content` means *a false positive to ignore*, so filing a gate as content does not mislabel a finding, it **retires it, permanently and silently**. That is this PR's own failure mode, reproduced inside its guard.

The scan already knows the subject expression — that is how the two content entries were identified as matching against a parsed `receiver` rather than a path — so the difference is now **asserted**: a gate's literal must be compared against a path-derived expression; a content match's must not.

Path taint is a **may-analysis** over single-file bindings, plus parameters that receive a path-derived argument at a same-file call site (`isVueFile`, `isPlayRoutesFile`, `isSqlxMigrationFile` — every helper this matters for is called from its own file). **Its polarity is the point:** taint that fails to follow a subject makes the **gate** list fail loudly ("listed as a gate but its subject is not path-derived"); it cannot become a silent pass. Requiring a *single* binding first reported two genuine gates as content matches, because `fp` is bound in several functions of one file — literal resolution wants MUST, taint wants MAY, and using one polarity for both was wrong.


### What it cannot see — stated because a guard presented as complete is a trap

Each was **scored ALIVE**, not assumed. The scan reaches a literal in `strings.HasSuffix`/`EqualFold`, an equality comparison, or a `switch` case, and resolves an identifier bound **exactly once** to a literal **in the same file**. It does **not** see: a suffix built by concatenation or returned by a function; an identifier bound in another file or imported; an identifier assigned more than once (dropped, not guessed); `strings.Contains`/`HasPrefix`/a regexp/a path-**segment** test — the lua `Contains(ext, "nginx")` disjunct is exactly this shape, and it happens to be live; or a gate in a helper package outside `internal/custom/**`.

What it does guarantee: the shapes that produced all 26 instances cannot grow a 27th without a failure, and **no package is exempt from being asked**.

### Mutants — 13 scored, 13 DEAD

Every mutant the reviewer scored ALIVE — M1/M2/M3 in round 2, CM-1 in round 3 — was re-scored against the current revision, plus controls for each failure mode the fixes introduced.

| | mutant | verdict |
|---|---|---|
| **M1** | dead `.razor` gate in `javascript/vue.go` `isVueFile` — the `extreg` alias package (was **ALIVE**) | **DEAD** — names the exact site |
| **M2** | dead `.razor` gate in `php/laravel.go` with subject `low := strings.ToLower(file.Path)` (was **ALIVE**) | **DEAD** |
| **M3** | `const razorSuffix = ".razor"` + `HasSuffix(file.Path, razorSuffix)` in `kotlin/orm_query.go` (was **ALIVE**) | **DEAD** — same-file constant resolution added; it was cheaper to close than to document |
| **N1** | add a NEW dead gate (`.templ` in `custom/golang/nethttp.go`) | **DEAD** |
| **N1b** | add a **live** gate (`.go`, same site, same shape) | **PASSES** — the guard discriminates on reachability, not on "any new `HasSuffix`" |
| **N2b** | repoint `customGateRoot` at `../extractors` — 311 non-test files, parses fine, clears the file floor | **DEAD** via 4 live-gate controls + 28 reverse-direction failures. This is the "reads the wrong file" no-op a count floor does not catch |
| **N3** | repair a listed site (delete `blazor_deep`'s `.razor` disjunct) without delisting | **DEAD** — reverse direction |
| **N4** | `gateIsReachable` always returns `true` (match, then do not act) | **DEAD** |
| **N5** | point `registryImportPath` at a non-existent package — simulating exactly the H1 alias-resolution failure | **DEAD**, 21 keyless-package failures. Under the old code this was **silent** |
| **W1** | revert `gateKey` to the pre-fix `filepath.ToSlash`-then-strip | **DEAD on macOS** — the Windows bug is now catchable from a Unix leg |
| **CM-1** | move a real gate (`csharp/blazor.go` `.razor`) into `knownContentMatchLiterals` (was **ALIVE**) | **DEAD** — fails on the subject being path-derived |
| **CM-2** | the opposite misfile: a content match (`inngest` `.step`) listed as a gate | **DEAD** |
| **CM-3** | pin every subject verdict to `false` | **DEAD** on all **26** gates — the gate branch is not inert |
| **CM-4** | pin every subject verdict to `true` | **DEAD** on both content entries — the content branch is not inert |

Each edit proven to land with an exact occurrence count (`assert s.count(old)==1` before replacing, then `grep -c` on the result) and the enclosing function named; `go vet` on the touched package before scoring; every restore `cp` from a shasum-verified backup, **never `git checkout`**, with `git status --porcelain` checked afterwards.

**One restore trap worth recording:** restoring `blazor_deep.go` from a backup taken *before* the round-1 comment landed silently reverted that committed comment. `shasum` matched the backup and said nothing — `git diff` against HEAD is what caught it, which is why the check is against HEAD and not against the backup.

## Verification

- `go test -count=1` green: `internal/extractors` (37.1s), `internal/custom/csharp`, `internal/custom/javascript`, `internal/custom/java`, `internal/custom/php`.
- **`./cmd/grafel/`** with a **fresh isolated** `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT` and `GOMAXPROCS=3`: **ok, exit 0, 175.8s**. Run after the last non-test source edit; every later change is inside `internal/extractors`' `_test.go`, which `cmd/grafel` does not compile.
- **Golden ratchet** (`scripts/quality/run.sh --ratchet`, its own fresh isolated home, `GOMAXPROCS=3`): **38 gated fixtures held their baseline, 29 at 100% must-have recall**, exit 0. **No baseline was regenerated** — the only non-test edits in this PR are comments, so a moved baseline would itself have been the bug.
- `gofmt -l` clean, `go vet` clean. Round 3 touches one `_test.go` in `internal/extractors` and nothing else (`git diff HEAD` against the round-2 commit), so the `cmd/grafel` and ratchet runs above still hold.
- No corpus index was run: another agent was indexing django on the same box, and the question is answerable by construction.

Closes #6978
Refs #6975, #6977, #6973, #6966, #6996, #6997

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
