### PR TITLE
fix(#6923): the #6847 guard could not see a language ERODE — pin each language's population, both directions

### DIFF
--- a/internal/extractors/file_anchored_carrier_runtime_6847_test.go
+++ b/internal/extractors/file_anchored_carrier_runtime_6847_test.go
@@ -693,6 +693,51 @@ func TestFileAnchoredCarrier_CorpusCoverage_6847(t *testing.T) {
 func TestFileAnchoredCarrier_PerLanguagePopulation_6847(t *testing.T) {
 	res := carrierScan(t)
 
+	// THE TABLE-SHAPE PIN, and it is here because of what this file IS. This
+	// guard exists to stop ANOTHER guard being silenced, and without the three
+	// numbers below it could be silenced in one edit itself: gutting all 35
+	// rows to {0, 0} leaves every name, every loop and every message in place
+	// and the whole suite green — MEASURED as ALIVE by the review of #7010.
+	// Deleting a row is already caught (the key set is derived from this table,
+	// so the language disappears from the anchoring set diff); HOLLOWING the
+	// rows out was not, and given this file's documented history of being made
+	// vacuous (#6834, #6908) it is the likelier edit of the two.
+	//
+	// These are pins on the TABLE, not on the walk — they read no measurement —
+	// so they cost nothing on a corpus addition: a deliberate bump only ever
+	// RAISES a floor, and both sums only rise with it. The one edit that must
+	// touch them is the legitimate relocation case — an extractor that properly
+	// learns to anchor files it used to skip moves count from minNonAnchoring
+	// to minAnchoring — which lowers the second sum and must bump it in the
+	// same commit. That is one deliberate edit for one deliberate behaviour
+	// change, which is the point.
+	const (
+		anchoringBoundsRows6847         = 35
+		anchoringBoundsAnchoringSum6847 = 581
+		anchoringBoundsNonAnchoringSum  = 129
+	)
+	if len(anchoringBounds6847) != anchoringBoundsRows6847 {
+		t.Errorf("anchoringBounds6847 has %d rows, want exactly %d — a language was added or "+
+			"removed. Adding one is a real event (the anchoring set diff will say so too); "+
+			"removing one means this guard covers less than it did.",
+			len(anchoringBounds6847), anchoringBoundsRows6847)
+	}
+	sumAnchoring, sumNonAnchoring := 0, 0
+	for _, b := range anchoringBounds6847 {
+		sumAnchoring += b.minAnchoring
+		sumNonAnchoring += b.minNonAnchoring
+	}
+	if sumAnchoring < anchoringBoundsAnchoringSum6847 || sumNonAnchoring < anchoringBoundsNonAnchoringSum {
+		t.Errorf("anchoringBounds6847 was HOLLOWED OUT: minAnchoring sums to %d (want >= %d) and "+
+			"minNonAnchoring to %d (want >= %d).\n"+
+			"Lowering a floor without a corpus file having been deleted is how a guard gets "+
+			"silenced while still looking intact — this file exists because that happened to the "+
+			"one next to it. Name the deleted or renamed corpus file, or the extractor behaviour "+
+			"change that moved files between the two columns, in the same commit that lowers "+
+			"these constants.",
+			sumAnchoring, anchoringBoundsAnchoringSum6847, sumNonAnchoring, anchoringBoundsNonAnchoringSum)
+	}
+
 	for _, lang := range sortedStringKeys(anchoringBounds6847) {
 		want := anchoringBounds6847[lang]
 

--- a/internal/extractors/file_anchored_carrier_runtime_6847_test.go
+++ b/internal/extractors/file_anchored_carrier_runtime_6847_test.go
@@ -199,18 +199,112 @@ var exercisedLanguages6847 = []string{
 	"vbnet", "vue", "yaml", "zig",
 }
 
-// anchoringLanguages6847 is the exact set of exercised languages whose corpus
-// files actually PRODUCE a path-anchored FromID. This is vacuity layer 3 ("the
-// FULL content"): a truncated or gutted corpus file still classifies and still
-// extracts, so it would leave exercisedLanguages6847 intact — but the import
-// statements would be gone and the language would drop out of this set.
-var anchoringLanguages6847 = []string{
-	"astro", "bicep", "clojure", "cobol", "cpp", "crystal", "csharp", "dart",
-	"dockerfile", "elixir", "fish", "fsharp", "go", "graphql", "groovy",
-	"html", "java", "javascript", "just", "kotlin", "lua", "markdown", "php",
-	"protobuf", "python", "ruby", "rust", "scala", "shell", "swift",
-	"terraform", "typescript", "vue", "yaml", "zig",
+// anchoringBounds6847 pins, PER LANGUAGE and as an INDEPENDENT LITERAL, how
+// much of the corpus each language contributes to this guard. Its keys are also
+// the exact set of exercised languages whose corpus files PRODUCE a
+// path-anchored FromID (vacuity layer 3, "the FULL content": a truncated or
+// gutted corpus file still classifies and still extracts, so it would leave
+// exercisedLanguages6847 intact — but the import statements would be gone and
+// the language would drop out of this set).
+//
+// WHY COUNTS AND NOT JUST A SET (#6923). Everything this file asserted about a
+// language was either set MEMBERSHIP or a RELATIVE comparison between counters
+// that all move together (carried == anchoring, detected == anchoring). So a
+// language whose corpus contribution SHRANK — a narrowed regex, a moved
+// fixture, a rewritten extractor arm — kept every assertion satisfied while the
+// guard measured a fraction of what it used to. Measured, with the boundary
+// located exactly: zig 3 -> 1 anchoring file was ALIVE (whole suite green);
+// only zig 3 -> 0, which drops it out of the SET, was caught. That is "vacuous
+// walk reports clean" one level up: not a walk that does nothing, but a walk
+// whose POPULATION erodes underneath it.
+//
+// THE SHAPE, and why it is not exact counts. The issue offered two acceptable
+// shapes — a per-language floor, or exact counts with a "bump me deliberately"
+// message. Exact counts were rejected on a measurement, not a preference: over
+// the last 200 commits that touch a testdata/ path, 547 testdata files were
+// ADDED. An exact table would go red on a large fraction of those commits for
+// reasons unrelated to the invariant, and this guard already carries a
+// documented history of being silenced rather than maintained (#6834, #6908).
+// Both numbers below are therefore FLOORS, and both are monotone-safe under
+// corpus GROWTH — adding a corpus file can only raise one of them, never lower
+// either — so the maintenance edit is only ever required by a DELETION or a
+// RENAME, which is exactly the event this pin exists to make loud.
+//
+// BOTH DIRECTIONS ARE GRADED, which a floor alone cannot do (#6902: recall
+// assertions cannot see over-firing):
+//
+//   - minAnchoring is the EROSION direction. It is the number of corpus files
+//     of that language observed to anchor on their own path. Fewer than this
+//     and the guard is measuring less of the language than it used to.
+//
+//   - minNonAnchoring is the OVER-FIRING direction, and it is the count of
+//     exercised files of that language that must NOT anchor (exercised minus
+//     anchoring). A predicate that broadens — a language starting to anchor
+//     files it has no business anchoring — consumes this gap and trips the
+//     floor while every recall-shaped assertion above stays green. It too is
+//     addition-safe: a new anchoring file raises exercised and anchoring
+//     together and leaves the gap alone.
+//
+//     WHERE THIS DIRECTION IS UNGRADED, said plainly rather than implied. For
+//     the thirteen languages whose every exercised file already anchors
+//     (minNonAnchoring 0 — astro, clojure, cpp, crystal, dockerfile, elixir,
+//     fish, fsharp, graphql, java, php, swift, zig), there is no corpus
+//     file left for a broadened predicate to wrongly claim, so a 0 floor grades
+//     nothing and is recorded as 0 rather than pretended otherwise. The
+//     cross-language half of the over-firing question IS graded, by the set
+//     comparisons: a language at zero anchoring today (css, jcl, razor, sql,
+//     svelte, vbnet, commonlisp) that starts anchoring appears as "unexpected"
+//     in the anchoring set diff.
+//
+// TO CHANGE A NUMBER HERE: it is a deliberate bump, not a formality. Raise a
+// floor when a corpus file is genuinely added; LOWER one only when you can name
+// the corpus file that was deleted or renamed. Lowering it to match a red run
+// is how this guard was made vacuous before.
+//
+// MEASURED 2026-09-08 on macOS/APFS, in-tree walk over 907 candidate files.
+var anchoringBounds6847 = map[string]struct{ minAnchoring, minNonAnchoring int }{
+	"astro":      {2, 0},
+	"bicep":      {1, 1},
+	"clojure":    {3, 0},
+	"cobol":      {2, 9},
+	"cpp":        {3, 0},
+	"crystal":    {1, 0},
+	"csharp":     {6, 1},
+	"dart":       {3, 1},
+	"dockerfile": {3, 0},
+	"elixir":     {8, 0},
+	"fish":       {1, 0},
+	"fsharp":     {1, 0},
+	"go":         {98, 18},
+	"graphql":    {4, 0},
+	"groovy":     {4, 2},
+	"html":       {2, 2},
+	"java":       {31, 0},
+	"javascript": {9, 6},
+	"just":       {1, 2},
+	"kotlin":     {6, 1},
+	"lua":        {1, 2},
+	"markdown":   {17, 4},
+	"php":        {12, 0},
+	"protobuf":   {2, 1},
+	"python":     {94, 15},
+	"ruby":       {3, 10},
+	"rust":       {20, 1},
+	"scala":      {5, 3},
+	"shell":      {1, 5},
+	"swift":      {3, 0},
+	"terraform":  {2, 3},
+	"typescript": {209, 25},
+	"vue":        {7, 1},
+	"yaml":       {13, 16},
+	"zig":        {3, 0},
 }
+
+// anchoringLanguages6847 is the key set of anchoringBounds6847 — the same exact
+// set this file pinned as a literal slice before #6923, now derived from the
+// table so the two cannot disagree. The table is itself a hand-written literal,
+// so nothing here is derived from the collection under test.
+var anchoringLanguages6847 = sortedStringKeys(anchoringBounds6847)
 
 // noExtractorLanguages6847 is the exact set of languages the classifier DOES
 // produce over this corpus but for which no extractor is registered, so the
@@ -580,6 +674,52 @@ func TestFileAnchoredCarrier_CorpusCoverage_6847(t *testing.T) {
 			"changed:\n%s\nA language that leaves this set is exercised but no longer "+
 			"exercises the INVARIANT — its corpus file has lost the import statements the "+
 			"check needs, and the guard is vacuous for it.", diff)
+	}
+}
+
+// TestFileAnchoredCarrier_PerLanguagePopulation_6847 pins the SIZE of each
+// language's contribution, in both directions (#6923).
+//
+// The set comparisons above answer "is this language still here"; every other
+// assertion in this file is relative (carried == anchoring, detected ==
+// anchoring) and so is satisfied by all four counters shrinking together. That
+// left the population free to erode to a single file per language with the
+// suite green — measured: zig 3 -> 1 anchoring file was ALIVE, zig 3 -> 0 was
+// DEAD. This test is what makes the first row fail too.
+//
+// Both assertions are floors, for the maintenance reason written at
+// anchoringBounds6847: they are monotone-safe under corpus growth, so only a
+// deletion or a rename requires an edit here.
+func TestFileAnchoredCarrier_PerLanguagePopulation_6847(t *testing.T) {
+	res := carrierScan(t)
+
+	for _, lang := range sortedStringKeys(anchoringBounds6847) {
+		want := anchoringBounds6847[lang]
+
+		// EROSION. Fewer anchoring files than the language is pinned at means
+		// the guard is measuring less of it than it used to, while every
+		// relative assertion in this file still balances.
+		if got := res.anchoring[lang]; got < want.minAnchoring {
+			t.Errorf("language %q ERODED: %d corpus files anchor on their own path, pinned at >= %d.\n"+
+				"Every other assertion in this file is relative (carried == anchoring == detected), "+
+				"so a shrinking population passes them all — this floor is the only thing that sees "+
+				"it. Name the corpus file that was deleted or renamed before lowering the number in "+
+				"anchoringBounds6847; lowering it to match a red run is how this guard was made "+
+				"vacuous before.", lang, got, want.minAnchoring)
+		}
+
+		// OVER-FIRING. The files of this language that must NOT anchor. A
+		// broadened predicate consumes this gap, and no recall-shaped
+		// assertion can see that happen (#6902).
+		if got := res.exercised[lang] - res.anchoring[lang]; got < want.minNonAnchoring {
+			t.Errorf("language %q OVER-FIRES: only %d of its %d exercised corpus files do NOT anchor "+
+				"on their own path, pinned at >= %d.\n"+
+				"Files that never anchored are now anchoring, which is a predicate that grew too "+
+				"broad — the direction a floor on the anchoring count cannot see. If the extractor "+
+				"legitimately learned to anchor these files, raise minAnchoring and lower "+
+				"minNonAnchoring together, in one deliberate edit.",
+				lang, got, res.exercised[lang], want.minNonAnchoring)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #6923.

## The gap, reproduced before anything was changed

`internal/extractors/file_anchored_carrier_runtime_6847_test.go` built four per-language counters and then compared them only by **set membership** (`diffStringSets(anchoringLanguages6847, ...)`) or **relatively** (`carried == anchoring`, `detected == anchoring`). All four counters move together, so a language's corpus contribution could erode with every assertion still satisfied.

Both rows of the issue reproduced on the **pre-change** file (worktree `.../scratchpad/impl-6923-k7r2w/wt`, macOS/APFS, `-count=1`):

| mutant on the pre-change file | verdict |
|---|---|
| zig 3 → **1** anchoring file | **ALIVE** — `go test -run 'FileAnchoredCarrier\|PathAnchoredKinds' ./internal/extractors/` exit 0 |
| zig 3 → **0** anchoring files | **DEAD** — `EveryAnchoringFileCarries_6847` and `CorpusCoverage_6847` both fail, `missing (expected, not observed): [zig]` |

Row 2 is the non-vacuity control: the mechanism fires, so row 1 is a real gap and not an unapplied edit. The mutant was applied by an exact-occurrence-count script (`APPLIED: 1 occurrence(s)` asserted on every application), and the file was restored by `cp` from a backup whose sha256 equals `git show HEAD:<file>`.

## The change (test-only)

`anchoringBounds6847` — a hand-written literal `map[string]struct{ minAnchoring, minNonAnchoring int }` over the same 35 languages — replaces the `anchoringLanguages6847` literal slice, which is now derived from the table's keys (so the set pin and the count pin cannot disagree; the table itself is an independent literal, not derived from the walk). A new `TestFileAnchoredCarrier_PerLanguagePopulation_6847` asserts both directions, plus a table-shape pin (below).

### Which shape, and why — floors, not exact counts

The issue allowed either a per-language floor or exact counts with a "bump me deliberately" message. **Floors**, on a measurement rather than a preference: over the last 200 commits that touch a `testdata/` path, **547 testdata files were added**. An exact table would go red on a large fraction of those commits for reasons unrelated to the invariant, and this guard already carries a documented history (#6834, #6908) of being *silenced* rather than maintained. Both floors are **monotone-safe under corpus growth** — adding a corpus file can only raise one of them, never lower either — so a maintenance edit is required only by a **deletion or a rename**, which is exactly the event the pin exists to make loud.

### The floors tolerate zero slack — measured on all 35 rows

The usual cost of a floor is the drift it silently allows. Here that cost is **zero, and it was measured rather than assumed**: the review dumped `res.exercised` / `res.anchoring` from the real walk over all 907 candidates and compared row by row against the table, finding `minAnchoring == anchoring` **and** `minNonAnchoring == exercised - anchoring` on **every one of the 35 entries** (spot-checks across the range: `cobol 2/9`, `go 98/18`, `markdown 17/4`, `ruby 3/10`, `shell 1/5`, `typescript 209/25`, `yaml 13/16`, `zig 3/0`). Both directions were then confirmed empirically at the ±1 boundary: **zig 3 → 2 is DEAD** (exactly one `--- FAIL` — the boundary the old guard was blind to, since only 3 → 0 reached it), and **ruby over-firing by exactly one file** (10 → 9 non-anchoring) is DEAD too.

### Both directions are graded

- **`minAnchoring` — erosion.** Files of that language observed to anchor on their own path.
- **`minNonAnchoring` — over-firing.** `exercised - anchoring`: the files that must **NOT** anchor. A predicate that broadens consumes this gap while every recall-shaped assertion stays green (#6902's lesson). Also addition-safe: a new anchoring file raises `exercised` and `anchoring` together.
- **Where the over-firing direction is ungraded, said in the file rather than implied:** the thirteen languages whose every exercised file already anchors (astro, clojure, cpp, crystal, dockerfile, elixir, fish, fsharp, graphql, java, php, swift, zig) have `minNonAnchoring 0` — there is no corpus file left for a broadened predicate to wrongly claim, so that 0 grades nothing and is recorded as 0 rather than dressed up. The review confirmed this is **inherent to the corpus, not a shape choice**: the only real fix is a negative corpus fixture per language, which is fixture work and out of scope here. The *cross-language* half of the same question is graded by the existing set diff: a language at zero anchoring today (css, jcl, razor, sql, svelte, vbnet, commonlisp) that starts anchoring shows up as "unexpected".

### The table-shape pin — killing the hollow-out mutant (added after review)

The review found one ALIVE mutant: **gutting all 35 rows to `{0, 0}`** left every name, loop and message in place and the suite green. Deleting a row was already DEAD (the key set is derived from the table, so the language turns up as `unexpected` in the anchoring set diff), but *hollowing the rows out* was not — and this is a guard whose entire purpose is to stop another guard being silenced, in a file with a documented history of exactly that.

Three constants next to the loop, ~5 lines and no second mechanism: an exact row count (**35**) and floors on **`sum(minAnchoring)` = 581** and **`sum(minNonAnchoring)` = 129**. They read the **table, not the walk**, so a corpus addition never touches them — a deliberate bump only ever raises a floor and both sums rise with it. The one edit that must touch them is the legitimate relocation case (an extractor that properly learns to anchor files it used to skip moves count between the two columns), which is one deliberate edit for one deliberate behaviour change.

Both sums sit at exactly today's total, so there is **no margin to hide in** — the pin catches a full gut *and* a single row, in either column:

| hollowing mutant | verdict |
|---|---|
| all 35 rows → `{0, 0}` (35 hits asserted, 35 `{0, 0},` rows confirmed after) | **DEAD**, 1 `--- FAIL` — `minAnchoring sums to 0 (want >= 581) and minNonAnchoring to 0 (want >= 129)` |
| one row's erosion floor: `zig {3, 0}` → `{0, 0}` | **DEAD**, 1 `--- FAIL` — `sums to 578 (want >= 581)` |
| one row's over-firing floor: `shell {1, 5}` → `{1, 0}` | **DEAD**, 1 `--- FAIL` — `minNonAnchoring to 124 (want >= 129)` |
| delete the `"zig"` row outright (0 `"zig":` lines remaining, asserted) | **DEAD**, 3 `--- FAIL` — key-set derivation, `unexpected (observed, not expected): [zig]` |

## Mutants scored on the population assertions

Green baseline immediately before each score; `go vet` first; `-count=1` throughout; each mutant applied with an asserted occurrence count and hit set.

| mutant | verdict | killed by |
|---|---|---|
| erosion: zig contributes only its first anchoring file (3 → 1) | **DEAD** (exit 1, 1 `--- FAIL`) | `PerLanguagePopulation_6847` — `language "zig" ERODED: 1 corpus files anchor on their own path, pinned at >= 3`. This is the mutant that was ALIVE before. Re-scored after the table-shape pin: unchanged. |
| over-firing: `shell` anchors **and carries** a file it should not (synthetic carrier + anchored edge injected for every shell file) | **DEAD** (exit 1) | `PerLanguagePopulation_6847` — `language "shell" OVER-FIRES: only 0 of its 6 exercised corpus files do NOT anchor on their own path, pinned at >= 5`. **Only** that test failed: the mutant carries as well as anchors, so `carried == anchoring == detected` all stay balanced and the kill is isolated to the new assertion. |
| on my own assertion: make the expected values agree with the measurement by construction (`want := {res.anchoring[lang], res.exercised[lang]-res.anchoring[lang]}`) | **survives alone (green)**, and — the point — it takes the erosion mutant back to **ALIVE (exit 0)** when applied together | nothing, deliberately. This is the proof that the kills above rest on the **independent literal** and not on the collection under test. Reproduced independently by the review. |

## Verification

- `gofmt -l internal/extractors/` clean, `go vet ./internal/extractors/` clean.
- `go test -count=1 ./internal/extractors/...` — **exit 0**, zero `FAIL` lines (both before and after the table-shape pin).
- `./cmd/grafel/` and the golden ratchet **skipped, with a reason**: the diff is one file and that file is a `_test.go` — verified again after the follow-up commit (`1 file changed, 45 insertions(+)`), not taken on trust. No extractor behaviour, no non-test file, so no graph digest or golden artefact can move.

## Finding, not papered over (per the issue's "not established")

No git archaeology was done, so **no claim is made that any language has actually eroded historically** — the floors record what the corpus measures *today* (907 candidate files). What the enumeration does show, reported rather than silently baselined: seven languages exercise this invariant on a **single anchoring file** — `bicep` 1/2, `crystal` 1/1, `fish` 1/1, `fsharp` 1/1, `just` 1/3, `lua` 1/3, `shell` 1/6.

**How much this PR actually buys for those seven, corrected after review** — the earlier wording over-credited it. With `minAnchoring: 1`, `got < 1` ⟺ `got == 0` ⟺ the language drops out of the anchoring set, which `CorpusCoverage_6847` / `EveryAnchoringFileCarries_6847` **already** caught (the issue's own 3 → 0 row). So the erosion direction adds **nothing** for any of the seven. Four of them gain real new coverage from the over-firing floor — `bicep {1,1}`, `just {1,2}`, `lua {1,2}`, `shell {1,5}` — while for **`crystal {1,0}`, `fish {1,0}`, `fsharp {1,0}`** both floors are unreachable and the new pin is **strictly redundant** with the pre-existing set membership. That is a limit of the corpus rather than of the pin, and it is fixture work, not assertion work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
