### PR TITLE
feat(#6912): rust fields carried their declared type only as a property and in the Signature — emit the field→type REFERENCES edge, same-file targets only

### DIFF
--- a/internal/extractors/rust/field_type_refs.go
+++ b/internal/extractors/rust/field_type_refs.go
@@ -1,0 +1,287 @@
+package rust
+
+import (
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// field_type_refs.go — the field→declared-type edge for Rust (issue #6912,
+// arm C; arm A is internal/extractors/csharp/field_type_refs.go (#6984), arm B
+// internal/extractors/proto/field_type_refs.go (#6991)).
+//
+// WHAT RUST ALREADY HAD, ASKED THE WAY ARM B TAUGHT US TO ASK IT. #6912's body
+// says no core extractor emits this edge; that sentence has now been corrected
+// twice, so the question this arm answered FIRST is arm B's: is the FIELD
+// record the anchor of some existing type edge, or is something else? For Rust
+// the answer is NEITHER. Every relationship this package produces was
+// enumerated (struct_fields.go:224 and rust.go:156/208/294/552/918):
+//
+//	struct/enum → field         CONTAINS   (attachRustFieldContains, #4854)
+//	trait/impl  → method        CONTAINS   (#144)
+//	operation   → callee        CALLS      (#616)
+//	file        → module        IMPORTS
+//	trait       → supertrait    EXTENDS
+//
+// None of them carries a field's declared type at any anchor — unlike protobuf,
+// where buildMessage already wired the MESSAGE and left the field a leaf. So
+// this arm ADDS the relation rather than duplicating an anchor: there is no
+// existing topology to preserve, and nothing to double-count against. The type
+// was retained only as the `field_type` PROPERTY and inside the Signature
+// ("<type> <wire>"), which is exactly the shape #6912 describes: `Order.buyer`
+// knows it is a `Customer` and the graph cannot answer "which fields point at
+// Customer?".
+//
+// VOCABULARY AND ADDRESS ARE INHERITED, NOT RE-DECIDED. Kind REFERENCES with
+// the property `ref_kind: "field_target_type"` — the custom lane's spelling in
+// five languages (`referencesClassEdge`), adopted by arms A and B. `TYPED_AS`
+// and `HAS_TYPE` were DELETED in #6992 precisely so a third spelling could not
+// be minted. The address is the structural, file-scoped
+// extractor.BuildComponentStructuralRef("rust", <file>, <Name>) —
+// `scope:component:class:rust:<file>:<Name>` — and NOT the custom lane's
+// `Class:<Name>`, which #6986 measured at 91.6% dangling because the bare-name
+// resolver tier goes AMBIGUOUS as soon as a second file declares the same name
+// (`Config`, `Error`, `Client` in any Rust workspace). Post-resolution the ToID
+// is the target entity's ID, so no query sees the dialect. There is ONE address
+// dialect on this arm, not arm A's two: a Rust `enum Foo` is a SCOPE.Component
+// (subtype "enum"), so it takes the same component address as a struct. The
+// separate SCOPE.Enum value-set nodes emitted by emitRustConstValueSets (#4431)
+// are a parallel population and are deliberately NOT targeted — targeting both
+// would put two edges on one field for one declaration.
+//
+// A NON-BINDING EDGE IS WORSE THAN NO EDGE. An unresolved stub is kept verbatim
+// and dangling and classified `bug-extractor`; there is no masking branch and
+// no drop pass, so every miss is a full hit and each emitted edge adds one
+// endpoint to the disposition denominator (#6906). The edge is therefore
+// emitted ONLY where the named type is DECLARED IN THE SAME FILE — the single
+// condition a pass-1 per-file extractor can verify. That one check is what
+// drops `String`, `HashMap`, `serde_json::Value` and every unmodelled name.
+//
+// WHAT THE CHECK IS NOT.
+//
+//   - IT IS NOT A PRIMITIVE BLOCKLIST, AND IT DOES NOT NEED ONE — this is the
+//     one guard arm B had to keep, and the reason Rust does not is a property
+//     of the grammar rather than of our corpus. In tree-sitter-rust, a
+//     primitive in TYPE POSITION is the node kind `primitive_type`, never
+//     `type_identifier`, at every depth: `i32`, `Vec<u8>`, `Box<str>`,
+//     `(Order, i32)`, `fn(Order) -> u8`. rustTypeRefCandidates collects
+//     `type_identifier` only, so no primitive is ever a candidate and there is
+//     nothing for a blocklist to catch. arm B's counter-example was
+//     CONSTRUCTED here rather than argued away (`struct i32;` beside a field
+//     `x: i32`, for all 16 primitive names): the shadowing struct IS in the
+//     in-file target set, and the field still yields no candidate because the
+//     grammar tokenised its type as `primitive_type`. If rustc resolves such a
+//     shadow to the struct, this pass MISSES an edge — the safe direction, a
+//     miss never dangles — where proto's missing blocklist EMITTED one protoc
+//     denies. Enumerated per member by
+//     TestRustFieldTypeRefs_EveryPrimitiveShadowedByASameFileStructProducesNoEdge.
+//
+//     The first cut of this arm ALSO carried explicit `primitive_type`,
+//     `lifetime` and `scoped_identifier` skip cases in rustTypeRefCandidates,
+//     and they were deleted after a mutant showed the primitive one to be
+//     INERT rather than redundant-but-live: all three node kinds are either
+//     leaf tokens or carry only `identifier` children, so the collector
+//     returns nothing for them whether the case is present or not. That is a
+//     stronger claim than arm B's deleted blocklist could make — it does not
+//     rest on "our corpus has no such file" — and it was checked in both
+//     directions anyway: the deletion leaves every fixture green AND leaves
+//     the corpus counts below byte-identical over 789 real .rs files. The one
+//     case that is LIVE, `scoped_type_identifier`, is kept and is graded by
+//     TestRustFieldTypeRefs_QualifiedPathIsNotStrippedToASameFileName.
+//
+//   - IT IS FILE SCOPE AND NOTHING ELSE. It consults neither Rust's module
+//     scope nor type-parameter scope, so it over-fires twice, and both
+//     over-fires produce an edge that BINDS — worse than a dangling edge,
+//     because `bug-extractor` never sees a bound edge:
+//
+//     mod a { pub struct Customer; }
+//     mod b { pub struct Order { buyer: Customer } }   ← one file: WRONG edge
+//     struct Box<Order> { item: Order }                ← beside a same-file
+//     struct Order: WRONG
+//
+//     So an open type parameter `T` is dropped only because nothing in the file
+//     happens to be named `T`, NOT because the guard understands type
+//     parameters. Both are PINNED as known-wrong by the two
+//     TestRustFieldTypeRefs_KnownOverFire_* cases, which a fix is expected to
+//     break.
+//
+//   - IT DOES NOT DESCEND A QUALIFIED PATH. `crate::models::Order`,
+//     `super::Order`, `self::Order` and `<Order as Trait>::Assoc` are
+//     `scoped_type_identifier` and are skipped WHOLE — the trailing segment is
+//     never taken. Writing `crate::other::Order` in a file that also declares
+//     its own `Order` names the OTHER type, and stripping to the last segment
+//     would bind the edge to the wrong entity, silently. Arm B carries a
+//     forbidden row named for exactly that mutation; so does this arm
+//     (TestRustFieldTypeRefs_QualifiedPathIsNotStrippedToASameFileName).
+//
+//   - THE WRAPPER IS NEVER THE TARGET, but not by a wrapper list. A
+//     `generic_type` contributes its constructor AND its arguments as
+//     candidates; `Vec`, `Option`, `Box`, `Arc`, `Mutex` and `HashMap` are not
+//     declared in the file, so only the element type survives the in-file
+//     check. A user-defined generic declared here (`struct Holder<T>`, used as
+//     `Holder<Order>`) is a legitimate target by the same rule, which is why
+//     the constructor is not blanket-dropped.
+//
+//   - `impl Order { … }` IS NOT A TYPE DECLARATION and is excluded from the
+//     target set. buildImpl emits a SCOPE.Component named after the implementing
+//     type, so a Rust file that declares `struct Order` and `impl Order` holds
+//     TWO components named `Order` — the overwhelmingly common shape. Treating
+//     the impl as a declaration would collide every such name and silently
+//     delete the edges this pass exists to add.
+//
+// THE COST OF THE SAME-FILE RULE, stated plainly: a field whose type is declared
+// in another module file gets no edge, and Rust's one-type-per-file convention
+// is weaker than C#'s but real. Closing that needs a cross-file type view, which
+// FileInput has none of in pass 1. Separate arm, not a widening of this one.
+
+// rustFieldTypeRefsMetaKey is the per-field stash written by rustFieldsFromList
+// and consumed — and deleted — by attachRustFieldTypeRefs. The candidates
+// cannot become edges during the walk: `struct Order { buyer: Customer }` may be
+// declared BEFORE `struct Customer` in the same file, so the set of in-file
+// declarations is complete only once the walk has finished.
+const rustFieldTypeRefsMetaKey = "field_type_refs"
+
+// rustFieldTargetRefKind is the value of the `ref_kind` edge property, matching
+// arm A's csFieldTargetRefKind, arm B's protoFieldTargetRefKind and the custom
+// lane's referencesClassEdge verbatim. The discriminator is what makes the edge
+// queryable as a field→declared-type edge across languages, so it is one string.
+const rustFieldTargetRefKind = "field_target_type"
+
+// rustTypeRefCandidates returns every bare type name written in a field's
+// declared type expression, in source order and without deduplication.
+//
+// It descends the type node and collects `type_identifier` leaves, which unwraps
+// reference (`&'a Customer`, `&mut Order`), pointer (`*const Order`), array
+// (`[Order; 3]`), tuple (`(Order, i32)`), dyn (`Box<dyn Shipper>`), function
+// (`fn(Order) -> u8`) and generic syntax for free. A lifetime carries its name as
+// an `identifier`, not a `type_identifier`, so `'a` is dropped by the same rule
+// that drops nothing else.
+//
+// ONE node kind is skipped WHOLE, without descending: `scoped_type_identifier`
+// — a qualified path. `crate::models::Order`, `super::Order`, `self::Order` and
+// `<Order as Trait>::Assoc` therefore yield NOTHING rather than `Order`, which
+// is the point (see the header block).
+//
+// There is deliberately no case for `primitive_type` or `lifetime`. A primitive
+// in type position is its own leaf token and a lifetime carries its name as an
+// `identifier`, so neither is — nor contains — a `type_identifier`, and a skip
+// case for either would be inert rather than protective. `i32`, `Vec<u8>`,
+// `Box<str>`, `(Order, i32)`, `fn(Order) -> u8` and `&'a Customer` are all
+// handled by the collector's one rule.
+func rustTypeRefCandidates(typ ts.Node, src []byte) []string {
+	var out []string
+	var walkType func(n ts.Node)
+	walkType = func(n ts.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "scoped_type_identifier":
+			return
+		case "type_identifier":
+			out = append(out, string(src[n.StartByte():n.EndByte()]))
+			return
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			walkType(n.NamedChild(i))
+		}
+	}
+	walkType(typ)
+	return out
+}
+
+// rustFieldTypeTarget is one in-file type declaration a field can point at: the
+// structural ToID that binds to it, and the bare name for the `target_type`
+// property.
+type rustFieldTypeTarget struct {
+	toID string
+	name string
+}
+
+// rustInFileTypeTargets indexes every TYPE DECLARED in this file that a
+// field-type edge may address, keyed by bare name.
+//
+// The four subtypes are exactly the Rust declaration forms that introduce a name
+// into the type namespace and that this package emits as entities: struct, enum,
+// trait and type_alias (`type Meters = f64;`). Subtype "impl" is excluded — it
+// is a declaration ABOUT a type, carries the implementing type's name, and
+// including it would make `struct Order` + `impl Order` a duplicate name (see
+// the header block). Subtype "file" (#577) is excluded for the same reason:
+// it is not a type.
+//
+// A name declared twice in one file — two `mod`s each declaring `Config`, or a
+// struct and a trait sharing a name — is REMOVED rather than resolved to either,
+// so the pass never guesses which declaration a field meant.
+func rustInFileTypeTargets(records []types.EntityRecord, filePath string) map[string]rustFieldTypeTarget {
+	targets := make(map[string]rustFieldTypeTarget)
+	collide := make(map[string]bool)
+	for i := range records {
+		r := &records[i]
+		if r.SourceFile != filePath || r.Kind != "SCOPE.Component" || r.Name == "" {
+			continue
+		}
+		switch r.Subtype {
+		case "struct", "enum", "trait", "type_alias":
+		default:
+			continue
+		}
+		if _, seen := targets[r.Name]; seen {
+			collide[r.Name] = true
+			continue
+		}
+		targets[r.Name] = rustFieldTypeTarget{
+			toID: extractor.BuildComponentStructuralRef("rust", filePath, r.Name),
+			name: r.Name,
+		}
+	}
+	for name := range collide {
+		delete(targets, name)
+	}
+	return targets
+}
+
+// attachRustFieldTypeRefs appends one REFERENCES edge per (field, in-file
+// declared type) pair and clears the stash it consumed.
+//
+// FromID is left empty so graph assembly anchors the edge on the field record
+// that carries it — the Django precedent at
+// internal/extractors/python/django_relational.go:246-252. (Hibernate sets an
+// explicit structural FromID because it hangs its edge off its own parallel
+// SCOPE.Component node; that is a different shape and not the one to copy —
+// #6912's own body was corrected on this point.)
+//
+// Relationships is APPENDED to, never assigned: a Rust field record carries no
+// outbound edge today, but assigning would silently clobber one added later.
+func attachRustFieldTypeRefs(records []types.EntityRecord, filePath string) []types.EntityRecord {
+	targets := rustInFileTypeTargets(records, filePath)
+	for i := range records {
+		r := &records[i]
+		if r.Metadata == nil {
+			continue
+		}
+		cands, _ := r.Metadata[rustFieldTypeRefsMetaKey].([]string)
+		delete(r.Metadata, rustFieldTypeRefsMetaKey)
+		if len(cands) == 0 || r.Kind != "SCOPE.Schema" || r.Subtype != "field" {
+			continue
+		}
+		emitted := make(map[string]bool)
+		for _, cand := range cands {
+			t, ok := targets[cand]
+			if !ok || emitted[t.toID] {
+				continue
+			}
+			emitted[t.toID] = true
+			r.Relationships = append(r.Relationships, types.RelationshipRecord{
+				ToID: t.toID,
+				Kind: string(types.RelationshipKindReferences),
+				Properties: types.Props{
+					{K: "field_name", V: r.Properties["field_name"]},
+					{K: "ref_kind", V: rustFieldTargetRefKind},
+					{K: "target_type", V: t.name},
+				},
+			})
+		}
+	}
+	return records
+}

--- a/internal/extractors/rust/field_type_refs_6912_test.go
+++ b/internal/extractors/rust/field_type_refs_6912_test.go
@@ -1,0 +1,695 @@
+package rust_test
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	_ "github.com/cajasmota/grafel/internal/extractors/rust"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6912 arm C — the field→declared-type edge for Rust. See field_type_refs.go
+// for the kind / address / same-file decisions; this file grades them.
+//
+// Every assertion below names FIELDS AND TARGETS. A count table cannot see a
+// substitution (#6973), and recall cannot see over-firing at all — so the
+// forbidden set (a named primitive field, a named `crate::`-path field, a named
+// wrapper-only field, the wrapper constructors themselves) is asserted BY NAME
+// beside the expected set.
+
+const rustFTOwnerPath = "src/models.rs"
+
+const rustFTSrc = `use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+pub enum OrderStatus { New, Shipped }
+
+pub trait Shipper { fn ship(&self); }
+
+pub type Meters = f64;
+
+pub struct Customer { pub name: String }
+
+pub struct Holder<T> { pub inner: T }
+
+pub enum Event { Placed { by: Customer }, Cancelled }
+
+pub struct Loan<'a> { pub cust: &'a Customer, pub order: &'a mut Order }
+
+pub struct Order {
+    pub buyer: Customer,
+    pub status: OrderStatus,
+    pub shipper: Box<dyn Shipper>,
+    pub distance: Meters,
+    pub watchers: Vec<Customer>,
+    pub by_name: HashMap<String, Customer>,
+    pub history: [Customer; 3],
+    pub parent: Option<Box<Order>>,
+    pub guarded: Arc<Mutex<Customer>>,
+    pub pair: (Customer, Customer),
+    pub nested: Holder<Customer>,
+    pub callback: fn(Customer) -> i32,
+    pub raw: *const Customer,
+    pub quantity: i32,
+    pub label: String,
+    pub tags: Vec<String>,
+    pub foreign: crate::other::Order,
+    pub sup: super::Customer,
+    pub me: Option<Self>,
+}
+`
+
+// A SECOND file declaring types of the SAME bare names. Its only job is to make
+// the bare-name resolver tier ambiguous, which is why the address is structural;
+// the edges from src/models.rs must be identical with and without it.
+const rustFTRivalPath = "src/other.rs"
+
+const rustFTRivalSrc = `pub struct Customer { pub other: String }
+pub struct Order { pub buyer: Customer }
+pub enum OrderStatus { A, B }
+`
+
+func extractRustFiles(t *testing.T, files map[string]string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("rust")
+	if !ok {
+		t.Fatal("rust extractor not registered")
+	}
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	var recs []types.EntityRecord
+	for _, p := range paths {
+		got, err := ext.Extract(context.Background(), extractor.FileInput{
+			Path:     p,
+			Content:  []byte(files[p]),
+			Language: "rust",
+			TSTree:   parseForTest(t, files[p]),
+		})
+		if err != nil {
+			t.Fatalf("Extract %s: %v", p, err)
+		}
+		recs = append(recs, got...)
+	}
+	return recs
+}
+
+// rustFieldTypeRefEdges returns "<field name> -> <ToID>" for every REFERENCES
+// edge carrying ref_kind=field_target_type, across ALL records, so an edge that
+// escaped onto some other record is still seen. It fails on a non-empty FromID:
+// the Django precedent leaves it empty so assembly anchors the edge on the field
+// that carries it.
+func rustFieldTypeRefEdges(t *testing.T, recs []types.EntityRecord) []string {
+	t.Helper()
+	var out []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || rustPropOf(r.Properties, "ref_kind") != "field_target_type" {
+				continue
+			}
+			if r.FromID != "" {
+				t.Errorf("%s -[REFERENCES]-> %s has FromID=%q, want empty",
+					recs[i].Name, r.ToID, r.FromID)
+			}
+			out = append(out, recs[i].Name+" -> "+r.ToID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func rustPropOf(p types.Props, key string) string {
+	for _, kv := range p {
+		if kv.K == key {
+			return kv.V
+		}
+	}
+	return ""
+}
+
+// TestRustFieldTypeRefs_EmittedEdges is the positive direction, written as an
+// INDEPENDENT LITERAL set (#6975) rather than derived from the production target
+// index. Each ToID is spelled out so a change of address dialect, of target
+// subtype, or of owning field fails here instead of passing silently.
+//
+// The four target SUBTYPES are each represented and each named: struct
+// (Customer / Order / Holder), enum (OrderStatus), trait (Shipper) and
+// type_alias (Meters).
+func TestRustFieldTypeRefs_EmittedEdges(t *testing.T) {
+	recs := extractRustFiles(t, map[string]string{rustFTOwnerPath: rustFTSrc})
+	const p = "scope:component:class:rust:src/models.rs:"
+	want := []string{
+		// enum-variant struct fields are field entities too (#4854).
+		"Event.Placed.by -> " + p + "Customer",
+		// &'a Customer / &'a mut Order — the target is the type, not the borrow,
+		// and the lifetime `'a` is not a candidate.
+		"Loan.cust -> " + p + "Customer",
+		"Loan.order -> " + p + "Order",
+		"Order.buyer -> " + p + "Customer",
+		"Order.by_name -> " + p + "Customer",
+		"Order.callback -> " + p + "Customer",
+		"Order.distance -> " + p + "Meters",
+		"Order.guarded -> " + p + "Customer",
+		"Order.history -> " + p + "Customer",
+		// A USER-DEFINED generic constructor declared in this file is itself a
+		// legitimate target, which is why the constructor is not blanket-dropped
+		// — two rows, in source order of the type expression.
+		"Order.nested -> " + p + "Customer",
+		"Order.nested -> " + p + "Holder",
+		"Order.parent -> " + p + "Order",
+		// ONE row, not two: `(Customer, Customer)` names the same target twice
+		// and the per-field dedup collapses it. A second identical row here is
+		// what a dropped dedup looks like.
+		"Order.pair -> " + p + "Customer",
+		"Order.raw -> " + p + "Customer",
+		"Order.shipper -> " + p + "Shipper",
+		"Order.status -> " + p + "OrderStatus",
+		"Order.watchers -> " + p + "Customer",
+	}
+	sort.Strings(want)
+	got := rustFieldTypeRefEdges(t, recs)
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("field-type edges mismatch\n got:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+// TestRustFieldTypeRefs_EdgeProperties cross-checks the two properties that are
+// otherwise only claimed in prose — `field_name` and `target_type` — against an
+// independent literal. `Order.by_name` is the interesting row: its declared type
+// is `HashMap<String, Customer>`, so target_type is `Customer` and NOT the
+// declared type string.
+func TestRustFieldTypeRefs_EdgeProperties(t *testing.T) {
+	recs := extractRustFiles(t, map[string]string{rustFTOwnerPath: rustFTSrc})
+	var got []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || rustPropOf(r.Properties, "ref_kind") != "field_target_type" {
+				continue
+			}
+			got = append(got, recs[i].Name+" field_name="+rustPropOf(r.Properties, "field_name")+
+				" target_type="+rustPropOf(r.Properties, "target_type"))
+		}
+	}
+	sort.Strings(got)
+	want := []string{
+		"Event.Placed.by field_name=by target_type=Customer",
+		"Loan.cust field_name=cust target_type=Customer",
+		"Loan.order field_name=order target_type=Order",
+		"Order.buyer field_name=buyer target_type=Customer",
+		"Order.by_name field_name=by_name target_type=Customer",
+		"Order.callback field_name=callback target_type=Customer",
+		"Order.distance field_name=distance target_type=Meters",
+		"Order.guarded field_name=guarded target_type=Customer",
+		"Order.history field_name=history target_type=Customer",
+		"Order.nested field_name=nested target_type=Customer",
+		"Order.nested field_name=nested target_type=Holder",
+		"Order.pair field_name=pair target_type=Customer",
+		"Order.parent field_name=parent target_type=Order",
+		"Order.raw field_name=raw target_type=Customer",
+		"Order.shipper field_name=shipper target_type=Shipper",
+		"Order.status field_name=status target_type=OrderStatus",
+		"Order.watchers field_name=watchers target_type=Customer",
+	}
+	sort.Strings(want)
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("edge properties mismatch\n got:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+// TestRustFieldTypeRefs_ForbiddenTargets is the negative direction, BY NAME.
+// Recall is structurally blind to over-firing, and over-firing is the failure
+// mode that hurts: every non-binding edge is one more `bug-extractor` endpoint
+// (#6906), so a too-broad predicate makes the graph worse, not better.
+func TestRustFieldTypeRefs_ForbiddenTargets(t *testing.T) {
+	recs := extractRustFiles(t, map[string]string{rustFTOwnerPath: rustFTSrc})
+	edges := rustFieldTypeRefEdges(t, recs)
+
+	for _, field := range []string{
+		"Order.quantity", // i32 — a NAMED primitive field
+		"Order.label",    // String — declared nowhere in this file
+		"Order.tags",     // Vec<String> — a NAMED wrapper-only field
+		"Order.foreign",  // crate::other::Order — a NAMED crate:: path field
+		"Order.sup",      // super::Customer — qualified, not descended into
+		"Order.me",       // Option<Self> — Self is not a declaration
+		"Customer.name",  // String
+		"Holder.inner",   // T — an open type parameter
+	} {
+		for _, e := range edges {
+			if strings.HasPrefix(e, field+" -> ") {
+				t.Errorf("%s must have no field-type edge, got %q", field, e)
+			}
+		}
+	}
+
+	// The wrapper CONSTRUCTORS are targets in their own right if anything emits
+	// to them. `Vec<Customer>` must reach Customer and never Vec.
+	for _, banned := range []string{
+		"Vec", "Box", "Option", "HashMap", "Arc", "Mutex", "String", "Self", "T", "i32", "f64",
+	} {
+		for _, e := range edges {
+			if strings.HasSuffix(e, ":"+banned) {
+				t.Errorf("no field-type edge may target %q, got %q", banned, e)
+			}
+		}
+	}
+}
+
+// rustPrimitiveNames is the tree-sitter-rust `primitive_type` set, written here
+// as an INDEPENDENT LITERAL (#6975): production has no such list, and that is
+// the claim under test — the grammar classifies these names, so no blocklist
+// exists to be compared against.
+var rustPrimitiveNames = []string{
+	"i8", "i16", "i32", "i64", "i128", "isize",
+	"u8", "u16", "u32", "u64", "u128", "usize",
+	"f32", "f64", "bool", "str", "char",
+}
+
+// TestRustFieldTypeRefs_EveryPrimitiveShadowedByASameFileStructProducesNoEdge
+// is arm B's counter-example, CONSTRUCTED for Rust rather than argued away.
+//
+// Arm B (#6991) deleted its protobuf scalar blocklist on the argument that the
+// in-file gate already dropped every scalar, and review broke it by writing
+// `message string { … }`: the shadowing message IS in the gate's local set, so
+// the edge was emitted and BOUND while protoc denied it. The lesson recorded
+// there was that a mutant killed only by its own unit test is equally consistent
+// with the fixture space lacking the case.
+//
+// So the case is built here. For EVERY primitive name, this file declares
+// `struct <name>;` — which puts that name in the in-file target set, proven by
+// the positive control below — and a field of that type. No edge may appear,
+// because tree-sitter tokenises the type position as `primitive_type` and
+// rustTypeRefCandidates never yields a candidate. That makes the guard the
+// GRAMMAR, not a list, and it fails in the SAFE direction: if rustc resolves
+// such a shadow to the struct, this pass misses an edge; it never invents one.
+func TestRustFieldTypeRefs_EveryPrimitiveShadowedByASameFileStructProducesNoEdge(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("pub struct Order { pub inner: i8 }\n")
+	for _, p := range rustPrimitiveNames {
+		b.WriteString("pub struct " + p + ";\n")
+	}
+	b.WriteString("pub struct Shadow {\n")
+	for i, p := range rustPrimitiveNames {
+		b.WriteString("    pub f" + string(rune('a'+i)) + ": " + p + ",\n")
+	}
+	b.WriteString("    pub ctrl: Order,\n}\n")
+	src := b.String()
+
+	recs := extractRustFiles(t, map[string]string{"src/prim.rs": src})
+
+	// Positive control 1: every shadowing struct is really in the file's target
+	// population, so "no edge" is not true for the trivial reason that the name
+	// is undeclared.
+	declared := map[string]bool{}
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Subtype == "struct" {
+			declared[recs[i].Name] = true
+		}
+	}
+	for _, p := range rustPrimitiveNames {
+		if !declared[p] {
+			t.Fatalf("fixture did not declare `struct %s`; the shadow case is not exercised", p)
+		}
+	}
+
+	// Positive control 2: a non-primitive field in the SAME struct does get its
+	// edge, so the pipeline is live.
+	want := "Shadow.ctrl -> scope:component:class:rust:src/prim.rs:Order"
+	got := rustFieldTypeRefEdges(t, recs)
+	if strings.Join(got, "\n") != want {
+		t.Fatalf("a primitive field gained an edge, or the control was lost\n got:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), want)
+	}
+
+	// And per member, so a single surviving primitive is named rather than
+	// buried in a set diff.
+	for i, p := range rustPrimitiveNames {
+		field := "Shadow.f" + string(rune('a'+i))
+		for _, e := range got {
+			if strings.HasPrefix(e, field+" -> ") {
+				t.Errorf("primitive %q gained a field-type edge: %q", p, e)
+			}
+		}
+	}
+}
+
+// TestRustFieldTypeRefs_NonTypeIdentifiersAreNotCandidates grades the
+// collector's ONE rule — it takes `type_identifier` and nothing else — at the
+// two places where a type expression carries a NAME that is not a type: a
+// lifetime (`&'a Customer` holds an `identifier` "a") and an array length
+// (`[Order; SIZE]` holds an `identifier` "SIZE").
+//
+// The fixture DECLARES `struct a;` and `struct SIZE;` so both names are in the
+// in-file target set. Without them the assertion would hold for the trivial
+// reason that nothing by those names exists, and widening the collector to
+// `identifier` — a live, production-reachable over-fire — would survive
+// unnoticed. That mutant is what this test exists for.
+func TestRustFieldTypeRefs_NonTypeIdentifiersAreNotCandidates(t *testing.T) {
+	const src = `pub struct a;
+pub struct SIZE;
+pub struct Customer { pub n: u32 }
+pub struct Order { pub n: u32 }
+
+pub struct Holder<'a> {
+    pub cust: &'a Customer,
+    pub many: [Order; SIZE],
+    pub ctrl: Customer,
+}
+`
+	recs := extractRustFiles(t, map[string]string{"src/l.rs": src})
+	// Positive control: both non-type names really are declared here.
+	declared := map[string]bool{}
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Subtype == "struct" {
+			declared[recs[i].Name] = true
+		}
+	}
+	if !declared["a"] || !declared["SIZE"] {
+		t.Fatalf("fixture did not declare `struct a` and `struct SIZE` (%v); "+
+			"the shadow case is not exercised", declared)
+	}
+	const p = "scope:component:class:rust:src/l.rs:"
+	want := []string{
+		"Holder.cust -> " + p + "Customer",
+		"Holder.ctrl -> " + p + "Customer",
+		"Holder.many -> " + p + "Order",
+	}
+	sort.Strings(want)
+	if got := rustFieldTypeRefEdges(t, recs); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("a non-type identifier became a target\n got:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+// TestRustFieldTypeRefs_QualifiedPathIsNotStrippedToASameFileName pins the one
+// place the rule is stricter than "is it declared in this file": a qualified
+// path is skipped WHOLE, so `crate::other::Order` does NOT bind to this file's
+// own `Order` even though the trailing segment matches it. Descending the path
+// is the permissive mutation arm B carries a forbidden row for; this is that
+// row for Rust.
+func TestRustFieldTypeRefs_QualifiedPathIsNotStrippedToASameFileName(t *testing.T) {
+	const src = `pub trait Trait { type Assoc; }
+
+pub struct Order { pub id: u32 }
+
+pub struct Holder {
+    pub a: crate::other::Order,
+    pub b: super::Order,
+    pub c: self::Order,
+    pub d: <Order as Trait>::Assoc,
+    pub e: Order,
+}
+`
+	recs := extractRustFiles(t, map[string]string{"src/h.rs": src})
+	want := []string{"Holder.e -> scope:component:class:rust:src/h.rs:Order"}
+	if got := rustFieldTypeRefEdges(t, recs); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("qualified-path edges\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// TestRustFieldTypeRefs_CrossFileTypeGetsNoEdge states the deliberate cost of
+// the same-file rule as an assertion rather than as prose: a field whose type is
+// declared in ANOTHER file gets nothing, because pass 1 has no cross-file view
+// and an edge it cannot verify would dangle.
+func TestRustFieldTypeRefs_CrossFileTypeGetsNoEdge(t *testing.T) {
+	recs := extractRustFiles(t, map[string]string{
+		"src/order.rs":   "use crate::shipper::Shipper;\n\npub struct Order { pub via: Shipper }\n",
+		"src/shipper.rs": "pub struct Shipper { pub name: String }\n",
+	})
+	// Positive control: the field whose type lives in the other file must exist,
+	// otherwise "no edges" is trivially true for the wrong reason.
+	found := false
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" && recs[i].Name == "Order.via" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("fixture produced no Order.via field; the cross-file case is not exercised")
+	}
+	if got := rustFieldTypeRefEdges(t, recs); len(got) != 0 {
+		t.Fatalf("cross-file declared type must produce no edge, got %v", got)
+	}
+}
+
+// TestRustFieldTypeRefs_SameNameInTwoFiles is the reason the address is
+// structural. The rival file declares Customer / Order / OrderStatus under the
+// same bare names; the edges emitted for src/models.rs must be byte-identical to
+// the single-file run. #6986 measured the bare-name `Class:<Name>` form at 91.6%
+// dangling for exactly this reason.
+func TestRustFieldTypeRefs_SameNameInTwoFiles(t *testing.T) {
+	alone := rustFieldTypeRefEdges(t, extractRustFiles(t, map[string]string{
+		rustFTOwnerPath: rustFTSrc,
+	}))
+	withRival := rustFieldTypeRefEdges(t, extractRustFiles(t, map[string]string{
+		rustFTOwnerPath: rustFTSrc,
+		rustFTRivalPath: rustFTRivalSrc,
+	}))
+	wantExtra := "Order.buyer -> scope:component:class:rust:src/other.rs:Customer"
+	var got []string
+	for _, e := range withRival {
+		if e != wantExtra {
+			got = append(got, e)
+		}
+	}
+	if strings.Join(got, "\n") != strings.Join(alone, "\n") {
+		t.Fatalf("a same-named type in another file changed this file's edges\n got:\n%s\nwant:\n%s",
+			strings.Join(got, "\n"), strings.Join(alone, "\n"))
+	}
+	if len(withRival) != len(alone)+1 {
+		t.Fatalf("rival file's own edge missing: %v", withRival)
+	}
+}
+
+// TestRustFieldTypeRefs_SameNameDeclaredTwiceInOneFile — a name declared twice
+// in the SAME file is removed from the target index rather than resolved to
+// either declaration, so the pass never guesses. Two inline `mod`s each
+// declaring `Config` is the idiomatic Rust way to get there.
+func TestRustFieldTypeRefs_SameNameDeclaredTwiceInOneFile(t *testing.T) {
+	const src = `pub mod a { pub struct Config { pub x: u32 } }
+pub mod b { pub struct Config { pub y: u32 } }
+
+pub struct Holder { pub cfg: Config }
+`
+	recs := extractRustFiles(t, map[string]string{"src/dup.rs": src})
+	configs := 0
+	holderField := false
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Name == "Config" {
+			configs++
+		}
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" && recs[i].Name == "Holder.cfg" {
+			holderField = true
+		}
+	}
+	if configs != 2 || !holderField {
+		t.Fatalf("fixture did not produce two Config declarations and a Holder.cfg field "+
+			"(configs=%d holderField=%v); the duplicate-name case is not exercised",
+			configs, holderField)
+	}
+	for _, e := range rustFieldTypeRefEdges(t, recs) {
+		if strings.HasPrefix(e, "Holder.cfg -> ") {
+			t.Fatalf("Config is declared twice in this file; Holder.cfg must get no edge, got %q", e)
+		}
+	}
+}
+
+// TestRustFieldTypeRefs_ImplBlockIsNotATypeDeclaration is Rust-specific and it
+// is load-bearing, not decorative. buildImpl emits a SCOPE.Component NAMED AFTER
+// the implementing type, so `struct Order` + `impl Order` — the commonest shape
+// in the language — puts two components called `Order` in one file. If the
+// target index counted the impl as a declaration, the duplicate-name rule would
+// delete the target and every such struct would silently lose its edges.
+func TestRustFieldTypeRefs_ImplBlockIsNotATypeDeclaration(t *testing.T) {
+	const src = `pub struct Customer { pub name: String }
+
+pub struct Order { pub buyer: Customer }
+
+impl Order {
+    pub fn new(buyer: Customer) -> Self { Order { buyer } }
+}
+
+impl Customer {
+    pub fn name(&self) -> &str { &self.name }
+}
+`
+	recs := extractRustFiles(t, map[string]string{"src/i.rs": src})
+	// Positive control: the file really does hold an impl component named after
+	// each struct, so the collision this test guards against is present.
+	impls := map[string]bool{}
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Subtype == "impl" {
+			impls[recs[i].Name] = true
+		}
+	}
+	if !impls["Order"] || !impls["Customer"] {
+		t.Fatalf("fixture produced no impl components named Order and Customer (%v); "+
+			"the name-collision case is not exercised", impls)
+	}
+	want := []string{"Order.buyer -> scope:component:class:rust:src/i.rs:Customer"}
+	if got := rustFieldTypeRefEdges(t, recs); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("impl blocks must not count as type declarations\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// TestRustFieldTypeRefs_KnownOverFire_ModuleScopeIsNotConsulted and
+// TestRustFieldTypeRefs_KnownOverFire_TypeParameterShadowsSameFileType PIN A
+// KNOWN DEFECT, and they are the only assertions in this file that describe
+// behaviour that is WRONG.
+//
+// "Declared in this same file" is a FILE-scoped check with no module scope and
+// no type-parameter scope behind it. Both consequences are reproduced here, and
+// both are worse than a dangling edge by the same logic that chose this pass's
+// address: the edge BINDS, so it never reaches `bug-extractor` and no
+// disposition figure will surface it.
+//
+// These two tests are expected to FAIL when a follow-up fixes them. That is the
+// point: they make the limitation observable at the code, so a fix has to come
+// here and say so rather than changing behaviour silently.
+func TestRustFieldTypeRefs_KnownOverFire_ModuleScopeIsNotConsulted(t *testing.T) {
+	const src = `pub mod a { pub struct Customer { pub n: String } }
+pub mod b { pub struct Order { pub buyer: Customer } }
+`
+	recs := extractRustFiles(t, map[string]string{"src/f.rs": src})
+	want := []string{"Order.buyer -> scope:component:class:rust:src/f.rs:Customer"}
+	if got := rustFieldTypeRefEdges(t, recs); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("KNOWN over-fire changed shape — if module scope is now consulted, "+
+			"delete this test and say so\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestRustFieldTypeRefs_KnownOverFire_TypeParameterShadowsSameFileType(t *testing.T) {
+	const src = `pub struct Customer { pub n: String }
+
+pub struct Box2<Customer> { pub item: Customer }
+`
+	recs := extractRustFiles(t, map[string]string{"src/f.rs": src})
+	want := []string{"Box2.item -> scope:component:class:rust:src/f.rs:Customer"}
+	if got := rustFieldTypeRefEdges(t, recs); strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("KNOWN over-fire changed shape — if type-parameter scope is now "+
+			"consulted, delete this test and say so\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// TestRustFieldTypeRefs_ResolverBindsEveryEdge is the gate this whole issue
+// class turns on: #6906 exists because a comment described a binding nobody
+// built. Every emitted edge is driven through the PRODUCTION resolver
+// (BuildIndex → ReferencesEmbedded, exactly as graph assembly does) and must
+// come back REWRITTEN to a real entity ID. A dangling edge is worse than no edge
+// — it is one more `bug-extractor` endpoint — so zero non-resolved dispositions
+// is the assertion, not a ratio.
+//
+// The fixture carries the rival file (bare names ambiguous) AND an `impl Order`
+// in the owner file, because the impl shares its name with the struct in the
+// same file and is the Rust-specific way this address could have gone wrong.
+func TestRustFieldTypeRefs_ResolverBindsEveryEdge(t *testing.T) {
+	recs := extractRustFiles(t, map[string]string{
+		rustFTOwnerPath: rustFTSrc + "\nimpl Order { pub fn total(&self) -> i32 { 0 } }\n",
+		rustFTRivalPath: rustFTRivalSrc,
+	})
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6912", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+	idx := resolve.BuildIndex(recs)
+
+	// Positive control on the address dialect itself: the BARE-name form of the
+	// same target is AMBIGUOUS here, which is why it is not what we emit.
+	if _, st := idx.LookupStatusHint("Customer", "REFERENCES"); st == 1 {
+		t.Fatalf("the bare name %q binds in this fixture, so the ambiguity this "+
+			"test controls for is not present and the structural address is ungraded", "Customer")
+	}
+
+	// A struct and its `impl` block are ONE graph node, not two: graph.EntityID
+	// hashes (repo, Kind, Name, SourceFile) and both are SCOPE.Component/Order
+	// in src/models.rs, so they share an ID by construction. The description
+	// below therefore carries the SORTED SET of subtypes behind each ID —
+	// `Order` must come back as "impl+struct" — because keying a map by ID and
+	// writing the subtype into it would silently report whichever record came
+	// last and read as a mis-binding.
+	idToName := map[string]string{}
+	idToSubs := map[string]map[string]bool{}
+	for i := range recs {
+		id := recs[i].ID
+		idToName[id] = recs[i].SourceFile + ":" + recs[i].Kind + ":" + recs[i].Name
+		if idToSubs[id] == nil {
+			idToSubs[id] = map[string]bool{}
+		}
+		idToSubs[id][recs[i].Subtype] = true
+	}
+	describe := func(id string) string {
+		subs := make([]string, 0, len(idToSubs[id]))
+		for s := range idToSubs[id] {
+			subs = append(subs, s)
+		}
+		sort.Strings(subs)
+		return idToName[id] + " [" + strings.Join(subs, "+") + "]"
+	}
+
+	before := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "REFERENCES" && rustPropOf(r.Properties, "ref_kind") == "field_target_type" {
+				before++
+			}
+		}
+	}
+	if before == 0 {
+		t.Fatal("no field-type edges to drive through the resolver")
+	}
+
+	resolve.ReferencesEmbedded(recs, idx)
+
+	var bound []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || rustPropOf(r.Properties, "ref_kind") != "field_target_type" {
+				continue
+			}
+			_, ok := idToName[r.ToID]
+			if !ok {
+				t.Errorf("%s -[REFERENCES]-> %q did NOT bind to an entity ID (dangling stub)",
+					recs[i].Name, r.ToID)
+				continue
+			}
+			bound = append(bound, recs[i].SourceFile+":"+recs[i].Name+" => "+describe(r.ToID))
+		}
+	}
+	sort.Strings(bound)
+	const m = "src/models.rs:"
+	want := []string{
+		m + "Event.Placed.by => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Loan.cust => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Loan.order => " + m + "SCOPE.Component:Order [impl+struct]",
+		m + "Order.buyer => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.by_name => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.callback => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.distance => " + m + "SCOPE.Component:Meters [type_alias]",
+		m + "Order.guarded => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.history => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.nested => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.nested => " + m + "SCOPE.Component:Holder [struct]",
+		m + "Order.pair => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.parent => " + m + "SCOPE.Component:Order [impl+struct]",
+		m + "Order.raw => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.shipper => " + m + "SCOPE.Component:Shipper [trait]",
+		m + "Order.status => " + m + "SCOPE.Component:OrderStatus [enum]",
+		m + "Order.watchers => " + m + "SCOPE.Component:Customer [struct]",
+		"src/other.rs:Order.buyer => src/other.rs:SCOPE.Component:Customer [struct]",
+	}
+	sort.Strings(want)
+	if strings.Join(bound, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("resolved endpoints mismatch\n got:\n%s\nwant:\n%s",
+			strings.Join(bound, "\n"), strings.Join(want, "\n"))
+	}
+}

--- a/internal/extractors/rust/field_type_refs_6912_test.go
+++ b/internal/extractors/rust/field_type_refs_6912_test.go
@@ -179,6 +179,30 @@ func TestRustFieldTypeRefs_EmittedEdges(t *testing.T) {
 		t.Fatalf("field-type edges mismatch\n got:\n%s\nwant:\n%s",
 			strings.Join(got, "\n"), strings.Join(want, "\n"))
 	}
+
+	// The candidate stash is CONSUMED, not left behind. graph.go:176 copies
+	// EntityRecord.Metadata onto the JSON-serialised Entity.Metadata
+	// (`json:"metadata,omitempty"`), so without attachRustFieldTypeRefs's
+	// delete() every Rust field entity in every indexed repo would persist a
+	// `field_type_refs` array into the graph. The doc comment claims the clear;
+	// this is what observes it — deleting the line is otherwise ALIVE through
+	// all three suites including ./cmd/grafel/ (review of #7000).
+	fieldsSeen := 0
+	for i := range recs {
+		if recs[i].Kind != "SCOPE.Schema" || recs[i].Subtype != "field" {
+			continue
+		}
+		fieldsSeen++
+		if v, ok := recs[i].Metadata["field_type_refs"]; ok {
+			t.Errorf("%s leaked the candidate stash into Metadata: %v", recs[i].Name, v)
+		}
+	}
+	// Positive control: the fixture's field records must actually be here, or
+	// "no stash" is true because nothing was inspected. 19 Order fields + 1
+	// Customer + 1 Holder + 2 Loan + 1 Event.Placed.
+	if fieldsSeen != 24 {
+		t.Fatalf("expected 24 field records to inspect for a leaked stash, got %d", fieldsSeen)
+	}
 }
 
 // TestRustFieldTypeRefs_EdgeProperties cross-checks the two properties that are

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -75,6 +75,13 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// function, the config-change blast radius (parity with go/java/php/python).
 	// Append-only supplemental pass; entities[0] is the file entity.
 	emitConfigConsumerEdges(file.TSTree.RootNode(), file.Content, &entities)
+	// Issue #6912 — field→declared-type REFERENCES edges, for the types
+	// DECLARED IN THIS FILE only. Runs after the walk because the set of
+	// in-file declarations is complete only once every declaration is on the
+	// table; see field_type_refs.go for why the target is addressed
+	// structurally rather than by bare name, and why `impl Order` is not a
+	// declaration.
+	entities = attachRustFieldTypeRefs(entities, file.Path)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "rust")
 	extractor.TagEntitiesLanguage(entities, "rust")

--- a/internal/extractors/rust/struct_fields.go
+++ b/internal/extractors/rust/struct_fields.go
@@ -157,6 +157,16 @@ func rustFieldsFromList(
 			Metadata:           map[string]interface{}{"subtype": "field", "owner": owner},
 			EnrichmentRequired: false,
 		})
+		// Issue #6912 — stash every bare type name written in the declared
+		// type for attachRustFieldTypeRefs, which turns the ones DECLARED IN
+		// THIS FILE into REFERENCES edges once the walk has seen every
+		// declaration. Nothing is decided here: a field may be declared before
+		// the type it names. The TYPE NODE is read, not the `field_type`
+		// string, so the grammar's own primitive/qualified-path classification
+		// is what the candidate rule stands on (field_type_refs.go).
+		if cands := rustTypeRefCandidates(ch.ChildByFieldName("type"), file.Content); len(cands) > 0 {
+			out[len(out)-1].Metadata[rustFieldTypeRefsMetaKey] = cands
+		}
 	}
 	return out
 }

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -259,7 +259,7 @@
       "relationship_found": 13,
       "relationship_expected": 13,
       "entity_extracted_total": 31,
-      "relationship_extracted_total": 63
+      "relationship_extracted_total": 64
     },
     "scala-play-mini": {
       "entity_found": 30,


### PR DESCRIPTION
Arm C of #6912 — Rust. Arm A is C# (#6984), arm B protobuf (#6991). Languages remain, so **Refs #6912**, not Closes.

## Arm B's question, answered before anything was designed

Arm B corrected #6912's central claim for the second time: the right question per language is not *"does a field→type edge exist"* but **"is the FIELD record the anchor, or is something else"** — an edge anchored on the parent leaves the field a leaf and leaves #6726's orphan rate exactly where it was.

For Rust the answer is **neither**. Every relationship the package emits was enumerated (`internal/extractors/rust/struct_fields.go:224`, `rust.go:156/208/294/552/918`):

| edge | anchor |
|---|---|
| `CONTAINS` struct/enum → field (#4854) | owner component |
| `CONTAINS` trait/impl → method (#144) | trait / impl |
| `CALLS` (#616) | operation |
| `IMPORTS` | file |
| `EXTENDS` supertrait | trait |

None carries a field's declared type at **any** anchor — unlike protobuf, where `buildMessage` already wired the message. So this arm **adds** the relation rather than duplicating an anchor: there is no existing topology to preserve (#6419/#6422 has no Rust counterpart) and nothing to double-count against. The type was retained only as the `field_type` property and inside the `Signature`.

## Design — inherited, not re-litigated

`REFERENCES` + `ref_kind: "field_target_type"`; empty `FromID` so assembly anchors the edge on the field record (Django precedent); target addressed by `extractor.BuildComponentStructuralRef("rust", <file>, <Name>)`, **not** the custom lane's `Class:<Name>` (#6986: 91.6% dangling). One address dialect, not arm A's two — a Rust `enum` is a `SCOPE.Component`, so it takes the same component address as a struct. The `SCOPE.Enum` value-set nodes from #4431 are a parallel population and are deliberately not targeted; targeting both would put two edges on one field for one declaration.

Emitted **only** where the named type is declared in the same file. Same-file rule, no cross-file tier — the Python arm's cross-file behaviour comes from a tier its resolver already had; Rust has none, so none was invented.

## Rust specifics, each with its own assertion

- **Primitives** — no blocklist, and the reason is the grammar, not our corpus. In tree-sitter-rust a primitive in type position is the node kind `primitive_type`, never `type_identifier`, at every depth (`i32`, `Vec<u8>`, `Box<str>`, `(Order, i32)`, `fn(Order) -> u8`). The collector takes `type_identifier` only, so no primitive is ever a candidate. **Arm B's counter-example is constructed rather than argued away**: the fixture declares `struct <p>;` for all 16 primitive names — proven present in the in-file target set by a positive control — beside a field of each type, and asserts per member that no edge appears. Where proto's missing blocklist **emitted** an edge protoc denies, Rust's absent one can only **miss** one, which never dangles.
- **Generic wrappers** — `Vec<Order>`, `Option<Box<Order>>`, `Arc<Mutex<Customer>>`, `HashMap<String, Customer>`: the constructor and the arguments are both candidates and the in-file check separates them, so the wrapper is never a target. A **user-defined** generic declared in the file (`Holder<Customer>`) legitimately yields two edges, which is why the constructor is not blanket-dropped.
- **References, lifetimes, pointers, arrays, tuples, `dyn`, fn-types** — `&'a Customer`, `&mut Order`, `*const Customer`, `[Customer; 3]`, `(Customer, Customer)`, `Box<dyn Shipper>`, `fn(Customer) -> i32` all reach the type and not the borrow. The lifetime `'a` and an array-length const are `identifier` nodes, not `type_identifier`.
- **Paths** — `crate::models::Order`, `super::Order`, `self::Order`, `<Order as Trait>::Assoc` are `scoped_type_identifier` and are skipped **whole**. Never stripped to the last segment: arm B carries a forbidden row named for exactly that mutation, and so does this arm.
- **Type parameters** — an open `T` is dropped only because nothing is named `T`; a parameter shadowing a same-file type over-fires. **Pinned as known-wrong.**
- **Enums and traits** are legitimate same-file targets; so is a `type` alias.
- **`impl Order` is not a type declaration**, and this one is load-bearing and Rust-specific: `buildImpl` emits a `SCOPE.Component` named after the implementing type, so `struct Order` + `impl Order` — the commonest shape in the language — puts two components called `Order` in one file. Counting the impl as a declaration would trip the duplicate-name rule and silently delete the edges this pass exists to add. Asserted by `TestRustFieldTypeRefs_ImplBlockIsNotATypeDeclaration`, with a positive control that both impl components exist.

A `WHAT THE CHECK IS NOT` header block carries all of this at the code, arm A's shape.

## A guard that was deleted, and the evidence that it was inert rather than merely redundant

**Review settled this with the compiler.** rustc **1.98.1** was installed into scratch and the case enumerated: `struct i32;` beside `pub f: i32` compiles **RC=0 for all 17 primitive names**, and rustc really does bind the field to the shadowing struct — `S { f: i32 }` (the name used as a *value*) compiles only with the shadow present, and fails `error[E0423]` without it. Then 17 primitives × 16 nesting shapes = **272 enumerated cases**, each carrying two positive controls (the shadowing `struct P` asserted present in the in-file target set, **and** the identical shape written with `Customer` required to produce an edge). All 272 pass; no primitive edges at any depth.

So the case arm B taught us to construct **is** constructible in Rust — and that *strengthens* the deletion rather than undermining it, because grafel's failure mode here is a **miss**, never a wrong emission. proto's absent blocklist emitted an edge protoc denies; Rust's absent one can only fail to emit one, and a miss never dangles.

**The harness note is part of the result, not a footnote.** The reviewer's first rustc pass returned RC=1 for all 17 names — which would have supported the *opposite* finding, that the case cannot be written at all. It was a broken harness (`-o /dev/null` failing to make a temp dir), and it was caught by the **positive control**, not by inspection. A compiler-verified claim is only as trustworthy as the control that proves the compiler was actually invoked; without it this PR would have carried a confident, backwards conclusion.

The first cut also carried `primitive_type`, `lifetime` and `scoped_identifier` skip cases. A mutant removing `primitive_type` came back **ALIVE**, and arm B's lesson says an alive-or-dead unit result settles nothing on its own — so the mechanism was checked instead: all three node kinds are leaf tokens or carry only `identifier` children, so the collector returns nothing for them **whether the case is present or not**. That is a stronger claim than arm B's deleted blocklist could make (it does not rest on "our corpus has no such file"), and it was checked in both directions anyway: deletion leaves every fixture green **and** leaves the corpus edge counts below byte-identical over 789 real `.rs` files. The one **live** case, `scoped_type_identifier`, is kept and graded.

## Verification

`go test -count=1` green on `./internal/extractors/rust/...`, `./internal/custom/rust/...` and **`./cmd/grafel/`** (fresh isolated `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`, 148s), `gofmt`/`go vet` clean. Golden ratchet green: **38 gated fixtures held**.

**The golden baseline moved by exactly +1**, enumerated: `rust-tokio-mini` `relationship_extracted_total` 63 → 64, which is `MemoryStore.users: HashMap<String, User>` → `User` in `src/store.rs`. Hand-edited as ONE number and **proven identical to a regeneration**: `--update-baseline` was run at HEAD *and* at the untouched parent (`2d6c82ba8`) and the two generated baselines diffed — the entire difference is that single line. Committing a blanket regeneration would have **lowered** `*_extracted_total` ceilings on six other fixtures (this machine's detector env differs from the recorded one), and `--ratchet` does not fail on a ceiling drop, so it would have been a silent weakening (#6991).

### Measured, gate-independent, macOS/APFS (pass-1 extractor only; no detector output is read)

| corpus | .rs files | field entities | fields gaining an edge | edges |
|---|---|---|---|---|
| tokio | 373 | 972 | 212 (21.8%) | 213 |
| just | 236 | 760 | 29 (3.8%) | 29 |
| actix-examples | 152 | 234 | 16 (6.8%) | 16 |
| mini-redis | 28 | 58 | 7 (12.1%) | 7 |
| **total** | **789** | **2,024** | **264 (13.0%)** | **265** |

Every emitted edge's target is declared in the same file **by construction**, so that check is a re-derivation of the gate rather than an independent confirmation of it; the independent evidence is `TestRustFieldTypeRefs_ResolverBindsEveryEdge`, which drives every edge through the production resolver (`BuildIndex` → `ReferencesEmbedded`) and asserts each ToID comes back rewritten to a real entity ID, with a positive control that the bare-name form is AMBIGUOUS in the same fixture.

**#6726's 99.3% is their corpus and Rust is not in it — no claim is made that it moves.** The `just` figure (3.8%) is the honest floor of a same-file rule on a codebase whose types live one per module file.

One incidental finding, recorded in the resolver test rather than in prose: a struct and its `impl` block are **one graph node**. `graph.EntityID` (`internal/graph/graph.go:259`) hashes `repo ∥ Kind ∥ Name ∥ SourceFile` — **`Subtype` is not in the hash** — and both records are `SCOPE.Component`/`Order`/same file, so there is no second node to mis-bind to and the `[impl+struct]` subtype set cannot mask one. (Confirmed in review by reading the hash rather than this sentence. The shape is not hypothetical: the gated fixture `rust-tokio-mini/src/store.rs` is `struct MemoryStore` + `impl MemoryStore` in one file.) The test therefore reports the sorted **set** of subtypes behind each resolved ID (`Order` comes back as `impl+struct`); keying a map by ID and storing the subtype reads as a mis-binding when it is nothing of the kind.

## Mutants, scored in the MORE PERMISSIVE direction

Each edit was applied by exact-occurrence count with the enclosing function asserted, `go vet` first, a green baseline immediately before, and restored by `cp` from a shasum-verified backup.

| mutant | verdict |
|---|---|
| descend a qualified path (`crate::x::Order` → `Order`) | **DEAD** — 5 tests, incl. the forbidden row named for it |
| drop the same-file check (emit to any name) | **DEAD** — 10 tests |
| count `impl` as a type declaration | **DEAD** — 2 tests |
| drop the duplicate-name removal | **DEAD** |
| drop the per-field target dedup | **DEAD** — 3 tests |
| assign `Relationships` instead of appending | **DEAD** — 3 tests |
| collect bare `identifier` as well as `type_identifier` | **ALIVE, production-reachable** (`&'a Customer` beside a `struct a`; `[Order; SIZE]` beside a `struct SIZE`) → graded by the new `TestRustFieldTypeRefs_NonTypeIdentifiersAreNotCandidates`, then **DEAD** |
| delete the `primitive_type` skip case | **equivalent** — the case is inert (see above); the guard was removed rather than left ungraded |
| *(review R1)* collect primitives: `case "primitive_type", "type_identifier"` | **DEAD** — the 16-primitive shadow test. The behaviour the deleted guard described is graded even though the guard is gone |
| *(review R2)* drop `\|\| r.Subtype != "field"` from the compound guard | **equivalent under the current producer** — the stash has exactly one writer (`struct_fields.go`) on records hardcoded `Kind: "SCOPE.Schema", Subtype: "field"`, so no record can reach the guard failing it. Defence-in-depth against a second future writer; recorded as equivalent, not as DEAD |
| *(review R3)* delete `delete(r.Metadata, rustFieldTypeRefsMetaKey)` | was **ALIVE, production-reachable and ungraded** — survived all three suites incl. `./cmd/grafel/` → graded in `2d0b05705`, now **DEAD** |

## The one item review left open, and it is now closed (`2d0b05705`)

Deleting `attachRustFieldTypeRefs`'s `delete(r.Metadata, rustFieldTypeRefsMetaKey)` was **ALIVE through every suite, `./cmd/grafel/` included**, and it is not cosmetic: `internal/graph/graph.go:176` copies `EntityRecord.Metadata` straight onto the JSON-serialised `Entity.Metadata` (`json:"metadata,omitempty"`), so without that line **every Rust field entity in every indexed repo would persist a `field_type_refs` array into the graph**. The doc comment said "and clears the stash it consumed" and nothing observed it — the dominant defect class, prose asserting what no test observes.

`TestRustFieldTypeRefs_EmittedEdges` now asserts the key is absent on every field record, with a positive control on the record count so the assertion cannot pass by inspecting nothing. Re-scored after the change: **DEAD** — and the failure names `Customer.name` leaking `[String]`, i.e. a field that gets *no* edge leaks the stash too, which is why the assertion is over the whole field population rather than over the edge-bearing subset. Test-only change; no production file was touched (`git diff HEAD` clean on `field_type_refs.go` after the mutant, restored by `cp` from a shasum-verified backup).

## Remaining on #6912

java, kotlin, scala, go, php, swift, cpp, ruby. Java still retains no type string at all, only a `Signature` — a capture problem before an edge problem.

Refs #6912, #6984, #6991, #6986, #6726, #6906, #6975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
