### PR TITLE
fix(#6916): the aws_cdk `Config CALLS Component` edge could never bind — the entity was named `new cdk.App(`, the edge sources on the variable

### DIFF
--- a/internal/engine/aws_cdk_app_name_6916_test.go
+++ b/internal/engine/aws_cdk_app_name_6916_test.go
@@ -79,10 +79,25 @@ new ApiStack(app, 'ApiStack');
 
 // cdk6916PyAttrApp is the Python analogue and grades the SAME widening in the
 // Python rule. Python has no declarator keyword, so the multi-declarator line
-// above has no Python spelling; the shape that separates `(\w+)` from `(.+)`
-// here is an ATTRIBUTE target, `self.app = cdk.App()`, which is idiomatic when
-// the App is built inside a class. `(\w+)` captures "app"; `(.+)` captures
-// "self.app", which the CALLS rule's `(\w+)` source group can never equal.
+// above has no Python spelling; the shape that separates `(\w+)` from `(.+)` and
+// from `([\w.]+)` here is an ATTRIBUTE target, `self.app = cdk.App()`, which is
+// idiomatic when the App is built inside a class. `(\w+)` (with the rule's
+// `(?:\w+\.)?` prefix consuming `self.`) names it "app"; the widened captures
+// name it "self.app".
+//
+// CORRECTED (review ask 4): this fixture grades the NAME ONLY. It emits no
+// relationship at all — the Python CALLS rule is `(\w+Stack)\s*\(\s*(\w+)\s*,`
+// and `ApiStack(self.app, "ApiStack")` has no `,` directly after a bare `(\w+)`,
+// so NEITHER spelling produces an edge here. The earlier comment implied "app"
+// would bind and "self.app" would not; measured, neither does. The binding is
+// graded by TestIssue6916_CDKCallsEdgeBindsAtItsSource, not here.
+//
+// The second method carries a MULTI-LEVEL attribute chain, `self.inner.app`. The
+// rule's `(?:\w+\.)?` prefix is one level deep, so that line mints nothing —
+// correct, because a dotted name could never equal the CALLS rule's `(\w+)`
+// source anyway. It grades the dotted-capture mutant `(\w+)` -> `([\w.]+)`,
+// which the single-level `self.app` line cannot: there the `(?:\w+\.)?` prefix
+// already eats `self.` and both spellings name it "app".
 const cdk6916PyAttrApp = `import aws_cdk as cdk
 
 class ApiStack(cdk.Stack):
@@ -93,6 +108,79 @@ class Deployment:
     def build(self):
         self.app = cdk.App()
         ApiStack(self.app, "ApiStack")
+
+    def build_nested(self):
+        self.inner.app = cdk.App()
+`
+
+// cdk6916TSAnnotated carries a TYPE ANNOTATION, which is ordinary TypeScript and
+// which no fixture covered (review ask 2 / mutant RM4). Deleting the rule's
+// `(?:\s*:\s*[\w.]+)?` group makes `(\w+)` land inside the annotation and mint
+// `Config:App` — the TYPE name — so the edge dangles again.
+const cdk6916TSAnnotated = `import * as cdk from 'aws-cdk-lib';
+
+export class ApiStack extends cdk.Stack {
+}
+
+const app: cdk.App = new cdk.App();
+new ApiStack(app, 'ApiStack');
+`
+
+// cdk6916PyMultiTarget is the review BLOCKER made into a fixture. Python's
+// `App()` is a plain call, so the text of a multi-target assignment contains the
+// literal substring `env = cdk.App()`. An unanchored `(\w+)\s*=` captures `env`
+// — which is the string "prod" — and the CALLS edge then BINDS TO THE WRONG
+// VARIABLE. Before #6916 that edge merely dangled; a confidently wrong endpoint
+// is worse than a known-bad one.
+//
+// The rule's `(?m)^[ \t]*` anchor makes this mint nothing instead. That is the
+// deliberate cost and it is pinned as such: no Config entity, and no relationship
+// sourced on a Config.
+const cdk6916PyMultiTarget = `import aws_cdk as cdk
+
+class EnvStack(cdk.Stack):
+    pass
+
+app, env = cdk.App(), "prod"
+EnvStack(env, "EnvStack")
+`
+
+// cdk6916TSDestructured is the nearest JS/TS spelling of the same hazard. It is
+// here to SHOW the JS rule does not have the seam rather than to assume it: the
+// JS pattern requires `= new ... App(` immediately, so `(\w+)` can only ever be
+// the token directly left of that `=`, which in JS is the assignment target.
+// A destructuring form matches nothing at all.
+const cdk6916TSDestructured = `import * as cdk from 'aws-cdk-lib';
+
+export class EnvStack extends cdk.Stack {
+}
+
+const [app, env] = [new cdk.App(), 'prod'];
+new EnvStack(env, 'EnvStack');
+`
+
+// cdk6916TSPlainAppCall / cdk6916TSNewAppCall are the OVER-FIRING pair (review
+// ask 3 / coordinator mutant CV-1). They are the same file except for the word
+// `new`. `App()` as a plain call is an ordinary React component invocation in a
+// repo with no CDK anywhere; `new` is the only thing keeping this rule off it.
+//
+// The `new` leg is the POSITIVE CONTROL: it proves the rule can reach this file
+// at all, so the absence asserted on the other leg is not vacuous. Both are
+// deliberately free of any CDK marker.
+const cdk6916TSPlainAppCall = `import App from './App';
+
+function bootstrap() {
+  const app = App();
+  return app;
+}
+`
+
+const cdk6916TSNewAppCall = `import App from './App';
+
+function bootstrap() {
+  const app = new App();
+  return app;
+}
 `
 
 // cdk6916TSBareApp / cdk6916PyBareApp are the construction with NO assignment.
@@ -166,6 +254,7 @@ func TestIssue6916_CDKAppConfigIsNamedAfterVariable(t *testing.T) {
 		forbidden string
 	}{
 		{"typescript", "bin/app.ts", "typescript", cdk6916TSApp, "new cdk.App("},
+		{"typescript with type annotation", "bin/app.ts", "typescript", cdk6916TSAnnotated, "new cdk.App("},
 		{"python", "app.py", "python", cdk6916PyApp, "cdk.App()"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -190,6 +279,7 @@ func TestIssue6916_CDKAppConfigIsNamedAfterVariable(t *testing.T) {
 func TestIssue6916_CDKCallsEdgeBindsAtItsSource(t *testing.T) {
 	for _, tc := range []struct{ name, path, lang, src string }{
 		{"typescript", "bin/app.ts", "typescript", cdk6916TSApp},
+		{"typescript with type annotation", "bin/app.ts", "typescript", cdk6916TSAnnotated},
 		{"python", "app.py", "python", cdk6916PyApp},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -284,5 +374,99 @@ func TestIssue6916_UnassignedAppMintsNoConfig(t *testing.T) {
 					strings.Join(ids, "\n  "))
 			}
 		})
+	}
+}
+
+// TestIssue6916_MultiTargetAssignmentDoesNotMisattribute is the review blocker,
+// pinned. The failure mode it guards is NOT "an edge goes missing" — it is "an
+// edge binds to the wrong variable", which the rest of this file cannot see
+// because the wrong name (`env`) is identifier-shaped and passes every other
+// assertion here.
+//
+// Both legs assert the same two things: no Config entity is minted from a
+// multi-target / destructuring assignment, and the `Config:env --CALLS-->` edge
+// the relationship rule emits from `EnvStack(env, …)` therefore does NOT BIND.
+//
+// That edge is emitted either way — the relationship rule is independent of the
+// entity rule and fires on the `EnvStack(env,` text alone. It dangled before
+// #6916 and it must go on dangling: the whole point of this issue is that a
+// dangling endpoint is a known-bad one, while an endpoint that resolves to the
+// WRONG variable is a wrong answer stated confidently. Asserting "the edge is
+// absent" would be false; asserting "the edge does not bind" is the real
+// guarantee. Component:EnvStack is the positive control on each leg.
+func TestIssue6916_MultiTargetAssignmentDoesNotMisattribute(t *testing.T) {
+	for _, tc := range []struct {
+		name, path, lang, src string
+		// wrong is the name the unanchored capture donated. Named so a future
+		// failure reads as this defect rather than as a general absence.
+		wrong string
+	}{
+		{"python tuple assignment", "app.py", "python", cdk6916PyMultiTarget, "env"},
+		{"typescript array destructuring", "bin/app.ts", "typescript", cdk6916TSDestructured, "env"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := detect6916(t, tc.path, tc.lang, tc.src)
+			ids := entityIDs6916(res)
+			rels := rels6916(res)
+
+			for _, id := range ids {
+				if strings.HasPrefix(id, "Config:") {
+					t.Errorf("a multi-target assignment minted %q. The App is bound to `app`; "+
+						"any other name here makes the CALLS edge resolve to the WRONG variable "+
+						"(%q is a string literal), which is worse than the dangling edge it replaced.",
+						id, tc.wrong)
+				}
+			}
+			for _, r := range rels {
+				src, _, ok := strings.Cut(r, " --")
+				if !ok || !strings.HasPrefix(src, "Config:") {
+					continue
+				}
+				if slices.Contains(ids, src) {
+					t.Errorf("the edge %q BINDS: its source %s names an entity emitted by this "+
+						"same run. It dangled before #6916 and must go on dangling — resolving it "+
+						"to %q (a string literal, not the App) is a confidently wrong answer.",
+						r, src, tc.wrong)
+				}
+			}
+
+			// Positive control — without it both loops pass on a fixture that
+			// stopped producing anything at all.
+			if !slices.Contains(ids, "Component:EnvStack") {
+				t.Errorf("positive control missing: this fixture no longer emits "+
+					"Component:EnvStack, so the absence assertions above prove nothing. Entities:\n  %s",
+					strings.Join(ids, "\n  "))
+			}
+		})
+	}
+}
+
+// TestIssue6916_PlainAppCallIsNotACDKApp grades the rule in the OVER-FIRING
+// direction — the direction every mutant on the first round of this change
+// missed, and the one #7013 measured at 24.5% of minted framework entities
+// landing in repos that do not use the framework (Config at 60.5%).
+//
+// The interaction is worth stating: making the Name useful also makes an
+// over-firing hit HARDER to spot. Before #6916 a stray match was named `App(`,
+// visibly junk; now it would be named `app`, which reads as a real CDK
+// application.
+func TestIssue6916_PlainAppCallIsNotACDKApp(t *testing.T) {
+	// Negative: `const app = App()` in a file with no CDK anywhere.
+	ids := entityIDs6916(detect6916(t, "src/bootstrap.tsx", "typescript", cdk6916TSPlainAppCall))
+	for _, id := range ids {
+		if strings.HasPrefix(id, "Config:") {
+			t.Errorf("a plain `App()` call in a non-CDK file minted %q. `new` is the only thing "+
+				"separating this rule from every JS file that calls a function named App().", id)
+		}
+	}
+
+	// Positive control: the SAME file with `new` added must mint Config:app.
+	// Without this the assertion above would also pass if the rule had stopped
+	// firing on this path, this language, or this content entirely.
+	ctrl := entityIDs6916(detect6916(t, "src/bootstrap.tsx", "typescript", cdk6916TSNewAppCall))
+	if !slices.Contains(ctrl, "Config:app") {
+		t.Errorf("positive control missing: `const app = new App()` at the same path no longer "+
+			"mints Config:app, so the absence asserted above proves nothing about `new`. Entities:\n  %s",
+			strings.Join(ctrl, "\n  "))
 	}
 }

--- a/internal/engine/aws_cdk_app_name_6916_test.go
+++ b/internal/engine/aws_cdk_app_name_6916_test.go
@@ -1,0 +1,288 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+)
+
+// #6916 (Tier B, aws_cdk arm): the two aws_cdk `Config` source_patterns used
+// `name_group: 0`, so the entity's Name was the whole regex match —
+// `"new cdk.App("` (JS/TS) and `"cdk.App()"` (Python).
+//
+// The relationship rule in the SAME file could therefore never bind:
+//
+//	source_type: Config
+//	target_type: Component
+//	relationship: CALLS
+//	source_group: 2   // the VARIABLE in `new MyStack(app, 'Id')` -> "app"
+//
+// The edge's source name is the variable `app`; the entity's name was the
+// marker string `new cdk.App(`. Those two strings can never be equal, so the
+// edge shipped dangling at its source end — the #6906 `bug-extractor` shape.
+//
+// Narrowing the capture to the assigned variable (the express.yaml:91 shape)
+// makes an ALREADY-EMITTED edge start binding. These tests pin the ARTEFACT:
+// the entity's Name and the edge with BOTH endpoint IDs, driven through the
+// real LoadAllRules() + Detector.Detect() path. A count is not evidence.
+//
+// The detector builds a relationship endpoint ID as "<type>:<captured name>"
+// (detector.go:562) and an entity carries Kind + Name; the source end BINDS
+// exactly when some emitted entity has Kind/Name equal to the edge's FromID
+// halves. That equality is what these tests assert, in both directions.
+
+// cdk6916TSApp is the canonical CDK entry point (`bin/app.ts`). The Stack class
+// is declared in the same file so BOTH endpoints of the CALLS edge are emitted
+// here and can be named.
+const cdk6916TSApp = `import * as cdk from 'aws-cdk-lib';
+
+export class ApiStack extends cdk.Stack {
+}
+
+const app = new cdk.App();
+new ApiStack(app, 'ApiStack');
+app.synth();
+`
+
+// cdk6916PyApp is the Python idiom. Python has no const/let/var, so the JS
+// regex is NOT reusable here — this fixture is what pins that the Python rule
+// was written for Python rather than copied.
+const cdk6916PyApp = `import aws_cdk as cdk
+
+class ApiStack(cdk.Stack):
+    pass
+
+app = cdk.App()
+ApiStack(app, "ApiStack")
+app.synth()
+`
+
+// cdk6916TSMultiDeclarator exists to grade the WIDENING mutant: replacing the
+// variable capture `(\w+)` with `(.+)`. On a single-declarator line `(.+)` is
+// still forced to stop at the `=`, so it captures "app" and is indistinguishable
+// there. A multi-declarator line separates them: `(.+)` captures
+// "region = 'eu-west-1', app" and the edge stops binding again.
+const cdk6916TSMultiDeclarator = `import * as cdk from 'aws-cdk-lib';
+
+export class ApiStack extends cdk.Stack {
+}
+
+const region = 'eu-west-1', app = new cdk.App();
+new ApiStack(app, 'ApiStack');
+`
+
+// cdk6916PyAttrApp is the Python analogue and grades the SAME widening in the
+// Python rule. Python has no declarator keyword, so the multi-declarator line
+// above has no Python spelling; the shape that separates `(\w+)` from `(.+)`
+// here is an ATTRIBUTE target, `self.app = cdk.App()`, which is idiomatic when
+// the App is built inside a class. `(\w+)` captures "app"; `(.+)` captures
+// "self.app", which the CALLS rule's `(\w+)` source group can never equal.
+const cdk6916PyAttrApp = `import aws_cdk as cdk
+
+class ApiStack(cdk.Stack):
+    pass
+
+
+class Deployment:
+    def build(self):
+        self.app = cdk.App()
+        ApiStack(self.app, "ApiStack")
+`
+
+// cdk6916TSBareApp / cdk6916PyBareApp are the construction with NO assignment.
+// This is the deliberate cost of the narrowing and is pinned as such: an
+// unassigned App mints no Config entity at all. It is also the fixture that
+// kills a mutant re-widening the pattern to match without the assignment.
+//
+// Each carries the Stack class as its POSITIVE CONTROL: the file must still
+// emit Component:ApiStack, so "no Config entity" cannot pass because the
+// fixture stopped producing anything.
+const cdk6916TSBareApp = `import * as cdk from 'aws-cdk-lib';
+
+export class ApiStack extends cdk.Stack {
+}
+
+new cdk.App();
+`
+
+const cdk6916PyBareApp = `import aws_cdk as cdk
+
+class ApiStack(cdk.Stack):
+    pass
+
+cdk.App()
+`
+
+func detect6916(t *testing.T, path, lang, src string) *DetectResult {
+	t.Helper()
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	res, err := New(rules).Detect(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: lang,
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	return res
+}
+
+func rels6916(res *DetectResult) []string {
+	out := make([]string, 0, len(res.Relationships))
+	for _, r := range res.Relationships {
+		out = append(out, fmt.Sprintf("%s --%s--> %s", r.FromID, r.Kind, r.ToID))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// entityIDs6916 renders every emitted entity in the same "<Kind>:<Name>" shape
+// the detector uses for relationship endpoints, which is what makes the
+// binding assertion below a real comparison rather than two separate greps.
+func entityIDs6916(res *DetectResult) []string {
+	out := make([]string, 0, len(res.Entities))
+	for _, e := range res.Entities {
+		out = append(out, fmt.Sprintf("%s:%s", e.Kind, e.Name))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestIssue6916_CDKAppConfigIsNamedAfterVariable pins the entity Name. Before
+// the change it failed with Config:"new cdk.App(" / Config:"cdk.App()".
+func TestIssue6916_CDKAppConfigIsNamedAfterVariable(t *testing.T) {
+	for _, tc := range []struct {
+		name, path, lang, src string
+		// forbidden is the marker Name the shipped `name_group: 0` produced.
+		forbidden string
+	}{
+		{"typescript", "bin/app.ts", "typescript", cdk6916TSApp, "new cdk.App("},
+		{"python", "app.py", "python", cdk6916PyApp, "cdk.App()"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, tc.path, tc.lang, tc.src))
+
+			if !slices.Contains(ids, "Config:app") {
+				t.Errorf("the CDK App entity is not named after its assigned variable; "+
+					"expected Config:app among the emitted entities:\n  %s",
+					strings.Join(ids, "\n  "))
+			}
+			if slices.Contains(ids, "Config:"+tc.forbidden) {
+				t.Errorf("the #6916 marker Name is back: Config:%q. name_group must be the "+
+					"variable capture, not 0 (the whole match).", tc.forbidden)
+			}
+		})
+	}
+}
+
+// TestIssue6916_CDKCallsEdgeBindsAtItsSource is the point of the change: the
+// already-shipped `Config CALLS Component` edge now resolves at BOTH ends.
+// Both endpoint IDs are named explicitly.
+func TestIssue6916_CDKCallsEdgeBindsAtItsSource(t *testing.T) {
+	for _, tc := range []struct{ name, path, lang, src string }{
+		{"typescript", "bin/app.ts", "typescript", cdk6916TSApp},
+		{"python", "app.py", "python", cdk6916PyApp},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := detect6916(t, tc.path, tc.lang, tc.src)
+			rels := rels6916(res)
+			ids := entityIDs6916(res)
+
+			const want = "Config:app --CALLS--> Component:ApiStack"
+			if !slices.Contains(rels, want) {
+				t.Fatalf("expected the CDK app->stack edge %q; relationships emitted:\n  %s",
+					want, strings.Join(rels, "\n  "))
+			}
+
+			// The binding itself: every endpoint of that edge must name an
+			// entity this same run emitted. Before #6916 the source end,
+			// Config:app, had no referent — the entity was Config:"new cdk.App(".
+			for _, endpoint := range []string{"Config:app", "Component:ApiStack"} {
+				if !slices.Contains(ids, endpoint) {
+					t.Errorf("edge %q dangles: endpoint %s names no emitted entity. Entities:\n  %s",
+						want, endpoint, strings.Join(ids, "\n  "))
+				}
+			}
+		})
+	}
+}
+
+// TestIssue6916_GreedyCaptureWouldBreakBinding grades the `(.+)` widening of
+// the variable capture, in BOTH rules. The single-assignment fixtures cannot
+// grade it: there `(.+)` is pinned by the `=` and captures "app" too, so it is
+// indistinguishable. Each language needs the shape that separates them, and
+// the two languages do NOT share one — JS/TS has a multi-declarator `const`
+// line, Python has no declarator keyword at all and uses an attribute target.
+func TestIssue6916_GreedyCaptureWouldBreakBinding(t *testing.T) {
+	identifier := regexp.MustCompile(`^\w+$`)
+
+	for _, tc := range []struct{ name, path, lang, src string }{
+		{"typescript multi-declarator const", "bin/app.ts", "typescript", cdk6916TSMultiDeclarator},
+		{"python attribute target", "app.py", "python", cdk6916PyAttrApp},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, tc.path, tc.lang, tc.src))
+
+			if !slices.Contains(ids, "Config:app") {
+				t.Errorf("the CDK App Config entity must be named `app` here too; the variable "+
+					"capture has to be identifier-shaped, not greedy. Entities:\n  %s",
+					strings.Join(ids, "\n  "))
+			}
+			for _, id := range ids {
+				name, ok := strings.CutPrefix(id, "Config:")
+				if !ok {
+					continue
+				}
+				// These fixtures carry no CfnOutput, so every Config here
+				// comes from the App rule and must be a bare identifier —
+				// anything else cannot equal the CALLS rule's `(\w+)` source.
+				if !identifier.MatchString(name) {
+					t.Errorf("a Config entity was minted with a non-identifier Name: %q. "+
+						"The CALLS rule sources on `(\\w+)`, so such a name can never bind.", name)
+				}
+			}
+		})
+	}
+}
+
+// TestIssue6916_UnassignedAppMintsNoConfig pins the DELIBERATE COST of the
+// narrowing, so it is a decision on the record rather than a silent regression.
+// A bare `new cdk.App()` cannot be passed to a Stack constructor, so it has no
+// edge to anchor; the shipped rule gave it a marker node instead.
+func TestIssue6916_UnassignedAppMintsNoConfig(t *testing.T) {
+	for _, tc := range []struct{ name, path, lang, src string }{
+		{"typescript", "bin/app.ts", "typescript", cdk6916TSBareApp},
+		{"python", "app.py", "python", cdk6916PyBareApp},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, tc.path, tc.lang, tc.src))
+
+			for _, id := range ids {
+				// CfnOutput also mints Config; this fixture has none, so any
+				// Config here comes from the App rule.
+				if strings.HasPrefix(id, "Config:") {
+					t.Errorf("an UNASSIGNED `App()` construction minted %q. The #6916 rule is "+
+						"anchored on the assignment on purpose: without a variable there is "+
+						"nothing for the CALLS edge to bind to.", id)
+				}
+			}
+
+			// Positive control — without it the loop above passes vacuously
+			// on a fixture that stopped producing anything at all.
+			if !slices.Contains(ids, "Component:ApiStack") {
+				t.Errorf("positive control missing: this fixture no longer emits "+
+					"Component:ApiStack, so the absence assertion above proves nothing. Entities:\n  %s",
+					strings.Join(ids, "\n  "))
+			}
+		})
+	}
+}

--- a/internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml
@@ -46,10 +46,12 @@ source_patterns:
     entity_type: Component
     name_group: 1
     scope: class
-  # App instantiation: new cdk.App() / new App()
-  - pattern: "new\\s+(?:cdk\\.)?App\\s*\\("
+  # App instantiation, named after the ASSIGNED VARIABLE (#6916): const app = new cdk.App()
+  # name_group 0 named this entity "new cdk.App(" — a marker string the CALLS rule
+  # below (source_group 2 = the variable) could never bind to.
+  - pattern: "(?:(?:const|let|var)\\s+)?(\\w+)(?:\\s*:\\s*[\\w.]+)?\\s*=\\s*new\\s+(?:cdk\\.)?App\\s*\\("
     entity_type: Config
-    name_group: 0
+    name_group: 1
     scope: file
   # CfnOutput: new cdk.CfnOutput(this, 'OutputId', …)
   - pattern: "(?:new\\s+)?(?:cdk\\.)?CfnOutput\\s*\\(\\s*\\w+\\s*,\\s*[\"']([^\"']+)[\"']"

--- a/internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml
@@ -49,7 +49,17 @@ source_patterns:
   # App instantiation, named after the ASSIGNED VARIABLE (#6916): const app = new cdk.App()
   # name_group 0 named this entity "new cdk.App(" — a marker string the CALLS rule
   # below (source_group 2 = the variable) could never bind to.
-  - pattern: "(?:(?:const|let|var)\\s+)?(\\w+)(?:\\s*:\\s*[\\w.]+)?\\s*=\\s*new\\s+(?:cdk\\.)?App\\s*\\("
+  #
+  # `new` is LOAD-BEARING and graded (review CV-1): without it this fires on any
+  # JS file calling a function named App() — `const app = App()` in ordinary
+  # React — minting a plausible-looking `Config:app` in a repo with no CDK.
+  # The `(?:\\s*:\\s*[\\w.]+)?` annotation group is load-bearing too (review RM4):
+  # without it `const app: cdk.App = new cdk.App()` captures the TYPE, `App`.
+  # There is no `^` anchor here and none is needed: `(\\w+)` is forced to be the
+  # token immediately left of `= new ... App(`, which in JS is always the
+  # assignment target. Python's `App()` is a plain call and DOES need the
+  # anchor — see that file.
+  - pattern: "(\\w+)(?:\\s*:\\s*[\\w.]+)?\\s*=\\s*new\\s+(?:cdk\\.)?App\\s*\\("
     entity_type: Config
     name_group: 1
     scope: file

--- a/internal/engine/rules/python/frameworks/aws_cdk.yaml
+++ b/internal/engine/rules/python/frameworks/aws_cdk.yaml
@@ -43,10 +43,12 @@ source_patterns:
     entity_type: Component
     name_group: 1
     scope: class
-  # App instantiation: cdk.App() / App()
-  - pattern: "(?:cdk\\.)?App\\s*\\(\\s*\\)"
+  # App instantiation, named after the ASSIGNED VARIABLE (#6916): app = cdk.App()
+  # name_group 0 named this entity "cdk.App()" — a marker string the CALLS rule
+  # below (source_group 2 = the variable) could never bind to.
+  - pattern: "(\\w+)\\s*=\\s*(?:cdk\\.)?App\\s*\\(\\s*\\)"
     entity_type: Config
-    name_group: 0
+    name_group: 1
     scope: file
   # CfnOutput: CfnOutput(self, "OutputId", ...)
   - pattern: "(?:cdk\\.)?CfnOutput\\s*\\(\\s*\\w+\\s*,\\s*[\"']([^\"']+)[\"']"

--- a/internal/engine/rules/python/frameworks/aws_cdk.yaml
+++ b/internal/engine/rules/python/frameworks/aws_cdk.yaml
@@ -46,7 +46,15 @@ source_patterns:
   # App instantiation, named after the ASSIGNED VARIABLE (#6916): app = cdk.App()
   # name_group 0 named this entity "cdk.App()" — a marker string the CALLS rule
   # below (source_group 2 = the variable) could never bind to.
-  - pattern: "(\\w+)\\s*=\\s*(?:cdk\\.)?App\\s*\\(\\s*\\)"
+  #
+  # The `(?m)^[ \\t]*` ANCHOR is load-bearing and graded (review blocker). Python
+  # `App()` is a plain call, so an unanchored `(\\w+)\\s*=` matches the tail of a
+  # multi-target assignment: `app, env = cdk.App(), "prod"` contains the literal
+  # text `env = cdk.App()` and would mint `Config:env`, making the CALLS edge
+  # bind to the WRONG variable — a confidently wrong answer, strictly worse than
+  # the marker node it replaced. `(?:\\w+\\.)?` keeps `self.app = cdk.App()` naming
+  # `app` rather than `self`.
+  - pattern: "(?m)^[ \\t]*(?:\\w+\\.)?(\\w+)\\s*=\\s*(?:cdk\\.)?App\\s*\\(\\s*\\)"
     entity_type: Config
     name_group: 1
     scope: file


### PR DESCRIPTION
## Tier B, aws_cdk arm — 2 of the 39 `name_group: 0` sites. The other 37 are untouched.

This is the proving arm for #6916: it is the one site pair where the narrowing does not merely
improve a name, it makes an **already-shipped, already-emitted edge start binding**.

Measured in a detached worktree at `3199981ad`,
`.../scratchpad/impl-6916b-q7k2v/wt`, **macOS/APFS, Darwin 25.6.0** (#6966 gate — every figure
below is that platform only).

### The defect

Both aws_cdk `Config` source_patterns used `name_group: 0`, so the Name is the whole match:

| file | shipped pattern | shipped Name |
|---|---|---|
| `javascript_typescript/frameworks/aws_cdk.yaml:50` | `new\s+(?:cdk\.)?App\s*\(` | `new cdk.App(` |
| `python/frameworks/aws_cdk.yaml:47` | `(?:cdk\.)?App\s*\(\s*\)` | `cdk.App()` |

The `Config CALLS Component` relationship rule **in the same file** sources on `source_group: 2` of
`new (\w+Stack)\s*\(\s*(\w+)` — the **variable**, `app`. The entity is named `new cdk.App(`. Those
two strings can never be equal, so the edge dangles at its source end by construction. That is the
#6906 `bug-extractor` shape, and it has already shipped.

### The change

Both patterns now capture the **assignment target**, following `express.yaml:91`. The two languages
are **not** the same regex — Python has no declarator keyword:

```yaml
# javascript_typescript
- pattern: "(\\w+)(?:\\s*:\\s*[\\w.]+)?\\s*=\\s*new\\s+(?:cdk\\.)?App\\s*\\("
  name_group: 1
# python
- pattern: "(?m)^[ \\t]*(?:\\w+\\.)?(\\w+)\\s*=\\s*(?:cdk\\.)?App\\s*\\(\\s*\\)"
  name_group: 1
```

**Both patterns changed after review** — see the round-2 comment below for the blocker (Python needed
a left anchor or it bound the CALLS edge to the *wrong* variable), the type-annotation gap, and the
over-firing fixture.

**Correction to an earlier claim in this body:** it said the JS `(?:(?:const|let|var)\s+)?`
declarator group was "found by a failing test". That was wrong. Review mutant RM3 measured the group
**inert** — `(\w+)` alone already backtracks to the assignment target on `const`/`let`/`var`,
multi-declarator and attribute lines alike — and it has been **deleted** rather than described. What a
failing test did find was that the *first* JS spelling, which required the declarator, could not
reach a multi-declarator line.

**Exact edit landing**: the replacement was applied with a scripted `assert count == 1` on each
file, and `grep -c 'name_group: 0'` over both files is now `0` / `0`. Two files carry near-identical
rules; the hit set is exactly those two lines, `git diff --stat` = 2 files, 10 insertions, 6
deletions.

### 1. The edge binds — named, both endpoints

Driven through the real `LoadAllRules()` + `Detector.Detect()`. The detector builds a relationship
endpoint ID as `"<type>:<captured name>"` (`detector.go:562`); the source end binds exactly when an
emitted entity has that Kind and Name.

Fixture (`bin/app.ts`, and its Python twin) declaring both endpoints in one file:

```
Config:app --CALLS--> Component:ApiStack
```

- **Before**: entities were `Config:"new cdk.App("` + `Component:ApiStack`. The edge's source
  endpoint `Config:app` **named no emitted entity**.
- **After**: entities are `Config:app` + `Component:ApiStack`. **Both endpoints of that edge name an
  entity emitted by the same run.**

`TestIssue6916_CDKCallsEdgeBindsAtItsSource` asserts the edge string and then each endpoint against
the emitted entity set — not a count. (#6973: `TESTS` moved +8 net while 7,221 edges were
substituted underneath.)

### 2. What it costs: the unassigned construction

A bare `new cdk.App()` / `cdk.App()` with no assignment now matches nothing and mints no entity.
That is pinned deliberately by `TestIssue6916_UnassignedAppMintsNoConfig`, each leg carrying
`Component:ApiStack` as a positive control so the absence cannot pass vacuously.

**How many corpus occurrences is that? Zero — because the corpus contains zero CDK at all.**
Measured over `/Users/jorgecajas/Projects/archigraph-corpora` (60 repos, `node_modules`/`dist`/
`build`/`.next`/`venv` excluded): **0** matches of `new\s+(cdk\.)?App\s*\(` in `.ts/.js/.tsx/.jsx`
and **0** matches of `(cdk\.)?App\s*\(\s*\)` in `.py`. That is consistent with the #6916 measurement
comment, which attributed **0 entities** to both aws_cdk sites.

**So this bullet is honestly under-measured and I am flagging it rather than claiming it.** A
corpus zero is corpus-relative, never a capability claim. What I can put on the record:

- The **only** CDK App construction anywhere in this repo's trees,
  `testdata/fixtures/real-world/cdk/api_lambda_dynamodb_stack.ts:130`, is `const app = new App();` —
  **assigned**.
- Structurally, an unassigned App is **unusable**: every stack takes the app as its scope argument
  (`new MyStack(app, 'Id')`), and the relationship rule's own `source_group: 2` is `(\w+)` — a
  variable. An App that is never bound to a name can never appear in that edge, so the node it used
  to mint was a per-file boolean marker with nothing to attach to.

If you want this measured against a real CDK population before Tier A copies the shape, that is a
fair hold and I will take it.

### 3. Migration: **no `fbversion.Version` bump.** Deliberate, and here is why.

`internal/types/kinds.go:26` already settles this class of question explicitly: *"A rename must
therefore NOT be expressed as an fbversion bump. That would reindex every registered group behind
the user's back."* `fbversion.Version` (currently `6`) versions the FlatBuffers **payload format**;
a bump makes `internal/graph`'s min-version gate reject the stored graph, which `internal/daemon`
turns into an automatic full reindex of **every** registered group.

This change alters no format, no schema, and no entity **kind** — it changes one entity **Name**, in
one framework, in two languages. `KindVocabularyVersion` is also not in scope: it is bumped when a
kind is renamed or retired, and `Config` is neither.

The consequence, stated rather than hidden: `ComputeID` hashes
`OrgID+ProjectID+SourceFile+Kind+Name` (`internal/types/entity.go:139`), so this changes the entity
ID. A **full re-index is clean** (whole-document FlatBuffers generation, no rows). The two
**incremental** paths carry no rule digest in the manifest, so a rule edit there yields a mixed-ID
graph plus dangling edges the merge never cleans — **#6085, pre-existing, not created by this PR and
not fixed by it**. Forcing a fleet-wide reindex to paper over it costs every user a full index for a
two-line rule change in one framework; the #6757-arm-C call was that the user gets to choose when to
pay that.

### Verification (all in the worktree above, `-count=1`, `go vet` first, `gofmt -l` clean)

- `go test ./internal/engine/` — **ok, 43.996s**
- `go test ./cmd/grafel/` — **ok, 148.029s**, in a **fresh** `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`
  (+ `HOME`) sandbox under the scratchpad. The real `~/.grafel` was never touched.
- `scripts/quality/run.sh --ratchet` — **exit 0**, `quality ratchet OK — 38 gated fixtures held
  their baseline (29 at 100% must-have recall)`. **No baseline moved**, so no fixture-member
  enumeration is owed; no constant was bumped and `--update-baseline` was never run.

### Mutants — scored in the permissive direction, `-count=1`, green baseline immediately before each

| # | mutant | verdict |
|---|---|---|
| M1a | JS `name_group: 1` → `0` | **DEAD** — `Config:app` gone; edge reported dangling; `Config:"app = new cdk.App("` flagged non-identifier |
| M1b | Python `name_group: 1` → `0` | **DEAD** — same two assertions |
| M2a | JS variable capture `(\w+)` → `(.+)` | **DEAD** — minted `Config:"region = 'eu-west-1', app"` |
| M2b | Python variable capture `(\w+)` → `(.+)` | **DEAD** — minted `Config:"self.app"` |
| M4 | full revert of **both** sites to the shipped state | **DEAD** — both marker Names named in the failure |
| M5 | JS: assignment prefix made **optional**, `name_group: 1` | **ALIVE — equivalent, with a mechanism** |

**M2b was ALIVE on the first score and that is why the Python leg exists.** The single-assignment
fixture cannot grade `(.+)`: forced to stop at the `=`, it captures `app` too, so it is
indistinguishable there. The shape that separates them is **not shared between the languages** —
JS/TS needs a multi-declarator `const` line, Python has no declarator keyword and needs an attribute
target (`self.app = cdk.App()`). Two fixtures, one per language; grading one and assuming the other
is exactly the "fixtures pin one axis and leave the neighbour open" failure.

**M5 is equivalent under the detector, not merely under the suite.** With the assignment optional
and `name_group: 1`, a bare `new cdk.App()` matches but capture group 1 is empty; `detector.go` only
falls back to the full match when `nameGroup == 0`, so an empty name `continue`s and no entity is
emitted. Every input therefore produces the identical entity set. That is not an argument —
`TestIssue6916_UnassignedAppMintsNoConfig` passing under M5 **is** the demonstration that the
optional branch emits nothing.

### Known uncovered, deliberately

A re-add that renames the `Config` kind itself slips past these tests, exactly as noted on the #6914
pin. Closing it would mean asserting a whole-graph absence, which fights the Tier A work that will
legitimately add `Config` anchors.

Refs #6916, #6914, #6906, #6912, #6726, #6085.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
