### PR TITLE
fix(#6999): the bridge's singleton was keyed on a machine-global socket path, so every new mcp-bridge SIGTERMed every other session's — the reap is deleted, not rescoped

### DIFF
--- a/internal/cli/mcp_bridge.go
+++ b/internal/cli/mcp_bridge.go
@@ -500,16 +500,20 @@ func (b *bridge) defaultSocketPath() (string, error) {
 func (b *bridge) run(r io.Reader, w io.Writer) error {
 	defer b.closeRPCClient()
 
-	// #5633: guarantee exactly one bridge per daemon socket. Reap an orphaned
-	// prior bridge (e.g. one left attached after a daemon restart) and claim a
-	// per-socket pidfile. Best-effort: a failure here must not stop us serving,
-	// so we log and continue. Skipped when the socket path cannot be resolved.
+	// #5633, rescoped by #6999: record this process as the bridge serving this
+	// socket FOR THIS SESSION, and arm the signal logger so an externally
+	// terminated bridge says so in the daemon log. Nothing here signals another
+	// process. Best-effort: a failure must not stop us serving, so we log and
+	// continue. Skipped when the socket path cannot be resolved.
 	if socketPath, serr := b.defaultSocketPath(); serr == nil && socketPath != "" {
-		if release, aerr := acquireBridgeSingleton(socketPath, b.log); aerr != nil {
+		release, pidfile, aerr := acquireBridgeSingleton(socketPath, b.log)
+		if aerr != nil {
 			b.log("bridge singleton: %v (continuing)", aerr)
 		} else {
 			defer release()
 		}
+		stopSignalLogger := installBridgeSignalLogger(pidfile, socketPath, b.log)
+		defer stopSignalLogger()
 	}
 
 	br := bufio.NewReaderSize(r, 64*1024)

--- a/internal/cli/mcp_bridge.go
+++ b/internal/cli/mcp_bridge.go
@@ -506,11 +506,20 @@ func (b *bridge) run(r io.Reader, w io.Writer) error {
 	// process. Best-effort: a failure must not stop us serving, so we log and
 	// continue. Skipped when the socket path cannot be resolved.
 	if socketPath, serr := b.defaultSocketPath(); serr == nil && socketPath != "" {
-		release, pidfile, aerr := acquireBridgeSingleton(socketPath, b.log)
-		if aerr != nil {
-			b.log("bridge singleton: %v (continuing)", aerr)
+		// The record dir comes from the layout ROOT, never from the socket's
+		// own directory: on Windows the socket is a named pipe and has no
+		// directory, which is why no record was ever written there (#6999).
+		var pidfile string
+		if recordDir, derr := bridgeRecordDir(); derr != nil {
+			b.log("bridge singleton: %v (continuing)", derr)
 		} else {
-			defer release()
+			release, path, aerr := acquireBridgeSingleton(recordDir, socketPath, b.log)
+			pidfile = path
+			if aerr != nil {
+				b.log("bridge singleton: %v (continuing)", aerr)
+			} else {
+				defer release()
+			}
 		}
 		stopSignalLogger := installBridgeSignalLogger(pidfile, socketPath, b.log)
 		defer stopSignalLogger()

--- a/internal/cli/mcp_bridge_multisession_test.go
+++ b/internal/cli/mcp_bridge_multisession_test.go
@@ -1,0 +1,429 @@
+package cli
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/process"
+)
+
+// mcp_bridge_multisession_test.go — the #6999 artefact test.
+//
+// #6999 is a cross-process defect: a bridge SIGTERMed OTHER processes. No
+// in-process assertion can observe it, so these tests run real bridge processes
+// and assert on what survives. The children are copies of this test binary
+// named "grafel", because process.PidIsGrafel gates the (now deleted) reap on
+// the executable's name: with a child called "cli.test" the old code would have
+// skipped the reap and the test would have passed against the bug.
+
+const envBridgeChildMode = "GRAFEL_TEST_BRIDGE_CHILD"
+
+// TestHelperBridgeChild is the child entrypoint. It is inert unless the parent
+// sets envBridgeChildMode, so a normal `go test` run never enters it.
+func TestHelperBridgeChild(t *testing.T) {
+	switch os.Getenv(envBridgeChildMode) {
+	case "":
+		t.Skip("child entrypoint; not run directly")
+	case "bridge":
+		// A real bridge over the parent's pipes, using the DEFAULT socket path
+		// (GRAFEL_DAEMON_ROOT points it at the parent's temp root) so the
+		// production singleton path is the one under test.
+		b := &bridge{}
+		_ = b.run(os.Stdin, os.Stdout)
+		os.Exit(0)
+	case "idle":
+		// A live, grafel-named process that is NOT a bridge: the reap target
+		// stand-in. Exits when its stdin closes or after a bounded wait.
+		done := make(chan struct{})
+		go func() { _, _ = io.Copy(io.Discard, os.Stdin); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(60 * time.Second):
+		}
+		os.Exit(0)
+	}
+}
+
+// ── harness ──────────────────────────────────────────────────────────────────
+
+type childProc struct {
+	t    *testing.T
+	cmd  *exec.Cmd
+	pid  int
+	in   io.WriteCloser
+	out  *bufio.Reader
+	wait chan error
+}
+
+// isolateGrafelRoot points the daemon layout at a per-test temp root. Every
+// test in this file MUST call it: without it the bridge resolves the real
+// ~/.grafel and would write (pre-#6999, signal) into the developer's live
+// daemon directory.
+func isolateGrafelRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "sockets"), 0o755); err != nil {
+		t.Fatalf("mkdir sockets: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "logs"), 0o755); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
+	t.Setenv("GRAFEL_DAEMON_ROOT", root)
+	t.Setenv("GRAFEL_HOME", root)
+	return root
+}
+
+// grafelNamedTestBinary copies this test binary to a file named "grafel" so
+// children are classified by process.PidIsGrafel exactly as a real bridge is.
+func grafelNamedTestBinary(t *testing.T) string {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Skipf("cannot locate test binary: %v", err)
+	}
+	src, err := os.ReadFile(self)
+	if err != nil {
+		t.Skipf("cannot read test binary: %v", err)
+	}
+	name := "grafel"
+	if runtime.GOOS == "windows" {
+		name = "grafel.exe"
+	}
+	// Not t.TempDir(): the binary must outlive per-subtest cleanup ordering.
+	dir, err := os.MkdirTemp("", "grafel-bin")
+	if err != nil {
+		t.Fatalf("tempdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dst := filepath.Join(dir, name)
+	if err := os.WriteFile(dst, src, 0o755); err != nil {
+		t.Skipf("cannot copy test binary: %v", err)
+	}
+	return dst
+}
+
+// startChild launches a grafel-named child in the given mode and cwd.
+func startChild(t *testing.T, exe, mode, cwd string, extraEnv ...string) *childProc {
+	t.Helper()
+	cmd := exec.Command(exe, "-test.run=^TestHelperBridgeChild$", "-test.timeout=120s")
+	cmd.Dir = cwd
+	cmd.Env = append(os.Environ(),
+		envBridgeChildMode+"="+mode,
+		"GRAFEL_DAEMON_ROOT="+os.Getenv("GRAFEL_DAEMON_ROOT"),
+		"GRAFEL_HOME="+os.Getenv("GRAFEL_HOME"),
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	cmd.Stderr = os.Stderr
+	in, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start child: %v", err)
+	}
+	c := &childProc{t: t, cmd: cmd, pid: cmd.Process.Pid, in: in, out: bufio.NewReader(out), wait: make(chan error, 1)}
+	go func() { c.wait <- cmd.Wait() }()
+	t.Cleanup(func() {
+		_ = in.Close()
+		_ = cmd.Process.Kill()
+		<-c.wait
+	})
+	return c
+}
+
+// serves sends one MCP `initialize` and returns true if a well-formed response
+// comes back — i.e. this bridge is alive AND still doing its job.
+func (c *childProc) serves(id int) bool {
+	c.t.Helper()
+	req := fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"initialize","params":{}}`+"\n", id)
+	if _, err := io.WriteString(c.in, req); err != nil {
+		c.t.Logf("pid %d: write: %v", c.pid, err)
+		return false
+	}
+	type resp struct {
+		ID     float64         `json:"id"`
+		Result json.RawMessage `json:"result"`
+	}
+	line := make(chan string, 1)
+	go func() {
+		s, err := c.out.ReadString('\n')
+		if err != nil && s == "" {
+			line <- ""
+			return
+		}
+		line <- s
+	}()
+	select {
+	case s := <-line:
+		var r resp
+		if err := json.Unmarshal([]byte(strings.TrimSpace(s)), &r); err != nil {
+			c.t.Logf("pid %d: bad response %q: %v", c.pid, s, err)
+			return false
+		}
+		return int(r.ID) == id && len(r.Result) > 0
+	case <-time.After(10 * time.Second):
+		c.t.Logf("pid %d: no response within 10s", c.pid)
+		return false
+	}
+}
+
+func (c *childProc) exited() bool {
+	select {
+	case err := <-c.wait:
+		c.wait <- err
+		return true
+	default:
+		return false
+	}
+}
+
+// TestBridge_ConcurrentSessionsAllSurviveAndServe is the headline assertion of
+// #6999: N bridges started against ONE daemon socket from different working
+// directories all stay alive and all keep serving. Before the fix, each new
+// bridge SIGTERMed the incumbent and only the newest survived.
+//
+// Each member of the set is asserted individually — a second project and a
+// git worktree of the first are distinct members, not one representative,
+// because those are the two shapes #6999 was reported in.
+func TestBridge_ConcurrentSessionsAllSurviveAndServe(t *testing.T) {
+	root := isolateGrafelRoot(t)
+	exe := grafelNamedTestBinary(t)
+
+	work := t.TempDir()
+	projectA := filepath.Join(work, "project-a")
+	projectB := filepath.Join(work, "project-b")
+	worktreeA := filepath.Join(projectA, ".worktrees", "tsk_1fce9975")
+	for _, d := range []string{projectA, projectB, worktreeA} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	sessions := []struct {
+		name string
+		cwd  string
+	}{
+		{"project-a", projectA},
+		{"project-b (different project, same socket)", projectB},
+		{"worktree of project-a", worktreeA},
+	}
+
+	var started []*childProc
+	for _, s := range sessions {
+		c := startChild(t, exe, "bridge", s.cwd)
+		// Each bridge must be serving before the next one starts, so that the
+		// next one's startup is what we are testing.
+		if !c.serves(1) {
+			t.Fatalf("session %q did not come up", s.name)
+		}
+		// Every session started BEFORE this one must still be serving.
+		for i, prev := range started {
+			if prev.exited() {
+				t.Fatalf("session %q (pid %d) DIED when session %q started — a bridge terminated another session's bridge (#6999)",
+					sessions[i].name, prev.pid, s.name)
+			}
+			if !prev.serves(100 + i) {
+				t.Fatalf("session %q (pid %d) stopped serving when session %q started (#6999)",
+					sessions[i].name, prev.pid, s.name)
+			}
+		}
+		started = append(started, c)
+	}
+
+	// Every session must own a DISTINCT ownership record naming its own pid.
+	// Under the pre-#6999 per-socket key there is exactly one such file for the
+	// whole machine.
+	socketDir := filepath.Join(root, "sockets")
+	entries, err := os.ReadDir(socketDir)
+	if err != nil {
+		t.Fatalf("read socket dir: %v", err)
+	}
+	recorded := map[int]string{}
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), "mcp-bridge-") || !strings.HasSuffix(e.Name(), ".pid") {
+			continue
+		}
+		p := filepath.Join(socketDir, e.Name())
+		pid, ok := readBridgePID(p)
+		if !ok {
+			t.Fatalf("unreadable bridge record %s", p)
+		}
+		if other, dup := recorded[pid]; dup {
+			t.Fatalf("pid %d recorded twice (%s and %s)", pid, other, p)
+		}
+		recorded[pid] = p
+	}
+	for i, c := range started {
+		if _, ok := recorded[c.pid]; !ok {
+			t.Fatalf("session %q (pid %d) has no ownership record of its own; records=%v — the key is not per-session (#6999)",
+				sessions[i].name, c.pid, recorded)
+		}
+	}
+	if len(recorded) != len(started) {
+		t.Fatalf("want %d distinct bridge records, got %d: %v", len(started), len(recorded), recorded)
+	}
+}
+
+// TestBridge_DoesNotSignalAnotherLiveGrafelProcess is the negative: starting a
+// bridge must leave every other grafel process alone, including one whose pid a
+// stale record names. Pre-#6999 that record was machine-global AND
+// PidIsGrafel matched any grafel process, so this pid was SIGTERMed.
+func TestBridge_DoesNotSignalAnotherLiveGrafelProcess(t *testing.T) {
+	root := isolateGrafelRoot(t)
+	exe := grafelNamedTestBinary(t)
+	cwd := t.TempDir()
+
+	victim := startChild(t, exe, "idle", cwd)
+	if !process.IsAlive(victim.pid) {
+		t.Fatalf("victim pid %d not alive", victim.pid)
+	}
+	if ok, err := process.PidIsGrafel(victim.pid); err != nil || !ok {
+		t.Skipf("cannot classify victim as a grafel process (ok=%v err=%v); "+
+			"without that this test cannot observe a reap", ok, err)
+	}
+
+	// Seed the victim's pid into EVERY plausible record path: the per-socket
+	// path the pre-#6999 code used, and this process's own session path.
+	socket := filepath.Join(root, "sockets", "daemon.sock")
+	seed := []string{
+		legacyPerSocketPidfilePath(socket),
+		bridgeSingletonPath(socket, bridgeSessionID()),
+	}
+	for _, p := range seed {
+		if err := os.WriteFile(p, []byte(strconv.Itoa(victim.pid)+"\n"), 0o600); err != nil {
+			t.Fatalf("seed %s: %v", p, err)
+		}
+	}
+
+	b := startChild(t, exe, "bridge", cwd)
+	if !b.serves(1) {
+		t.Fatal("bridge did not come up")
+	}
+	time.Sleep(300 * time.Millisecond) // the pre-#6999 reap grace was 500ms; SIGTERM itself is instant
+	if victim.exited() {
+		t.Fatalf("a starting bridge terminated another live grafel process (pid %d) — #6999", victim.pid)
+	}
+}
+
+// legacyPerSocketPidfilePath reproduces the pre-#6999 per-socket key so a test
+// can seed the exact file the old code read. It is test-only: production must
+// never derive a path from the socket alone again.
+func legacyPerSocketPidfilePath(socketPath string) string {
+	sum := sha256.Sum256([]byte(socketPath))
+	return filepath.Join(filepath.Dir(socketPath), "mcp-bridge-"+hex.EncodeToString(sum[:6])+".pid")
+}
+
+// TestBridge_SignalledBridgeNamesItselfInTheDaemonLog asserts the second half
+// of the fix end-to-end, through the production wiring: a REAL bridge process
+// (bridge.run, which is what arms the handler) is SIGTERMed the way a
+// pre-#6999 bridge was, and must leave one line in ~/.grafel/logs/daemon.log
+// naming its pidfile, its socket and #6999 — while still exiting 143.
+//
+// This is the artefact that turns the next occurrence into a five-minute
+// triage instead of an excavation: before the fix the reaped bridge died on the
+// default SIGTERM disposition and wrote nothing anywhere.
+func TestBridge_SignalledBridgeNamesItselfInTheDaemonLog(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGTERM delivery is unix-only")
+	}
+	root := isolateGrafelRoot(t)
+	exe := grafelNamedTestBinary(t)
+
+	c := startChild(t, exe, "bridge", t.TempDir())
+	if !c.serves(1) {
+		t.Fatal("bridge did not come up")
+	}
+
+	if err := c.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("signal: %v", err)
+	}
+
+	var werr error
+	select {
+	case werr = <-c.wait:
+		c.wait <- werr
+	case <-time.After(20 * time.Second):
+		t.Fatal("signalled bridge did not exit")
+	}
+	code := 0
+	if ee, ok := werr.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if werr != nil {
+		t.Fatalf("child: %v", werr)
+	}
+	if code != 143 {
+		t.Fatalf("signalled bridge exit code = %d, want 143 (128+SIGTERM)", code)
+	}
+
+	body, rerr := os.ReadFile(filepath.Join(root, "logs", "daemon.log"))
+	if rerr != nil {
+		t.Fatalf("no daemon log line for a signalled bridge: %v", rerr)
+	}
+	socket := filepath.Join(root, "sockets", "daemon.sock")
+	for _, want := range []string{"terminating on signal", "#6999", "socket=" + socket, "pidfile=" + filepath.Join(root, "sockets", "mcp-bridge-")} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("daemon log does not name %q:\n%s", want, body)
+		}
+	}
+	// One death, one line.
+	if n := strings.Count(string(body), "terminating on signal"); n != 1 {
+		t.Fatalf("daemon log has %d termination lines, want exactly 1:\n%s", n, body)
+	}
+}
+
+// ── shared helpers for the singleton unit tests ──────────────────────────────
+
+// startFakeGrafelChild starts a live process that process.PidIsGrafel
+// classifies as grafel — the stand-in for a prior bridge.
+func startFakeGrafelChild(t *testing.T) *childProc {
+	t.Helper()
+	isolateGrafelRoot(t)
+	return startChild(t, grafelNamedTestBinary(t), "idle", t.TempDir())
+}
+
+// startNonGrafelChild starts a live process that is NOT grafel (this test
+// binary under its own name) — the recycled-pid stand-in.
+func startNonGrafelChild(t *testing.T) *childProc {
+	t.Helper()
+	isolateGrafelRoot(t)
+	self, err := os.Executable()
+	if err != nil {
+		t.Skipf("cannot locate test binary: %v", err)
+	}
+	if strings.Contains(strings.ToLower(filepath.Base(self)), "grafel") {
+		t.Skipf("test binary %q is itself named grafel; cannot model a non-grafel pid", self)
+	}
+	return startChild(t, self, "idle", t.TempDir())
+}
+
+// aliveAfter reports whether the child is still running after d.
+func (c *childProc) aliveAfter(d time.Duration) bool {
+	time.Sleep(d)
+	return !c.exited() && process.IsAlive(c.pid)
+}
+
+func anyContains(lines []string, sub string) bool {
+	for _, l := range lines {
+		if strings.Contains(l, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/mcp_bridge_multisession_test.go
+++ b/internal/cli/mcp_bridge_multisession_test.go
@@ -250,17 +250,27 @@ func TestBridge_ConcurrentSessionsAllSurviveAndServe(t *testing.T) {
 	// Every session must own a DISTINCT ownership record naming its own pid.
 	// Under the pre-#6999 per-socket key there is exactly one such file for the
 	// whole machine.
-	socketDir := filepath.Join(root, "sockets")
-	entries, err := os.ReadDir(socketDir)
+	// Enumerate the PRODUCTION record dir, not a fabricated one: deriving it
+	// here the same way the bridge does is what exposed the Windows gap, where
+	// filepath.Dir(SocketPath) is the named pipe `\\.\pipe` and no record was
+	// ever written at all.
+	recordDir, err := bridgeRecordDir()
 	if err != nil {
-		t.Fatalf("read socket dir: %v", err)
+		t.Fatalf("bridge record dir: %v", err)
+	}
+	if want := filepath.Join(root, "sockets"); recordDir != want {
+		t.Fatalf("record dir = %q, want %q", recordDir, want)
+	}
+	entries, err := os.ReadDir(recordDir)
+	if err != nil {
+		t.Fatalf("read bridge record dir %s: %v", recordDir, err)
 	}
 	recorded := map[int]string{}
 	for _, e := range entries {
 		if !strings.HasPrefix(e.Name(), "mcp-bridge-") || !strings.HasSuffix(e.Name(), ".pid") {
 			continue
 		}
-		p := filepath.Join(socketDir, e.Name())
+		p := filepath.Join(recordDir, e.Name())
 		pid, ok := readBridgePID(p)
 		if !ok {
 			t.Fatalf("unreadable bridge record %s", p)
@@ -304,7 +314,7 @@ func TestBridge_DoesNotSignalAnotherLiveGrafelProcess(t *testing.T) {
 	socket := filepath.Join(root, "sockets", "daemon.sock")
 	seed := []string{
 		legacyPerSocketPidfilePath(socket),
-		bridgeSingletonPath(socket, bridgeSessionID()),
+		bridgeSingletonPath(filepath.Join(root, "sockets"), socket, bridgeSessionID()),
 	}
 	for _, p := range seed {
 		if err := os.WriteFile(p, []byte(strconv.Itoa(victim.pid)+"\n"), 0o600); err != nil {

--- a/internal/cli/mcp_bridge_session_unix.go
+++ b/internal/cli/mcp_bridge_session_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// stdinIdentity returns a stable identifier for this process's stdin — the
+// device/inode pair of the pipe the MCP client handed us. Two bridges started
+// by two different clients hold two different pipes, so this separates
+// concurrent sessions without naming a path, a repo or a worktree.
+//
+// It is best-effort: an unstattable stdin, or one whose Sys() is not a unix
+// stat, returns ("", false) and the caller falls back to the process pid. A
+// COLLIDING identity (both bridges on /dev/null) is harmless — the identity
+// only scopes a diagnostic record's filename, never a signal.
+func stdinIdentity() (string, bool) {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return "", false
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("%d-%d", uint64(st.Dev), uint64(st.Ino)), true
+}

--- a/internal/cli/mcp_bridge_session_windows.go
+++ b/internal/cli/mcp_bridge_session_windows.go
@@ -1,0 +1,10 @@
+package cli
+
+// stdinIdentity has no cheap device/inode equivalent on Windows: os.Stdin's
+// Sys() carries file attributes, not an identity. Returning ("", false) makes
+// bridgeSessionID fall back to this process's pid, which is unique by
+// construction — one record per bridge. That is strictly safe here because the
+// record gates nothing but a log line (#6999).
+func stdinIdentity() (string, bool) {
+	return "", false
+}

--- a/internal/cli/mcp_bridge_signal.go
+++ b/internal/cli/mcp_bridge_signal.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// mcp_bridge_signal.go — make a terminated bridge name its own death (#6999).
+//
+// #6999 took a full excavation because the death was silent on BOTH sides: the
+// bridge had no SIGTERM handler (exit 143 is the default action, so nothing was
+// logged and no drain ran), and the killer's own line went to the CLIENT's
+// stderr, which nobody keeps. From here on a signalled bridge writes one line
+// naming the signal, its pidfile, its socket and where to look — to its stderr
+// AND to ~/.grafel/logs/daemon.log, which survives the session.
+
+// bridgeSignalExitCode maps a terminating signal to the shell convention
+// (128+signum) so the exit status a supervisor sees is unchanged by the fact
+// that we now handle the signal rather than dying by default action.
+func bridgeSignalExitCode(sig os.Signal) int {
+	if s, ok := sig.(syscall.Signal); ok {
+		return 128 + int(s)
+	}
+	return 143
+}
+
+// bridgeTerminationNotice is the line written when the bridge is terminated by
+// a signal. It is a pure function so its content is assertable.
+func bridgeTerminationNotice(sig os.Signal, pidfile, socketPath string) string {
+	return fmt.Sprintf(
+		"mcp-bridge (pid %d) terminating on signal %v: the client's stdin was still open, "+
+			"so this was an external termination, not an end-of-session. "+
+			"pidfile=%s socket=%s. grafel itself never signals another bridge (#6999); "+
+			"before v0.3.3 a newly started bridge reaped this one. "+
+			"If you are on an older build, that is the first thing to check.",
+		os.Getpid(), sig, pidfile, socketPath)
+}
+
+// handleBridgeSignal writes the termination notice to the bridge's own logger
+// and to the daemon log, then exits with the conventional status. exit is a
+// parameter so the behaviour is testable without killing the test binary.
+func handleBridgeSignal(sig os.Signal, pidfile, socketPath string, logf func(string, ...any), exit func(int)) {
+	notice := bridgeTerminationNotice(sig, pidfile, socketPath)
+	if logf != nil {
+		logf("%s", notice)
+	}
+	appendDaemonLog(notice)
+	exit(bridgeSignalExitCode(sig))
+}
+
+// installBridgeSignalLogger arms the SIGTERM/SIGINT handler for the lifetime of
+// a bridge session. The returned stop function disarms it.
+func installBridgeSignalLogger(pidfile, socketPath string, logf func(string, ...any)) (stop func()) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGTERM, syscall.SIGINT)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case sig := <-ch:
+			handleBridgeSignal(sig, pidfile, socketPath, logf, os.Exit)
+		case <-done:
+		}
+	}()
+	return func() {
+		signal.Stop(ch)
+		close(done)
+	}
+}
+
+// appendDaemonLog appends one timestamped line to the daemon log so a bridge
+// death is recorded somewhere that outlives the client's stderr. Best-effort:
+// a missing directory or an unwritable log must never affect the bridge.
+func appendDaemonLog(line string) {
+	path := daemonLogPath()
+	if path == "" || path == "." {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintf(f, "%s grafel-mcp-bridge: %s\n",
+		time.Now().Format("2006/01/02 15:04:05"), line)
+}

--- a/internal/cli/mcp_bridge_singleton.go
+++ b/internal/cli/mcp_bridge_singleton.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/process"
 )
 
@@ -25,10 +26,21 @@ import (
 //
 // Why deleting it is safe rather than a regression of #5633:
 //
-//   - A bridge whose client is gone exits on its own. bridge.run reads stdin
-//     and returns on io.EOF; when the MCP client dies its end of the pipe is
-//     closed and the bridge falls out of its loop. Nothing external is needed to
-//     collect it, and TestBridge_ExitsWhenStdinCloses pins that.
+//   - A bridge that is IDLE when its client goes collects itself. bridge.run
+//     reads stdin and returns on io.EOF; when the client's end of the pipe is
+//     closed the bridge falls out of its loop and nothing external is needed to
+//     collect it. Verified with real processes on three shapes: client SIGKILL,
+//     client SIGTERM, and a live client that closes the bridge's stdin.
+//     TestBridge_ExitsWhenStdinCloses pins the EOF-while-idle case in process.
+//
+//     It is NOT true of every client-less bridge, and the comment must not say
+//     so. A bridge BLOCKED in a daemon call is not in its read loop and never
+//     observes the EOF: callDaemon → net/rpc Call has no deadline, so against a
+//     daemon that accepts and never replies (wedged or swapping — on record for
+//     this project) the bridge stays alive indefinitely after its client dies.
+//     That residual is #7003. It is not an argument for the reap: the old reap
+//     only collected such a bridge when a NEW bridge started, which is the
+//     #6999 event itself, and it collected healthy concurrent bridges with it.
 //   - The orphan #5633 saw therefore had a LIVE client (a daemon restart does
 //     not touch stdin). Such a process is indistinguishable, from the outside,
 //     from a second concurrent session's perfectly healthy bridge — there is no
@@ -65,13 +77,43 @@ func bridgeSessionID() string {
 	return "pid:" + strconv.Itoa(os.Getpid())
 }
 
-// bridgeSingletonPath derives the per-session bridge pidfile path. It lives
-// beside the daemon socket so it shares the socket's per-user directory and
-// lifecycle. Both the socket path AND the session id are hashed into the name:
-// keying on the socket alone is #6999, because one file then names the single
-// bridge of an entire machine.
-func bridgeSingletonPath(socketPath, sessionID string) string {
-	dir := filepath.Dir(socketPath)
+// bridgeRecordDir returns the directory the ownership records live in:
+// <Layout.Root>/sockets, on every platform.
+//
+// It is derived from the LAYOUT ROOT, not from filepath.Dir(SocketPath), and
+// that is the whole point. SocketPath is not a filesystem path everywhere: on
+// Windows it is a named pipe (`\\.\pipe\grafel-<hash>`, see
+// internal/daemon/paths_windows.go, where SocketDir is deliberately ""), so
+// filepath.Dir of it is `\\.\pipe` — not a directory anything can write into.
+// The pre-#6999 code keyed off filepath.Dir(SocketPath) too, so on Windows the
+// pidfile write ALWAYS failed and the record never existed at all: readBridgePID
+// therefore never returned a prior pid and the reap never fired there. Windows
+// users were never hit by #6999, and they also never got the diagnostic record
+// this file exists to leave behind. Layout.Root is a real directory on both
+// platforms, so deriving from it fixes the diagnostic everywhere.
+//
+// On unix this keeps the record in the same <root>/sockets it already used
+// under GRAFEL_DAEMON_ROOT; it also pins it there when the socket itself lives
+// in XDG_RUNTIME_DIR, which is a per-boot tmpfs rather than grafel's own state.
+// sockets/ is already one of grafel's scratch dirs (internal/install:
+// grafelScratchDirs), so uninstall --purge still cleans these up.
+func bridgeRecordDir() (string, error) {
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		return "", fmt.Errorf("resolve grafel layout for bridge record: %w", err)
+	}
+	if strings.TrimSpace(layout.Root) == "" {
+		return "", fmt.Errorf("grafel layout has no root; cannot place bridge record")
+	}
+	return filepath.Join(layout.Root, "sockets"), nil
+}
+
+// bridgeSingletonPath derives the per-session bridge pidfile path inside dir.
+// Both the socket path AND the session id are hashed into the name: keying on
+// the socket alone is #6999, because one file then names the single bridge of
+// an entire machine. The socket stays in the hash so two daemons (two roots,
+// two sockets) never share a record even if a session id repeats.
+func bridgeSingletonPath(dir, socketPath, sessionID string) string {
 	sum := sha256.Sum256([]byte(socketPath + "\x00" + sessionID))
 	name := "mcp-bridge-" + hex.EncodeToString(sum[:6]) + ".pid"
 	return filepath.Join(dir, name)
@@ -88,12 +130,18 @@ func bridgeSingletonPath(socketPath, sessionID string) string {
 //
 // Errors are non-fatal by design: a bridge that cannot write its record should
 // still serve, so callers log and continue rather than aborting the session.
-func acquireBridgeSingleton(socketPath string, logf func(string, ...any)) (release func(), pidfile string, err error) {
+func acquireBridgeSingleton(recordDir, socketPath string, logf func(string, ...any)) (release func(), pidfile string, err error) {
 	if logf == nil {
 		logf = func(string, ...any) {}
 	}
-	path := bridgeSingletonPath(socketPath, bridgeSessionID())
+	path := bridgeSingletonPath(recordDir, socketPath, bridgeSessionID())
 	self := os.Getpid()
+
+	// The record dir is grafel's own scratch dir, and nothing else guarantees
+	// it exists: on Windows no socket is ever bound inside it.
+	if merr := os.MkdirAll(recordDir, 0o700); merr != nil {
+		return func() {}, path, fmt.Errorf("create bridge record dir %s: %w", recordDir, merr)
+	}
 
 	if prior, ok := readBridgePID(path); ok && prior != self && isLiveBridge(prior) {
 		// #6999: log, never signal. A prior bridge is not ours to terminate.

--- a/internal/cli/mcp_bridge_singleton.go
+++ b/internal/cli/mcp_bridge_singleton.go
@@ -8,108 +8,135 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/cajasmota/grafel/internal/process"
 )
 
-// mcp_bridge_singleton.go — single-bridge guarantee (#5633).
+// mcp_bridge_singleton.go — per-SESSION bridge ownership record.
 //
-// Claude Code spawns one `grafel mcp-bridge` per session. A daemon restart (or
-// a crashed/abandoned session) can leave a PRIOR bridge orphaned — reparented
-// to init and still attached to the daemon socket — so two bridges race for the
-// same daemon connection. This is the "two mcp-bridge processes at once"
-// symptom in #5633.
+// History. #5633 asked for "exactly one bridge per daemon socket" and this file
+// implemented it by reaping (SIGTERM) whatever pid a per-SOCKET pidfile named.
+// The socket path (internal/daemon.DefaultLayout) has no cwd, repo, worktree or
+// session component: it is per-user, i.e. one pidfile for the whole machine. So
+// every newly started bridge SIGTERMed the incumbent bridge of every OTHER live
+// session — #6999, observed as a tool-agnostic `Transport closed`.
 //
-// We guarantee exactly one bridge per daemon socket with a per-socket pidfile,
-// mirroring the daemon's own AcquirePIDFile reap approach (internal/daemon/
-// pidfile.go) and the watcher-reaping precedent (#5632 / internal/process):
+// #6999: the reap is GONE. This file no longer signals any process, ever.
 //
-//   - On startup the bridge reads the per-socket pidfile. If it names a LIVE
-//     grafel process that is not us, that is an orphaned prior bridge for this
-//     socket — we reap it (SIGTERM via process.Kill) and wait briefly for it to
-//     exit before claiming ownership.
-//   - We then write our own pid into the pidfile and return a release closure
-//     that removes it on clean shutdown.
+// Why deleting it is safe rather than a regression of #5633:
 //
-// A stale pidfile (dead pid, or a recycled pid that is not a grafel process) is
-// overwritten silently — a crashed bridge must never wedge the next session.
+//   - A bridge whose client is gone exits on its own. bridge.run reads stdin
+//     and returns on io.EOF; when the MCP client dies its end of the pipe is
+//     closed and the bridge falls out of its loop. Nothing external is needed to
+//     collect it, and TestBridge_ExitsWhenStdinCloses pins that.
+//   - The orphan #5633 saw therefore had a LIVE client (a daemon restart does
+//     not touch stdin). Such a process is indistinguishable, from the outside,
+//     from a second concurrent session's perfectly healthy bridge — there is no
+//     key that unifies "an orphan and its replacement" while separating "two
+//     concurrent sessions", because they look identical. Choosing to kill in
+//     that ambiguity is exactly what produced #6999.
+//   - The remedy for a bridge that has lost the DAEMON (the real #5633 case) is
+//     owned by that bridge itself: reconnect (#6722) or exit — not a signal from
+//     a stranger.
+//
+// What remains is an ownership RECORD: a per-session pidfile naming the bridge
+// currently serving this socket for this session, plus a log line when a prior
+// record for the same session is still live. It is diagnostic only. Its key
+// includes a session identity so that concurrent sessions cannot overwrite each
+// other's record; a session identity that collides (two bridges whose stdin is
+// /dev/null, say) costs nothing beyond an overwritten record, because no signal
+// is ever derived from it.
 
-// bridgeReapGrace bounds how long we wait for a reaped prior bridge to exit
-// after SIGTERM before claiming the pidfile anyway. Kept short: the prior
-// bridge is a thin stdio proxy with nothing to flush.
-var bridgeReapGrace = 500 * time.Millisecond
+// EnvBridgeSession lets an MCP client name the session explicitly. When unset,
+// bridgeSessionID falls back to the identity of the client's stdin pipe, then
+// to this process's own pid (which is unique by construction).
+const EnvBridgeSession = "GRAFEL_MCP_SESSION"
 
-// bridgeSingletonPath derives the per-socket bridge pidfile path. It lives
+// bridgeSessionID returns an identifier for the client session this bridge
+// serves. It is used only to scope the ownership record's filename; it is never
+// a licence to signal another process.
+func bridgeSessionID() string {
+	if v := strings.TrimSpace(os.Getenv(EnvBridgeSession)); v != "" {
+		return "env:" + v
+	}
+	if id, ok := stdinIdentity(); ok {
+		return "stdin:" + id
+	}
+	return "pid:" + strconv.Itoa(os.Getpid())
+}
+
+// bridgeSingletonPath derives the per-session bridge pidfile path. It lives
 // beside the daemon socket so it shares the socket's per-user directory and
-// lifecycle. The socket basename is hashed into the name so distinct sockets
-// (e.g. a test override) never collide, without embedding a long path.
-func bridgeSingletonPath(socketPath string) string {
+// lifecycle. Both the socket path AND the session id are hashed into the name:
+// keying on the socket alone is #6999, because one file then names the single
+// bridge of an entire machine.
+func bridgeSingletonPath(socketPath, sessionID string) string {
 	dir := filepath.Dir(socketPath)
-	sum := sha256.Sum256([]byte(socketPath))
+	sum := sha256.Sum256([]byte(socketPath + "\x00" + sessionID))
 	name := "mcp-bridge-" + hex.EncodeToString(sum[:6]) + ".pid"
 	return filepath.Join(dir, name)
 }
 
-// acquireBridgeSingleton ensures this is the only live bridge for socketPath.
-// It reaps an orphaned prior bridge (if any) and records our pid. The returned
-// release closure removes the pidfile and must be called on shutdown. Errors
-// are non-fatal by design: a bridge that cannot write its pidfile should still
-// serve (degrading to the pre-#5633 best-effort behavior), so callers log and
-// continue rather than aborting the session.
-func acquireBridgeSingleton(socketPath string, logf func(string, ...any)) (release func(), err error) {
+// acquireBridgeSingleton records this process as the bridge serving socketPath
+// for this session and returns the pidfile path plus a release closure that
+// removes it on clean shutdown.
+//
+// It sends no signal to any process. If a prior record for THIS session still
+// names a live grafel process, that is logged and left alone: it is either an
+// orphan that will exit when its stdin closes, or a bridge that is still
+// serving somebody.
+//
+// Errors are non-fatal by design: a bridge that cannot write its record should
+// still serve, so callers log and continue rather than aborting the session.
+func acquireBridgeSingleton(socketPath string, logf func(string, ...any)) (release func(), pidfile string, err error) {
 	if logf == nil {
 		logf = func(string, ...any) {}
 	}
-	path := bridgeSingletonPath(socketPath)
+	path := bridgeSingletonPath(socketPath, bridgeSessionID())
 	self := os.Getpid()
 
-	if prior, ok := readBridgePID(path); ok && prior != self {
-		if isLiveBridge(prior) {
-			logf("reaping orphaned prior mcp-bridge (pid %d) for socket %s", prior, socketPath)
-			reapPriorBridge(prior)
-		}
+	if prior, ok := readBridgePID(path); ok && prior != self && isLiveBridge(prior) {
+		// #6999: log, never signal. A prior bridge is not ours to terminate.
+		logf("mcp-bridge: prior bridge (pid %d) for this session is still live; "+
+			"leaving it alone — grafel never signals another bridge (#6999). pidfile %s",
+			prior, path)
 	}
 
 	if werr := os.WriteFile(path, []byte(strconv.Itoa(self)+"\n"), 0o600); werr != nil {
-		return func() {}, fmt.Errorf("write bridge pidfile %s: %w", path, werr)
+		return func() {}, path, fmt.Errorf("write bridge pidfile %s: %w", path, werr)
 	}
 	return func() {
-		// Only remove the pidfile if it still names us — a newer bridge that
-		// reaped us may already own it.
+		// Only remove the record if it still names us — a newer bridge for the
+		// same session may already own it.
 		if cur, ok := readBridgePID(path); ok && cur == self {
 			_ = os.Remove(path)
 		}
-	}, nil
+	}, path, nil
 }
 
-// reapPriorBridge sends SIGTERM to a confirmed orphaned prior bridge and waits
-// (bounded) for it to exit. Best-effort: a signal/exit failure is non-fatal —
-// the new bridge claims the pidfile regardless so the session proceeds.
-func reapPriorBridge(pid int) {
-	_ = process.Kill(pid)
-	_ = waitForExit(pid, bridgeReapGrace)
-}
-
-// isLiveBridge reports whether pid names a live grafel process (a prior
-// bridge). PidIsGrafel defeats pid reuse: after a bridge dies its pid can be
-// recycled by an unrelated program, and we must not SIGTERM that. On platforms
-// where process enumeration is unavailable we fall back to a bare liveness
-// probe, matching daemon.pidIsLiveDaemon's conservative behavior.
+// isLiveBridge reports whether pid names a live grafel process. It gates a log
+// line only.
+//
+// When the executable behind pid cannot be verified we answer FALSE. The
+// pre-#6999 code answered true ("reaping a live grafel pid is the safe failure
+// mode"), which was the opposite of safe: PidIsGrafel matches ANY grafel
+// process by basename, so a recycled pid belonging to the daemon or the engine
+// satisfied it, and the answer fed a SIGTERM. Nothing signals on this answer
+// any more, and it still must not assert what it cannot verify.
 func isLiveBridge(pid int) bool {
 	if !process.IsAlive(pid) {
 		return false
 	}
-	isGrafel, err := process.PidIsGrafel(pid)
+	isGrafel, err := pidIsGrafel(pid)
 	if err != nil {
-		// Cannot verify the name (unsupported platform / transient scan
-		// failure). The pid is alive; honor it as a bridge to reap rather than
-		// leave a possible duplicate. Reaping a live grafel pid is the safe
-		// failure mode here.
-		return true
+		return false
 	}
 	return isGrafel
 }
+
+// pidIsGrafel is a seam over process.PidIsGrafel so the unverifiable-executable
+// branch of isLiveBridge is reachable from a test.
+var pidIsGrafel = process.PidIsGrafel
 
 func readBridgePID(path string) (int, bool) {
 	b, err := os.ReadFile(path)

--- a/internal/cli/mcp_bridge_singleton_test.go
+++ b/internal/cli/mcp_bridge_singleton_test.go
@@ -6,11 +6,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
 )
 
 // TestBridgeSingleton_ClaimsAndReleases asserts the happy path: a clean
@@ -20,11 +23,11 @@ func TestBridgeSingleton_ClaimsAndReleases(t *testing.T) {
 	dir := t.TempDir()
 	socket := filepath.Join(dir, "daemon.sock")
 
-	release, path, err := acquireBridgeSingleton(socket, nil)
+	release, path, err := acquireBridgeSingleton(dir, socket, nil)
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
-	if want := bridgeSingletonPath(socket, bridgeSessionID()); path != want {
+	if want := bridgeSingletonPath(dir, socket, bridgeSessionID()); path != want {
 		t.Fatalf("acquire returned pidfile %q, want %q", path, want)
 	}
 	pid, ok := readBridgePID(path)
@@ -37,6 +40,46 @@ func TestBridgeSingleton_ClaimsAndReleases(t *testing.T) {
 	}
 }
 
+// TestBridgeSingleton_ReleaseLeavesANewerOwnersRecord grades the `cur == self`
+// guard in the release closure. Two bridges can share a session id (a shared
+// GRAFEL_MCP_SESSION, or two stdins on /dev/null), and then the second one's
+// acquire overwrites the first one's record. When the FIRST bridge later exits,
+// an unconditional os.Remove would delete the record of a bridge that is still
+// serving — so the record is asserted, not a counter: the file must still exist
+// and must still name the newer owner.
+func TestBridgeSingleton_ReleaseLeavesANewerOwnersRecord(t *testing.T) {
+	t.Setenv(EnvBridgeSession, "sess-newer-owner")
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "daemon.sock")
+
+	release, path, err := acquireBridgeSingleton(dir, socket, nil)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if pid, ok := readBridgePID(path); !ok || pid != os.Getpid() {
+		t.Fatalf("precondition: record pid = %d (ok=%v), want %d", pid, ok, os.Getpid())
+	}
+
+	// A newer bridge for the same session claims the record.
+	const newer = 999123
+	if newer == os.Getpid() {
+		t.Fatalf("pick a pid that is not ours: %d", newer)
+	}
+	if err := os.WriteFile(path, []byte(strconv.Itoa(newer)+"\n"), 0o600); err != nil {
+		t.Fatalf("seed newer owner: %v", err)
+	}
+
+	release()
+
+	pid, ok := readBridgePID(path)
+	if !ok {
+		t.Fatalf("release deleted a record it no longer owns: %s is gone, but pid %d owns it", path, newer)
+	}
+	if pid != newer {
+		t.Fatalf("record pid = %d, want %d — release must not disturb a newer owner's record", pid, newer)
+	}
+}
+
 // TestBridgeSingleton_StalePidOverwritten asserts that a pidfile naming a DEAD
 // process is silently overwritten — a crashed bridge must not wedge the next
 // session.
@@ -44,12 +87,12 @@ func TestBridgeSingleton_StalePidOverwritten(t *testing.T) {
 	t.Setenv(EnvBridgeSession, "sess-stale")
 	dir := t.TempDir()
 	socket := filepath.Join(dir, "daemon.sock")
-	path := bridgeSingletonPath(socket, bridgeSessionID())
+	path := bridgeSingletonPath(dir, socket, bridgeSessionID())
 
 	if err := os.WriteFile(path, []byte("999999\n"), 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	release, _, err := acquireBridgeSingleton(socket, nil)
+	release, _, err := acquireBridgeSingleton(dir, socket, nil)
 	if err != nil {
 		t.Fatalf("acquire over stale pidfile: %v", err)
 	}
@@ -70,7 +113,7 @@ func TestBridgeSingleton_NeverSignalsPriorBridge(t *testing.T) {
 	t.Setenv(EnvBridgeSession, "sess-prior")
 	dir := t.TempDir()
 	socket := filepath.Join(dir, "daemon.sock")
-	path := bridgeSingletonPath(socket, bridgeSessionID())
+	path := bridgeSingletonPath(dir, socket, bridgeSessionID())
 
 	child := startFakeGrafelChild(t)
 	if !isLiveBridge(child.pid) {
@@ -82,7 +125,7 @@ func TestBridgeSingleton_NeverSignalsPriorBridge(t *testing.T) {
 	}
 
 	var logged []string
-	release, _, err := acquireBridgeSingleton(socket, func(f string, a ...any) {
+	release, _, err := acquireBridgeSingleton(dir, socket, func(f string, a ...any) {
 		logged = append(logged, strings.TrimSpace(fmt.Sprintf(f, a...)))
 	})
 	if err != nil {
@@ -106,21 +149,85 @@ func TestBridgeSingleton_NeverSignalsPriorBridge(t *testing.T) {
 // turned on: two sessions sharing ONE socket must not share a record. Keying on
 // the socket alone (the pre-#6999 behaviour) makes these equal.
 func TestBridgeSingleton_PathIsPerSessionNotPerSocket(t *testing.T) {
+	dir := filepath.Join("x", "y", "sockets")
 	socket := filepath.Join("x", "y", "daemon.sock")
-	a := bridgeSingletonPath(socket, "session-A")
-	b := bridgeSingletonPath(socket, "session-B")
+	a := bridgeSingletonPath(dir, socket, "session-A")
+	b := bridgeSingletonPath(dir, socket, "session-B")
 	if a == b {
 		t.Fatalf("two sessions on one socket share a pidfile %q — this is #6999", a)
 	}
-	if a != bridgeSingletonPath(socket, "session-A") {
-		t.Fatal("path not stable for a fixed (socket, session)")
+	if a != bridgeSingletonPath(dir, socket, "session-A") {
+		t.Fatal("path not stable for a fixed (dir, socket, session)")
 	}
-	other := bridgeSingletonPath(filepath.Join("x", "y", "other.sock"), "session-A")
+	other := bridgeSingletonPath(dir, filepath.Join("x", "y", "other.sock"), "session-A")
 	if other == a {
 		t.Fatalf("distinct sockets share a pidfile: %q", a)
 	}
-	if got, want := filepath.Clean(filepath.Dir(a)), filepath.Clean(filepath.Join("x", "y")); got != want {
-		t.Fatalf("pidfile not beside socket: dir=%q want %q (path %q)", got, want, a)
+	if got, want := filepath.Clean(filepath.Dir(a)), filepath.Clean(dir); got != want {
+		t.Fatalf("pidfile not in the record dir: dir=%q want %q (path %q)", got, want, a)
+	}
+}
+
+// TestBridgeRecordDir_IsAWritableDirectoryOnEveryPlatform is the pin the
+// Windows CI leg needed and nobody had. It runs everywhere, unskipped, and it
+// asserts the property the record depends on: the directory the record goes in
+// is a REAL, writable filesystem directory derived from the layout ROOT.
+//
+// Before this, the record dir was filepath.Dir(Layout.SocketPath). On Windows
+// SocketPath is a named pipe (`\\.\pipe\grafel-<hash>`) and SocketDir is
+// deliberately "", so that expression yielded `\\.\pipe` and every record write
+// failed — silently, because acquire's error is non-fatal by design. The
+// consequence ran both ways: no diagnostic record existed on Windows, and the
+// pre-#6999 reap could never fire there either, since readBridgePID never
+// returned a prior pid.
+//
+// It writes through acquireBridgeSingleton rather than asserting a string, so
+// a path that merely LOOKS filesystem-shaped on a platform still fails here.
+//
+// Scope, stated honestly: the DERIVATION (root vs socket dir) is only
+// distinguishable where the two differ, i.e. on Windows — under GRAFEL_DAEMON_ROOT
+// the unix socket already lives at <root>/sockets, so on unix the old and new
+// expressions coincide and the equality assertion below cannot separate them.
+// What this test does grade on every platform is that the dir is created and
+// written through, which is the half that never happened on Windows.
+func TestBridgeRecordDir_IsAWritableDirectoryOnEveryPlatform(t *testing.T) {
+	root := isolateGrafelRoot(t)
+	t.Setenv(EnvBridgeSession, "sess-record-dir")
+
+	dir, err := bridgeRecordDir()
+	if err != nil {
+		t.Fatalf("bridgeRecordDir: %v", err)
+	}
+	if want := filepath.Join(root, "sockets"); dir != want {
+		t.Fatalf("record dir = %q, want %q (it must come from Layout.Root)", dir, want)
+	}
+
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	// The regression itself, stated directly: the socket's own directory is not
+	// usable as the record dir on every platform, so it must not be the source.
+	if runtime.GOOS == "windows" && filepath.Dir(layout.SocketPath) == dir {
+		t.Fatalf("record dir %q was derived from the named pipe %q", dir, layout.SocketPath)
+	}
+
+	// Remove the dir first: nothing else creates it on Windows, so acquire has
+	// to. This is the step the old code had no way to perform.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("clear record dir: %v", err)
+	}
+	release, path, err := acquireBridgeSingleton(dir, layout.SocketPath, nil)
+	if err != nil {
+		t.Fatalf("acquire against the real layout socket %q failed: %v — "+
+			"the ownership record does not exist on this platform", layout.SocketPath, err)
+	}
+	defer release()
+	if pid, ok := readBridgePID(path); !ok || pid != os.Getpid() {
+		t.Fatalf("record %q pid = %d (ok=%v), want %d", path, pid, ok, os.Getpid())
+	}
+	if got := filepath.Dir(path); got != dir {
+		t.Fatalf("record written to %q, want it inside %q", got, dir)
 	}
 }
 
@@ -180,8 +287,14 @@ func TestIsLiveBridge_UnverifiableExecutableIsNotABridge(t *testing.T) {
 }
 
 // TestBridge_ExitsWhenStdinCloses establishes the premise the whole fix rests
-// on: a bridge whose client is gone collects ITSELF. No external reaper is
-// needed, so no bridge needs the right to signal another.
+// on: a bridge that is IDLE when its client goes collects ITSELF. No external
+// reaper is needed, so no bridge needs the right to signal another.
+//
+// Scope, deliberately narrow: this runs an idle in-process bridge over an
+// io.Pipe, so it pins EOF-while-idle only. It does NOT observe a bridge blocked
+// in a daemon call, which never returns to its read loop and so never sees the
+// EOF — that residual is #7003, and the header of mcp_bridge_singleton.go says
+// so rather than claiming this test covers every client-less bridge.
 func TestBridge_ExitsWhenStdinCloses(t *testing.T) {
 	isolateGrafelRoot(t)
 	pr, pw := io.Pipe()
@@ -214,6 +327,16 @@ func TestBridgeSignal_NoticeNamesItsCause(t *testing.T) {
 		t.Fatalf("mkdir logs: %v", err)
 	}
 
+	// daemon.log is the DAEMON's log, not a bridge-private file: the daemon and
+	// other bridges append to it concurrently. Seed prior content so the write
+	// offset is observable — without this the test writes the file from empty
+	// and a clobber cannot be seen by construction.
+	logPath := filepath.Join(root, "logs", "daemon.log")
+	prior := "2026/09/02 10:00:00 daemon: graceful shutdown complete\n"
+	if err := os.WriteFile(logPath, []byte(prior), 0o600); err != nil {
+		t.Fatalf("seed daemon log: %v", err)
+	}
+
 	var logged []string
 	var exited []int
 	handleBridgeSignal(syscall.SIGTERM, "/tmp/x/mcp-bridge-abc.pid", "/tmp/x/daemon.sock",
@@ -235,12 +358,21 @@ func TestBridgeSignal_NoticeNamesItsCause(t *testing.T) {
 		t.Fatalf("SIGINT exit code = %d, want 130", got)
 	}
 
-	body, err := os.ReadFile(filepath.Join(root, "logs", "daemon.log"))
+	body, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("daemon log not written: %v", err)
 	}
 	if !strings.Contains(string(body), "mcp-bridge-abc.pid") ||
 		!strings.Contains(string(body), "terminating on signal") {
 		t.Fatalf("daemon log does not record the termination: %s", body)
+	}
+	// HasPrefix, not Contains: the failure mode is a write at the wrong OFFSET
+	// (an open without O_APPEND lands the notice at byte 0, destroying the head
+	// of the daemon's log and leaving a corrupt fragment). Contains(prior) still
+	// passes when the notice is written in front of the prior line, so it cannot
+	// grade this; only "the prior bytes are still first" can.
+	if !strings.HasPrefix(string(body), prior) {
+		t.Fatalf("the bridge overwrote pre-existing daemon log content — daemon.log is shared "+
+			"with the daemon and with concurrent bridges, so the notice must be APPENDED:\n%s", body)
 	}
 }

--- a/internal/cli/mcp_bridge_singleton_test.go
+++ b/internal/cli/mcp_bridge_singleton_test.go
@@ -1,26 +1,31 @@
 package cli
 
 import (
+	"errors"
+	"fmt"
+	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
-
-	"github.com/cajasmota/grafel/internal/process"
 )
 
 // TestBridgeSingleton_ClaimsAndReleases asserts the happy path: a clean
-// acquire writes our pid to the per-socket pidfile and release removes it.
+// acquire writes our pid to the per-session pidfile and release removes it.
 func TestBridgeSingleton_ClaimsAndReleases(t *testing.T) {
+	t.Setenv(EnvBridgeSession, "sess-claims")
 	dir := t.TempDir()
 	socket := filepath.Join(dir, "daemon.sock")
-	path := bridgeSingletonPath(socket)
 
-	release, err := acquireBridgeSingleton(socket, nil)
+	release, path, err := acquireBridgeSingleton(socket, nil)
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
+	}
+	if want := bridgeSingletonPath(socket, bridgeSessionID()); path != want {
+		t.Fatalf("acquire returned pidfile %q, want %q", path, want)
 	}
 	pid, ok := readBridgePID(path)
 	if !ok || pid != os.Getpid() {
@@ -36,15 +41,15 @@ func TestBridgeSingleton_ClaimsAndReleases(t *testing.T) {
 // process is silently overwritten — a crashed bridge must not wedge the next
 // session.
 func TestBridgeSingleton_StalePidOverwritten(t *testing.T) {
+	t.Setenv(EnvBridgeSession, "sess-stale")
 	dir := t.TempDir()
 	socket := filepath.Join(dir, "daemon.sock")
-	path := bridgeSingletonPath(socket)
+	path := bridgeSingletonPath(socket, bridgeSessionID())
 
-	// Seed a stale pidfile with a pid that is essentially guaranteed dead.
 	if err := os.WriteFile(path, []byte("999999\n"), 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	release, err := acquireBridgeSingleton(socket, nil)
+	release, _, err := acquireBridgeSingleton(socket, nil)
 	if err != nil {
 		t.Fatalf("acquire over stale pidfile: %v", err)
 	}
@@ -54,109 +59,188 @@ func TestBridgeSingleton_StalePidOverwritten(t *testing.T) {
 	}
 }
 
-// TestBridgeSingleton_ReapsLivePriorBridge asserts that a live prior process
-// recorded in the pidfile is reaped (signalled to exit) before we claim
-// ownership — the core "single bridge" guarantee (#5633 part 3).
+// TestBridgeSingleton_NeverSignalsPriorBridge is the direct pin on the #6999
+// fix: acquiring over a pidfile that names a LIVE grafel-named process must
+// leave that process running. Before #6999 this path sent SIGTERM.
 //
-// We use a real child process (a long sleep) as the stand-in for the orphan.
-// isLiveBridge would normally require the pid to be a grafel process, but on
-// non-grafel test children PidIsGrafel returns false; to exercise the reap path
-// deterministically without spawning a real grafel binary we drive the reap
-// through the exported helpers with a child we then confirm receives SIGTERM.
-func TestBridgeSingleton_ReapsLivePriorBridge(t *testing.T) {
-	// Spawn a child that ignores nothing and exits on SIGTERM (default).
-	child := exec.Command("sleep", "30")
-	if err := child.Start(); err != nil {
-		t.Skipf("cannot spawn child process: %v", err)
-	}
-	priorPID := child.Process.Pid
-	// Ensure cleanup even if the test fails before reaping.
-	defer func() { _ = child.Process.Kill() }()
-
+// The child is a copy of the test binary named "grafel", so process.PidIsGrafel
+// classifies it exactly as it would a real bridge — without which the old reap
+// would have been skipped and this test would prove nothing.
+func TestBridgeSingleton_NeverSignalsPriorBridge(t *testing.T) {
+	t.Setenv(EnvBridgeSession, "sess-prior")
 	dir := t.TempDir()
 	socket := filepath.Join(dir, "daemon.sock")
-	path := bridgeSingletonPath(socket)
-	if err := os.WriteFile(path, []byte(strconv.Itoa(priorPID)+"\n"), 0o600); err != nil {
+	path := bridgeSingletonPath(socket, bridgeSessionID())
+
+	child := startFakeGrafelChild(t)
+	if !isLiveBridge(child.pid) {
+		t.Fatalf("precondition: child pid %d must classify as a live grafel process; "+
+			"without it this test cannot observe a reap", child.pid)
+	}
+	if err := os.WriteFile(path, []byte(strconv.Itoa(child.pid)+"\n"), 0o600); err != nil {
 		t.Fatalf("seed prior pid: %v", err)
 	}
 
-	// The child is not a grafel process, so isLiveBridge → false and the reap
-	// path is skipped (we must never SIGTERM a recycled non-grafel pid). Assert
-	// that: the child survives and we still claim ownership.
-	if isLiveBridge(priorPID) {
-		t.Fatal("isLiveBridge returned true for a non-grafel child; reap would target a foreign pid")
-	}
-
-	release, err := acquireBridgeSingleton(socket, nil)
+	var logged []string
+	release, _, err := acquireBridgeSingleton(socket, func(f string, a ...any) {
+		logged = append(logged, strings.TrimSpace(fmt.Sprintf(f, a...)))
+	})
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
 	defer release()
-	if pid, _ := readBridgePID(path); pid != os.Getpid() {
-		t.Fatalf("did not claim pidfile: pid=%d want %d", pid, os.Getpid())
-	}
 
-	// Child must still be alive (it was not a grafel process, so not reaped).
-	time.Sleep(50 * time.Millisecond)
-	if child.ProcessState != nil && child.ProcessState.Exited() {
-		t.Fatal("non-grafel child was killed — reap must be gated on PidIsGrafel")
+	// The prior bridge must still be alive: no signal was sent.
+	if !child.aliveAfter(200 * time.Millisecond) {
+		t.Fatalf("prior bridge (pid %d) was terminated by acquire — #6999 reap is back", child.pid)
+	}
+	if pid, _ := readBridgePID(path); pid != os.Getpid() {
+		t.Fatalf("did not claim record: pid=%d want %d", pid, os.Getpid())
+	}
+	if !anyContains(logged, "leaving it alone") {
+		t.Fatalf("a live prior bridge must be reported, not silently ignored; logged=%v", logged)
 	}
 }
 
-// TestBridgeSingleton_ReapTargetsLiveGrafel exercises the reap of a process we
-// CAN classify as a bridge: we kill it via the same path the acquire uses and
-// confirm it exits. We model the live-grafel case by directly invoking the
-// reap logic on a child whose liveness we control, asserting waitForExit
-// observes the exit after SIGTERM.
-func TestBridgeSingleton_ReapTargetsLiveGrafel(t *testing.T) {
-	child := exec.Command("sleep", "30")
-	if err := child.Start(); err != nil {
-		t.Skipf("cannot spawn child: %v", err)
+// TestBridgeSingleton_PathIsPerSessionNotPerSocket asserts the key that #6999
+// turned on: two sessions sharing ONE socket must not share a record. Keying on
+// the socket alone (the pre-#6999 behaviour) makes these equal.
+func TestBridgeSingleton_PathIsPerSessionNotPerSocket(t *testing.T) {
+	socket := filepath.Join("x", "y", "daemon.sock")
+	a := bridgeSingletonPath(socket, "session-A")
+	b := bridgeSingletonPath(socket, "session-B")
+	if a == b {
+		t.Fatalf("two sessions on one socket share a pidfile %q — this is #6999", a)
 	}
-	pid := child.Process.Pid
-	exited := make(chan struct{})
-	go func() { _ = child.Wait(); close(exited) }()
+	if a != bridgeSingletonPath(socket, "session-A") {
+		t.Fatal("path not stable for a fixed (socket, session)")
+	}
+	other := bridgeSingletonPath(filepath.Join("x", "y", "other.sock"), "session-A")
+	if other == a {
+		t.Fatalf("distinct sockets share a pidfile: %q", a)
+	}
+	if got, want := filepath.Clean(filepath.Dir(a)), filepath.Clean(filepath.Join("x", "y")); got != want {
+		t.Fatalf("pidfile not beside socket: dir=%q want %q (path %q)", got, want, a)
+	}
+}
 
-	// Simulate the reap action acquire would take for a confirmed live bridge.
-	if !process.IsAlive(pid) {
-		t.Fatal("expected child to be alive")
+// TestBridgeSessionID_DistinctPerSession covers the three identity sources by
+// name: the explicit env override, the stdin identity fallback, and the pid
+// fallback of last resort. Two sessions must never share an id by accident.
+func TestBridgeSessionID_DistinctPerSession(t *testing.T) {
+	t.Setenv(EnvBridgeSession, "alpha")
+	alpha := bridgeSessionID()
+	t.Setenv(EnvBridgeSession, "beta")
+	beta := bridgeSessionID()
+	if alpha == beta {
+		t.Fatalf("explicit session ids collided: %q", alpha)
 	}
-	reapPriorBridge(pid)
+	if !strings.HasPrefix(alpha, "env:") {
+		t.Fatalf("explicit session id not honoured: %q", alpha)
+	}
+
+	t.Setenv(EnvBridgeSession, "   ")
+	fallback := bridgeSessionID()
+	if strings.HasPrefix(fallback, "env:") {
+		t.Fatalf("blank env must not be honoured as a session id: %q", fallback)
+	}
+	if id, ok := stdinIdentity(); ok {
+		if fallback != "stdin:"+id {
+			t.Fatalf("fallback = %q, want stdin identity %q", fallback, "stdin:"+id)
+		}
+	} else if fallback != "pid:"+strconv.Itoa(os.Getpid()) {
+		t.Fatalf("last-resort fallback = %q, want pid identity", fallback)
+	}
+}
+
+// TestIsLiveBridge_RejectsNonGrafelPid asserts a recycled pid belonging to some
+// other program is not honoured as a bridge.
+func TestIsLiveBridge_RejectsNonGrafelPid(t *testing.T) {
+	child := startNonGrafelChild(t)
+	if isLiveBridge(child.pid) {
+		t.Fatalf("pid %d is not a grafel process but was classified as a live bridge", child.pid)
+	}
+	if isLiveBridge(0) || isLiveBridge(-1) || isLiveBridge(999999) {
+		t.Fatal("dead/invalid pids must not classify as live bridges")
+	}
+}
+
+// TestIsLiveBridge_UnverifiableExecutableIsNotABridge pins the conservative
+// default: when the executable behind a live pid cannot be read, the answer is
+// NO. The pre-#6999 code answered YES and fed that answer to a SIGTERM, so a
+// recycled pid belonging to the daemon or the engine was a valid kill target.
+func TestIsLiveBridge_UnverifiableExecutableIsNotABridge(t *testing.T) {
+	orig := pidIsGrafel
+	t.Cleanup(func() { pidIsGrafel = orig })
+	pidIsGrafel = func(int) (bool, error) { return false, errors.New("cannot enumerate processes") }
+
+	if isLiveBridge(os.Getpid()) {
+		t.Fatal("a live pid whose executable cannot be verified must not be treated as a bridge")
+	}
+}
+
+// TestBridge_ExitsWhenStdinCloses establishes the premise the whole fix rests
+// on: a bridge whose client is gone collects ITSELF. No external reaper is
+// needed, so no bridge needs the right to signal another.
+func TestBridge_ExitsWhenStdinCloses(t *testing.T) {
+	isolateGrafelRoot(t)
+	pr, pw := io.Pipe()
+	b := &bridge{socketPath: filepath.Join(t.TempDir(), "daemon.sock")}
+
+	done := make(chan error, 1)
+	go func() { done <- b.run(pr, io.Discard) }()
+
+	// Client goes away: its end of the pipe closes.
+	_ = pw.Close()
 
 	select {
-	case <-exited:
-		// Reaped successfully.
-	case <-time.After(2 * time.Second):
-		_ = child.Process.Kill()
-		t.Fatal("prior bridge was not reaped within the grace window")
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("bridge.run after stdin close = %v, want nil (clean exit)", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("bridge did not exit when stdin closed — the self-collection premise of #6999 is false")
 	}
 }
 
-// TestBridgeSingleton_PathStableAndPerSocket asserts the pidfile path is
-// deterministic for a socket and differs across sockets (no cross-socket
-// collision).
-func TestBridgeSingleton_PathStableAndPerSocket(t *testing.T) {
-	// Build socket paths with filepath.Join so the separators match the host
-	// OS (backslash on Windows, slash elsewhere). Comparing against a literal
-	// "/x/y" would spuriously fail on Windows, where filepath.Dir returns the
-	// backslash form (\x\y) — the production placement is correct; only the
-	// fixture was unix-only.
-	dir := filepath.Join("x", "y")
-	aSock := filepath.Join(dir, "a.sock")
-	bSock := filepath.Join(dir, "b.sock")
+// ── signal notice ────────────────────────────────────────────────────────────
 
-	a1 := bridgeSingletonPath(aSock)
-	a2 := bridgeSingletonPath(aSock)
-	b := bridgeSingletonPath(bSock)
-	if a1 != a2 {
-		t.Fatalf("path not stable: %q vs %q", a1, a2)
+// TestBridgeSignal_NoticeNamesItsCause asserts the ARTEFACT a future triage
+// will read: the line must name the signal, the pidfile, the socket and #6999,
+// and it must reach the daemon log, not just the client's stderr.
+func TestBridgeSignal_NoticeNamesItsCause(t *testing.T) {
+	root := isolateGrafelRoot(t)
+	if err := os.MkdirAll(filepath.Join(root, "logs"), 0o755); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
 	}
-	if a1 == b {
-		t.Fatalf("distinct sockets share a pidfile: %q", a1)
+
+	var logged []string
+	var exited []int
+	handleBridgeSignal(syscall.SIGTERM, "/tmp/x/mcp-bridge-abc.pid", "/tmp/x/daemon.sock",
+		func(f string, a ...any) { logged = append(logged, fmt.Sprintf(f, a...)) },
+		func(code int) { exited = append(exited, code) })
+
+	if len(logged) != 1 {
+		t.Fatalf("want exactly one stderr line, got %v", logged)
 	}
-	// The pidfile must live beside the socket: compare cleaned directories on
-	// both sides so the assertion is separator-agnostic.
-	if got, want := filepath.Clean(filepath.Dir(a1)), filepath.Clean(dir); got != want {
-		t.Fatalf("pidfile not beside socket: dir=%q want %q (path %q)", got, want, a1)
+	for _, want := range []string{"terminating on signal", "mcp-bridge-abc.pid", "daemon.sock", "#6999"} {
+		if !strings.Contains(logged[0], want) {
+			t.Fatalf("notice does not name %q: %s", want, logged[0])
+		}
+	}
+	if len(exited) != 1 || exited[0] != 143 {
+		t.Fatalf("exit codes = %v, want [143] (128+SIGTERM)", exited)
+	}
+	if got := bridgeSignalExitCode(syscall.SIGINT); got != 130 {
+		t.Fatalf("SIGINT exit code = %d, want 130", got)
+	}
+
+	body, err := os.ReadFile(filepath.Join(root, "logs", "daemon.log"))
+	if err != nil {
+		t.Fatalf("daemon log not written: %v", err)
+	}
+	if !strings.Contains(string(body), "mcp-bridge-abc.pid") ||
+		!strings.Contains(string(body), "terminating on signal") {
+		t.Fatalf("daemon log does not record the termination: %s", body)
 	}
 }


### PR DESCRIPTION
Closes #6999.

## What was wrong

`internal/cli/mcp_bridge_singleton.go` implemented #5633's "exactly one bridge per daemon socket" with a pidfile keyed on the **daemon socket path**. `daemon.DefaultLayout()` makes that `<per-user root>/sockets/daemon.sock` — no cwd, repo, worktree or session component. So **one pidfile named the single bridge of an entire machine**, and every newly started bridge read it and `process.Kill`ed the pid it found: the incumbent bridge of some *other* live session, across projects and across worktrees.

The victim had **no SIGTERM handler**, so it died on the default disposition (exit 143) with stdin still open and wrote nothing anywhere. The reaper's own line went to the *client's* stderr, so `~/.grafel/logs/` recorded nothing either. Client-visible result: a tool-agnostic `Transport closed` killing whatever call was in flight.

## First question: is the reap needed at all?

**No — established, and pinned by a test.**

`bridge.run` reads stdin and returns `nil` on `io.EOF`. When an MCP client dies, its end of the pipe closes and the bridge falls out of its loop unaided. `TestBridge_ExitsWhenStdinCloses` asserts exactly that, and names it as the premise the fix rests on.

It follows that the orphan #5633 observed had a **live client** (a daemon restart does not touch stdin). And a bridge with a live client that has lost the *daemon* is, from the outside, **indistinguishable from a second concurrent session's perfectly healthy bridge** — same executable, same socket, same everything a pidfile can see. There is no key that unifies "an orphan and its replacement" while separating "two concurrent sessions". Choosing to kill inside that ambiguity is precisely what produced #6999, so the fix is not a narrower key for the kill: **the kill is deleted.** The remedy for a bridge that has lost the daemon is owned by that bridge — reconnect (#6722) or exit — not by a stranger with a signal.

## What the change does

1. **No bridge signals any process, ever.** `reapPriorBridge` and `bridgeReapGrace` are gone.
2. **The record is per-session**, keyed on `(socket, session id)`. The session id is the explicit `GRAFEL_MCP_SESSION`, else the device/inode of the client's stdin pipe, else this process's pid. It scopes a filename and nothing else; a colliding id costs one overwritten record, because no signal is derived from it.
3. **A signalled bridge names its own death** — one line to stderr *and* to `~/.grafel/logs/daemon.log` giving the pidfile, the socket, the signal, and #6999 — then exits 128+signum, so a supervisor sees the same status as before.
4. #5633's other two parts (graceful drain, reconnect+retry) are untouched; they are what actually fixed its reported symptom.

## Secondary hazard — verified, and eliminated

Confirmed real on `main`: `isLiveBridge` returned **true** when `process.PidIsGrafel` errored, and `PidIsGrafel` matches **any** grafel process by executable basename (`exeBaseNameIsGrafel`, substring match). A stale pidfile whose pid had been recycled by the daemon or the engine was therefore a valid SIGTERM target — **the bridge could kill the daemon.**

It is eliminated by construction (nothing signals on that answer any more), and additionally fixed: the unverifiable case now answers **false**. Graded — see M3.

## Tests

`#6999` is a cross-process defect; no in-process assertion can observe it. The new tests run **real bridge processes**, and the children are copies of the test binary named `grafel`, because the old reap was gated on `PidIsGrafel`: with a child called `cli.test` the reap would have been skipped and the test would have passed against the bug.

- `TestBridge_ConcurrentSessionsAllSurviveAndServe` — the headline. Three bridges on **one** socket from a project, a **second project**, and a **worktree of the first** (each member asserted individually, not one representative). After each start, every earlier session must still be alive **and still answer an `initialize`**. Then: three **distinct** ownership records, each naming its own pid.
- `TestBridge_DoesNotSignalAnotherLiveGrafelProcess` — the negative. A live grafel-named process is seeded into both the legacy per-socket path and this session's path; starting a bridge must leave it running.
- `TestBridgeSingleton_NeverSignalsPriorBridge` — the unit-level pin: acquiring over a record naming a live grafel process leaves it alive and logs instead.
- `TestBridge_SignalledBridgeNamesItselfInTheDaemonLog` — end-to-end through the production wiring: a real bridge is SIGTERMed and must leave exactly one line in `daemon.log` naming its pidfile, its socket and #6999, while still exiting 143.
- Plus: stdin-close self-exit, per-session vs per-socket key, session-id sources, and `isLiveBridge` on an unverifiable executable.

## Mutants (permissive direction), `go vet` first, green baseline before each, `-count=1`

| # | Mutant | Verdict |
|---|---|---|
| M1 | restore the reap (`process.Kill(prior)`) | **DEAD** — `NeverSignalsPriorBridge`: "prior bridge (pid N) was terminated by acquire" |
| M2 | widen the key back to the socket alone | **DEAD** — `ConcurrentSessions…` ("has no ownership record of its own") + `PathIsPerSessionNotPerSocket` |
| **M1+M2** | **both — i.e. the exact pre-#6999 code** | **DEAD** — `ConcurrentSessions…`: *session "project-a" DIED when session "project-b" started*; also `DoesNotSignalAnotherLiveGrafelProcess` and 2 more. This is the production repro. |
| M3 | `isLiveBridge` returns true when `PidIsGrafel` errors | **DEAD after grading.** Initially *distinguishable and ungraded* — no seam made the error branch reachable. Priced at 4 lines (a `pidIsGrafel` package var), taken; `TestIsLiveBridge_UnverifiableExecutableIsNotABridge` now kills it. |
| M4 | drop the daemon-log mirror | **DEAD** — both daemon-log assertions |
| M5 | never arm the signal logger in `bridge.run` | **DEAD** — signalled bridge exits −1 (killed) instead of 143 |
| M6 | collapse every signal to exit 143 | **DEAD** — SIGINT must be 130 |

Each edit was applied with an asserted occurrence count of 1, its enclosing function printed, and restored by `cp` from a shasum-verified backup with `git status` confirming a clean tree afterwards (`grep -rn MUTANT internal/cli/` finds only a pre-existing unrelated comment).

## Verification

Tree: `…/scratchpad/fix-6999-v8n3p/wt`, branched from `c6a99d75f`. Every run under a fresh isolated `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`; the developer's `~/.grafel` was never written to.

- `go test -count=1 ./internal/cli/...` — ok (58.6s) + wiztui ok
- `go test -count=1 ./cmd/grafel/` — ok (149.2s), fresh isolated root
- `go test -count=1 ./internal/quality/ ./internal/process/ ./internal/daemon/` — all ok
- `gofmt -l internal/cli` clean, `go vet ./internal/cli/` clean

**Not run: the full `scripts/quality/run.sh --ratchet`.** The diff touches only the MCP bridge's process lifecycle (`internal/cli/mcp_bridge*`) — no extractor, resolver or graph surface — and the always-on structural gate `go test ./internal/quality -run TestBaseline` is green as part of the package run above. Say the word if you want the ~40-minute indexing ratchet run anyway.

**This PR needs the `ci:full` label** — it is `runtime.GOOS`-conditional territory (signals, pidfiles, unix vs windows session identity), and macOS tests only run with that label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861


---

## Review round on `d766d630a` → `36da881db`

### New finding: **#6999 never affected Windows, and neither did the fix's diagnostic**

The Windows CI leg on `d766d630a` was red, and it was a real platform gap, not a flake:

```
--- FAIL: TestBridge_ConcurrentSessionsAllSurviveAndServe
    session "project-a" (pid 2380) has no ownership record of its own; records=map[]
```

`records=map[]` — **empty**. Every earlier assertion passed, so all three bridges started, survived and kept serving; only the record enumeration failed, because **no record was written by anybody**.

Cause, verified along the whole chain (`bridge.run` → `defaultSocketPath` → `daemon.DefaultLayout().SocketPath` → `bridgeSingletonPath` → `filepath.Dir`): on Windows `SocketPath` is a **named pipe** (`\\.\pipe\grafel-<hash>`) and `SocketDir` is deliberately `""` (`internal/daemon/paths_windows.go`: *"named pipes have no filesystem directory"*). So `filepath.Dir(SocketPath)` is `\\.\pipe`, `os.WriteFile` always fails there, and `acquireBridgeSingleton`'s error is **non-fatal by design** — the bridge logged `bridge singleton: … (continuing)` and served on. The record has never existed on Windows.

**The pre-#6999 code derived the pidfile the same way** (`bridgeSingletonPath(socketPath) { dir := filepath.Dir(socketPath) … }`, `d766d630a^`). The reap was gated on `readBridgePID(path)` returning a prior pid, and that file was never written — so **the reap never fired on Windows. Windows users were never affected by #6999.**

Its limits, stated plainly: the reap evidence in the issue (83 reap lines across 10 project dirs) is **macOS-only**. It is *consistent with* this conclusion but is **not independent confirmation** of it — the conclusion rests on the code path above, not on the absence of Windows log lines, which nobody collected.

### Fix: derive the record dir from `Layout.Root`, not from the socket

`bridgeRecordDir()` returns `<Layout.Root>/sockets` on every platform, and `acquireBridgeSingleton` `MkdirAll`s it (nothing binds a socket there on Windows, so nothing else creates it). Rationale for that choice over the alternatives:

- `Layout.Root` is a real, writable directory on **both** platforms; `SocketDir` is empty on Windows and `filepath.Dir(SocketPath)` is a pipe namespace.
- It **keeps the unix location unchanged** under `GRAFEL_DAEMON_ROOT` (already `<root>/sockets`), so nothing moves for the tests or for the common case. It additionally pins the record to grafel's own state when the socket is in `XDG_RUNTIME_DIR` (a per-boot tmpfs).
- `sockets/` is already one of grafel's scratch dirs (`internal/install.grafelScratchDirs`), so `uninstall --purge` still cleans records up.
- The session id **stays in the hash**, and so does the socket path.

New pin, unskipped on every platform: `TestBridgeRecordDir_IsAWritableDirectoryOnEveryPlatform` removes the dir, then writes through the production `acquireBridgeSingleton` against the real `DefaultLayout().SocketPath`. Its scope is stated in its doc comment: the *derivation* is only distinguishable where root and socket dir differ (Windows); what it grades everywhere is that the dir is created and written through — the half that never happened on Windows. `TestBridge_ConcurrentSessionsAllSurviveAndServe` now enumerates `bridgeRecordDir()` rather than a hand-built `filepath.Join(root, "sockets")`.

**Why this was invisible until now:** the old singleton tests used fabricated paths under `t.TempDir()` (`filepath.Join("x","y","daemon.sock")`), so they never exercised the real layout. The multisession test found it precisely because its children run `bridge.run` with the **production** `DefaultLayout`. That is the argument for the test.

### Two ALIVE mutants graded — both now DEAD

Each mutant applied with an asserted occurrence count of **1** and its hit set printed, `go vet` clean, green `-count=1` baseline immediately before, restored by `cp` from a shasum-verified backup with `git diff HEAD` empty.

| # | Mutant | Before | After |
|---|---|---|---|
| **M-C** | `appendDaemonLog` drops `os.O_APPEND` (occurrence 1, line 81; `grep -c O_APPEND` = 0 after) | ALIVE | **DEAD** — `TestBridgeSignal_NoticeNamesItsCause` now seeds prior content and asserts **`strings.HasPrefix`**. `Contains(prior)` still passes when the notice is written *in front of* it, and a wrong write offset is exactly the failure mode. `daemon.log` is the **daemon's** log, shared with concurrent writers. |
| **M-A** | release closure removes the record unconditionally (drop `cur == self`, occurrence 1) | ALIVE | **DEAD** — `TestBridgeSingleton_ReleaseLeavesANewerOwnersRecord` seeds a *different* pid as the newer owner, calls `release()`, and requires the file to still exist and still name that pid. The artefact, not a counter. |
| **new** | drop `acquireBridgeSingleton`'s `MkdirAll` | — | **DEAD** — `TestBridgeRecordDir_IsAWritableDirectoryOnEveryPlatform`. |

### The self-collection claim is now scoped to what is actually pinned

`mcp_bridge_singleton.go`'s header said a bridge whose client is gone *"exits on its own"* and named `TestBridge_ExitsWhenStdinCloses` as the pin. That test runs an **idle in-process bridge over an `io.Pipe`**: it pins EOF-while-idle, not "whose client is gone" — the same defect class this PR fixes one level down.

The header now says which shapes self-collect (client SIGKILL, client SIGTERM, client closes stdin while alive — all three verified with real processes by the reviewer), and names the one that does not: a bridge **blocked in a daemon call** is not in its read loop and never observes the EOF, because `callDaemon` → `net/rpc` `Call` has **no deadline**. Filed as **#7003**, and deliberately not fixed here — the old reap only collected that case when a *new* bridge started, i.e. the #6999 event itself. `TestBridge_ExitsWhenStdinCloses`'s doc comment now states its scope.

### Verification (this round)

Fresh isolated `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT` per run; the developer's `~/.grafel` was never written to; no process I did not start was signalled.

- `go test -count=1 ./internal/cli/ ./internal/daemon/ ./internal/process/` — all ok (58.5s / 32.3s / 1.0s)
- `go test -count=1 ./cmd/grafel/` — ok (177.3s), fresh isolated root
- `gofmt -l internal/cli` clean, `go vet ./internal/cli/ ./internal/daemon/` clean
- Cross-`vet` for `GOOS=windows` is not possible in this tree (the tree-sitter cgo bindings exclude all files under a cross build) — a pre-existing limitation, unrelated to this diff. **The Windows leg in CI is the check that matters here**, which is why the `ci:full` label was removed and re-added after the push.
