### PR TITLE
test(#6998): pin lookupStructural's cross-file unique-name tier to python — deleting the lang guard was ALIVE against the whole golden ratchet

### DIFF
--- a/internal/resolve/structural_component_lang_guard_6998_test.go
+++ b/internal/resolve/structural_component_lang_guard_6998_test.go
@@ -1,0 +1,147 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6998 — lookupStructural's cross-file, whole-graph unique-name fallback
+// (lookupUniqueRealComponentByName) fires for `component`-scope structural
+// addresses with lang == "python" and for no other language. Removing that
+// guard was ALIVE: the resolver package, the touched extractor packages and
+// the full golden ratchet all stayed green, so the restriction of the widest
+// tier in the structural lookup to one language was asserted by nothing.
+//
+// Today's behaviour is correct; this file is the missing assertion. The tier
+// is what makes the Python address dialect NOT same-file-only, which is
+// exactly what separates it from the C# (#6984) and protobuf (#6991) ports —
+// both deliberately same-file because a cross-file guess is #6369's
+// wrong-node hazard. Widening it would give every language a whole-graph
+// unique-name fallback: the permissive direction, where a binding that should
+// not happen becomes a confidently-wrong edge that reads as valid.
+//
+// The pin is behavioural, not a source scan for the literal `lang ==
+// "python"` — a scan-and-assert guard has several independent no-op modes and
+// would survive the very rewrite it exists to catch.
+//
+// AXES. Varied: the address's language segment (and the entity Language /
+// file extension that go with it). Held constant: the entity kind and
+// subtype, the declared name, the global uniqueness of that name, the
+// cross-file relationship (the consumer's file declares nothing), the
+// directory (so pkgDirOf is identical), and the address's scope-kind and
+// subtype segments. Case `ruby-on-python-paths` additionally holds the FILE
+// PATHS constant too, so the only thing separating it from the binding case
+// is the language segment itself — the guard cannot be mistaken for a
+// path- or extension-keyed effect.
+
+// langGuardFixture6998 builds the one shape both halves of the pair share:
+// a class `SharedBase` declared in `app/base<ext>`, globally unique, and a
+// consumer file `app/child<ext>` that declares NOTHING. The structural
+// address is minted with the CONSUMER's file — the Python dialect's
+// convention (the hierarchy extractor addresses `class Child(SharedBase):`
+// by the file the subclass declaration lives in), so the same-file
+// lookupLocationKind tier necessarily misses and only the cross-file tier
+// can bind.
+func langGuardFixture6998(lang, ext string) (base types.EntityRecord, consumer types.EntityRecord, ref string) {
+	baseFile := "app/base" + ext
+	childFile := "app/child" + ext
+	base = types.EntityRecord{
+		ID: "c0de6998ba5e0001", Kind: "Class", Subtype: "class",
+		Name: "SharedBase", QualifiedName: "SharedBase",
+		SourceFile: baseFile, Language: lang,
+	}
+	// The consumer entity exists only so the consumer file is a real file in
+	// the index with a real, DIFFERENT name in it — the same-file tier has
+	// something to miss on rather than nothing at all.
+	consumer = types.EntityRecord{
+		ID: "c0de6998c41d0002", Kind: "Class", Subtype: "class",
+		Name: "Child", QualifiedName: "Child",
+		SourceFile: childFile, Language: lang,
+	}
+	ref = "scope:component:class:" + lang + ":" + childFile + ":SharedBase"
+	return base, consumer, ref
+}
+
+func TestStructuralComponentCrossFileTier_IsPythonOnly6998(t *testing.T) {
+	cases := []struct {
+		name     string
+		lang     string
+		ext      string
+		wantBind bool
+	}{
+		// The positive control. Without it the three negatives below could
+		// all pass by the tier never firing at all, which is the commonest
+		// way an absence assertion here turns out to be decoration.
+		{name: "python", lang: "python", ext: ".py", wantBind: true},
+		{name: "ruby", lang: "ruby", ext: ".rb", wantBind: false},
+		{name: "java", lang: "java", ext: ".java", wantBind: false},
+		// Language varied, file paths held identical to the python case.
+		{name: "ruby-on-python-paths", lang: "ruby", ext: ".py", wantBind: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base, consumer, ref := langGuardFixture6998(tc.lang, tc.ext)
+			idx := BuildIndex([]types.EntityRecord{base, consumer})
+
+			// Premise 1 — the cross-file tier's own precondition holds in
+			// EVERY case, binding and non-binding alike. `SharedBase` is
+			// globally unique, so lookupUniqueRealComponentByName would
+			// return the base class if it were reached. This is what makes
+			// the negatives sharp: the ONLY thing withholding the binding is
+			// the language guard, not an absent or ambiguous candidate.
+			if id, ok := idx.lookupUniqueRealComponentByName("SharedBase"); !ok || id != base.ID {
+				t.Fatalf("premise: lookupUniqueRealComponentByName(SharedBase) = (%q,%v), "+
+					"want (%q,true) — the cross-file tier could not have bound in this "+
+					"fixture for a reason unrelated to the language guard (#6998)",
+					id, ok, base.ID)
+			}
+
+			// Premise 2 — the same-file tier misses. The consumer's file does
+			// not declare `SharedBase`, so nothing but the cross-file tier
+			// can produce a binding here.
+			if id, ok := idx.lookupLocationKind(consumer.SourceFile, "SharedBase", componentKindFamily); ok {
+				t.Fatalf("premise: lookupLocationKind(%q, SharedBase) = (%q,true); the "+
+					"consumer file must not declare the name or the same-file tier, not "+
+					"the cross-file one, is what this case measures (#6998)",
+					consumer.SourceFile, id)
+			}
+
+			id, status, handled := idx.lookupStructural(ref)
+			if !handled {
+				t.Fatalf("lookupStructural did not claim %q (handled=false)", ref)
+			}
+
+			if tc.wantBind {
+				if id != base.ID {
+					t.Fatalf("lookupStructural(%q) = %q (status=%d), want the class "+
+						"%q declared in %q — the Python cross-file unique-name tier "+
+						"must still bind (#6998 positive control)",
+						ref, id, status, base.ID, base.SourceFile)
+				}
+				if status != statusRewritten {
+					t.Fatalf("lookupStructural(%q) status = %d, want statusRewritten=%d (#6998)",
+						ref, status, statusRewritten)
+				}
+				return
+			}
+
+			if id == base.ID {
+				t.Fatalf("lookupStructural(%q) bound the class %q declared in %q — a "+
+					"lang=%q structural address reached the whole-graph unique-name "+
+					"fallback, which is python-only. A cross-file guess in another "+
+					"language's dialect is a confidently-wrong edge (#6998, #6369)",
+					ref, base.ID, base.SourceFile, tc.lang)
+			}
+			if id != "" {
+				t.Fatalf("lookupStructural(%q) = %q, want no binding (#6998)", ref, id)
+			}
+			if status != statusUnmatched {
+				t.Fatalf("lookupStructural(%q) status = %d, want statusUnmatched=%d — the "+
+					"address must dangle honestly rather than resolve or report an "+
+					"ambiguity it did not find (#6998)", ref, status, statusUnmatched)
+			}
+		})
+	}
+}

--- a/internal/resolve/structural_component_lang_guard_6998_test.go
+++ b/internal/resolve/structural_component_lang_guard_6998_test.go
@@ -25,7 +25,11 @@ import (
 // "python"` — a scan-and-assert guard has several independent no-op modes and
 // would survive the very rewrite it exists to catch.
 //
-// AXES. Varied: the address's language segment (and the entity Language /
+// AXES. Two axes are graded here: the address's LANGUAGE segment and its
+// SCOPE segment (rows `config-scope` / `operation-scope`), each varied while
+// the other is held at the binding value.
+//
+// Varied: the address's language segment (and the entity Language /
 // file extension that go with it). Held constant: the entity kind and
 // subtype, the declared name, the global uniqueness of that name, the
 // cross-file relationship (the consumer's file declares nothing), the
@@ -59,7 +63,7 @@ import (
 // by the file the subclass declaration lives in), so the same-file
 // lookupLocationKind tier necessarily misses and only the cross-file tier
 // can bind.
-func langGuardFixture6998(lang, ext string) (base types.EntityRecord, consumer types.EntityRecord, ref string) {
+func langGuardFixture6998(scopeKind, lang, ext string) (base types.EntityRecord, consumer types.EntityRecord, ref string) {
 	baseFile := "app/base" + ext
 	childFile := "app/child" + ext
 	base = types.EntityRecord{
@@ -75,13 +79,14 @@ func langGuardFixture6998(lang, ext string) (base types.EntityRecord, consumer t
 		Name: "Child", QualifiedName: "Child",
 		SourceFile: childFile, Language: lang,
 	}
-	ref = "scope:component:class:" + lang + ":" + childFile + ":SharedBase"
+	ref = "scope:" + scopeKind + ":class:" + lang + ":" + childFile + ":SharedBase"
 	return base, consumer, ref
 }
 
 func TestStructuralComponentCrossFileTier_IsPythonOnly6998(t *testing.T) {
 	cases := []struct {
 		name     string
+		scope    string
 		lang     string
 		ext      string
 		wantBind bool
@@ -89,13 +94,13 @@ func TestStructuralComponentCrossFileTier_IsPythonOnly6998(t *testing.T) {
 		// The positive control. Without it every negative below could pass
 		// by the tier never firing at all, which is the commonest way an
 		// absence assertion here turns out to be decoration.
-		{name: "python", lang: "python", ext: ".py", wantBind: true},
+		{name: "python", scope: "component", lang: "python", ext: ".py", wantBind: true},
 		// Second positive control: the guard reads `strings.ToLower(...)`,
 		// so the invariant is case-INSENSITIVE python-only. A reader would
 		// otherwise reasonably assume an exact byte match, and a future
 		// edit that dropped the ToLower would be a silent narrowing that
 		// no other row here can see.
-		{name: "Python-mixed-case", lang: "Python", ext: ".py", wantBind: true},
+		{name: "Python-mixed-case", scope: "component", lang: "Python", ext: ".py", wantBind: true},
 		// The negatives are an ENUMERATION of the guard's neighbours, not a
 		// sample. Two sampled members cannot detect a predicate that got
 		// BROADER (#6998's own shape), and each of the following was scored
@@ -107,19 +112,47 @@ func TestStructuralComponentCrossFileTier_IsPythonOnly6998(t *testing.T) {
 		// deliberately same-file precisely because a cross-file guess is
 		// #6369's wrong-node hazard, so those two rows pin the actual
 		// decision rather than a general principle.
-		{name: "csharp", lang: "csharp", ext: ".cs", wantBind: false},
-		{name: "protobuf", lang: "protobuf", ext: ".proto", wantBind: false},
-		{name: "php", lang: "php", ext: ".php", wantBind: false},
-		{name: "python3", lang: "python3", ext: ".py", wantBind: false},
-		{name: "ruby", lang: "ruby", ext: ".rb", wantBind: false},
-		{name: "java", lang: "java", ext: ".java", wantBind: false},
+		{name: "csharp", scope: "component", lang: "csharp", ext: ".cs", wantBind: false},
+		{name: "protobuf", scope: "component", lang: "protobuf", ext: ".proto", wantBind: false},
+		{name: "php", scope: "component", lang: "php", ext: ".php", wantBind: false},
+		{name: "python3", scope: "component", lang: "python3", ext: ".py", wantBind: false},
+		{name: "ruby", scope: "component", lang: "ruby", ext: ".rb", wantBind: false},
+		{name: "java", scope: "component", lang: "java", ext: ".java", wantBind: false},
 		// Language varied, file paths held identical to the python case.
-		{name: "ruby-on-python-paths", lang: "ruby", ext: ".py", wantBind: false},
+		{name: "ruby-on-python-paths", scope: "component", lang: "ruby", ext: ".py", wantBind: false},
+		// SCOPE is the second graded axis. The nine rows above vary the
+		// language and hold the scope segment at "component", so on their own
+		// they say nothing about the OTHER guard on refs.go:3094
+		// (`strings.EqualFold(scopeKind, "component")`). Widening that one to
+		// `HasPrefix(strings.ToLower(scopeKind), "co")` was scored ALIVE
+		// against them — and it is reachable on an address production emits
+		// today: internal/extractors/python/config_consumer.go:333 mints
+		// `scope:config:ref:python:<file>:<Name>`, which under that widening
+		// bound a CONFIG reference to a class in another file. A
+		// confidently-wrong edge of exactly #6369's shape.
+		//
+		// Both rows hold lang at "python" — the language guard is satisfied,
+		// so a failure here is unambiguously about the scope guard.
+		//
+		// The subtype segment stays "class" rather than production's "ref":
+		// lookupStructural never reads it. The only segments it indexes are
+		// stubScopeKindIndex(1), stubScopeLangIndex(3), stubScopeFileIndex(4)
+		// and stubScopeTailIndex(5) — there is no `parts[2]` in the function —
+		// so `scope:config:ref:…` and `scope:config:class:…` take an identical
+		// path, and holding the subtype constant keeps scope the only varied
+		// axis at no cost in fidelity.
+		{name: "config-scope", scope: "config", lang: "python", ext: ".py", wantBind: false},
+		// "operation" is the largest scope kind in the tree, and the comment
+		// above this block says the package-keyed path "only fires for
+		// operation scope" — the two are entangled in a reader's mind, so pin
+		// that they stay separate. Deliberately not the whole scope
+		// vocabulary: the goal is a pin that survives an obvious widening.
+		{name: "operation-scope", scope: "operation", lang: "python", ext: ".py", wantBind: false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			base, consumer, ref := langGuardFixture6998(tc.lang, tc.ext)
+			base, consumer, ref := langGuardFixture6998(tc.scope, tc.lang, tc.ext)
 			idx := BuildIndex([]types.EntityRecord{base, consumer})
 
 			// Premise 1 — the cross-file tier's own precondition holds in
@@ -138,7 +171,7 @@ func TestStructuralComponentCrossFileTier_IsPythonOnly6998(t *testing.T) {
 			// Premise 2 — the same-file tier misses. The consumer's file does
 			// not declare `SharedBase`, so nothing but the cross-file tier
 			// can produce a binding here.
-			if id, ok := idx.lookupLocationKind(consumer.SourceFile, "SharedBase", componentKindFamily); ok {
+			if id, ok := idx.lookupLocationKind(consumer.SourceFile, "SharedBase", structuralKindFamilies(tc.scope)); ok {
 				t.Fatalf("premise: lookupLocationKind(%q, SharedBase) = (%q,true); the "+
 					"consumer file must not declare the name or the same-file tier, not "+
 					"the cross-file one, is what this case measures (#6998)",

--- a/internal/resolve/structural_component_lang_guard_6998_test.go
+++ b/internal/resolve/structural_component_lang_guard_6998_test.go
@@ -34,6 +34,22 @@ import (
 // PATHS constant too, so the only thing separating it from the binding case
 // is the language segment itself — the guard cannot be mistaken for a
 // path- or extension-keyed effect.
+//
+// The ADDRESS's language segment is the load-bearing half of that joint
+// variation; the entity's `Language` field is not read by this tier at all.
+// Probed directly during review: entity Language=ruby with a python address
+// BINDS, entity Language=python with a ruby address does NOT. The fixture
+// varies both only because that is what a realistic record looks like.
+//
+// Two facts recorded here so the next reader does not re-derive them:
+//   - Mixed-case `Python` BINDS, because the guard reads
+//     `strings.ToLower(parts[stubScopeLangIndex])` on the line above. The
+//     invariant is case-insensitive python-only, and the `Python-mixed-case`
+//     row below is what grades it.
+//   - An EMPTY language segment dangles honestly (statusUnmatched). It takes
+//     no third path: the `(lang == "" || lang == "python")` conditions near
+//     refs.go:4574 are disposition routing in a different function, not a
+//     binding tier. Enumerated and confirmed, not assumed.
 
 // langGuardFixture6998 builds the one shape both halves of the pair share:
 // a class `SharedBase` declared in `app/base<ext>`, globally unique, and a
@@ -70,10 +86,31 @@ func TestStructuralComponentCrossFileTier_IsPythonOnly6998(t *testing.T) {
 		ext      string
 		wantBind bool
 	}{
-		// The positive control. Without it the three negatives below could
-		// all pass by the tier never firing at all, which is the commonest
-		// way an absence assertion here turns out to be decoration.
+		// The positive control. Without it every negative below could pass
+		// by the tier never firing at all, which is the commonest way an
+		// absence assertion here turns out to be decoration.
 		{name: "python", lang: "python", ext: ".py", wantBind: true},
+		// Second positive control: the guard reads `strings.ToLower(...)`,
+		// so the invariant is case-INSENSITIVE python-only. A reader would
+		// otherwise reasonably assume an exact byte match, and a future
+		// edit that dropped the ToLower would be a silent narrowing that
+		// no other row here can see.
+		{name: "Python-mixed-case", lang: "Python", ext: ".py", wantBind: true},
+		// The negatives are an ENUMERATION of the guard's neighbours, not a
+		// sample. Two sampled members cannot detect a predicate that got
+		// BROADER (#6998's own shape), and each of the following was scored
+		// as an individually ALIVE widening before these rows existed:
+		//   `HasPrefix(lang, "py")`  admits python3
+		//   `HasPrefix(lang, "p")`   admits php, protobuf, proto
+		//   `lang == "python" || lang == "csharp" || ...`
+		// csharp and protobuf are the two ports (#6984, #6991) that are
+		// deliberately same-file precisely because a cross-file guess is
+		// #6369's wrong-node hazard, so those two rows pin the actual
+		// decision rather than a general principle.
+		{name: "csharp", lang: "csharp", ext: ".cs", wantBind: false},
+		{name: "protobuf", lang: "protobuf", ext: ".proto", wantBind: false},
+		{name: "php", lang: "php", ext: ".php", wantBind: false},
+		{name: "python3", lang: "python3", ext: ".py", wantBind: false},
 		{name: "ruby", lang: "ruby", ext: ".rb", wantBind: false},
 		{name: "java", lang: "java", ext: ".java", wantBind: false},
 		// Language varied, file paths held identical to the python case.


### PR DESCRIPTION
Closes #6998.

**Behaviour is unchanged. This is the missing assertion, not a fix.** The `lang == "python"` guard at `internal/resolve/refs.go:3098` is exactly as it was.

## What was ungraded

`lookupStructural` resolves a `scope:component:...` address in two tiers: same-file `lookupLocationKind`, then — for `component` scope with **`lang == "python"` only** — `lookupUniqueRealComponentByName`, which binds when exactly one entity in the whole graph declares the name. That second tier is the widest one in the structural lookup, and the only thing making the Python address dialect *not* same-file-only — which is precisely what separates it from the C# (#6984) and protobuf (#6991) ports, both deliberately same-file because a cross-file guess is #6369's wrong-node hazard.

Removing the guard was **ALIVE**: the resolver package, the touched extractor packages and the full golden ratchet all stayed green. So if the guard drifted, every other language would silently gain a whole-graph unique-name fallback and it would ship green. That is the **permissive** direction — a binding that should not happen is a confidently-wrong edge, which reads as valid and is worse than a dangling one. Not capped by the #6966 default-off gate: `lookupStructural` is core resolution.

## The pin — a behavioural pair, in `internal/resolve/structural_component_lang_guard_6998_test.go`

`TestStructuralComponentCrossFileTier_IsPythonOnly6998`, table-driven over one fixture builder:

| case | address lang | expected |
|---|---|---|
| `python` (**positive control**) | `python` | binds to `SharedBase` in `app/base.py`, `statusRewritten` |
| `Python-mixed-case` (**second positive control**) | `Python` | **binds** — see below |
| `csharp` | `csharp` | no binding, `statusUnmatched` |
| `protobuf` | `protobuf` | no binding, `statusUnmatched` |
| `php` | `php` | no binding, `statusUnmatched` |
| `python3` | `python3` | no binding, `statusUnmatched` |
| `ruby` | `ruby` | no binding, `statusUnmatched` |
| `java` | `java` | no binding, `statusUnmatched` |
| `ruby-on-python-paths` | `ruby`, with the python case's **exact file paths** | no binding, `statusUnmatched` |
| `config-scope` | scope `config`, lang `python` | no binding, `statusUnmatched` |
| `operation-scope` | scope `operation`, lang `python` | no binding, `statusUnmatched` |

**Round 2 — the negatives are an enumeration, not a sample.** The first version graded `ruby` and `java`, which pins "not ruby, not java", not "python only". A negative set of two members cannot detect a predicate that got *broader* — #6998's own shape. The review scored three widenings ALIVE against it: `HasPrefix(lang, "py")`, `HasPrefix(lang, "p")` (**one character**, admitting `php`/`protobuf`/`proto`, all live language tokens), and the guard extended with `csharp`/`typescript`/`go`. `csharp` and `protobuf` are exactly the ports this PR cites as deliberately same-file (#6984, #6991), so a drift admitting either is #6369's wrong-node hazard in the permissive direction, arriving green. Those four rows close it.

**Round 3 — SCOPE is now a graded axis too.** Round 2's nine rows all varied the language and all held the scope segment at `component`, so nothing asserted the **other** guard on that line, `refs.go:3094`'s `strings.EqualFold(scopeKind, "component")`. Widening it to `strings.HasPrefix(strings.ToLower(scopeKind), "co")` (CS-1) was ALIVE — and reachable on an address production emits today: `internal/extractors/python/config_consumer.go:333` mints `scope:config:ref:python:<file>:<Name>`, and `config` starts with `co`. Under the mutant that address **bound to a class in another file** — #6369's wrong-node hazard in the permissive direction, arriving green. Two rows close it, with `lang` held at `python` so a failure is unambiguously about scope. Deliberately two, not the scope vocabulary.

The subtype segment stays `class` rather than production's `ref`: `lookupStructural` never reads it — the only segments it indexes are `stubScopeKindIndex(1)`, `stubScopeLangIndex(3)`, `stubScopeFileIndex(4)`, `stubScopeTailIndex(5)`, and there is no `parts[2]` in the function — so `scope:config:ref:…` and `scope:config:class:…` take an identical path. Holding it constant keeps scope the only varied axis at no cost in fidelity.

**Round 2 — the invariant is case-INSENSITIVE python-only.** Mixed-case `Python` binds, via the `strings.ToLower(parts[stubScopeLangIndex])` on the line above the guard. That was ungraded, and a reader would reasonably have assumed an exact byte match. `Python-mixed-case` is a second positive control and it is what kills the narrowing mutant R6.

The entities are named in the assertions (`SharedBase` in `app/base<ext>`, consumer `Child` in `app/child<ext>`); no count is asserted. The positive control is what stops the negatives passing by the tier never firing at all.

Explicitly **not** a source scan for the string `lang == "python"` — a scan-and-assert guard has several independent no-op modes and would survive the very rewrite it exists to catch.

### Axes

**Varied:** the address's language segment, and the entity `Language` / file extension that go with it.
**Held constant:** entity kind (`Class`) and subtype, the declared name (`SharedBase`), its global uniqueness, the cross-file relationship (the consumer's file declares nothing of that name), the directory (so `pkgDirOf` is identical), and the address's scope-kind and subtype segments.
The `ruby-on-python-paths` case holds the **file paths** constant too, so the only thing separating it from the binding case is the language segment itself — the guard cannot be mistaken for a path- or extension-keyed effect.

Of that joint variation the **address's** language segment is the load-bearing half: the entity's `Language` field is not read by this tier at all. The review probed it both ways — entity `Language=ruby` with a python address binds; entity `Language=python` with a ruby address does not. The fixture varies both only because that is what a realistic record looks like. Also enumerated and confirmed: an **empty** language segment dangles honestly, taking no third path (the `lang == ""` conditions near `refs.go:4574` are disposition routing in a different function, not a binding tier). Both facts are now recorded in the test comment.

### Both premises are asserted per case, before the outcome

1. `lookupUniqueRealComponentByName("SharedBase")` returns the base class in **every** case, binding and non-binding alike. So a negative can never pass because the candidate was absent or ambiguous: the only thing withholding the binding is the language guard.
2. `lookupLocationKind(consumerFile, "SharedBase", componentKindFamily)` must **miss**, so the same-file tier is not what the case is measuring.

## Mutants

Both proven applied by an **exact occurrence count of 1** at `refs.go:3098`, with the enclosing function asserted to be `lookupStructural` — `lang == "python"` appears **12 times** in that file, so a naive replace lands on the wrong conjunct. Green baseline immediately before each score, `go vet` and `gofmt -l` clean, `-count=1` always, restored by `cp` from a shasum-verified backup (`326b6412…` before and after), zero `MUTANT` text remaining, `git diff HEAD` empty on the production file.

- **M1 — the issue's mutant: delete the guard** (`if true {` in place of `if lang == "python" {`). **DEAD.** `./internal/resolve/` goes RED on `TestStructuralComponentCrossFileTier_IsPythonOnly6998` — subtests `ruby`, `java` and `ruby-on-python-paths` fail; `python` still passes.
- **M2 — complementary: the python tier made same-file-only** (`lookupLocationKind(filePath, tail, componentKindFamily)` in place of `lookupUniqueRealComponentByName(tail)`, guard kept). **DEAD, and killed by the `python` subtest ALONE** — the three negatives still pass. So the pin is not satisfiable by an unrelated failure, and the positive control is load-bearing rather than decorative.

- **R2 — `strings.HasPrefix(lang, "py")`**. Was ALIVE; now **DEAD**, killed by `python3`.
- **R3 — `strings.HasPrefix(lang, "p")`**, the one-character widening. Was ALIVE; now **DEAD**, killed by `protobuf`, `php` and `python3`.
- **R4 — guard extended with `csharp`, `typescript`, `go`** (`go` even pre-empts the package-scoped go tier ten lines below). Was ALIVE; now **DEAD**, killed by `csharp`.
- **R6 — narrowing: `parts[stubScopeLangIndex] == "python"`**, i.e. the case fold dropped. **DEAD**, killed by `Python-mixed-case` **alone** — so that row is load-bearing, not decoration.

- **CS-1 — the SCOPE guard at `refs.go:3094` widened to a `co` prefix**. Was ALIVE; now **DEAD**, killed by `config-scope`.
- **CS-2 — the scope guard extended with `operation`**. **DEAD**, killed by `operation-scope`.

No row is decoration: `python3` kills R2 and R3, `protobuf` and `php` kill R3, `csharp` kills R4, `Python-mixed-case` kills R6, `config-scope` kills CS-1, `operation-scope` kills CS-2, and `ruby`/`java`/`ruby-on-python-paths` kill M1. M1 and R3 were re-scored after the round-3 fixture change to confirm the language axis did not regress. The two guards sit one line apart and were addressed by distinct line numbers — scope at `:3094` (that token occurs once), language at `:3098` (`lang == "python"` occurs 12 times).

Round-2 mutants were applied by a script that asserts, and prints, all of: `lang == "python"` occurs exactly **12** times in `refs.go`; the target line is `refs.go:3098`; its enclosing `func` is `lookupStructural`; and **exactly one** line differs from the backup (the hit set itself is printed).

Worth recording, and **independently reproduced in review**: under M2 **no other test in `./internal/resolve/` failed** — notably not the Django FK path, which `django_fk.go:172` documents as depending on this tier. So before this PR the cross-file tier's *firing* was ungraded in that package, not merely its language restriction. This PR closes the firing half outright. That gap is being filed separately and is not chased here.

## Verification

All in `/private/tmp/claude-501/-Users-jorgecajas-Projects-archigraph/c0fefed4-0195-4c81-9a94-07a7145710a4/scratchpad/impl-6998-q4v9x/wt` (worktree at `82396b1ca`). macOS/APFS, Apple Silicon, `GOMAXPROCS=3`, `nice -n 10`, isolated `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT` per run.

- `go vet ./internal/resolve/` — clean; `gofmt -l internal/resolve/` — empty.
- `go test -count=1 ./internal/resolve/` — **ok** (0.9s), every round.
- `go test -count=1 ./cmd/grafel/` — **ok** (163s), fresh isolated home, on the round-1 tree. **Not re-run for round 2, deliberately**: nothing outside the `_test.go` changed, and a test file is not linked into the `grafel` binary the ratchet grades.
- `bash scripts/quality/run.sh --ratchet` — **exit 0** in all three rounds, `38 gated fixtures held their baseline (29 at 100% must-have recall)`. No baseline moved; no constant touched.

## Out of scope, on purpose

Nobody has measured what would change if the fallback applied to other languages, and #6998 says that measurement is worth having **before** anyone moves the guard in either direction. I did not move it and I did not produce that measurement — scoring M1 against `./internal/resolve/` alone is not it. If some language wants the tier, that is a deliberate change with its own both-directions grading (#6369), not a side effect of adding a test.

Refs #6994, #6986, #6984, #6991, #6369, #6966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
