### PR TITLE
fix(#6909): the link pass never seeded SCOPE.ChannelBinding — and the sidecar it writes is what grafel_dead_code reads

### DIFF
--- a/internal/links/reachability.go
+++ b/internal/links/reachability.go
@@ -110,7 +110,14 @@ var reachabilityEdgeKinds = map[string]bool{
 // an HTTP route — and #6776 arm B7 added both kinds together because both are
 // live. Seeding only the prefixed one persisted every Java/Spring/Django
 // route into the sidecar as unreachable, along with everything only it reaches.
-// internal/mcp/dead_code.go's frameworkEntryKindsMCP mirrors this map.
+// #6909: internal/mcp/dead_code.go used to hand-copy this map (and
+// reachabilityEdgeKinds) into frameworkEntryKindsMCP. The two copies diverged
+// twice — on "Route" (#6902) and on "SCOPE.ChannelBinding" — and the second
+// divergence was live, because handleDeadCode PREFERS the sidecar this pass
+// writes and only consults its own map when the sidecar fails to load. There
+// is now no copy: mcp consumes IsFrameworkEntryKind / IsReachabilityEdgeKind
+// below. (internal/coverage has its own edge-kind set for a different
+// question — test reachability — and is deliberately not folded in here.)
 var frameworkEntryKinds = map[string]bool{
 	"http_endpoint_definition": true,
 	"http_endpoint":            true,
@@ -118,10 +125,27 @@ var frameworkEntryKinds = map[string]bool{
 	"SCOPE.Route":              true,
 	"Route":                    true, // #6902
 	"SCOPE.MessageTopic":       true,
+	// #5782 (ADR-0025), added here by #6909: a ChannelBinding is a
+	// config-side messaging declaration with no callers by design — never
+	// report it as dead code. ADR-0025 §3 named only the MCP map because
+	// that was the only seed set at the time; the sidecar this pass writes
+	// is what the tool actually reads, so the seed has to be here too.
+	"SCOPE.ChannelBinding":     true,
 	"SCOPE.GrpcMethod":         true,
 	"SCOPE.ServerlessFunction": true,
 	"SCOPE.EventBusEvent":      true,
 }
+
+// IsFrameworkEntryKind reports whether an entity of this kind is a
+// framework-managed entry-point, i.e. a BFS seed that needs no inbound edge.
+//
+// Exported for internal/mcp's grafel_dead_code fallback, which used to keep a
+// hand-copied mirror of frameworkEntryKinds. #6909: one set, one consumer path.
+func IsFrameworkEntryKind(kind string) bool { return frameworkEntryKinds[kind] }
+
+// IsReachabilityEdgeKind reports whether an edge of this kind propagates
+// reachability. Exported for the same reason as IsFrameworkEntryKind (#6909).
+func IsReachabilityEdgeKind(kind string) bool { return reachabilityEdgeKinds[kind] }
 
 // reachabilityEntry is one persistent reachability fact for the sidecar.
 type reachabilityEntry struct {

--- a/internal/links/reachability.go
+++ b/internal/links/reachability.go
@@ -147,6 +147,33 @@ func IsFrameworkEntryKind(kind string) bool { return frameworkEntryKinds[kind] }
 // reachability. Exported for the same reason as IsFrameworkEntryKind (#6909).
 func IsReachabilityEdgeKind(kind string) bool { return reachabilityEdgeKinds[kind] }
 
+// FrameworkEntryKinds returns every seed kind, sorted.
+//
+// The predicate above cannot be tested by sampling: a positive/negative list of
+// SOME members grades only those members, so deleting an unlisted seed — say
+// "SCOPE.GrpcMethod", which would report every gRPC method as dead code — is
+// silent. This exists so a test can assert the WHOLE set against an independent
+// hand-written literal, which is the only shape that catches a member being
+// added, removed or renamed. Review of #6909 scored three such mutants ALIVE
+// against a sampled pin.
+//
+// The grading test lives in internal/mcp (channelbinding_sidecar_seed_6909_test.go)
+// because that is where the consumer is: an edit to this map that breaks the
+// dead-code tool leaves ./internal/links/ green. Do not delete it as "not about
+// links".
+//
+// Seeding a kind makes its whole TRANSITIVE CLOSURE reachable, not just the
+// entity itself — that is the intended semantics (a route's handlers are live
+// because the route is), and it is the blast radius of adding a member here.
+func FrameworkEntryKinds() []string {
+	out := make([]string, 0, len(frameworkEntryKinds))
+	for k := range frameworkEntryKinds {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // reachabilityEntry is one persistent reachability fact for the sidecar.
 type reachabilityEntry struct {
 	Repo         string   `json:"repo"`

--- a/internal/links/reachability.go
+++ b/internal/links/reachability.go
@@ -147,6 +147,34 @@ func IsFrameworkEntryKind(kind string) bool { return frameworkEntryKinds[kind] }
 // reachability. Exported for the same reason as IsFrameworkEntryKind (#6909).
 func IsReachabilityEdgeKind(kind string) bool { return reachabilityEdgeKinds[kind] }
 
+// ReachabilityEdgeKinds returns every reachability-propagating edge kind,
+// sorted, for the same reason FrameworkEntryKinds exists: this set cannot be
+// graded by sampling.
+//
+// It is the BFS TRAVERSAL FILTER (see the `if !reachabilityEdgeKinds[e.Kind]`
+// below), so a member leaving it is worse for a user than a missing seed:
+// an entity reachable only through, say, an IMPORTS edge stops being reachable
+// and the dead-code tool reports LIVE code as dead. Under-reporting is a
+// quietly useless tool; over-reporting sends people to delete working code.
+// Deleting "IMPORTS" was scored ALIVE against every test in this repo before
+// the enumeration in internal/mcp existed.
+//
+// NOT to be confused with internal/coverage's identically-named
+// reachabilityEdgeKinds, whose line 208 is syntactically identical to the one
+// below. That set is {TESTS, CALLS} built from types.RelationshipKind*
+// constants and answers "which tests reach this entity" (coverage.PropTestReachable),
+// not "is this dead". It is a name collision, not a copy of this set, and must
+// not be folded in here — the resemblance has already produced one issue filed
+// on a wrong premise (#7012, closed invalid).
+func ReachabilityEdgeKinds() []string {
+	out := make([]string, 0, len(reachabilityEdgeKinds))
+	for k := range reachabilityEdgeKinds {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // FrameworkEntryKinds returns every seed kind, sorted.
 //
 // The predicate above cannot be tested by sampling: a positive/negative list of

--- a/internal/mcp/channelbinding_sidecar_seed_6909_test.go
+++ b/internal/mcp/channelbinding_sidecar_seed_6909_test.go
@@ -260,6 +260,32 @@ func TestReachabilitySeedSetsAreNotDuplicated_6909(t *testing.T) {
 				"and silences the dead-code tool.", kind)
 		}
 	}
+	// The SECOND exported predicate, enumerated the same way and for a sharper
+	// reason: this set is the BFS TRAVERSAL FILTER, so a member leaving it makes
+	// entities reachable only through that edge kind report as DEAD — the tool
+	// names live code for deletion. Review of this PR scored deleting "IMPORTS"
+	// ALIVE against every test in the repo. Hand-written, not derived from the
+	// map under test, for the same reason as wantSeeds above.
+	wantEdgeKinds := []string{
+		"CALLS", "CONSUMES", "CONTAINS", "DEPENDS_ON", "DISCRIMINATES_ON",
+		"ENTRY_POINT_OF", "EXTENDS", "FETCHES", "HANDLES", "HANDLES_SIGNAL",
+		"IMPLEMENTS", "IMPORTS", "NAVIGATES_TO", "PRODUCES", "REFERENCES",
+		"REGISTERS", "RENDERS", "RESOLVES_TO", "ROUTES_TO", "STEP_IN_PROCESS",
+		"TESTS", "UNRESOLVED_FETCH", "USES", "USES_HOOK",
+	}
+	gotEdgeKinds := links.ReachabilityEdgeKinds()
+	if !slices.Equal(gotEdgeKinds, wantEdgeKinds) {
+		t.Errorf("links.ReachabilityEdgeKinds() has drifted from the set this repo "+
+			"intends to propagate reachability along.\n got:  %q\n want: %q\n"+
+			"A kind REMOVED here makes every entity reachable only via that edge "+
+			"report as dead code — the false-positive direction, which sends users "+
+			"to delete working code. A kind ADDED lights up entities nothing really "+
+			"reaches. If the change is intended, edit wantEdgeKinds in the same "+
+			"commit. (internal/coverage has an identically-named set answering test "+
+			"reachability — it is a name collision, not this set.)",
+			gotEdgeKinds, wantEdgeKinds)
+	}
+
 	if !links.IsReachabilityEdgeKind("CALLS") || !links.IsReachabilityEdgeKind("CONTAINS") {
 		t.Errorf("links.IsReachabilityEdgeKind must accept CALLS and CONTAINS; "+
 			"got CALLS=%v CONTAINS=%v",

--- a/internal/mcp/channelbinding_sidecar_seed_6909_test.go
+++ b/internal/mcp/channelbinding_sidecar_seed_6909_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
@@ -203,6 +204,42 @@ func TestDeadCode_ChannelBindingIsSeededOnTheSidecarPath_6909(t *testing.T) {
 // other: SCOPE.ChannelBinding and Route must be seeds (ADR-0025, #6902), and
 // SCOPE.Class must not be, or the dead-code tool reports nothing at all.
 func TestReachabilitySeedSetsAreNotDuplicated_6909(t *testing.T) {
+	// ENUMERATION, not sampling. The review of this PR scored three mutants
+	// ALIVE against the positive/negative loops below: deleting the
+	// pre-existing seed "SCOPE.GrpcMethod" (every gRPC method then reports as
+	// dead code), adding a plausible new seed "SCOPE.Interface", and adding an
+	// empty-string key. A list of SOME members grades only those members, and
+	// nothing tells a reader which half is covered — so the whole set is
+	// asserted against a literal written out BY HAND here. It is deliberately
+	// not derived from links.FrameworkEntryKinds(): a want list computed from
+	// the set under test agrees with any deletion.
+	//
+	// Changing the seed set intentionally? Edit this literal in the same
+	// commit, and say in the message which kind moved and why.
+	wantSeeds := []string{
+		"Route",                    // #6902, bare spelling
+		"SCOPE.ChannelBinding",     // #5782 / ADR-0025, #6909
+		"SCOPE.Endpoint",           //
+		"SCOPE.EventBusEvent",      //
+		"SCOPE.GrpcMethod",         //
+		"SCOPE.MessageTopic",       // #5781
+		"SCOPE.Route",              // #6902, prefixed spelling
+		"SCOPE.ServerlessFunction", //
+		"http_endpoint",            //
+		"http_endpoint_definition", //
+	}
+	gotSeeds := links.FrameworkEntryKinds()
+	if !slices.Equal(gotSeeds, wantSeeds) {
+		t.Errorf("links.FrameworkEntryKinds() has drifted from the set this "+
+			"repo intends to seed the dead-code BFS from.\n got:  %q\n want: %q\n"+
+			"A kind REMOVED here is reported as dead code from the next link pass "+
+			"on; a kind ADDED makes it and its whole transitive closure "+
+			"unconditionally reachable, silencing genuine findings. If the change "+
+			"is intended, edit wantSeeds in the same commit.", gotSeeds, wantSeeds)
+	}
+
+	// The two loops below are kept for the diagnosis they give: the exact-set
+	// assertion says "drifted", these say which direction and why it matters.
 	for _, kind := range []string{
 		"SCOPE.ChannelBinding", // #5782 / ADR-0025
 		"Route",                // #6902

--- a/internal/mcp/channelbinding_sidecar_seed_6909_test.go
+++ b/internal/mcp/channelbinding_sidecar_seed_6909_test.go
@@ -1,0 +1,235 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/links"
+)
+
+// ---------------------------------------------------------------------------
+// #6909 — SCOPE.ChannelBinding was a dead-code entry seed in internal/mcp and
+// NOT in internal/links, and the sidecar is what decides.
+//
+// ADR-0025 §3 asks that a ChannelBinding — a config-side messaging declaration
+// with no callers by design — is never reported as dead code, and #5782
+// implemented that in internal/mcp's frameworkEntryKindsMCP. But handleDeadCode
+// PREFERS the on-disk <group>-links-reachability.json sidecar and consults its
+// own seed set only when `from` is set or the sidecar fails to load. The sidecar
+// is written by internal/links' frameworkEntryKinds, which lacked the kind — so
+// on the normal path a ChannelBinding was reported dead.
+//
+// WHY THIS TEST GOES THROUGH links.RunAllPasses AND NOT newTestServer ALONE:
+// a test that hands handleDeadCode an in-memory graph with no sidecar exercises
+// computeDeadCodeLive — the FALLBACK — which already honoured ADR-0025 and would
+// pass with the defect fully present (#6902's TestDeadCode_BareRouteIsAFramework
+// EntryPoint_6902 is exactly that shape). The defect lives on the path
+// "link pass writes the sidecar → handleDeadCode reads it", so the test drives
+// the real link pass and then asserts what the tool says. The
+// `source == "sidecar"` assertion below is the guard that keeps it there: if the
+// handler ever falls back to a recompute, this test stops testing the defect and
+// says so instead of quietly passing.
+//
+// GRADING BOTH DIRECTIONS. Adding a seed is a WIDENING — it makes more entities
+// reachable, i.e. produces FEWER dead-code reports, which can mask genuinely
+// dead code. So the test names one entity that must STOP being reported (the
+// ChannelBinding) and one that must STILL be reported (deadFn6909, an
+// unexported, uncalled, unsniffable function with no inbound edges).
+//
+// POSITIVE CONTROL for the forbidden row: deadFn6909 has no inbound edge of any
+// reachability kind, its kind (SCOPE.Function) is in neither seed set, and it is
+// not a Go entry-point the pass's source sniffer recognises — it is not `main`,
+// not `init`, not a test function. Nothing but a wrongly-widened seed set can
+// make it reachable.
+// ---------------------------------------------------------------------------
+
+const (
+	channelBindingName6909 = "mp.messaging.outgoing.orders-6909"
+	deadFnName6909         = "reconcileLedger6909"
+)
+
+// deadCodeDoc6909 is the in-memory twin of the fixture graph written to disk
+// below. handleDeadCode needs a loaded group to resolve at all; the VERDICT it
+// returns comes from the sidecar, not from this document.
+func deadCodeDoc6909() *graph.Document {
+	return &graph.Document{
+		Repo: "svc6909",
+		Entities: []graph.Entity{
+			{ID: "cb-6909", Name: channelBindingName6909, Kind: "SCOPE.ChannelBinding",
+				SourceFile: "src/application.properties", StartLine: 1},
+			{ID: "dead-6909", Name: deadFnName6909, Kind: "SCOPE.Function",
+				SourceFile: "src/ledger.go", StartLine: 3},
+		},
+	}
+}
+
+// runLinkPassForDeadCode6909 writes a one-repo fixture graph plus its real
+// source files, runs the actual link passes, and returns the group name. The
+// reachability sidecar it leaves behind is the artefact handleDeadCode reads.
+func runLinkPassForDeadCode6909(t *testing.T) string {
+	t.Helper()
+
+	// Isolate: the sidecar must land under a temp home, and handleDeadCode
+	// resolves its own path from GRAFEL_HOME. Resolving the home through
+	// links.GroupHome("") and handing THAT to RunAllPasses is what makes the
+	// writer and the reader agree by construction rather than by convention.
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_DAEMON_ROOT", "")
+	home, err := links.GroupHome("")
+	if err != nil {
+		t.Fatalf("GroupHome: %v", err)
+	}
+
+	graphsRoot := t.TempDir()
+	repoRoot := filepath.Join(graphsRoot, "svc6909")
+	write := func(rel, body string) {
+		t.Helper()
+		p := filepath.Join(repoRoot, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	// Real source files: #6839 makes the pass DEGRADE a repo whose source root
+	// or entry-point files it cannot read, and a degraded repo produces no dead
+	// list at all — which would make every assertion below vacuous.
+	write("src/ledger.go", "package svc\n\nfunc reconcileLedger6909() {}\n")
+	write("src/application.properties", "mp.messaging.outgoing.orders-6909.topic=orders\n")
+
+	doc := map[string]any{
+		"version": 1,
+		"repo":    "svc6909",
+		"entities": []map[string]any{
+			{"id": "cb-6909", "name": channelBindingName6909,
+				"kind": "SCOPE.ChannelBinding", "source_file": "src/application.properties"},
+			{"id": "dead-6909", "name": deadFnName6909,
+				"kind": "SCOPE.Function", "source_file": "src/ledger.go"},
+		},
+		"relationships": []map[string]string{},
+	}
+	buf, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal fixture graph: %v", err)
+	}
+	write(filepath.Join(".grafel", "graph.json"), string(buf))
+
+	if _, err := links.RunAllPasses("test", graphsRoot, home); err != nil {
+		t.Fatalf("RunAllPasses: %v", err)
+	}
+
+	sidecar, err := links.PassSidecarPath("", "test", "reachability")
+	if err != nil {
+		t.Fatalf("PassSidecarPath: %v", err)
+	}
+	if _, err := os.Stat(sidecar); err != nil {
+		t.Fatalf("the link pass wrote no reachability sidecar at %s (%v); "+
+			"handleDeadCode would fall back to a live recompute and this test "+
+			"would grade the fallback, not the defect", sidecar, err)
+	}
+	return "test"
+}
+
+// TestDeadCode_ChannelBindingIsSeededOnTheSidecarPath_6909 is the whole issue:
+// the link pass's seed set decides, via the sidecar, what grafel_dead_code says.
+func TestDeadCode_ChannelBindingIsSeededOnTheSidecarPath_6909(t *testing.T) {
+	group := runLinkPassForDeadCode6909(t)
+
+	srv := newTestServer(t, deadCodeDoc6909())
+	out := callFlowTool(t, srv.handleDeadCode, map[string]any{
+		"group": group,
+		"limit": float64(200),
+	})
+
+	// 0. PATH GUARD. Everything below only grades #6909 if the verdict came
+	//    from the sidecar the link pass just wrote.
+	if src, _ := out["source"].(string); src != "sidecar" {
+		t.Fatalf("source = %q, want \"sidecar\". #6909 only exists on the sidecar "+
+			"path — the live-recompute fallback already seeds SCOPE.ChannelBinding, "+
+			"so on any other path this test grades nothing. Response: %v", src, out)
+	}
+
+	items, _ := out["dead_code"].([]any)
+	names := make([]string, 0, len(items))
+	for _, it := range items {
+		m, _ := it.(map[string]any)
+		n, _ := m["name"].(string)
+		names = append(names, n)
+	}
+	has := func(want string) bool {
+		for _, n := range names {
+			if n == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	// 1. VACUITY GUARD / the forbidden direction. Seeding a new kind is a
+	//    widening; a widening that also silences genuinely dead code is a
+	//    regression, and it is also the failure mode that would make the
+	//    absence assertion in (2) free.
+	if !has(deadFnName6909) {
+		t.Fatalf("dead_code = %v does not report %q, an uncalled unexported "+
+			"function with no inbound edges. Either the widening in #6909 leaked "+
+			"beyond SCOPE.ChannelBinding, or the pass produced no verdicts at all "+
+			"(a degraded repo) — in both cases the assertion below is vacuous. "+
+			"Response: %v", names, deadFnName6909, out)
+	}
+
+	// 2. The #6909 direction: ADR-0025 on the path the tool actually uses.
+	if has(channelBindingName6909) {
+		t.Errorf("dead_code = %v reports the SCOPE.ChannelBinding %q as dead. "+
+			"internal/links' frameworkEntryKinds is what wrote this sidecar; if it "+
+			"does not seed SCOPE.ChannelBinding then ADR-0025's guarantee exists "+
+			"only on handleDeadCode's fallback path, which is precisely the path "+
+			"that does not run once a group has had link passes.",
+			names, channelBindingName6909)
+	}
+}
+
+// TestReachabilitySeedSetsAreNotDuplicated_6909 pins the DURABLE half. The two
+// seed sets were hand-maintained copies in two packages and diverged twice — on
+// bare "Route" (#6902) and on SCOPE.ChannelBinding (this issue). The fix deletes
+// the copy rather than asserting equality between two things that can drift
+// together, so what is pinned here is that internal/mcp reads the link pass's
+// own predicate and agrees with it on both of the kinds that have gone wrong.
+//
+// The expected values are INDEPENDENT literals, not one map read against the
+// other: SCOPE.ChannelBinding and Route must be seeds (ADR-0025, #6902), and
+// SCOPE.Class must not be, or the dead-code tool reports nothing at all.
+func TestReachabilitySeedSetsAreNotDuplicated_6909(t *testing.T) {
+	for _, kind := range []string{
+		"SCOPE.ChannelBinding", // #5782 / ADR-0025
+		"Route",                // #6902
+		"SCOPE.Route",
+		"SCOPE.MessageTopic",
+		"http_endpoint_definition",
+	} {
+		if !links.IsFrameworkEntryKind(kind) {
+			t.Errorf("links.IsFrameworkEntryKind(%q) = false; grafel_dead_code seeds "+
+				"its BFS from this predicate on both its sidecar and recompute paths, "+
+				"so a missing kind is reported as dead code.", kind)
+		}
+	}
+	for _, kind := range []string{"SCOPE.Class", "SCOPE.Function", "SCOPE.Variable"} {
+		if links.IsFrameworkEntryKind(kind) {
+			t.Errorf("links.IsFrameworkEntryKind(%q) = true. Seeding an ordinary "+
+				"code kind makes every entity of that kind unconditionally reachable "+
+				"and silences the dead-code tool.", kind)
+		}
+	}
+	if !links.IsReachabilityEdgeKind("CALLS") || !links.IsReachabilityEdgeKind("CONTAINS") {
+		t.Errorf("links.IsReachabilityEdgeKind must accept CALLS and CONTAINS; "+
+			"got CALLS=%v CONTAINS=%v",
+			links.IsReachabilityEdgeKind("CALLS"), links.IsReachabilityEdgeKind("CONTAINS"))
+	}
+	if links.IsReachabilityEdgeKind("SAME_AS") {
+		t.Error("links.IsReachabilityEdgeKind(\"SAME_AS\") = true; a similarity edge " +
+			"does not propagate reachability.")
+	}
+}

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -1282,7 +1282,8 @@ func (s *Server) handleFindPaths(_ context.Context, req mcpapi.CallToolRequest) 
 // #5781: Kafka topics are extracted as kind "SCOPE.MessageTopic" (leaf
 // "messagetopic"), which ends in "messagetopic" — NOT ".topic" — so the old
 // suffix set silently excluded every message-topic entity from the topology
-// scans. dead_code.go (frameworkEntryKindsMCP) and denoise.go
+// scans. The reachability seed set (internal/links frameworkEntryKinds; it
+// lived here as frameworkEntryKindsMCP until #6909) and denoise.go
 // (isStructuralLineless) already treat SCOPE.MessageTopic / messagetopic as
 // topic-like; this restores consistency with them.
 func isTopic(e *graph.Entity) bool { return isTopicKind(e.Kind) }

--- a/internal/mcp/dead_code.go
+++ b/internal/mcp/dead_code.go
@@ -210,43 +210,13 @@ func loadReachabilitySidecar(path string) (*reachabilitySidecarDoc, bool) {
 	return &doc, true
 }
 
-// reachabilityEdgeKindsMCP mirrors the link-pass edge kind set. Kept
-// in this file (not imported from links/) to avoid an mcp → links
-// dependency.
-var reachabilityEdgeKindsMCP = map[string]bool{
-	"CALLS": true, "IMPORTS": true, "REFERENCES": true, "USES": true,
-	"USES_HOOK": true, "HANDLES": true, "HANDLES_SIGNAL": true,
-	"NAVIGATES_TO": true, "ROUTES_TO": true, "IMPLEMENTS": true,
-	"EXTENDS": true, "RENDERS": true, "FETCHES": true, "TESTS": true,
-	"REGISTERS": true, "RESOLVES_TO": true, "STEP_IN_PROCESS": true,
-	"PRODUCES": true, "CONSUMES": true, "CONTAINS": true,
-	"DEPENDS_ON": true, "ENTRY_POINT_OF": true,
-	"DISCRIMINATES_ON": true, "UNRESOLVED_FETCH": true,
-}
-
-// frameworkEntryKindsMCP mirrors the link-pass framework seeds
-// (internal/links/reachability.go frameworkEntryKinds).
-//
-// #6902: BOTH Route spellings are seeds. Bare "Route"
-// (types.EntityKindRouteBare) is what the Java route extractors and
-// internal/engine/{spring,django}_routes.go emit; "SCOPE.Route" is what the
-// Lua / Vaadin / gateway synthesisers emit. Both mean an HTTP route, so
-// neither is ever dead code. Seeding only the prefixed spelling made this tool
-// report every Java/Spring/Django route as dead.
-var frameworkEntryKindsMCP = map[string]bool{
-	"http_endpoint_definition": true,
-	"http_endpoint":            true,
-	"SCOPE.Endpoint":           true,
-	"SCOPE.Route":              true,
-	"Route":                    true, // #6902
-	"SCOPE.MessageTopic":       true,
-	// #5782 (ADR-0025): a ChannelBinding is a config-side messaging
-	// declaration with no callers by design — never report it as dead code.
-	"SCOPE.ChannelBinding":     true,
-	"SCOPE.GrpcMethod":         true,
-	"SCOPE.ServerlessFunction": true,
-	"SCOPE.EventBusEvent":      true,
-}
+// #6909: frameworkEntryKindsMCP and reachabilityEdgeKindsMCP used to live
+// here as hand-copied mirrors of internal/links' frameworkEntryKinds and
+// reachabilityEdgeKinds, "kept in this file to avoid an mcp -> links
+// dependency". That dependency already exists (reachabilitySidecarPath above
+// calls links.PassSidecarPath), and the copies diverged twice: on bare "Route"
+// (#6902) and on "SCOPE.ChannelBinding" (#6909, ADR-0025). Both sets are now
+// consumed from links directly, so there is nothing left to keep in sync.
 
 // deadCodeItem is the per-entry wire shape returned by handleDeadCode.
 type deadCodeItem struct {
@@ -274,7 +244,7 @@ func computeDeadCodeLive(lg *LoadedGroup, repoFilter map[string]bool, kindFilter
 		}
 		adj := map[string][]string{}
 		r.forEachRelationship(func(rel *graph.Relationship) bool {
-			if !reachabilityEdgeKindsMCP[rel.Kind] {
+			if !links.IsReachabilityEdgeKind(rel.Kind) {
 				return true
 			}
 			adj[rel.FromID] = append(adj[rel.FromID], rel.ToID)
@@ -282,7 +252,7 @@ func computeDeadCodeLive(lg *LoadedGroup, repoFilter map[string]bool, kindFilter
 		})
 		seeds := map[string]bool{}
 		r.forEachEntity(func(e *graph.Entity) bool {
-			if frameworkEntryKindsMCP[e.Kind] || isFrameworkOrHandler(e) {
+			if links.IsFrameworkEntryKind(e.Kind) || isFrameworkOrHandler(e) {
 				seeds[e.ID] = true
 			}
 			return true
@@ -353,7 +323,7 @@ func computeDeadCodeFromEntry(lg *LoadedGroup, fromID string, repoFilter map[str
 		}
 		adj := map[string][]string{}
 		r.forEachRelationship(func(rel *graph.Relationship) bool {
-			if !reachabilityEdgeKindsMCP[rel.Kind] {
+			if !links.IsReachabilityEdgeKind(rel.Kind) {
 				return true
 			}
 			adj[rel.FromID] = append(adj[rel.FromID], rel.ToID)


### PR DESCRIPTION
Fixes #6909.

`grafel_dead_code` could report a `SCOPE.ChannelBinding` as dead code — the exact
outcome ADR-0025 forbids — because the protection was installed in the wrong one of
two hand-copied seed sets.

## The defect

Two sets decided the same question in two packages:

- `internal/links/reachability.go` `frameworkEntryKinds` — the link pass's BFS seed
  set. Its verdict is **persisted** to `<group>-links-reachability.json`.
- `internal/mcp/dead_code.go` `frameworkEntryKindsMCP` — a hand-copy whose comment
  claimed it "mirrors the link-pass framework seeds".

#5782 added `"SCOPE.ChannelBinding": true` to the **MCP** copy, citing ADR-0025 §3
(a ChannelBinding is a config-side messaging declaration with no callers by design).
`links` never got it. And `handleDeadCode` **prefers the on-disk sidecar**, consulting
its own map only when `from` is set or the sidecar fails to load — so in the normal
case, once a group has had link passes, the MCP map is not consulted at all and the
verdict comes from the sidecar written without the seed.

This is the **second** divergence in this same pair; #6907 fixed `Route`.

**Latency, honestly stated:** this is **latent**, not observed. The measured local
index contains **zero** `SCOPE.ChannelBinding` entities, so nobody has hit it. A zero
measurement is corpus-relative and does not mean it cannot occur — but it equally does
not license a claim of incidence, and none is made here.

## The fix — one set, no copy

1. `SCOPE.ChannelBinding` is added to `internal/links`' `frameworkEntryKinds`, so the
   persisted sidecar honours ADR-0025.
2. **`frameworkEntryKindsMCP` and `reachabilityEdgeKindsMCP` are deleted.** They existed
   "to avoid an mcp → links dependency" — a dependency that already exists two functions
   above them (`reachabilitySidecarPath` calls `links.PassSidecarPath`). `internal/mcp`
   now calls `links.IsFrameworkEntryKind` / `links.IsReachabilityEdgeKind`. Eliminating
   the duplication is preferred over asserting equality between two things that can
   drift together.

`internal/coverage` keeps its own edge-kind set: it answers a different question
(test reachability, `coverage.PropTestReachable`), and folding it in here would be a
behaviour change out of this issue's scope. It is called out in the new comment.

## Grading — both directions, on the defect's path

`internal/mcp/channelbinding_sidecar_seed_6909_test.go`:

- `TestDeadCode_ChannelBindingIsSeededOnTheSidecarPath_6909` writes a one-repo fixture
  graph **plus real source files** (#6839 degrades a repo whose sources it cannot read,
  which would make every assertion vacuous), runs the real `links.RunAllPasses`, and then
  calls `handleDeadCode`. A test that only builds an in-memory graph exercises the
  **fallback**, which already had the seed and passes with the defect fully present —
  that is the shape of #6902's existing test. The `source == "sidecar"` assertion is the
  guard that keeps this one on the defect's path.
  - recall row: `mp.messaging.outgoing.orders-6909` (`SCOPE.ChannelBinding`) must **not**
    be reported.
  - forbidden row: `reconcileLedger6909` — unexported, uncalled, no inbound edge, not a
    sniffable Go entry-point — must **still** be reported. Adding a seed is a widening,
    and a widening that silences genuinely dead code is a regression.
- `TestReachabilitySeedSetsAreNotDuplicated_6909` pins the durable half by
  **enumerating the whole seed set** — `links.FrameworkEntryKinds()` (sorted) asserted
  against a **hand-written literal of all ten kinds**, deliberately not derived from the
  set under test, since a want list computed from the thing it checks agrees with any
  deletion. Sampling loops are kept alongside for diagnosis (`SCOPE.Class` /
  `SCOPE.Function` / `SCOPE.Variable` must never be seeds; `CALLS`/`CONTAINS` propagate
  reachability and `SAME_AS` does not).

**Why a NEW test rather than an extended one.** Under the seed-removal mutant, the
pre-existing `TestDeadCode_BareRouteIsAFrameworkEntryPoint_6902` — the fallback-shaped
test for the *first* divergence in this same pair — stayed **GREEN**. That is direct
evidence this defect could not have been caught by extending the existing coverage.
Symmetrically, a mutant in `internal/links` leaves `./internal/links/` green: the only
thing grading that package's seed set lives in `internal/mcp`, which is where the
consumer is. Both facts are recorded in the code comments.

## Mutants (each applied by exact-match count, restored by `cp` from a shasum-verified
backup, scored with `-count=1` off a green baseline)

| Mutant | Verdict |
|---|---|
| Remove `"SCOPE.ChannelBinding"` from `links.frameworkEntryKinds` | **DEAD** — and it reproduces the issue verbatim: `dead_code = [mp.messaging.outgoing.orders-6909 reconcileLedger6909]` |
| Force `handleDeadCode` to never prefer the sidecar (`ok = false`) | **DEAD** — `source = "live_recompute"`, i.e. the vacuity check fires rather than the test quietly passing on the fallback |
| Add an unrelated kind (`"SCOPE.Function"`) to the seed set — the **more permissive** direction | **DEAD** twice: the forbidden row goes empty (`dead_code = []`) and the seed-set pin rejects the kind |
| Add an empty-string key `""` to the seed set | **DEAD** — `FrameworkEntryKinds()` drift |
| **Delete a pre-existing seed**, `"SCOPE.GrpcMethod"` | **DEAD** — `FrameworkEntryKinds()` drift. `./internal/links/` stays green under it, which is why the grading test lives in `internal/mcp` and says so |
| Add a *plausible* new seed `"SCOPE.Interface"` | **DEAD** — `FrameworkEntryKinds()` drift |

The last three were **ALIVE** against the first revision's sampled pin (5 of 10 kinds) and
are what the second commit fixes; one enumeration kills all three.

The third commit applies the same enumeration to the **other** exported set,
`reachabilityEdgeKinds` — the BFS **traversal filter** (`if !reachabilityEdgeKinds[e.Kind]`),
which the second revision exported and did not pin:

| Mutant | Verdict |
|---|---|
| **Delete `"IMPORTS"`** from the traversal filter | **DEAD** — `ReachabilityEdgeKinds()` drift. Was **ALIVE** against both packages before this commit |
| Add `"SAME_AS"` | **DEAD** — drift, plus the pre-existing `SAME_AS` row |
| Add `""` | **DEAD** — drift |

A member leaving that set is the **false-positive** direction and is worse for a user than
the false negative this PR fixes: an entity reachable only through, say, an import edge stops
being reachable and the tool names **live code** for deletion. Under-reporting is quietly
useless; over-reporting sends people to delete working code. That reasoning is recorded at the
definition, so the next reader does not have to re-derive it.

## Verification (macOS 15 / APFS, arm64; worktree at `scratchpad/impl-6909-n4x8p/wt`)

- `go vet ./internal/links/ ./internal/mcp/` — clean; `gofmt -l` — clean.
- `go test -count=1 ./internal/links/ ./internal/mcp/` — **ok** (13.3s / 140.9s), run with
  the working tree byte-identical to the committed state (shasums checked).
- `go test -count=1 ./cmd/grafel/` under a fresh `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT` — **ok**
  (147.2s), run on the exact committed tree.
- `scripts/quality/run.sh --ratchet` — exit 0, "38 gated fixtures held their baseline
  (29 at 100% must-have recall)"; `internal/quality/golden/baseline.json` unmodified.
- The follow-up commit adds one exported enumerator with no caller in the pass and edits the
  test file, so production behaviour is unchanged by it and `./cmd/grafel/` + the ratchet were
  not re-run for it; `./internal/links/` + `./internal/mcp/` re-run green (8.5s / 99.1s).

- The third commit is likewise one exported enumerator with no caller in the pass plus the test
  file, so `./cmd/grafel/` and the ratchet are not re-run for it either; `./internal/links/` +
  `./internal/mcp/` green (9.3s / 99.9s).

`internal/coverage` is left alone deliberately: its `reachabilityEdgeKinds` is `{TESTS, CALLS}`
built from `types` constants and answers test-reachability — a name collision, not a duplicate
of this set. Its line 208, `if !reachabilityEdgeKinds[rel.Kind]`, is syntactically identical to
the links one, and that resemblance alone produced an issue filed on a wrong premise (#7012,
closed invalid). A note at the links definition now says which question each set answers, so the
next reader does not make the same round trip.

Refs #6907, #6902, #6846, #5782, #6839, ADR-0025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
