### PR TITLE
fix(#6997): the daemon's extract subprocess dispatched custom extractors under neither guard — align it with the other two sites and pin the agreement

### DIFF
--- a/cmd/grafel/custom_gate_optin_6997_test.go
+++ b/cmd/grafel/custom_gate_optin_6997_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// #6997 — subprocCustomExtractorsOptIn is what decides whether the
+// custom-extractor gate crosses into the extract subprocesses, and it must
+// forward ONLY the programmatic opt-in.
+//
+// Both error directions are real and neither is caught anywhere else:
+//
+//   - Always returning a non-nil false would send `--custom-extractors false`
+//     to every child on a default index. Config beats env, so that would
+//     SUPPRESS a set GRAFEL_INPROC_CUSTOM_EXTRACTORS in the child while the
+//     in-process path honoured it — the same disagreement between paths this
+//     issue exists to close, reintroduced from the other end.
+//   - Always returning a non-nil true would run ~340 custom extractors for
+//     operators who opted into GRAFEL_SUBPROC_EXTRACT and nothing else,
+//     deciding #6966's default-OFF question for them locally.
+func TestSubprocCustomExtractorsOptIn6997(t *testing.T) {
+	if got := subprocCustomExtractorsOptIn(false); got != nil {
+		t.Errorf("no programmatic opt-in must forward NOTHING (nil), so the child "+
+			"falls back to the inherited env exactly as the in-process path does; got %v", *got)
+	}
+	got := subprocCustomExtractorsOptIn(true)
+	if got == nil {
+		t.Fatal("WithCustomExtractors must survive the process boundary; got nil")
+	}
+	if !*got {
+		t.Errorf("opt-in forwarded as %v, want true", *got)
+	}
+}
+
+// TestSubprocCoordinatorGetsTheIndexersOwnOptIn6997 grades the one line the
+// helper test above cannot reach: WHAT Index() hands the coordinator.
+//
+// The subprocExtract() branch of Index() is not exercised by any test in this
+// repo — it forks `grafel extract` via os.Executable(), which inside a test
+// binary is the test binary, and there is no BinaryPath override on that path.
+// So `CustomExtractors: subprocCustomExtractorsOptIn(true)` — an unconditional
+// opt-in that would run ~340 custom extractors for every operator who set
+// GRAFEL_SUBPROC_EXTRACT=1 — survives every behavioural suite. Measured
+// distinguishing input, macOS/APFS: django-realworld indexes to 456 entities
+// with the gate on and 371 with it off.
+//
+// Rather than plumb a binary override into production for testability, the
+// forwarded EXPRESSION is asserted, the same instrument
+// TestRunCustomExtractorsCallSitesCarryBothGuards6997 uses on the dispatch
+// sites. A constant here fails; so does forwarding some other flag.
+func TestSubprocCoordinatorGetsTheIndexersOwnOptIn6997(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "index.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse index.go: %v", err)
+	}
+
+	const want = "subprocCustomExtractorsOptIn(i.customExtractors)"
+	found := 0
+	ast.Inspect(f, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		sel, ok := lit.Type.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "CoordinatorConfig" {
+			return true
+		}
+		found++
+		var got string
+		for _, el := range lit.Elts {
+			kv, ok := el.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			if key, ok := kv.Key.(*ast.Ident); ok && key.Name == "CustomExtractors" {
+				var sb strings.Builder
+				if err := printer.Fprint(&sb, fset, kv.Value); err != nil {
+					t.Fatalf("print: %v", err)
+				}
+				got = sb.String()
+			}
+		}
+		if got != want {
+			t.Errorf("extract.CoordinatorConfig.CustomExtractors = %q, want %q.\n"+
+				"The custom-extractor gate forwarded to the extract subprocesses must be "+
+				"the INDEXER's own opt-in; a constant decides #6966's default-OFF question "+
+				"for whoever set GRAFEL_SUBPROC_EXTRACT.", got, want)
+		}
+		return true
+	})
+	if found != 1 {
+		t.Fatalf("found %d extract.CoordinatorConfig literals in index.go, want exactly 1; "+
+			"a second call site would need the same forwarding and this test would not see it", found)
+	}
+}

--- a/cmd/grafel/extract.go
+++ b/cmd/grafel/extract.go
@@ -86,6 +86,21 @@ func subprocBatchSize() int {
 	return n
 }
 
+// subprocCustomExtractorsOptIn mirrors, for the subprocess-extract path, the
+// stamp classifyAndReadWithProgress applies to ExtractorConfig: only the
+// programmatic OPT-IN travels. An unset WithCustomExtractors must not be
+// forwarded as an explicit `false`, because Config beats env in both
+// directions — a forwarded false would suppress a set
+// GRAFEL_INPROC_CUSTOM_EXTRACTORS in the child while the in-process path
+// honoured it, which is the very disagreement #6997 is closing.
+func subprocCustomExtractorsOptIn(optedIn bool) *bool {
+	if !optedIn {
+		return nil
+	}
+	on := true
+	return &on
+}
+
 // skipPassNames flattens the indexer's skip-set into the slice the
 // coordinator forwards to each subprocess via --skip-pass.
 func skipPassNames(set map[string]bool) []string {
@@ -120,6 +135,10 @@ func runExtractSubprocess(argv []string) error {
 		skipPasses = fs.String("skip-pass", "", "comma-separated pass names to skip")
 		drfNames   = fs.String("drf-names", "", "path to coordinator-written DRF register-name file (#1292)")
 		ormFields  = fs.String("orm-fields", "", "path to coordinator-written ORM field-name file (#2505)")
+		// #6997 — tri-state: unset means "the parent said nothing", and the
+		// child then resolves the custom-extractor gate from the inherited
+		// environment exactly as the in-process path does.
+		customExtr = fs.String("custom-extractors", "", "programmatic custom-extractor opt-in (true/false); empty means fall back to GRAFEL_INPROC_CUSTOM_EXTRACTORS")
 	)
 	if err := fs.Parse(argv); err != nil {
 		return err
@@ -140,6 +159,18 @@ func runExtractSubprocess(argv []string) error {
 		}
 	}
 
+	var customExtractors *bool
+	switch strings.ToLower(strings.TrimSpace(*customExtr)) {
+	case "":
+		// nil — env fallback.
+	case "1", "true", "yes":
+		on := true
+		customExtractors = &on
+	default:
+		off := false
+		customExtractors = &off
+	}
+
 	return extract.Run(context.Background(), extract.SubprocessOptions{
 		RepoRoot:      *repo,
 		Language:      *lang,
@@ -149,5 +180,7 @@ func runExtractSubprocess(argv []string) error {
 		SkipPasses:    skipSet,
 		DRFNamesPath:  *drfNames,
 		ORMFieldsPath: *ormFields,
+
+		CustomExtractors: customExtractors,
 	})
 }

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -1806,6 +1806,13 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			// #5135: foreground rebuilds run at the higher rebuild cap;
 			// background scheduler reindexes stay throttled.
 			Interactive: i.interactive,
+			// #6997 — the same programmatic half of the custom-extractor gate
+			// classifyAndReadWithProgress stamps onto ExtractorConfig, carried
+			// to the children so this path evaluates the identical gate. Only
+			// the opt-in is stamped, for the same reason as there: a false
+			// would OVERRIDE a set env var, which is not what an unset option
+			// means.
+			CustomExtractors: subprocCustomExtractorsOptIn(i.customExtractors),
 		})
 		if cerr != nil {
 			trk.Fail(cerr.Error())

--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -77,6 +77,14 @@ type CoordinatorConfig struct {
 	// foreground rebuild runs fast; only the throttled background path keeps
 	// the conservative GRAFEL_EXTRACT_GOMAXPROCS default (1 since #5960).
 	Interactive bool
+
+	// CustomExtractors forwards the PROGRAMMATIC half of the
+	// custom-extractor gate to every child via --custom-extractors
+	// (#6997). nil (the production case) forwards nothing and lets each
+	// child resolve the gate from the inherited environment, which is the
+	// same answer the in-process path computes. See
+	// SubprocessOptions.CustomExtractors.
+	CustomExtractors *bool
 }
 
 // runtimeCaps is the process-wide runtime-reloadable cap store (#5137). The
@@ -526,6 +534,17 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 			}
 			if skip != "" {
 				args = append(args, "--skip-pass", skip)
+			}
+			// #6997 — carry the programmatic custom-extractor opt-in across
+			// the process boundary. Only forwarded when the parent actually
+			// said something; otherwise the child falls back to the env half,
+			// which it inherits through childEnv.
+			if cfg.CustomExtractors != nil {
+				if *cfg.CustomExtractors {
+					args = append(args, "--custom-extractors", "true")
+				} else {
+					args = append(args, "--custom-extractors", "false")
+				}
 			}
 
 			cmd := exec.CommandContext(ctx, bin, args...)

--- a/internal/daemon/extract/custom_gate_6997_test.go
+++ b/internal/daemon/extract/custom_gate_6997_test.go
@@ -1,0 +1,287 @@
+package extract
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+)
+
+// #6997 — the subprocess extract path used to dispatch custom extractors under
+// `runExtract` alone: no custom-extractor gate, no `TSTree != nil`. The two
+// other dispatch sites (cmd/grafel/index.go, internal/extractors/incremental.go)
+// carry both. This pins the gate half BEHAVIOURALLY, at this path's own
+// entrypoint, so a source-level scan is not the only thing standing between the
+// paths and a fresh divergence.
+//
+// Measured consequence of the fix, macOS/APFS, GRAFEL_SUBPROC_EXTRACT=1 (the
+// only way to reach this file in production; default-OFF), against 81f99d691:
+// django-realworld 456 -> 371 entities with the gate OFF, and 456 -> 456 with
+// GRAFEL_INPROC_CUSTOM_EXTRACTORS=1 — i.e. byte-for-byte the old behaviour when
+// the gate is on, and the in-proc path's behaviour when it is not.
+
+// runCustomGateArm runs one extraction of a Django-shaped python file and
+// returns the emitted entity identities as "<kind>|<name>".
+func runCustomGateArm(t *testing.T, custom *bool) []string {
+	t.Helper()
+	repo := t.TempDir()
+	src := "from django.db import models\n" +
+		"\n" +
+		"\n" +
+		"class Widget(models.Model):\n" +
+		"    name = models.CharField(max_length=10)\n"
+	if err := os.WriteFile(filepath.Join(repo, "models.py"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	batch := filepath.Join(t.TempDir(), "batch.txt")
+	if err := os.WriteFile(batch, []byte("models.py\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := Run(context.Background(), SubprocessOptions{
+		RepoRoot:         repo,
+		BatchPath:        batch,
+		BatchID:          "gate-6997",
+		Output:           &buf,
+		CustomExtractors: custom,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var got []string
+	dec := json.NewDecoder(strings.NewReader(buf.String()))
+	for dec.More() {
+		var env Envelope
+		if err := dec.Decode(&env); err != nil {
+			t.Fatalf("decode: %v\n---\n%s", err, buf.String())
+		}
+		if env.Type == KindEntity && env.Entity != nil {
+			got = append(got, string(env.Entity.Kind)+"|"+env.Entity.Name)
+		}
+	}
+	sort.Strings(got)
+	return got
+}
+
+func TestSubprocCustomExtractorsHonourTheGate6997(t *testing.T) {
+	ptr := func(b bool) *bool { return &b }
+
+	cases := []struct {
+		name string
+		env  string // "" means unset
+		cfg  *bool
+		want bool // custom entities expected
+		why  string
+	}{
+		{"default: env unset, no programmatic opt-in", "", nil, false,
+			"this is what every production caller passes; #6966 keeps the gate default-OFF"},
+		{"env opt-in", "1", nil, true,
+			"the child inherits os.Environ() from the coordinator, so the env half needs no plumbing"},
+		{"programmatic opt-in, env unset", "", ptr(true), true,
+			"WithCustomExtractors must survive the process boundary or `grafel quality` " +
+				"would measure a different graph on this path than in-process"},
+		{"config false BEATS a set env var", "1", ptr(false), false,
+			"ExtractorConfig precedence is config-first in BOTH directions (#2320); the " +
+				"tri-state pointer is what distinguishes 'config said no' from 'config did not say'"},
+	}
+
+	// Baseline: the entities the base python extractor emits with the gate off.
+	// Every custom-on arm must be a strict SUPERSET of it — the gate adds, it
+	// never replaces, on this path (the merge that can supersede lives in the
+	// in-process path, not here).
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+	base := runCustomGateArm(t, nil)
+	if len(base) == 0 {
+		t.Fatal("the base python extractor emitted nothing; the fixture no longer " +
+			"exercises anything and every assertion below would be vacuous")
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", tc.env)
+			got := runCustomGateArm(t, tc.cfg)
+
+			extra := diffMultiset6997(got, base)
+			hasCustom := len(extra) > 0
+			if hasCustom != tc.want {
+				t.Fatalf("custom entities present = %v, want %v (%s)\n  extra over the "+
+					"gate-off baseline: %v\n  full: %v", hasCustom, tc.want, tc.why, extra, got)
+			}
+			if !tc.want {
+				// Grade the negative direction on identity, not just on a count:
+				// an arm that swapped one entity for another would keep the count.
+				if strings.Join(got, "\n") != strings.Join(base, "\n") {
+					t.Fatalf("gate OFF but the output differs from the gate-off baseline:\n  got:  %v\n  base: %v", got, base)
+				}
+			}
+			if len(diffMultiset6997(base, got)) > 0 {
+				t.Fatalf("an arm LOST base entities; the custom pass on this path is "+
+					"additive by construction (no MergeWithCustom here)\n  missing: %v",
+					diffMultiset6997(base, got))
+			}
+		})
+	}
+}
+
+// TestSubprocCustomExtractorsRequireAParseTree6997 pins the SECOND guard
+// separately from the first, because `A && B` scored only as a unit grades
+// neither half, and two guards that only ever fire together grade nothing.
+//
+// The gate is ON throughout, so the only thing that can suppress output here is
+// `file.TSTree != nil`.
+//
+// THE FIXTURE IS A REAL PRODUCTION SHAPE, not a contrived nil. Nim has a
+// registered custom-extractor prefix (custom_nim_) and NO tree-sitter grammar,
+// so parser.Parse fails and file.TSTree stays nil for every .nim file in every
+// repo. internal/custom/nim/norm_orm.go is content-only — it never touches the
+// parse tree — so before this fix the subprocess path emitted its Norm ORM
+// schema entities while the in-process and incremental paths emitted none.
+// clojure, crystal, dart, erlang and fsharp are in the same position.
+//
+// This is also why the divergence could not be closed by DELETING the guard
+// from the other two sites: content-only extractors emit for files that failed
+// to parse, which is exactly the input the indexer decided it could not read.
+func TestSubprocCustomExtractorsRequireAParseTree6997(t *testing.T) {
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+
+	repo := t.TempDir()
+	src := "import norm/model\n" +
+		"\n" +
+		"type\n" +
+		"  User* = ref object of Model\n" +
+		"    name*: string\n" +
+		"    email*: string\n"
+	if err := os.WriteFile(filepath.Join(repo, "models.nim"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	batch := filepath.Join(t.TempDir(), "batch.txt")
+	if err := os.WriteFile(batch, []byte("models.nim\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := Run(context.Background(), SubprocessOptions{
+		RepoRoot: repo, BatchPath: batch, BatchID: "niltree-6997", Output: &buf,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var got []string
+	dec := json.NewDecoder(strings.NewReader(buf.String()))
+	for dec.More() {
+		var env Envelope
+		if err := dec.Decode(&env); err != nil {
+			t.Fatalf("decode: %v\n---\n%s", err, buf.String())
+		}
+		if env.Type == KindEntity && env.Entity != nil {
+			got = append(got, string(env.Entity.Kind)+"|"+env.Entity.Name+"|"+env.Entity.Subtype)
+		}
+	}
+	sort.Strings(got)
+
+	// POSITIVE CONTROL, so a fixture that stopped exercising anything cannot
+	// read as a pass: the same content, dispatched directly, MUST produce the
+	// Norm entities. If this ever stops holding, the assertion below is vacuous
+	// and the test says so instead of going green.
+	direct, _ := extractors.RunCustomExtractors(context.Background(), extractors.FileInput{
+		Path: "models.nim", Language: "nim", Content: []byte(src),
+	})
+	if len(direct) == 0 {
+		t.Fatal("positive control failed: RunCustomExtractors emits nothing for this " +
+			"nim fixture even with a nil tree, so the assertion below cannot distinguish " +
+			"the guard from an inert extractor. Fix the fixture, do not delete the check.")
+	}
+
+	for _, g := range got {
+		if strings.HasPrefix(g, "SCOPE.Schema|") {
+			t.Fatalf("custom-extractor output survived a nil parse tree: %q\n  all: %v\n"+
+				"  direct dispatch produces %d entities for the same content",
+				g, got, len(direct))
+		}
+	}
+}
+
+// diffMultiset6997 returns the members of a that are not covered by b,
+// counting duplicates.
+func diffMultiset6997(a, b []string) []string {
+	remaining := map[string]int{}
+	for _, x := range b {
+		remaining[x]++
+	}
+	var out []string
+	for _, x := range a {
+		if remaining[x] > 0 {
+			remaining[x]--
+			continue
+		}
+		out = append(out, x)
+	}
+	return out
+}
+
+// TestCoordinateForwardsTheProgrammaticCustomGate6997 grades the PROPAGATION,
+// which the two tests above cannot: they call Run in-process and hand it the
+// option directly, so they would pass just as well if the coordinator never
+// forwarded anything and `grafel quality`-style programmatic opt-in silently
+// died at the process boundary.
+//
+// The env half needs no forwarding (children get os.Environ()), so this test
+// clears GRAFEL_INPROC_CUSTOM_EXTRACTORS and drives the config half alone,
+// end to end: CoordinatorConfig → --custom-extractors → flag parse →
+// SubprocessOptions → the gate.
+func TestCoordinateForwardsTheProgrammaticCustomGate6997(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test (forks a built binary) — skipped in -short mode")
+	}
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+	bin := buildGrafel(t)
+
+	repo := t.TempDir()
+	src := "from django.db import models\n\n\nclass Widget(models.Model):\n" +
+		"    name = models.CharField(max_length=10)\n"
+	if err := os.WriteFile(filepath.Join(repo, "models.py"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	count := func(custom *bool) int {
+		var stderr bytes.Buffer
+		res, err := Coordinate(context.Background(), repo, []string{"models.py"},
+			CoordinatorConfig{BinaryPath: bin, Stderr: &stderr, CustomExtractors: custom})
+		if err != nil {
+			t.Fatalf("Coordinate: %v\n%s", err, stderr.String())
+		}
+		return len(res.Entities)
+	}
+
+	ptr := func(b bool) *bool { return &b }
+	off := count(nil)
+	on := count(ptr(true))
+	if off == 0 {
+		t.Fatal("the gate-off arm produced no entities at all; the fixture is not " +
+			"exercising the extract path and the comparison below is vacuous")
+	}
+	if on <= off {
+		t.Fatalf("CoordinatorConfig.CustomExtractors=true did not reach the child: "+
+			"entities off=%d on=%d (want on > off). The programmatic opt-in has to "+
+			"cross the process boundary as --custom-extractors; the env half does not.",
+			off, on)
+	}
+
+	// The false branch of the forwarding is not decoration: config beats env in
+	// BOTH directions, so an explicit false must cross the boundary too and
+	// suppress a set env var in the child. Without this arm, deleting the else
+	// branch in the coordinator is invisible.
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+	if envOn, cfgOff := count(nil), count(ptr(false)); cfgOff != off || envOn <= off {
+		t.Fatalf("config-false did not cross the process boundary: entities "+
+			"env-on=%d cfg-false=%d gate-off baseline=%d (want env-on > baseline and "+
+			"cfg-false == baseline)", envOn, cfgOff, off)
+	}
+}

--- a/internal/daemon/extract/subproc.go
+++ b/internal/daemon/extract/subproc.go
@@ -74,6 +74,20 @@ type SubprocessOptions struct {
 	// issue #2505. When empty (single-batch mode or tests) the subprocess
 	// falls back to scanning its own batch (the original #2448 behaviour).
 	ORMFieldsPath string
+
+	// CustomExtractors carries the PROGRAMMATIC half of the
+	// custom-extractor gate (#5989/#6960/#6997) across the process
+	// boundary. nil means "the parent did not opt in programmatically",
+	// which is what every production caller passes: the sole non-test
+	// caller of WithCustomExtractors is `grafel quality`, and that runs
+	// in-process. The ENV half (GRAFEL_INPROC_CUSTOM_EXTRACTORS) needs no
+	// plumbing — the coordinator hands each child os.Environ() — so a nil
+	// here still resolves through CustomExtractorsEnabled's env fallback.
+	//
+	// It is a tri-state pointer for the same reason ExtractorConfig's own
+	// field is: Config wins over env in BOTH directions, so "did not say"
+	// has to be distinguishable from "said false".
+	CustomExtractors *bool
 }
 
 // Run is the subprocess-side entrypoint. It is invoked from
@@ -136,6 +150,16 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 
 	crossExtractors := cross.AllExtractors()
 	runExtract := !opts.SkipPasses["extract"]
+	// #6997 — the custom-extractor gate, evaluated by the SAME expression the
+	// in-process (cmd/grafel/index.go) and incremental
+	// (internal/extractors/incremental.go) dispatch sites use. Before this,
+	// Pass 2 below dispatched under runExtract alone, so an operator who opted
+	// into GRAFEL_SUBPROC_EXTRACT got custom extractors whether or not the gate
+	// #6966 keeps default-OFF was on. That divergence is precisely what the
+	// GRAFEL_SUBPROC_EXTRACT rollout exists to rule out: the subprocess path's
+	// stated acceptance criterion is output byte-identical to in-process.
+	customCfg := &extractor.ExtractorConfig{InProcCustomExtractors: opts.CustomExtractors}
+	runCustom := runExtract && extractors.CustomExtractorsEnabled(customCfg)
 	runFramework := !opts.SkipPasses["framework"]
 	runCross := !opts.SkipPasses["cross-lang"]
 
@@ -360,7 +384,19 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 		// language-equivalent) extractor for the file's language. Results
 		// are emitted as independent entities — they do NOT replace the
 		// base Pass 1 output; downstream dedup handles any overlap.
-		if runExtract {
+		//
+		// BOTH GUARDS ARE THE OTHER TWO SITES' GUARDS (#6997), not new
+		// policy. `file.TSTree != nil` is load-bearing beyond avoiding a
+		// use-after-free: a subset of custom extractors work on file CONTENT
+		// and emit entities with no parse tree at all, so without it a file
+		// that FAILED to parse still produces custom entities — on exactly
+		// the inputs the indexer decided it could not understand. That is
+		// also why the guard cannot be dropped from the other two sites to
+		// "make them agree" downward.
+		//
+		// The three sites are frozen as a set by
+		// TestRunCustomExtractorsCallSitesCarryBothGuards6997.
+		if runCustom && file.TSTree != nil {
 			customEnts, _ := extractors.RunCustomExtractors(ctx, file)
 			rels := 0
 			for k := range customEnts {

--- a/internal/extractors/custom_dispatch_call_sites_6997_test.go
+++ b/internal/extractors/custom_dispatch_call_sites_6997_test.go
@@ -1,0 +1,347 @@
+package extractors_test
+
+// #6997 — the three RunCustomExtractors dispatch sites must carry the SAME two
+// guards, and a fourth site must not be able to appear with a fourth
+// combination in silence.
+//
+// WHAT THE TWO GUARDS ARE, AND WHY NEITHER IS OPTIONAL.
+//
+//   - `CustomExtractorsEnabled(cfg)` is the whole custom-extractor gate — the
+//     config half and the env half (custom_gate.go). #6966 keeps it
+//     default-OFF and treats flipping it as the owner's decision. A dispatch
+//     site that does not consult it makes that decision locally, for whichever
+//     users happen to be on that path.
+//   - `TSTree != nil` is load-bearing for a reason independent of the gate: a
+//     subset of custom extractors work on file CONTENT and emit entities with
+//     no parse tree, so a site without it produces custom entities for files
+//     that FAILED TO PARSE — the exact inputs the indexer decided it could not
+//     understand. "Make them agree" therefore cannot be satisfied downward, by
+//     deleting the guard from the two sites that have it.
+//
+// WHY A SCAN AND NOT THREE HAND-WRITTEN ASSERTIONS. Before this test, nothing
+// failed when the sites disagreed — internal/daemon/extract/subproc.go
+// dispatched under `runExtract` alone and had done so for its whole life. A
+// test naming three files can only ever re-state today's population; the
+// failure mode is the FOURTH site. So the population is derived by walking
+// every non-test .go file in the repo, and set equality against the frozen
+// list below is asserted in BOTH directions: a new site fails, and deleting or
+// moving one fails until this list is edited to match.
+//
+// WHY THE CONDITION IS EXPANDED RATHER THAN MATCHED AS TEXT. subproc.go's
+// guard reads `if runCustom && file.TSTree != nil`, with `runCustom` bound
+// earlier in the same function to `runExtract && CustomExtractorsEnabled(...)`.
+// A literal text match on the `if` condition would score that site as
+// unguarded and push the next author towards inlining a long expression into a
+// hot loop to satisfy a test. Single assignments within the enclosing function
+// are therefore substituted before the guard is judged.
+//
+// GRADED PART BY PART. Each site is checked for the two guards SEPARATELY and
+// reported separately, because `A && B` scored only as a unit grades neither
+// half: dropping only the gate, or only the nil-tree check, must each be a
+// distinct failure.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// dispatchScanRoot is the tree walked, relative to this package's directory
+// (where `go test` runs). The whole repo: a fourth dispatch site is not
+// obliged to appear in a package this test could have predicted.
+const dispatchScanRoot = "../.."
+
+// dispatcherName is the only dispatcher that selects a prefixed custom
+// extractor key; ordinary dispatch is an exact-key Get(file.Language) lookup
+// (registry.go) which cannot match "python_django".
+const dispatcherName = "RunCustomExtractors"
+
+// knownDispatchSites is the frozen population, as `<path>|<enclosing func>`.
+// HAND-WRITTEN, deliberately not derived from the scan it grades: a list built
+// from the thing under test cannot detect an addition to that thing.
+//
+// Line numbers are omitted on purpose — they rot on every edit above the site,
+// and a guard that must be re-baselined for unrelated edits gets re-baselined
+// without being read.
+var knownDispatchSites = []string{
+	"cmd/grafel/index.go|classifyAndReadWithProgress",
+	"internal/daemon/extract/subproc.go|Run",
+	"internal/extractors/incremental.go|tryIncremental",
+}
+
+// skipDirs are trees with no production dispatch site in them. Kept short: a
+// long skip list is how a scan quietly stops covering the repo.
+var skipDirs = map[string]bool{
+	".git": true, "node_modules": true, "testdata": true, "vendor": true,
+	"dist": true, "build": true, ".claude": true,
+}
+
+type dispatchSite struct {
+	key       string
+	guards    []string // expanded conjuncts of every enclosing if-condition
+	hasGate   bool
+	hasNilChk bool
+}
+
+func TestRunCustomExtractorsCallSitesCarryBothGuards6997(t *testing.T) {
+	sites := scanDispatchSites6997(t)
+
+	if len(sites) == 0 {
+		// A scan that finds nothing reports "all sites guarded" — the vacuous
+		// pass this test exists to make impossible.
+		t.Fatalf("scan found no %s call sites at all; the scanner is broken, "+
+			"not the repo (root %s)", dispatcherName, dispatchScanRoot)
+	}
+
+	var found []string
+	for _, s := range sites {
+		found = append(found, s.key)
+	}
+	sort.Strings(found)
+	want := append([]string(nil), knownDispatchSites...)
+	sort.Strings(want)
+
+	if strings.Join(found, "\n") != strings.Join(want, "\n") {
+		t.Errorf("the set of %s dispatch sites changed.\n  found:\n    %s\n  frozen:\n    %s\n\n"+
+			"A NEW site must carry BOTH guards (see this file's header) and be added "+
+			"to knownDispatchSites. A REMOVED site must be deleted from that list.",
+			dispatcherName, strings.Join(found, "\n    "), strings.Join(want, "\n    "))
+	}
+
+	for _, s := range sites {
+		if !s.hasGate {
+			t.Errorf("%s: dispatches %s WITHOUT the custom-extractor gate "+
+				"(CustomExtractorsEnabled). Guards in scope: %v.\n"+
+				"Without it this path decides #6966's default-OFF question locally, "+
+				"for whoever happens to be on it.", s.key, dispatcherName, s.guards)
+		}
+		if !s.hasNilChk {
+			t.Errorf("%s: dispatches %s WITHOUT the `TSTree != nil` guard. "+
+				"Guards in scope: %v.\n"+
+				"Content-only custom extractors emit entities with no parse tree, so "+
+				"this site produces custom entities for files that FAILED to parse.",
+				s.key, dispatcherName, s.guards)
+		}
+	}
+}
+
+// scanDispatchSites6997 walks the repo and returns one record per
+// non-test call to RunCustomExtractors, with every enclosing if-condition
+// expanded through single assignments in the enclosing function.
+func scanDispatchSites6997(t *testing.T) []dispatchSite {
+	t.Helper()
+	root, err := filepath.Abs(dispatchScanRoot)
+	if err != nil {
+		t.Fatalf("abs(%s): %v", dispatchScanRoot, err)
+	}
+	var out []dispatchSite
+	fset := token.NewFileSet()
+
+	err = filepath.WalkDir(root, func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return nil // unreadable trees are not evidence of absence we can act on
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] || strings.HasPrefix(d.Name(), ".") && d.Name() != "." {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(p, ".go") || strings.HasSuffix(p, "_test.go") {
+			return nil
+		}
+		src, rerr := os.ReadFile(p)
+		if rerr != nil {
+			return nil
+		}
+		if !strings.Contains(string(src), dispatcherName) {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, p, src, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", p, perr)
+		}
+		rel, _ := filepath.Rel(root, p)
+		rel = filepath.ToSlash(rel)
+
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			binds := singleAssignments6997(fset, fn)
+			collectSitesIn6997(fset, rel, fn.Name.Name, fn.Body, nil, binds, &out)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return out
+}
+
+// collectSitesIn6997 walks a statement tree carrying the stack of enclosing
+// if-conditions, so a call's guards are the conditions that actually dominate
+// it rather than whatever `if` happens to sit nearest in the file.
+func collectSitesIn6997(fset *token.FileSet, rel, fnName string, n ast.Node, guards []string, binds map[string]string, out *[]dispatchSite) {
+	switch s := n.(type) {
+	case *ast.IfStmt:
+		inner := append(append([]string(nil), guards...), conjuncts6997(fset, s.Cond, binds)...)
+		if s.Init != nil {
+			collectSitesIn6997(fset, rel, fnName, s.Init, guards, binds, out)
+		}
+		collectSitesIn6997(fset, rel, fnName, s.Body, inner, binds, out)
+		if s.Else != nil {
+			// An else branch is NOT guarded by the condition.
+			collectSitesIn6997(fset, rel, fnName, s.Else, guards, binds, out)
+		}
+		return
+	case *ast.BlockStmt:
+		for _, st := range s.List {
+			collectSitesIn6997(fset, rel, fnName, st, guards, binds, out)
+		}
+		return
+	}
+
+	// Any other node: record calls directly inside it, then recurse into
+	// children with the same guard stack (a nested if is handled above when
+	// reached, because ast.Inspect visits it as an *ast.IfStmt).
+	ast.Inspect(n, func(x ast.Node) bool {
+		if x == nil {
+			return false
+		}
+		if ifs, ok := x.(*ast.IfStmt); ok && ifs != n {
+			collectSitesIn6997(fset, rel, fnName, ifs, guards, binds, out)
+			return false
+		}
+		call, ok := x.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if !isDispatcherCall6997(call.Fun) {
+			return true
+		}
+		site := dispatchSite{key: rel + "|" + fnName, guards: guards}
+		for _, g := range guards {
+			if strings.Contains(g, "CustomExtractorsEnabled") {
+				site.hasGate = true
+			}
+			if strings.Contains(strings.ReplaceAll(g, " ", ""), "TSTree!=nil") {
+				site.hasNilChk = true
+			}
+		}
+		*out = append(*out, site)
+		return true
+	})
+}
+
+func isDispatcherCall6997(fun ast.Expr) bool {
+	switch f := fun.(type) {
+	case *ast.Ident:
+		return f.Name == dispatcherName
+	case *ast.SelectorExpr:
+		return f.Sel.Name == dispatcherName
+	}
+	return false
+}
+
+// singleAssignments6997 maps each identifier assigned EXACTLY ONCE in fn to the
+// source text of its right-hand side. Identifiers assigned more than once are
+// dropped: substituting one of several values would be a guess.
+func singleAssignments6997(fset *token.FileSet, fn *ast.FuncDecl) map[string]string {
+	rhs := map[string]string{}
+	count := map[string]int{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok || len(as.Lhs) != len(as.Rhs) {
+			return true
+		}
+		for i, l := range as.Lhs {
+			id, ok := l.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			count[id.Name]++
+			rhs[id.Name] = exprText6997(fset, as.Rhs[i])
+		}
+		return true
+	})
+	for name, c := range count {
+		if c > 1 {
+			delete(rhs, name)
+		}
+	}
+	return rhs
+}
+
+// conjuncts6997 splits a boolean condition into its top-level && operands and
+// expands single-assignment identifiers inside each, bounded to a few rounds so
+// a cyclic binding cannot hang the scan.
+func conjuncts6997(fset *token.FileSet, cond ast.Expr, binds map[string]string) []string {
+	var parts []ast.Expr
+	var split func(ast.Expr)
+	split = func(e ast.Expr) {
+		if b, ok := e.(*ast.BinaryExpr); ok && b.Op == token.LAND {
+			split(b.X)
+			split(b.Y)
+			return
+		}
+		parts = append(parts, e)
+	}
+	split(cond)
+
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		txt := exprText6997(fset, p)
+		for round := 0; round < 4; round++ {
+			expanded := txt
+			for name, val := range binds {
+				if identUsed6997(txt, name) {
+					expanded = strings.ReplaceAll(expanded, name, "("+val+")")
+				}
+			}
+			if expanded == txt {
+				break
+			}
+			txt = expanded
+		}
+		out = append(out, txt)
+	}
+	return out
+}
+
+// identUsed6997 reports whether name appears in txt as a whole identifier
+// rather than as a substring of a longer one.
+func identUsed6997(txt, name string) bool {
+	isIdentRune := func(r byte) bool {
+		return r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+	}
+	for i := 0; ; {
+		j := strings.Index(txt[i:], name)
+		if j < 0 {
+			return false
+		}
+		j += i
+		before := j == 0 || !isIdentRune(txt[j-1])
+		after := j+len(name) >= len(txt) || !isIdentRune(txt[j+len(name)])
+		if before && after {
+			return true
+		}
+		i = j + len(name)
+	}
+}
+
+func exprText6997(fset *token.FileSet, e ast.Expr) string {
+	var sb strings.Builder
+	if err := printer.Fprint(&sb, fset, e); err != nil {
+		return ""
+	}
+	return sb.String()
+}

--- a/internal/extractors/custom_dispatch_call_sites_6997_test.go
+++ b/internal/extractors/custom_dispatch_call_sites_6997_test.go
@@ -41,6 +41,7 @@ package extractors_test
 // distinct failure.
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/printer"
@@ -98,6 +99,38 @@ func TestRunCustomExtractorsCallSitesCarryBothGuards6997(t *testing.T) {
 		// pass this test exists to make impossible.
 		t.Fatalf("scan found no %s call sites at all; the scanner is broken, "+
 			"not the repo (root %s)", dispatcherName, dispatchScanRoot)
+	}
+
+	// COVERAGE CHECK — the scanner must not be able to MISS a dispatch.
+	//
+	// scanDispatchSites6997 descends into func declarations and matches a
+	// direct callee, so on review two fourth sites slipped past it with the
+	// whole suite green: one written as a package-level `var x = func(...)`,
+	// and one called through a function VALUE (`d := RunCustomExtractors;
+	// d(ctx, f)`). The second shape is not hypothetical here — `extract.Run`
+	// itself reaches production only as a function value (`Hooks{RunExtract:
+	// …}`), so the net was blind to the calling convention the surrounding
+	// code already uses.
+	//
+	// Every mention of the dispatcher in the scanned files is therefore
+	// counted by an INDEPENDENT traversal (its own walk, its own parse, its
+	// own visitor) and required to be accounted for by a collected site. A
+	// count derived from the collection it grades could not detect an omission
+	// in that collection — which is the shape of failure this whole test
+	// exists to prevent, one level down.
+	idents, filesScanned := scanDispatcherMentions6997(t)
+	if filesScanned == 0 || len(idents) == 0 {
+		t.Fatalf("the independent mention scan saw %d file(s) and %d mention(s) of %s; "+
+			"either would make the coverage check below pass trivially",
+			filesScanned, len(idents), dispatcherName)
+	}
+	if len(idents) != len(sites) {
+		t.Errorf("the scanner did not attribute every %s mention to a dispatch site: "+
+			"%d mention(s) across %d file(s), %d site(s) collected.\n  mentions:\n    %s\n"+
+			"A mention the site walk cannot see is a dispatch this test cannot grade — "+
+			"a package-level `var x = func(...)`, or a call through a function value. "+
+			"Teach scanDispatchSites6997 that shape rather than relaxing this count.",
+			dispatcherName, len(idents), filesScanned, len(sites), strings.Join(idents, "\n    "))
 	}
 
 	var found []string
@@ -344,4 +377,71 @@ func exprText6997(fset *token.FileSet, e ast.Expr) string {
 		return ""
 	}
 	return sb.String()
+}
+
+// scanDispatcherMentions6997 counts every mention of the dispatcher across the
+// same non-test file set, and returns one "<path>:<line>:<col>" per mention
+// plus the number of files it looked at.
+//
+// DELIBERATELY INDEPENDENT of scanDispatchSites6997: its own walk, its own
+// parse, and a flat ast.Inspect over identifiers rather than a statement walk
+// that has to understand guards, function literals or callee shapes. Sharing
+// either the walk or the visitor would make it agree with the site scan by
+// construction and detect nothing.
+//
+// The declaration's own name is not a mention: `func RunCustomExtractors(...)`
+// in custom_dispatch.go is the thing being called, not a call of it.
+func scanDispatcherMentions6997(t *testing.T) (mentions []string, files int) {
+	t.Helper()
+	root, err := filepath.Abs(dispatchScanRoot)
+	if err != nil {
+		t.Fatalf("abs(%s): %v", dispatchScanRoot, err)
+	}
+	fset := token.NewFileSet()
+	err = filepath.WalkDir(root, func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] || (p != root && strings.HasPrefix(d.Name(), ".")) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(p, ".go") || strings.HasSuffix(p, "_test.go") {
+			return nil
+		}
+		src, rerr := os.ReadFile(p)
+		if rerr != nil || !strings.Contains(string(src), dispatcherName) {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, p, src, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", p, perr)
+		}
+		files++
+		rel, _ := filepath.Rel(root, p)
+		rel = filepath.ToSlash(rel)
+		declNames := map[*ast.Ident]bool{}
+		for _, decl := range f.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok {
+				declNames[fn.Name] = true
+			}
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			id, ok := n.(*ast.Ident)
+			if !ok || id.Name != dispatcherName || declNames[id] {
+				return true
+			}
+			pos := fset.Position(id.Pos())
+			mentions = append(mentions, fmt.Sprintf("%s:%d:%d", rel, pos.Line, pos.Column))
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	sort.Strings(mentions)
+	return mentions, files
 }


### PR DESCRIPTION
Closes #6997.

Measured in `.../scratchpad/impl-6997-k7m2p/wt`, macOS/APFS, on `81f99d691`.

## The fork the issue implies does not exist, and the measurement is why

"Make all three sites agree" reads like a choice between removing custom
entities from every user's daemon graph and leaving the divergence documented.
Both halves of that framing are wrong, and tracing the call chain rather than
the call site is what shows it:

- `internal/daemon/extract/subproc.go` is reached only via `extract.Coordinate`,
  whose **single caller** is `cmd/grafel/index.go` behind `subprocExtract()` —
  `GRAFEL_SUBPROC_EXTRACT`, **default-OFF**.
- The daemon's default path is `GRAFEL_SUBPROCESS_INDEXER` (default-ON), which
  forks `grafel index-internal` and extracts **in-process** — through the
  *guarded* site. It never enters this file.

So the unguarded dispatch was never on any default graph. It was a disagreement
between an opt-in path and the two paths every custom-lane measurement is taken
on — and `GRAFEL_SUBPROC_EXTRACT`'s own stated acceptance criterion
(`cmd/grafel/extract.go`) is *"the in-process path stays the default until
benchmarks + quality fixtures confirm byte-identical output."* Aligning is not a
policy choice here; it is that rollout's contract.

**This PR does not touch #6966.** It makes this path *obey* the gate instead of
answering it locally.

## Blast radius, gate stated on every figure

Three arms per repo: the `81f99d691` binary (which ignores the gate), this
branch with the gate OFF, this branch with `GRAFEL_INPROC_CUSTOM_EXTRACTORS=1`.
All arms `GRAFEL_SUBPROC_EXTRACT=1` (nothing here is reachable otherwise),
`GOMAXPROCS=3`, `GRAFEL_SUBPROC_CONCURRENCY=3`, isolated `HOME`/`GRAFEL_HOME`/
`GRAFEL_DAEMON_ROOT`, corpora copied out of the read-only tree.

| repo | `81f99d691` | this branch, gate OFF | this branch, gate ON |
|---|---|---|---|
| django-realworld | 456 ent / 1463 rel | **371 / 1298** | 456 / 1463 |
| laravel-routing | 1159 / 3715 | **1108 / 3609** | 1159 / 3715 |
| dart-samples | 884 / 1877 | 884 / 1877 | 884 / 1877 |

**Gate-ON is identical to the old behaviour on all three**, so the entire delta
is the gate; the `TSTree != nil` guard removed **zero** entities here. That zero
is corpus-relative and not a claim that the guard is inert — see the nim
fixture below, where it removes real output.

What the gate removes, by kind:

| repo | kinds |
|---|---|
| django-realworld | `SCOPE.Operation` −51, `SCOPE.Datastore` −19, `SCOPE.Schema` −13, `SCOPE.Config`/`External`/`Pattern` −1 each, `SCOPE.Component` +1 (a merge that no longer supersedes) — 85 net |
| laravel-routing | `SCOPE.Pattern` −28, `SCOPE.Operation` −17, `SCOPE.Component` −5, `SCOPE.Process` −1 — 51 net |

Anyone on `GRAFEL_SUBPROC_EXTRACT=1` who wants those entities back sets
`GRAFEL_INPROC_CUSTOM_EXTRACTORS=1` — the same switch the in-process path has
always required.

## The named pin did not observe what it was named for

The issue and the in-proc comment both cite
`TestInProcCustomExtractorsNilTreeGuardIsLoadBearing`. It asserts only that
`RunCustomExtractors` *emits with a nil tree*, and `t.Skip`s if it does not. It
never observes any call site applying the guard, so **every one of the three
sites could have dropped it and that test would still be green.** The premise it
pins is true and worth keeping; the guard was unpinned. Both guards are now
graded separately, at all three sites.

## What changed

- `subproc.go` dispatches under `runCustom && file.TSTree != nil`, with
  `runCustom := runExtract && extractors.CustomExtractorsEnabled(customCfg)` —
  the same expression as the other two sites.
- The **programmatic** half of the gate (`WithCustomExtractors`) now crosses the
  process boundary: `CoordinatorConfig.CustomExtractors` → `--custom-extractors`
  → `SubprocessOptions.CustomExtractors`. The **env** half needs no plumbing —
  children get `os.Environ()`. Only the opt-in is forwarded, mirroring the
  in-proc stamp: a forwarded `false` would *suppress* a set env var in the
  child, since config beats env in both directions (#2320).

## Pinning the agreement

`TestRunCustomExtractorsCallSitesCarryBothGuards6997` (in `internal/extractors`,
the package that owns the dispatcher) parses **every non-test `.go` file in the
repo**, collects the enclosing `if` conditions that actually dominate each
`RunCustomExtractors` call, and expands single assignments within the enclosing
function so `subproc.go`'s `runCustom` resolves rather than reading as
unguarded (which would push the next author to inline a long expression into a
hot loop to satisfy a test). Shape borrowed from #6995's `gateKey` scan:

- Set equality on the three sites **in both directions** — a fourth site fails,
  and deleting or renaming one fails until the frozen list is edited. The list
  is hand-written, not derived from the scan it grades.
- Each guard is asserted and reported **separately**; `A && B` scored as a unit
  grades neither half.
- An empty scan is a `Fatal`, not a pass.
- **Coverage (review finding (b)).** The site walk descends only into
  `*ast.FuncDecl` and matches only a direct callee, so two fourth sites slipped
  past it with the whole suite green: a package-level `var x = func(...)` (R1)
  and a call through a function **value** (R1b). R1b is the shape this repo
  already uses — `extract.Run` reaches production only as
  `Hooks{RunExtract: runExtractSubprocess}`. Every mention of the dispatcher is
  now counted by an **independent** traversal (its own walk, its own parse, a
  flat ident visitor) and must be accounted for by a collected site; a count
  derived from the collection it grades could not detect an omission in it. The
  failure names the offending `file:line`. **R1, R1b — now DEAD** (4 mentions
  vs 3 sites), along with V1 (mention scan sees no files → the vacuity `Fatal`
  fires) and V2 (stop excluding the declaration's own name → the count is real).
  M4 and M5 re-scored DEAD.

Enclosing-function names, not line numbers, so unrelated edits above a site
never force a re-baseline.

## Mutants — all DEAD, scored with `-count=1`, each edit proved by an exact
occurrence count and the line it landed on

| # | mutant | result |
|---|---|---|
| M1 | the true pre-fix state: `runCustom := runExtract` + `if runCustom {` | **DEAD** — scanner reports *both* guards missing; all three behavioural tests RED |
| M2 | drop **only** `TSTree != nil` | **DEAD** — scanner reports only the TSTree finding; only `...RequireAParseTree6997` RED |
| M3 | drop **only** the gate | **DEAD** — scanner reports only the gate finding; only the gate + propagation tests RED |
| M4 | delete one entry from the frozen site list | **DEAD** |
| M5 | add a fourth production dispatch site, unguarded | **DEAD** — named in the failure output |
| M6 | `subprocCustomExtractorsOptIn` always returns `nil` | **DEAD** |
| M7 | *(permissive)* it always returns `&true` | **DEAD** |
| M8 | coordinator stops forwarding an explicit `false` | **DEAD** |
| M9 | *(permissive)* `index.go` forwards `subprocCustomExtractorsOptIn(true)` | **initially ALIVE**, then graded — see below |

M2 and M3 are the part-by-part grading: each fails a **disjoint** set of
assertions, so neither guard is riding on the other.

**M9 was alive and production-reachable.** Its distinguishing input is measured
above (456 vs 371 on django-realworld). Nothing in this repo exercises the
`subprocExtract()` branch of `Index()` — it forks `os.Executable()`, which
inside a test binary is the test binary, and that path takes no `BinaryPath`
override. Rather than plumb an override into production for testability, the
forwarded *expression* is asserted with the same AST instrument used on the
dispatch sites (`TestSubprocCoordinatorGetsTheIndexersOwnOptIn6997`, ~40 lines);
it also fails if a second `CoordinatorConfig` literal appears in `index.go`.

## Fixtures: what varies, what is held constant

- `TestSubprocCustomExtractorsHonourTheGate6997` — one file, four arms varying
  **only** (env half × config half): unset/nil, `1`/nil, unset/`true`,
  `1`/`false`. Same fixture, same path, so nothing but the gate can move the
  output. The negative arms are checked on **identity against the gate-off
  baseline**, not on a count (a swap keeps the count), and every arm must be a
  superset of the base entities.
- `TestSubprocCustomExtractorsRequireAParseTree6997` — gate held ON, so only the
  `TSTree` guard can suppress. The fixture is a **real production shape**: nim
  has a registered `custom_nim_` prefix and **no tree-sitter grammar**, so
  `TSTree` is nil for every `.nim` file in every repo, and
  `internal/custom/nim/norm_orm.go` is content-only. Same for clojure, crystal,
  dart, erlang, fsharp. A **positive control** fails the test if direct dispatch
  ever stops emitting for that content, so the assertion cannot go vacuous.
- `TestCoordinateForwardsTheProgrammaticCustomGate6997` — forks a built binary;
  the two tests above call `Run` in-process and would pass just as well if
  nothing were ever forwarded.

## Why CI is the only opinion on a diff of this shape

Per **#7005** this tree cannot be cross-compiled for Windows at all —
`GOOS=windows go vet ./internal/...` fails because cross-builds default to
`CGO_ENABLED=0` and every tree-sitter grammar package drops out. For a change
that forks a binary and plumbs a flag across a process boundary, CI is not a
second opinion, it is the only one; hence `ci:full` on this PR.

## Verification

- `go test -count=1 ./internal/daemon/extract/ ./internal/extractors/` — green
  (green baseline taken before each mutant score).
- `go test -count=1 ./cmd/grafel/` — green, with a **fresh** `HOME` +
  `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`.
- `scripts/quality/run.sh --ratchet` — *"38 gated fixtures held their baseline
  (29 at 100% must-have recall)"*. **No baseline moved**, so nothing was
  re-baselined.
- `gofmt -l`, `go vet` on all touched packages — clean.

## Not in scope

#6996 (routing `sql` to `custom_rust_`/`custom_nim_`) is untouched. #6966's
default is untouched — this PR gives that decision one place to be made instead
of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
