### PR TITLE
docs(#6911): the `SCOPE.` prefix is an accident for 11 kind pairs and load-bearing for the 12th — and only a comment said so

### DIFF
--- a/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
+++ b/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
@@ -65,6 +65,18 @@ package entkinds_test
 // is why `Module` validates by coincidence rather than by design. Nothing
 // documents an un-prefixed namespace, and nothing implements one.
 //
+// ONE EXCEPTION, ADDED BY #6911. The verdict above is true of every rule-YAML
+// kind except one: bare `Endpoint` (electron.yaml:41,46,52) is an Electron IPC
+// channel, while SCOPE.Endpoint is the HTTP entrypoint. #6776 arm B9 therefore
+// admitted it as a DISTINCT member rather than folding it, and #6820 priced and
+// DECLINED the rename that would have made the two names differ by more than a
+// prefix. For that one pair the `SCOPE.` prefix is load-bearing. Read the
+// paragraphs above as "an accident everywhere it has not been examined and
+// found otherwise", not as a licence to merge a prefixed and un-prefixed kind
+// on sight. See internal/types/kinds.go at EntityKindEndpointBare, and
+// internal/types/prefix_only_pairs_6911_test.go, which fails if the pair is
+// folded.
+//
 // This verdict stands and is now the repository's only one. The competing note
 // in internal/types/producer_kinds_test.go, which called the un-prefixed names
 // "intentionally outside the validator set", was retracted by #6776 arm B3; the

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -774,10 +774,25 @@ const (
 	// OWNER IN #6820 (a rename plus a stored-graph migration); that ruling
 	// stands, so the confusable spelling is deliberate and is carried here
 	// instead. Deleting this constant, or pointing it at "SCOPE.Endpoint",
-	// silently re-labels every Electron IPC channel as an HTTP endpoint.
-	// internal/types/prefix_only_pairs_6911_test.go fails if either happens,
-	// and pins the twelve-pair population so a thirteenth pair cannot be added
-	// without someone saying which of the two readings it is.
+	// re-labels every Electron IPC channel as an HTTP endpoint.
+	//
+	// THAT FOLD IS NOT SILENT, AND THE GUARDS ARE OLDER THAN THIS COMMENT — so
+	// do not delete any of them as redundant. Both spellings of the fold
+	// (repointing this constant, or dropping it from AllEntityKinds()) were
+	// scored on #6911 and each is caught by FOUR pre-existing tests:
+	// TestEndpointBare6776_IsADistinctValidEntityKind and
+	// TestEndpointBare6776_MembershipIsNotHTTPMembership
+	// (endpoint_bare_kind_6776_test.go), TestEntityKindVocabularyIsPinnedToItsVersion
+	// (kind_vocabulary_bump_guard_6779_test.go) and
+	// TestAllEntityKinds6830_ListsEveryDeclaredKindExactlyOnce
+	// (all_entity_kinds_roster_6830_test.go). Re-spelling the three
+	// electron.yaml producers is caught by a fifth,
+	// TestRuleDeclaredLedger6776_IsRetiredBecauseThePopulationIsEmpty.
+	// internal/types/prefix_only_pairs_6911_test.go adds a sixth lock on the
+	// fold, kept only because its failure text names #6820; what it adds that
+	// nothing else observed is the NEXT pair — it pins the twelve-pair
+	// population, so a thirteenth cannot be added without someone saying which
+	// of the two readings it is.
 	EntityKindEndpointBare EntityKind = "Endpoint"
 )
 

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -760,6 +760,24 @@ const (
 	//
 	// Spelling unchanged — nothing is renamed or retired — so
 	// KindVocabularyVersion does not move.
+	//
+	// #6911 — DO NOT FOLD THIS INTO SCOPE.Endpoint. THE MISSING PREFIX IS NOT
+	// AN ACCIDENT HERE. Twelve kinds in AllEntityKinds() have a `SCOPE.`-less
+	// twin; eleven of them (Component, Model, Schema, View, Config, Operation,
+	// Route, Service, Constraint, Plugin, Template — the `*Bare` constants
+	// above) really are one concept written two ways, which is why the #6776
+	// B-series and internal/entkinds' sweep guard call the prefix an accident.
+	// THIS PAIR IS THE ONE EXCEPTION: `Endpoint` is an Electron IPC channel,
+	// `SCOPE.Endpoint` is an HTTP entrypoint, and the prefix is the only thing
+	// telling them apart. Renaming the bare kind to something like `IPCChannel`
+	// so they differed by more than a prefix was PRICED AND DECLINED BY THE
+	// OWNER IN #6820 (a rename plus a stored-graph migration); that ruling
+	// stands, so the confusable spelling is deliberate and is carried here
+	// instead. Deleting this constant, or pointing it at "SCOPE.Endpoint",
+	// silently re-labels every Electron IPC channel as an HTTP endpoint.
+	// internal/types/prefix_only_pairs_6911_test.go fails if either happens,
+	// and pins the twelve-pair population so a thirteenth pair cannot be added
+	// without someone saying which of the two readings it is.
 	EntityKindEndpointBare EntityKind = "Endpoint"
 )
 

--- a/internal/types/prefix_only_pairs_6911_test.go
+++ b/internal/types/prefix_only_pairs_6911_test.go
@@ -20,7 +20,15 @@ package types_test
 //
 //   - TestPrefixOnlyPairs6911_EndpointPairIsNotFolded — the two kinds are
 //     present, distinct, and neither is spelled as the other. This is the one
-//     that fires when someone "fixes the obviously missing prefix".
+//     that fires when someone "fixes the obviously missing prefix". IT IS NOT
+//     THE ONLY ONE, AND IT WAS NOT FIRST: both spellings of that fold were
+//     scored on #6911 and each is already caught by four pre-existing tests
+//     (TestEndpointBare6776_IsADistinctValidEntityKind,
+//     TestEndpointBare6776_MembershipIsNotHTTPMembership,
+//     TestEntityKindVocabularyIsPinnedToItsVersion,
+//     TestAllEntityKinds6830_ListsEveryDeclaredKindExactlyOnce). This one is
+//     kept because its failure text names #6820, which none of theirs does —
+//     not because the fold was unguarded.
 //   - TestPrefixOnlyPairs6911_PopulationIsClassified — the SET of prefix-only
 //     pairs is exactly the twelve classified below. #6911 asks whether any
 //     OTHER pair means two things while differing only by the prefix; the
@@ -34,6 +42,36 @@ package types_test
 // pair SHRINKS the population, which the set assertion would also catch but
 // would report as "a pair went missing" rather than naming the concept; and a
 // new unclassified pair leaves the Endpoint pair untouched.
+//
+// # KNOWN LIMIT: only the STRICT direction is gated, and this was measured
+//
+// The table forces a thirteenth pair to be CLASSIFIED, not to be classified
+// HONESTLY. Classifying a newcomer `false` (semantically distinct) is a hard
+// failure until the twoConcept roster below moves with it; classifying it
+// `true` (synonym) is free and green, and nothing observes whether that is
+// true. The permissive half — the `Endpoint` situation recurring — is the
+// unguarded one.
+//
+// Tying a `true` row to the `*Bare` constant family was built and scored on
+// #6911 rather than argued about, and it does NOT close this. Two reasons, in
+// order of weight:
+//
+//   - The compiler forces the name. For any prefix-only pair the identifier
+//     `EntityKind<X>` is already taken by the PREFIXED kind (declaring a second
+//     one does not compile — scored), so the bare constant is pushed to
+//     `EntityKind<X>Bare` whatever the author means by it. A thirteenth pair
+//     that means two things, declared the way anyone would declare it and
+//     marked `true`, stayed GREEN under the check.
+//   - `EntityKindEndpointBare` is itself in that family. The one pair on this
+//     list that is NOT a synonym carries the `Bare` suffix, and kinds.go says
+//     why: the suffix names the SPELLING, not the concept. So family
+//     membership cannot mean "synonym" without contradicting the row this file
+//     exists for.
+//
+// The check only ever fired on a deliberately unconventional identifier, so it
+// would have graded orthography while reading as if it graded honesty. Left
+// unbuilt on purpose; there is no oracle for "same concept", and the failure
+// texts below state the intent instead.
 
 import (
 	"sort"
@@ -119,7 +157,7 @@ func TestPrefixOnlyPairs6911_EndpointPairIsNotFolded(t *testing.T) {
 			"These are two members naming two concepts — an Electron IPC channel and an HTTP "+
 			"entrypoint. The `SCOPE.` prefix looks like the accident #6776 describes and is not "+
 			"one here: the rename that would separate the names properly was declined in #6820, "+
-			"so folding them silently re-labels every Electron IPC channel as HTTP.",
+			"so folding them re-labels every Electron IPC channel as HTTP.",
 			bare, sawBare, prefixed, sawPrefixed)
 	}
 }

--- a/internal/types/prefix_only_pairs_6911_test.go
+++ b/internal/types/prefix_only_pairs_6911_test.go
@@ -1,0 +1,181 @@
+package types_test
+
+// prefix_only_pairs_6911_test.go — #6911.
+//
+// #6776's B-series, and internal/entkinds' sweep guard, record a verdict: an
+// entity kind written without the `SCOPE.` prefix is an ACCIDENT of the rule
+// layer, not a second namespace. Arms B5-B8 acted on it and every pair they
+// touched was a true synonym.
+//
+// Arm B9 could not. Bare `Endpoint` is an Electron IPC channel
+// (electron.yaml:41,46,52 — ipcMain.handle / ipcRenderer.invoke /
+// contextBridge.exposeInMainWorld); SCOPE.Endpoint is the HTTP entrypoint. The
+// rename that would make the two names differ by more than a prefix was priced
+// and DECLINED by the owner in #6820, so the confusable spelling is deliberate.
+// That leaves the repository with one pair whose only distinction is a prefix
+// its own comments call meaningless — and a comment does not fail a build. This
+// file is the build failure.
+//
+// Two assertions, and they grade different things:
+//
+//   - TestPrefixOnlyPairs6911_EndpointPairIsNotFolded — the two kinds are
+//     present, distinct, and neither is spelled as the other. This is the one
+//     that fires when someone "fixes the obviously missing prefix".
+//   - TestPrefixOnlyPairs6911_PopulationIsClassified — the SET of prefix-only
+//     pairs is exactly the twelve classified below. #6911 asks whether any
+//     OTHER pair means two things while differing only by the prefix; the
+//     answer at this commit is no, and this pins it so a thirteenth pair cannot
+//     appear without an author saying which of the two readings it is.
+//
+// Varies across the two tests: the granularity (one named pair vs the whole
+// population) and the failure it can see (a fold vs an unclassified newcomer).
+// Holds constant: the roster under test, AllEntityKinds(), and the definition
+// of a prefix-only pair. Neither subsumes the other — a fold of the Endpoint
+// pair SHRINKS the population, which the set assertion would also catch but
+// would report as "a pair went missing" rather than naming the concept; and a
+// new unclassified pair leaves the Endpoint pair untouched.
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// classifiedPrefixOnlyPairs maps the un-prefixed half of every kind pair in
+// AllEntityKinds() that differs only by `SCOPE.` to whether the two members
+// name the SAME concept.
+//
+// Eleven are synonyms — the `*Bare` constants in kinds.go, admitted by #6776
+// arms B6/B7/B8 as spellings rather than concepts. One is not.
+var classifiedPrefixOnlyPairs = map[string]bool{
+	// name: sameConcept
+	"Component":  true,
+	"Model":      true,
+	"Schema":     true,
+	"View":       true,
+	"Config":     true,
+	"Operation":  true,
+	"Route":      true,
+	"Service":    true,
+	"Constraint": true,
+	"Plugin":     true,
+	"Template":   true,
+
+	// The exception, and the reason this file exists. Bare `Endpoint` is an
+	// Electron IPC channel; SCOPE.Endpoint is the HTTP entrypoint. See #6820
+	// (rename declined) and kinds.go at EntityKindEndpointBare.
+	"Endpoint": false,
+}
+
+// prefixOnlyPairsIn returns the un-prefixed names for which both `X` and
+// `SCOPE.X` are members of the given roster.
+func prefixOnlyPairsIn(kinds []types.EntityKind) []string {
+	set := make(map[string]bool, len(kinds))
+	for _, k := range kinds {
+		set[string(k)] = true
+	}
+	var out []string
+	for s := range set {
+		if bare, ok := strings.CutPrefix(s, "SCOPE."); ok && set[bare] {
+			out = append(out, bare)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestPrefixOnlyPairs6911_EndpointPairIsNotFolded(t *testing.T) {
+	const bare, prefixed = "Endpoint", "SCOPE.Endpoint"
+
+	// The constants must still spell what their names claim. Repointing
+	// EntityKindEndpointBare at "SCOPE.Endpoint" is the cheapest possible
+	// fold and leaves both identifiers in place, so it is checked first.
+	if got := string(types.EntityKindEndpointBare); got != bare {
+		t.Fatalf("EntityKindEndpointBare = %q, want %q. This constant is the Electron IPC "+
+			"channel kind (electron.yaml:41,46,52); SCOPE.Endpoint is the HTTP entrypoint. "+
+			"They are NOT synonyms, and #6820 priced and declined the rename that would make "+
+			"them differ by more than the prefix — see #6911.", got, bare)
+	}
+	if got := string(types.EntityKindEndpoint); got != prefixed {
+		t.Fatalf("EntityKindEndpoint = %q, want %q — the HTTP half of the pair #6911 keeps apart",
+			got, prefixed)
+	}
+
+	// Both must be roster members, each exactly once. Dropping either spelling
+	// orphans every stored graph that carries it.
+	var sawBare, sawPrefixed int
+	for _, k := range types.AllEntityKinds() {
+		switch string(k) {
+		case bare:
+			sawBare++
+		case prefixed:
+			sawPrefixed++
+		}
+	}
+	if sawBare != 1 || sawPrefixed != 1 {
+		t.Errorf("AllEntityKinds() holds %q %d time(s) and %q %d time(s); want exactly one each. "+
+			"These are two members naming two concepts — an Electron IPC channel and an HTTP "+
+			"entrypoint. The `SCOPE.` prefix looks like the accident #6776 describes and is not "+
+			"one here: the rename that would separate the names properly was declined in #6820, "+
+			"so folding them silently re-labels every Electron IPC channel as HTTP.",
+			bare, sawBare, prefixed, sawPrefixed)
+	}
+}
+
+func TestPrefixOnlyPairs6911_PopulationIsClassified(t *testing.T) {
+	got := prefixOnlyPairsIn(types.AllEntityKinds())
+
+	want := make([]string, 0, len(classifiedPrefixOnlyPairs))
+	for name := range classifiedPrefixOnlyPairs {
+		want = append(want, name)
+	}
+	sort.Strings(want)
+
+	// Positive control: the detector must actually find pairs, or every
+	// assertion below is satisfied by a function that finds nothing.
+	if len(got) == 0 {
+		t.Fatal("fixture is inert: prefixOnlyPairsIn found no `X`/`SCOPE.X` pair at all, so it " +
+			"cannot observe a fold or a newcomer")
+	}
+
+	gotSet := map[string]bool{}
+	for _, name := range got {
+		gotSet[name] = true
+		if _, classified := classifiedPrefixOnlyPairs[name]; !classified {
+			t.Errorf("%q and SCOPE.%s are both entity kinds and differ only by the prefix, but "+
+				"no row here says whether that is one concept or two. Add it: `true` if the two "+
+				"spellings name the SAME concept (the #6776 reading — the prefix is an accident), "+
+				"`false` if the prefix carries meaning, as it does for Endpoint (#6820, #6911). "+
+				"An unclassified pair is exactly the hazard this file exists to prevent.",
+				name, name)
+		}
+	}
+	for _, name := range want {
+		if !gotSet[name] {
+			t.Errorf("%q/SCOPE.%s was a prefix-only pair and is no longer one — one of the two "+
+				"spellings left AllEntityKinds(). If that was a deliberate fold of a synonym, "+
+				"delete its row here. If it was %q, it was NOT a synonym (Electron IPC vs HTTP, "+
+				"rename declined in #6820) and folding it re-labels IPC channels as HTTP.",
+				name, name, "Endpoint")
+		}
+	}
+
+	// The table must keep saying that exactly one pair means two things, and
+	// that it is the Endpoint pair. Flipping the row to `true` would turn the
+	// classification above into a rubber stamp.
+	var twoConcept []string
+	for name, sameConcept := range classifiedPrefixOnlyPairs {
+		if !sameConcept {
+			twoConcept = append(twoConcept, name)
+		}
+	}
+	sort.Strings(twoConcept)
+	if len(twoConcept) != 1 || twoConcept[0] != "Endpoint" {
+		t.Fatalf("pairs classified as two concepts = %v, want exactly [Endpoint]. That row is "+
+			"#6820's ruling written down (Electron IPC vs HTTP, rename declined); if a second "+
+			"pair genuinely means two things, this test and kinds.go's 'one exception' comment "+
+			"both need updating together.", twoConcept)
+	}
+}

--- a/internal/types/producer_entity_kinds_6776_test.go
+++ b/internal/types/producer_entity_kinds_6776_test.go
@@ -81,6 +81,17 @@ package types_test
 //     It is ledgered rather than skipped precisely so the claim stops being
 //     prose and becomes a number that cannot move unnoticed.
 //
+// # The accident claim has exactly one exception (#6911)
+//
+// "Un-prefixed is an accident" is true of every kind in AllEntityKinds() except
+// the `Endpoint` / `SCOPE.Endpoint` pair: the bare spelling is an Electron IPC
+// channel (#6776 arm B9), the prefixed one is the HTTP entrypoint, and #6820
+// priced and DECLINED the rename that would separate them by more than the
+// prefix. So do not read "accident" as "safe to merge a prefixed and
+// un-prefixed kind": for that one pair the prefix carries the meaning.
+// internal/types/prefix_only_pairs_6911_test.go pins the population of
+// prefix-only pairs and fails if that one is folded.
+//
 // # What this guard is NOT
 //
 // The rule-YAML producer family (internal/engine/rules/**/*.yaml, ~532 sites)
@@ -141,7 +152,8 @@ var goPrefixedKindsDeferred = map[string]bool{}
 const goPrefixedKindsDeferredMax = 0
 
 // goUnprefixedKindsDeferred are the un-prefixed entity kinds a Go producer
-// declares. See the file header: drift, not a second namespace.
+// declares. See the file header: drift, not a second namespace — with the one
+// exception the header records, `Endpoint` (#6911).
 //
 // `File` is called out on #6776 as the largest non-enum entity kind (894
 // entities) and as an internal commit-coupling artefact rather than a


### PR DESCRIPTION
Fixes #6911.

## The debt

#6776's B-series settled that a missing `SCOPE.` prefix is an **accident, not a second namespace**, and arms B5–B8 acted on that reading by folding true synonyms into the prefixed spelling. Arm B9 could not: bare `Endpoint` is an **Electron IPC channel**, `SCOPE.Endpoint` is the **HTTP entrypoint**, and #6820 **priced and declined** the rename that would make the two names differ by more than a prefix.

So there is now exactly one pair of kinds whose only distinction is the `SCOPE.` prefix, and that distinction carries meaning — in a codebase whose comments say the prefix is meaningless.

## Why this is more than comments

The issue asks for documentation. A comment does not fail a build, and the hazard is build-shaped: someone tidying up "an obviously missing prefix" merges the two kinds and silently re-labels every Electron IPC channel as HTTP. Comments **and** a pin.

- **`internal/types/kinds.go`, at `EntityKindEndpointBare`** — a DO-NOT-FOLD paragraph: the eleven pairs where the prefix really is an accident, the one where it is not, and the load-bearing clause that the rename **was considered and declined by the owner in #6820**. Without that clause the next reader re-derives the decision or overturns it.
- **The two sites that make the accident claim** — `internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go`'s "The namespace question, answered", and `producer_entity_kinds_6776_test.go`'s header + `goUnprefixedKindsDeferred` — now record the exception where the claim is made.
- **`internal/types/prefix_only_pairs_6911_test.go`** — the pin.

## The issue's open question, answered

"Whether any **other** pair differs only by the `SCOPE.` prefix while meaning different things" is not left open. **Twelve** prefix-only pairs exist in `AllEntityKinds()`; eleven are the `*Bare` synonym constants (Component, Model, Schema, View, Config, Operation, Route, Service, Constraint, Plugin, Template) admitted by arms B6/B7/B8 as spellings, and `Endpoint` is the twelfth. The test carries that classification as a table, so a **thirteenth pair cannot appear without an author saying which of the two readings it is**.

## Mutants

Scored in the worktree, `-count=1`, `go vet` first, off a green baseline, each edit proved landed by an exact occurrence count.

| Mutant | Verdict |
|---|---|
| Fold by repointing — `EntityKindEndpointBare = "SCOPE.Endpoint"` | **DEAD**, both new tests, with the Electron-IPC-vs-HTTP reason in the failure text |
| …same mutant, with the new test file moved aside | **still DEAD**, via four pre-existing tests |
| Add an unclassified prefix-only pair — bare `Queue` beside `SCOPE.Queue`, with the vocabulary roster and both declaration counts re-pinned as a real author would | **DEAD**, and `TestPrefixOnlyPairs6911_PopulationIsClassified` is the **sole** failure |

**Reported rather than glossed:** for the fold mutant the new assertion is a second lock on a door already locked — `endpoint_bare_kind_6776_test.go` (×2), the vocabulary version pin and the declaration-match test all fire. It is kept because it names #6820 in its failure text, but the coverage this PR genuinely **adds** is the third row: nothing in the tree observed an unclassified prefix-only pair before.

## Scope

No behaviour change. Nothing renamed, no `IsValidEntityKind` caller touched, no stored graph migrated. `KindVocabularyVersion` does **not** move — no kind is added or retired.

## Verification

`gofmt -l`, `go vet`, and `go test -count=1 ./internal/types/ ./internal/entkinds/` green. `./cmd/grafel/` also run green under a **fresh** `GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT`, because `kinds.go` is not a `_test.go` file and holds the whole-graph digest pin; the change there is comment-only, so no extraction output can move.

## Reported, not fixed here (per brief)

`kinds.go`'s own `KindVocabularyVersion` v1 example cites #6499 — a *Name*-spelling change — as one of "two such renames", which contradicts the constant's own definition. Left alone deliberately; needs its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861

---

## Review follow-up (`f14e4648b`) — comments only, no assertion added or removed

**1. The "silently" claim in `kinds.go` was wrong, and in the direction that matters.** It credited only the new file for a fold that four pre-existing tests already catch — a reader could have deleted one of the four as redundant. The paragraph now names all four (`TestEndpointBare6776_*` x2, `TestEntityKindVocabularyIsPinnedToItsVersion`, `TestAllEntityKinds6830_ListsEveryDeclaredKindExactlyOnce`), plus the fifth that catches re-spelling the `electron.yaml` producers, and says the new file is a sixth lock kept only because its failure text names #6820. The fifth citation was re-verified here rather than taken on report: re-spelling all three `entity_type: Endpoint` sites fails `TestRuleDeclaredLedger6776_IsRetiredBecauseThePopulationIsEmpty`. All five names confirmed present at the files cited.

**2. Known limit, now written down: the table forces a classification, not a correct one.** Classifying a 13th pair `false` is a hard failure; classifying it `true` is free and green, and the permissive half is the one this repo keeps getting bitten in.

**Tying a `true` row to the `*Bare` constant family was built and scored, not argued about — and it does not close the gap.** Cost was not the problem (~18 lines reusing `declaredEntityKindsFromSource`):

| Mutant | Verdict |
|---|---|
| 13th pair `Queue` declared `EntityKindQueueBare`, classified `true` — the `Endpoint` situation recurring, named the way anyone would name it | **ALIVE, green** |
| ...declared `EntityKindQueue` instead | **does not compile** — the prefixed kind already owns the identifier, so the compiler *forces* the `*Bare` name |
| ...declared `EntityKindQueueUnprefixed`, classified `true` | **DEAD** — the only thing the check discriminates is orthography |
| The 11 genuine synonyms | pass |

And `EntityKindEndpointBare` is itself in that family: the one pair that is **not** a synonym carries the suffix, because the suffix names the spelling, not the concept. A check that reads as if it gates honesty while gating identifier spelling is worse than the recorded limit, so it is left unbuilt and the limit is documented in the test's own doc comment.

**Verification for this commit:** `gofmt -l`, `go vet`, `go test -count=1 ./internal/types/ ./internal/entkinds/` green; restores by `cp` from shasum-verified backups with `git diff HEAD` empty between scores. `./cmd/grafel/` skipped: the only changes are one `_test.go` and a comment in `kinds.go`, and it was already green on the parent commit. The extraction gate is `scripts/quality/run.sh --ratchet` (always-on in CI); it measures recall against fixtures and cannot move for a comment-plus-test change, so it was not run locally.
