### PR TITLE
fix(#6914): delete the four Go `.Use` middleware relationship rules — dead on 1 arg, fabricated on 2, silent on 3+

### DIFF
--- a/internal/engine/go_use_middleware_rule_6914_test.go
+++ b/internal/engine/go_use_middleware_rule_6914_test.go
@@ -87,6 +87,40 @@ func main() {
 }
 `
 
+// use6914TwoArgMultiline is the SAME two-argument content in gofmt's own
+// layout. Coordinator mutant CQ-1 re-added the defect with the arguments
+// separated by a newline —
+// `'\.Use\s*\(\s*(\w[\w.]*)\s*,\s*\n\s*(\w[\w.]*)'`, same
+// source_type/target_type/kind/groups — and a table whose every leg put both
+// arguments on ONE line slept through it. The deleted rules used `\s*`, and
+// RE2's `\s` matches `\n`, so they DID fire on this layout; the pin covered it
+// only incidentally, never by assertion, which is exactly what a narrower
+// re-add walks through.
+//
+// Three axes are enumerated here and that is where this stops: arity (the
+// NoCorrectEdgeWasLost test), identifier shape, and line layout. The goal is a
+// pin that survives the obvious rewrites, not one that anticipates every
+// possible regex.
+const use6914TwoArgMultiline = `package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func main() {
+	r := chi.NewRouter()
+	r.Use(
+		middleware.RequestID,
+		middleware.Logger,
+	)
+	r.Get("/orders", listOrders)
+	http.ListenAndServe(":8080", r)
+}
+`
+
 const use6914TwoArgBare = `package main
 
 import "github.com/gin-gonic/gin"
@@ -201,6 +235,11 @@ func TestIssue6914_TwoArgUseEmitsNoMiddlewareEdge(t *testing.T) {
 			name:    "bare identifiers (gin group middleware)",
 			src:     use6914TwoArgBare,
 			control: "Route:/v1/items --ROUTES_TO--> Controller:listItems",
+		},
+		{
+			name:    "gofmt multi-line layout (chi stack of three)",
+			src:     use6914TwoArgMultiline,
+			control: "Route:/orders --ROUTES_TO--> Controller:listOrders",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/engine/go_use_middleware_rule_6914_test.go
+++ b/internal/engine/go_use_middleware_rule_6914_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -53,9 +54,23 @@ import (
 // (the `name_group: 0` router anchor); if it ever lands it will legitimately
 // need this pin updated — deliberately, with the new edge named here.
 
-// use6914TwoArg is the form that produced the fabricated edge. It is the
-// idiomatic chi middleware stack, not a contrivance.
-const use6914TwoArg = `package main
+// use6914TwoArgDotted and use6914TwoArgBare are the two-argument form in its
+// TWO identifier shapes. Both are needed, and the first alone is not enough.
+//
+// The deleted pattern captured `(\w[\w.]*)` — dotted OR bare — so a fixture
+// using only `middleware.Logger` pins the ARITY axis and leaves its neighbour,
+// the IDENTIFIER SHAPE, wide open. Review mutant M-R5 exploited exactly that:
+// re-adding the rule with the pattern narrowed to the house style already used
+// by chi's own route rule, `'\.Use\s*\(\s*(\w+)\s*,\s*(\w+)\s*\)'`, is the
+// same defect with the same source_type/target_type/kind/groups, fires on
+// textbook gin middleware — and a dotted-only fixture sleeps through it.
+//
+// Each carries a route line as its POSITIVE CONTROL. Both files emit ZERO
+// relationships in total once the rules are gone, so without a control edge an
+// assertion of the form "no relationship touches a Middleware endpoint" would
+// keep passing even if the constant stopped producing anything at all — a
+// vacuous absence. The control edge is named per-fixture in the table below.
+const use6914TwoArgDotted = `package main
 
 import (
 	"net/http"
@@ -67,7 +82,21 @@ import (
 func main() {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger, middleware.Recoverer)
+	r.Get("/health", healthHandler)
 	http.ListenAndServe(":8080", r)
+}
+`
+
+const use6914TwoArgBare = `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.Default()
+	v1 := r.Group("/v1")
+	v1.Use(AuthRequired, Logger)
+	r.GET("/v1/items", listItems)
+	r.Run(":8080")
 }
 `
 
@@ -137,27 +166,71 @@ func rels6914(res *DetectResult) []string {
 //
 // The assertion is on the endpoint KIND, not on the exact fabricated edge
 // string, so it also kills a re-add that swaps the capture groups, reverses the
-// direction, or renames the captured symbols.
+// direction, renames the captured symbols, or narrows the identifier pattern.
+//
+// KNOWN UNCOVERED, deliberately: a re-add that also RENAMES THE KINDS — say
+// `source_type: Handler`, `target_type: Controller`, `relationship: CALLS` —
+// slips past this, because nothing in the emitted edge still says "Middleware".
+// Killing it would mean asserting that a `.Use` line emits NO relationship at
+// all. That is true today, but it would fight #6914 step 2, whose intended
+// `Middleware REGISTERED_ON <app>` edge comes off exactly these lines once
+// #6916 unblocks a per-variable router anchor. Naming the gap here beats
+// closing it in a way that a later, correct edge has to fight.
 func TestIssue6914_TwoArgUseEmitsNoMiddlewareEdge(t *testing.T) {
-	got := rels6914(detect6914Go(t, use6914TwoArg))
+	for _, tc := range []struct {
+		name string
+		src  string
+		// control is an edge the fixture must STILL emit. Without it an
+		// absence assertion cannot fail, and a fixture that quietly stopped
+		// producing anything would read as a pass. Verified able to fail:
+		// deleting the route line from either constant drops that fixture to
+		// zero relationships and this assertion fires.
+		//
+		// It is a liveness control, NOT a pin on any one framework's route
+		// rule — several Go rule files match the same route line, so flipping
+		// gin.yaml's ROUTES_TO to LINKS_TO leaves the control edge standing.
+		// Do not read a passing control as evidence about a specific rule.
+		control string
+	}{
+		{
+			name:    "dotted identifiers (chi middleware stack)",
+			src:     use6914TwoArgDotted,
+			control: "Route:/health --ROUTES_TO--> Controller:healthHandler",
+		},
+		{
+			name:    "bare identifiers (gin group middleware)",
+			src:     use6914TwoArgBare,
+			control: "Route:/v1/items --ROUTES_TO--> Controller:listItems",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rels6914(detect6914Go(t, tc.src))
 
-	var offenders []string
-	for _, r := range got {
-		if strings.HasPrefix(r, "Middleware:") || strings.Contains(r, "--> Middleware:") {
-			offenders = append(offenders, r)
-		}
-	}
-	if len(offenders) > 0 {
-		t.Errorf("a two-argument `.Use(A, B)` line emitted %d edge(s) touching a Middleware endpoint; "+
-			"`Use(A, B)` registers two middlewares, it does not relate A to B:\n  %s",
-			len(offenders), strings.Join(offenders, "\n  "))
+			var offenders []string
+			for _, r := range got {
+				if strings.HasPrefix(r, "Middleware:") || strings.Contains(r, "--> Middleware:") {
+					offenders = append(offenders, r)
+				}
+			}
+			if len(offenders) > 0 {
+				t.Errorf("a two-argument `.Use(A, B)` line emitted %d edge(s) touching a Middleware endpoint; "+
+					"`Use(A, B)` registers two middlewares, it does not relate A to B:\n  %s",
+					len(offenders), strings.Join(offenders, "\n  "))
+			}
+
+			if !slices.Contains(got, tc.control) {
+				t.Errorf("positive control missing: this fixture no longer emits %q, so the "+
+					"absence assertion above proves nothing. Relationships emitted:\n  %s",
+					tc.control, strings.Join(got, "\n  "))
+			}
+		})
 	}
 
 	// Name the exact edge the four deleted rules produced, so a reader of a
 	// future failure can tell this defect returning from some other rule
 	// growing a Middleware endpoint.
 	const fabricated = "Middleware:middleware.Logger --ROUTES_TO--> Controller:middleware.Recoverer"
-	for _, r := range got {
+	for _, r := range rels6914(detect6914Go(t, use6914TwoArgDotted)) {
 		if r == fabricated {
 			t.Errorf("the #6914 fabricated edge is back verbatim: %s", fabricated)
 		}

--- a/internal/engine/go_use_middleware_rule_6914_test.go
+++ b/internal/engine/go_use_middleware_rule_6914_test.go
@@ -1,0 +1,207 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+)
+
+// #6914 (step 1): gin, chi, echo and fiber each carried the SAME relationship
+// rule
+//
+//	pattern:      '\.Use\s*\(\s*(\w[\w.]*)\s*(?:,\s*(\w[\w.]*))?\s*\)'
+//	source_type:  Middleware
+//	target_type:  Controller
+//	relationship: ROUTES_TO
+//	source_group: 1
+//	target_group: 2
+//
+// whose second capture group is optional. Driven through the real
+// LoadAllRules() + Detector.Detect() path on the fixtures below, the rule was
+// measured to be wrong in every direction it could take:
+//
+//	r.Use(middleware.Logger)                     -> group 2 empty, detector.go
+//	                                                `continue`s: no edge, ever.
+//	r.Use(middleware.Logger, middleware.Recoverer)
+//	                                             -> FOUR copies (one per rule
+//	                                                file) of
+//	                                                Middleware:middleware.Logger
+//	                                                --ROUTES_TO-->
+//	                                                Controller:middleware.Recoverer
+//	r.Use(a, b, c)                               -> matches nothing.
+//	r.Use(gin.Recovery())                        -> `(\w[\w.]*)\s*\)` cannot
+//	                                                match `()`: invisible.
+//
+// The two-argument edge is FABRICATED: `Use(A, B)` registers two middlewares
+// on the router; it does not make A route to B. And it fires on ordinary chi
+// source, so it is not a theoretical case. The four rules were deleted.
+//
+// These tests pin the ARTEFACT — the edges the shipped rules actually emit for
+// a `.Use` line — not the rule count and not the YAML text. A count-of-rules or
+// grep-the-YAML assertion passes the moment someone re-adds the edge in a
+// different spelling; asserting the emitted graph does not.
+//
+// NOT in scope, deliberately: the `Middleware` ENTITY rules are untouched and
+// TestIssue6914_UseEntityRuleStillMintsMiddleware below holds them in place —
+// whether that shadow population should exist at all is #6914 step 4, and
+// internal/quality/golden/go-chi-mini/expected.json asserts the entity today.
+// A correct `Middleware REGISTERED_ON <app>` edge (step 2) is blocked on #6916
+// (the `name_group: 0` router anchor); if it ever lands it will legitimately
+// need this pin updated — deliberately, with the new edge named here.
+
+// use6914TwoArg is the form that produced the fabricated edge. It is the
+// idiomatic chi middleware stack, not a contrivance.
+const use6914TwoArg = `package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func main() {
+	r := chi.NewRouter()
+	r.Use(middleware.Logger, middleware.Recoverer)
+	http.ListenAndServe(":8080", r)
+}
+`
+
+// use6914OneArg is the common single-argument form. It mints the Middleware
+// ENTITY and — before and after the deletion alike — no edge.
+const use6914OneArg = `package main
+
+func main() {
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+}
+`
+
+// use6914ThreeArg and use6914CallExpr are the two remaining forms. Both
+// produced nothing before the deletion, so the deletion cannot have cost them
+// anything — asserted rather than asserted-in-prose.
+const use6914ThreeArg = `package main
+
+func main() {
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID, middleware.RealIP, middleware.Logger)
+}
+`
+
+const use6914CallExpr = `package main
+
+func main() {
+	r := gin.Default()
+	r.Use(gin.Recovery())
+}
+`
+
+func detect6914Go(t *testing.T, src string) *DetectResult {
+	t.Helper()
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	res, err := New(rules).Detect(context.Background(), extractor.FileInput{
+		Path:     "src/main.go",
+		Content:  []byte(src),
+		Language: "go",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	return res
+}
+
+// rels6914 renders every relationship as "FromID --Kind--> ToID". The detector
+// builds both endpoint IDs as "<type>:<captured name>", so the rendered string
+// carries the endpoint KINDS as well as the names — which is what lets these
+// assertions distinguish the `Middleware` KIND from an entity merely NAMED
+// something middleware-ish (the name/kind confusion that bit the grounding
+// sweep on nim-objects-mini's `from_name: "Config"`).
+func rels6914(res *DetectResult) []string {
+	out := make([]string, 0, len(res.Relationships))
+	for _, r := range res.Relationships {
+		out = append(out, fmt.Sprintf("%s --%s--> %s", r.FromID, r.Kind, r.ToID))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestIssue6914_TwoArgUseEmitsNoMiddlewareEdge is the regression pin. Before
+// the deletion it failed with four copies of the fabricated edge.
+//
+// The assertion is on the endpoint KIND, not on the exact fabricated edge
+// string, so it also kills a re-add that swaps the capture groups, reverses the
+// direction, or renames the captured symbols.
+func TestIssue6914_TwoArgUseEmitsNoMiddlewareEdge(t *testing.T) {
+	got := rels6914(detect6914Go(t, use6914TwoArg))
+
+	var offenders []string
+	for _, r := range got {
+		if strings.HasPrefix(r, "Middleware:") || strings.Contains(r, "--> Middleware:") {
+			offenders = append(offenders, r)
+		}
+	}
+	if len(offenders) > 0 {
+		t.Errorf("a two-argument `.Use(A, B)` line emitted %d edge(s) touching a Middleware endpoint; "+
+			"`Use(A, B)` registers two middlewares, it does not relate A to B:\n  %s",
+			len(offenders), strings.Join(offenders, "\n  "))
+	}
+
+	// Name the exact edge the four deleted rules produced, so a reader of a
+	// future failure can tell this defect returning from some other rule
+	// growing a Middleware endpoint.
+	const fabricated = "Middleware:middleware.Logger --ROUTES_TO--> Controller:middleware.Recoverer"
+	for _, r := range got {
+		if r == fabricated {
+			t.Errorf("the #6914 fabricated edge is back verbatim: %s", fabricated)
+		}
+	}
+}
+
+// TestIssue6914_UseEntityRuleStillMintsMiddleware holds the ENTITY rules in
+// place. Only the four RELATIONSHIP rules were deleted; deleting the entity
+// rules is #6914 step 4 and would break
+// internal/quality/golden/go-chi-mini/expected.json. Without this, an
+// over-broad "fix" that rips out the whole `.Use` block passes the pin above
+// for the wrong reason.
+func TestIssue6914_UseEntityRuleStillMintsMiddleware(t *testing.T) {
+	res := detect6914Go(t, use6914OneArg)
+
+	found := false
+	for _, e := range res.Entities {
+		if e.Kind == "Middleware" && e.Name == "middleware.Logger" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("single-arg `r.Use(middleware.Logger)` no longer mints Middleware:middleware.Logger; "+
+			"only the relationship rules were in scope for #6914 step 1. Entities: %v", res.Entities)
+	}
+}
+
+// TestIssue6914_NoCorrectEdgeWasLost demonstrates the other half of the
+// deletion's justification. The single-arg, three-arg and call-expression forms
+// each produced ZERO relationships while the rules were still present, so the
+// deletion cannot have removed a correct edge from any of them. Restoring the
+// four rules leaves every expectation below unchanged — which is the point:
+// what the rules contributed on these forms was nothing.
+func TestIssue6914_NoCorrectEdgeWasLost(t *testing.T) {
+	for _, tc := range []struct{ name, src string }{
+		{"one arg (the common form)", use6914OneArg},
+		{"three args", use6914ThreeArg},
+		{"call expression (the commonest gin idiom)", use6914CallExpr},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rels6914(detect6914Go(t, tc.src)); len(got) != 0 {
+				t.Errorf("expected no relationships from this `.Use` form, got %d:\n  %s",
+					len(got), strings.Join(got, "\n  "))
+			}
+		})
+	}
+}

--- a/internal/engine/rules/go/frameworks/chi.yaml
+++ b/internal/engine/rules/go/frameworks/chi.yaml
@@ -57,11 +57,3 @@ relationship_rules:
     relationship: ROUTES_TO
     source_group: 1
     target_group: 2
-
-  # Middleware USE: .Use(middlewareName) -> middlewareName
-  - pattern: '\.Use\s*\(\s*(\w[\w.]*)\s*(?:,\s*(\w[\w.]*))?\s*\)'
-    source_type: Middleware
-    target_type: Controller
-    relationship: ROUTES_TO
-    source_group: 1
-    target_group: 2

--- a/internal/engine/rules/go/frameworks/echo.yaml
+++ b/internal/engine/rules/go/frameworks/echo.yaml
@@ -43,12 +43,3 @@ relationship_rules:
     relationship: ROUTES_TO
     source_group: 1
     target_group: 2
-
-  # Middleware USE: .Use(middlewareName) -> middlewareName
-  - pattern: '\.Use\s*\(\s*(\w[\w.]*)\s*(?:,\s*(\w[\w.]*))?\s*\)'
-    source_type: Middleware
-    target_type: Controller
-    relationship: ROUTES_TO
-    source_group: 1
-    target_group: 2
-

--- a/internal/engine/rules/go/frameworks/fiber.yaml
+++ b/internal/engine/rules/go/frameworks/fiber.yaml
@@ -44,13 +44,5 @@ relationship_rules:
     source_group: 1
     target_group: 2
 
-  # Middleware USE: .Use(middlewareName) -> middlewareName
-  - pattern: '\.Use\s*\(\s*(\w[\w.]*)\s*(?:,\s*(\w[\w.]*))?\s*\)'
-    source_type: Middleware
-    target_type: Controller
-    relationship: ROUTES_TO
-    source_group: 1
-    target_group: 2
-
 # These run after YAML-driven extraction and contribute additional entities +
 # relationships to the pipeline result.

--- a/internal/engine/rules/go/frameworks/gin.yaml
+++ b/internal/engine/rules/go/frameworks/gin.yaml
@@ -43,12 +43,3 @@ relationship_rules:
     relationship: ROUTES_TO
     source_group: 1
     target_group: 2
-
-  # Middleware USE: .Use(handlerName) -> handlerName
-  - pattern: '\.Use\s*\(\s*(\w[\w.]*)\s*(?:,\s*(\w[\w.]*))?\s*\)'
-    source_type: Middleware
-    target_type: Controller
-    relationship: ROUTES_TO
-    source_group: 1
-    target_group: 2
-


### PR DESCRIPTION
## What

Deletes the four Go `.Use` middleware **relationship** rules (gin, chi, echo, fiber) and pins their
absence. This is **step 1 only** of #6914 — steps 2–4 stay open, hence `Refs`, not `Closes`.

## Why

All four files carried the identical rule, whose second capture group is optional:

```
pattern:      '\.Use\s*\(\s*(\w[\w.]*)\s*(?:,\s*(\w[\w.]*))?\s*\)'
source_type:  Middleware
target_type:  Controller
relationship: ROUTES_TO
source_group: 1
target_group: 2
```

Measured through the real `LoadAllRules()` + `Detector.Detect()` path on `src/main.go`, language `go`
(worktree at `.../scratchpad/impl-6914-k7m2/wt`, macOS/APFS):

| form | before | after |
|---|---|---|
| `r.Use(middleware.Logger)` | ents `[Middleware:middleware.Logger]`, rels `[]` | **identical** |
| `r.Use(middleware.Logger, middleware.Recoverer)` | rels = **4 ×** `Middleware:middleware.Logger --ROUTES_TO--> Controller:middleware.Recoverer` (one per rule file) | rels `[]` |
| `r.Use(middleware.RequestID, middleware.RealIP, middleware.Logger)` | ents `[]`, rels `[]` | **identical** |
| `r.Use(gin.Recovery())` | ents `[]`, rels `[]` | **identical** |

The only difference the deletion makes is the four fabricated edges disappearing. `Use(A, B)`
registers two middlewares on the router; it does not make A route to B. And it fires on
`r.Use(middleware.Logger, middleware.Recoverer)` — a line in essentially every chi service — so
reachability is settled without a corpus survey.

**No correct edge is lost**, demonstrated rather than argued: the one-arg, three-arg and
call-expression forms emitted **zero** relationships *while the rules were still present*, so the
deletion cannot have taken anything from them. `TestIssue6914_NoCorrectEdgeWasLost` asserts exactly
that, and it is unchanged by restoring the rules — which is the point.

**Entity rules untouched.** `Middleware:middleware.Logger` is still minted, held in place by
`TestIssue6914_UseEntityRuleStillMintsMiddleware` so an over-broad "fix" that rips out the whole
`.Use` block cannot pass the main pin for the wrong reason. Whether that shadow population should
exist at all is step 4, and `go-chi-mini/expected.json:28` asserts it today.

## Pinning the absence

The always-on gate is blind here. Verified by parsing every `expected.json` (not by grep): **zero
`expected_relationships` rows in any of the 38 golden fixtures name `Middleware` at either end** —
all `Middleware` rows are `expected_entities`/`forbidden_entities`. Nothing would catch this rule
returning.

The new test asserts the **emitted artefact** — no relationship with a `Middleware` endpoint from a
two-argument `.Use` line — not a count of rules and not a property of the YAML text. A
count-of-rules assertion passes the moment someone re-adds the edge in a different spelling. The
assertion reads the endpoint **kind** off `FromID`/`ToID` (the detector builds both as
`<type>:<name>`), so it cannot be fooled by an entity merely *named* something middleware-ish — the
name/kind confusion `nim-objects-mini`'s `from_name: "Config"` rows set up.

## Mutants

Each edit's landing was proved with an exact occurrence count **and** the hit set across all four
files, since the same rule text appears in four places. Green baseline immediately before each
score; `-count=1` throughout.

| # | mutant | verdict |
|---|---|---|
| M1 | restore the deleted rule verbatim in **chi.yaml only** (`target_type: Middleware` count: chi 1, gin/echo/fiber 0) | **DEAD** — 1 offending edge, both assertions fired |
| M2 | re-add to **gin.yaml only**, *reversed and renamed*: `source_type: Controller`, `target_type: Middleware`, `relationship: USES`, groups swapped | **DEAD** — `Controller:middleware.Recoverer --USES--> Middleware:middleware.Logger`. The kind-based assertion survives a direction flip, a group swap and a different relationship kind |
| M3a | delete the `Middleware` **entity** rule from **all four** files | **DEAD** — the scope guard fires |
| M3b | delete the `Middleware` entity rule from **chi.yaml only** (entity-rule count: chi 0, gin/echo/fiber 1) | **ALIVE — equivalent mutant by construction.** The four `Middleware` entity rules are byte-identical, none carries `requires_framework`, and `detector.go` sets the entity's `framework` property from **`lang`**, not from the producing file — so the emitted record is identical in Kind, Name, SourceFile, StartLine and every property whichever rule minted it, and the dedup key `entityType:name:file` collapses them. **No `.go` input can distinguish it.** Not "expensive to grade": ungradeable. Underlying defect filed as #7007 |

## Review round 2 — M-R5 and the missing positive control

Both blockers from the review are fixed in `08e8db3a7` (test-only, no rule YAML touched).

**M-R5** — re-add to `gin.yaml` alone with identical `source_type: Middleware` / `target_type: Controller` /
`ROUTES_TO` / groups 1,2, pattern narrowed to `'\.Use\s*\(\s*(\w+)\s*,\s*(\w+)\s*\)'` — was **ALIVE**
because the only two-argument fixture used **dotted** names, pinning arity and leaving identifier shape open. The
two-argument pin is now table-driven over both shapes (dotted chi stack + `v1.Use(AuthRequired, Logger)`).
Re-scored: **DEAD** — `Middleware:AuthRequired --ROUTES_TO--> Controller:Logger`, failing on the **new
bare-identifier leg** while the dotted leg passes, so the widening is what does the killing. Landing proved with
an asserted hit set: the mutant's fixed pattern string and `source_type: Middleware` each count gin 1,
chi/echo/fiber 0.

**Positive control** — each two-argument fixture emits **zero** relationships in total at HEAD, so the absence
assertion could not fail. Both now assert a control edge (`Route:/health --ROUTES_TO--> Controller:healthHandler`,
`Route:/v1/items --ROUTES_TO--> Controller:listItems`). **Verified able to fail:** deleting the route line from
either constant (1 occurrence each, asserted) drops that fixture to zero relationships and the control fires on
**both** legs. Recorded caveat, in the test comment: the control is *liveness only*, not a pin on a specific
route rule — several Go rule files match the same route line, so flipping `gin.yaml`'s `ROUTES_TO` to `LINKS_TO`
leaves the control edge standing and the suite green.

**M-R2** (re-add with renamed kinds, `Handler`/`CALLS`) is left **uncovered on purpose and named in the test
comment** with the reason: killing it means asserting a `.Use` line emits no relationship *at all*, true today but
in direct conflict with step 2's intended `Middleware REGISTERED_ON <app>` edge once #6916 unblocks a
per-variable router anchor.

Re-verified after the change (worktree `.../scratchpad/impl-6914-k7m2/wt`, macOS/APFS, `-count=1`): `gofmt -l`
clean, `go vet` clean, `go test ./internal/engine/` **ok** 49.2s, `scripts/quality/run.sh --ratchet` exit 0, 38
fixtures held, no baseline moved. `./cmd/grafel/` not re-run — nothing outside the test file changed. YAMLs
restored by `cp` from a shasum-verified backup after every mutant, and the test file likewise (shasum
`7e77cdae4`); `git status` confirmed test-file-only before committing.

## Review round 3 — CQ-1 (multi-line layout)

Fixed in `851b40b29` (test-only, no rule YAML touched).

**CQ-1** — re-add to `chi.yaml` alone with the same `source_type: Middleware` / `target_type: Controller` /
`ROUTES_TO` / groups 1,2, pattern requiring a newline between the arguments
(`'\.Use\s*\(\s*(\w[\w.]*)\s*,\s*\n\s*(\w[\w.]*)'`) — was **ALIVE**. Both existing legs put the
arguments on one line, so the table varied identifier shape while holding **line layout** constant: M-R5's class,
one axis over. The original rules *did* match this layout (they used `\s*`, and RE2's `\s` matches `\n`), so the
pin's multi-line coverage was incidental and never asserted.

Added a third table leg — the same two-argument content in gofmt's layout, with its own control
(`Route:/orders --ROUTES_TO--> Controller:listOrders`). **CQ-1 re-scored: DEAD** —
`Middleware:middleware.RequestID --ROUTES_TO--> Controller:middleware.Logger`, failing **only** on the new
multi-line leg while the dotted and bare legs pass. Landing proved with an asserted hit set: `MUTANT CQ-1` and
`source_type: Middleware` each count chi 1, gin/echo/fiber 0; chi restored by `cp` from a shasum-verified backup
(`cf1c1c6c2` both ways), `git status` test-file-only afterwards.

**Three axes, and it stops there**: arity (`TestIssue6914_NoCorrectEdgeWasLost`), identifier shape, line layout.
Stated in the test comment — the goal is a pin that survives the obvious rewrites, not one that anticipates every
possible regex.

Re-verified: `gofmt -l` clean, `go vet` clean, `go test -count=1 ./internal/engine/` **ok** 43.6s,
`scripts/quality/run.sh --ratchet` exit 0, 38 fixtures held, no baseline moved. `./cmd/grafel/` not re-run —
nothing outside the test file changed.

## Ratchet — the three claims, verified here rather than taken on trust

1. **One fixture source line** touches `.Use`: `go-chi-mini/src/main.go:19`, `r.Use(middleware.Logger)` — single-arg, which already produced no edge.
2. **One expected row** names `Middleware`: `go-chi-mini/expected.json:28`, an *entity* row.
3. **No `expected_relationships` row anywhere** names `Middleware` (parsed, per above).

`scripts/quality/run.sh --ratchet` → `quality ratchet OK — 38 gated fixtures held their baseline (29
at 100% must-have recall)`, exit 0. **No baseline file moved** (`git status` clean apart from the
four YAMLs and the new test).

## Verification

All in `.../scratchpad/impl-6914-k7m2/wt`, macOS/APFS, `-count=1`, exit codes read from redirected
files (never a pipe):

- `gofmt -l internal/engine/` — clean; `go vet ./internal/engine/` — clean
- `go test -count=1 ./internal/engine/` — **ok**, 44.4s
- `go test -count=1 ./cmd/grafel/` — **ok**, 149.2s, with a **fresh** `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`. This package digest-pins the whole graph, so a rule change must run it; it passed, i.e. the deletion moves no digest.
- `scripts/quality/run.sh --ratchet` — OK, no baseline movement

The four YAMLs were restored by `cp` from a shasum-verified backup after each mutant, never by `git
checkout`, and `git diff HEAD` was confirmed to hold only the intended deletion before committing.

Refs #6914
