### PR TITLE
fix(#7014): a typo inside source_patterns/relationship_rules/file_conventions was silently dropped — strict-unmarshal the executable half only

### DIFF
--- a/internal/engine/graphql_inert_rules_guard_6393_test.go
+++ b/internal/engine/graphql_inert_rules_guard_6393_test.go
@@ -197,8 +197,10 @@ func TestInertRuleFiles_RealRuleIsNotFlagged(t *testing.T) {
 		"detection markers only": "frameworks:\n  name: Yoga\n  detection:\n    import_markers:\n    - \"graphql-yoga\"\n",
 		"file conventions only":  "file_conventions:\n- glob: \"**/*.graphql\"\n  entity_type: Model\n",
 		"source patterns only":   "source_patterns:\n- pattern: \"type (\\\\w+)\"\n  entity_type: Model\n",
+		// `relationship`, not `relationship_type`: the latter is not a modelled
+		// key and, since #7014, does not load at all.
 		"relationship rules only": "relationship_rules:\n- pattern: \"implements (\\\\w+)\"\n  " +
-			"relationship_type: IMPLEMENTS\n",
+			"relationship: IMPLEMENTS\n",
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/engine/schema_strict.go
+++ b/internal/engine/schema_strict.go
@@ -1,0 +1,160 @@
+package engine
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// This file makes the EXECUTABLE half of the rule schema strict (#7014).
+//
+// The rule schema has two halves. The metadata half — `frameworks:`,
+// `category`, `github_stars_2025`, the fourteen different spellings of the
+// top-level container — is 95% unmodelled: 465 of 488 distinct key paths in the
+// rule tree are dropped by yaml.Unmarshal without a word. The executable half —
+// the entries of `source_patterns`, `relationship_rules` and `file_conventions`
+// — is by contrast exactly modelled: the audit on #7014 found ZERO unmodelled
+// keys inside those three list containers across all 520 loader-scoped files.
+//
+// That asymmetry is what makes this guard free. A typo in an executable
+// position (`name_group` misspelled, `source_group` written where
+// `target_group` was meant) is today indistinguishable from a key the loader
+// simply does not model: yaml.Unmarshal drops both in silence. That is the
+// defect class that produced #7014 in the first place —
+// `detection_signals.package_json_deps` sat unread in 59 files for the entire
+// life of the tree because nothing objects to a key nobody models.
+//
+// So: unknown keys INSIDE the three list containers are a load error. Unknown
+// keys ANYWHERE ELSE keep loading exactly as before.
+//
+// The boundary is deliberate, not an unfinished job. Full strict
+// `KnownFields(true)` unmarshalling turns 515 of 520 rule files red; a
+// top-level-key allowlist turns 254 red. Both are migrations with their own
+// decision to make (see #7013). Scoped to the three containers the cost today
+// is ZERO files. Widening it is a migration, not a tidy-up — see
+// Test7014_UnknownKeyOutsideExecutableContainersStillLoads, which exists to
+// make that widening fail loudly rather than land by accident.
+//
+// Key matching is exact and case-sensitive, which is marginally stricter than
+// yaml.v3's own field matching. No rule file in the tree relies on the
+// difference (measured: 0 red).
+
+// strictContainerFields returns the set of YAML keys a struct models, derived
+// from its `yaml:"..."` tags. Deriving it by reflection rather than hand-listing
+// the keys means a NEW field added to SourcePattern et al. is accepted the
+// moment it is declared — the guard cannot drift out of sync with the struct it
+// is guarding.
+func strictContainerFields(t reflect.Type) map[string]bool {
+	fields := make(map[string]bool, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+		name := strings.Split(f.Tag.Get("yaml"), ",")[0]
+		switch name {
+		case "-":
+			continue
+		case "":
+			name = strings.ToLower(f.Name)
+		}
+		fields[name] = true
+	}
+	return fields
+}
+
+// rejectUnknownContainerKeys fails if the mapping node carries any key the
+// struct type does not model. container names the list container for the error
+// message ("source_patterns", …).
+//
+// A non-mapping node is passed through untouched: that is a plain type error
+// and yaml.v3 reports it better than this function could.
+func rejectUnknownContainerKeys(value *yaml.Node, t reflect.Type, container string) error {
+	if value.Kind != yaml.MappingNode {
+		return nil
+	}
+	allowed := strictContainerFields(t)
+	var unknown []string
+	line := 0
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		key := value.Content[i].Value
+		if allowed[key] {
+			continue
+		}
+		unknown = append(unknown, key)
+		if line == 0 {
+			line = value.Content[i].Line
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	known := make([]string, 0, len(allowed))
+	for k := range allowed {
+		known = append(known, k)
+	}
+	sort.Strings(known)
+	return fmt.Errorf(
+		"line %d: unknown key %s in %s[]: the engine does not model it, so it would be silently ignored (known keys: %s)",
+		line, strings.Join(quoteAll(unknown), ", "), container, strings.Join(known, ", "))
+}
+
+func quoteAll(in []string) []string {
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = fmt.Sprintf("%q", s)
+	}
+	return out
+}
+
+// The three aliases below exist only to break the recursion: decoding into a
+// type that does NOT have an UnmarshalYAML method is what lets each
+// UnmarshalYAML delegate the real work back to yaml.v3.
+
+type fileConventionFields FileConvention
+
+// UnmarshalYAML rejects unknown keys inside a `file_conventions:` entry (#7014).
+func (c *FileConvention) UnmarshalYAML(value *yaml.Node) error {
+	if err := rejectUnknownContainerKeys(value, reflect.TypeOf(FileConvention{}), "file_conventions"); err != nil {
+		return err
+	}
+	var raw fileConventionFields
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	*c = FileConvention(raw)
+	return nil
+}
+
+type sourcePatternFields SourcePattern
+
+// UnmarshalYAML rejects unknown keys inside a `source_patterns:` entry (#7014).
+func (p *SourcePattern) UnmarshalYAML(value *yaml.Node) error {
+	if err := rejectUnknownContainerKeys(value, reflect.TypeOf(SourcePattern{}), "source_patterns"); err != nil {
+		return err
+	}
+	var raw sourcePatternFields
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	*p = SourcePattern(raw)
+	return nil
+}
+
+type relationshipRuleFields RelationshipRule
+
+// UnmarshalYAML rejects unknown keys inside a `relationship_rules:` entry (#7014).
+func (r *RelationshipRule) UnmarshalYAML(value *yaml.Node) error {
+	if err := rejectUnknownContainerKeys(value, reflect.TypeOf(RelationshipRule{}), "relationship_rules"); err != nil {
+		return err
+	}
+	var raw relationshipRuleFields
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	*r = RelationshipRule(raw)
+	return nil
+}

--- a/internal/engine/schema_strict.go
+++ b/internal/engine/schema_strict.go
@@ -40,13 +40,29 @@ import (
 //
 // Key matching is exact and case-sensitive, which is marginally stricter than
 // yaml.v3's own field matching. No rule file in the tree relies on the
-// difference (measured: 0 red).
+// difference (measured: 0 red), and the case-variant leg of
+// Test7014_UnknownKeyInsideExecutableContainerFailsLoad observes it.
+//
+// One further deliberate narrowing: a YAML MERGE KEY (`<<: *base`) inside a
+// guarded entry is rejected, because `<<` is not a modelled field name. Zero
+// rule files use one today. YAML ALIASES are unaffected — an aliased entry is
+// resolved before the guard sees it, so a typo reached through an alias fires
+// correctly (verified in review).
 
 // strictContainerFields returns the set of YAML keys a struct models, derived
 // from its `yaml:"..."` tags. Deriving it by reflection rather than hand-listing
 // the keys means a NEW field added to SourcePattern et al. is accepted the
 // moment it is declared — the guard cannot drift out of sync with the struct it
 // is guarding.
+//
+// One limit on that claim, recorded because it is a landmine rather than a
+// hazard: the walk is t.Field(i) only, so it does NOT understand an embedded or
+// `,inline` field. None of the three guarded structs has one today. If one is
+// added, this walk would allow the embedded type's own lowercased NAME and
+// reject the keys yaml.v3 actually inlines — which fails CLOSED (rule files go
+// red, nothing is silently accepted) and is caught by
+// Test7014_AllEmbeddedRuleFilesStillLoad, but it is a surprise worth naming
+// here rather than rediscovering.
 func strictContainerFields(t reflect.Type) map[string]bool {
 	fields := make(map[string]bool, t.NumField())
 	for i := 0; i < t.NumField(); i++ {

--- a/internal/engine/strict_containers_7014_test.go
+++ b/internal/engine/strict_containers_7014_test.go
@@ -34,10 +34,15 @@ import (
 
 // strict7014MinContainerEntries is the non-vacuity floor for mode 2: the number
 // of executable-container entries the strict decoder must actually have built
-// from the real embedded tree. The tree currently yields ~445
-// (329 source_patterns + 78 relationship_rules + 38 file_conventions); the floor
-// is set below that so ordinary rule authoring does not trip it, but far enough
-// above zero that a guard which never runs on real data cannot pass.
+// from the real embedded tree. The tree currently yields 562
+// (329 source_patterns + 155 file_conventions + 78 relationship_rules); the
+// floor is set below that so ordinary rule authoring does not trip it, but far
+// enough above zero that a guard which never runs on real data cannot pass.
+//
+// (An earlier revision of this comment said "~445 … 38 file_conventions". 38 is
+// the audit's FILE count for file_conventions, not its ENTRY count. Corrected
+// in review — a floor comment that misstates the population it floors is the
+// same defect class this file closes one layer down.)
 const strict7014MinContainerEntries = 350
 
 // goodRuleYAML is a rule file exercising all three executable containers with
@@ -110,6 +115,17 @@ func Test7014_UnknownKeyInsideExecutableContainerFailsLoad(t *testing.T) {
 			badKey: "name_form",
 		},
 		{
+			// Key matching is documented as exact and case-sensitive, which is
+			// marginally stricter than yaml.v3's own field matching. Nothing
+			// observed that until this leg: a future edit lowercasing keys
+			// "helpfully" would start accepting `Name_Group`, a widening in
+			// exactly the direction this guard exists to prevent.
+			name:      "case variant of a real key",
+			container: "source_patterns",
+			old:       "    name_group: 1", new: "    Name_Group: 1",
+			badKey: "Name_Group",
+		},
+		{
 			// The key that produced #7014, moved into an executable position.
 			name:      "unmodelled metadata key inside source_patterns",
 			container: "source_patterns",
@@ -133,7 +149,13 @@ func Test7014_UnknownKeyInsideExecutableContainerFailsLoad(t *testing.T) {
 				}
 			}
 			if got := len(rules["py"]); got != 1 {
-				t.Errorf("loaded %d py rules, want 1 (the good sibling only)", got)
+				t.Fatalf("loaded %d py rules, want 1 (the good sibling only)", got)
+			}
+			// The other half of the case pin: the exactly-spelled key is
+			// ACCEPTED, in the same run that rejects its case variant. A guard
+			// that rejected both would pass the leg above and be useless.
+			if got := rules["py"][0].SourcePatterns[0].NameGroup; got != 1 {
+				t.Errorf("the exactly-spelled `name_group` did not decode: NameGroup = %d, want 1", got)
 			}
 
 			if len(rep.Failures) != 1 {

--- a/internal/engine/strict_containers_7014_test.go
+++ b/internal/engine/strict_containers_7014_test.go
@@ -1,0 +1,258 @@
+package engine
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// Tests for #7014: unknown keys inside the three EXECUTABLE rule containers
+// (`source_patterns[]`, `relationship_rules[]`, `file_conventions[]`) must fail
+// at load; unknown keys anywhere else must keep loading.
+//
+// Vacuity. A "scan and assert absence" guard has five independent ways to be a
+// no-op, and a candidate-count floor closes only the first. Which test closes
+// which mode:
+//
+//  1. it inspects no files            -> the candidate floor in
+//     Test7014_AllEmbeddedRuleFilesStillLoad.
+//  2. it inspects the files but never reaches the containers (every list is
+//     empty, or the strict decoder is never on the decode path)
+//     -> the ENTRY floor in Test7014_AllEmbeddedRuleFilesStillLoad: those
+//     entries exist only because the strict UnmarshalYAML produced them.
+//  3. it reaches the containers but does not detect a bad key
+//     -> the positive control Test7014_UnknownKeyInsideExecutableContainerFailsLoad,
+//     one leg per container.
+//  4. it detects but does not act (logs and loads the file anyway)
+//     -> the same test asserts the file is absent from rules AND from
+//     rep.Loaded, not merely that a failure was recorded.
+//  5. it acts, but the assertion is so broad anything satisfies it
+//     -> the same test asserts the offending KEY NAME and the FILE PATH appear
+//     in the failure, and Test7014_UnknownKeyOutsideExecutableContainersStillLoads
+//     asserts the guard does NOT fire outside the three containers.
+
+// strict7014MinContainerEntries is the non-vacuity floor for mode 2: the number
+// of executable-container entries the strict decoder must actually have built
+// from the real embedded tree. The tree currently yields ~445
+// (329 source_patterns + 78 relationship_rules + 38 file_conventions); the floor
+// is set below that so ordinary rule authoring does not trip it, but far enough
+// above zero that a guard which never runs on real data cannot pass.
+const strict7014MinContainerEntries = 350
+
+// goodRuleYAML is a rule file exercising all three executable containers with
+// only modelled keys. Legs below mutate one key of it.
+const goodRuleYAML = `
+frameworks:
+  name: Widget
+  detection:
+    import_markers:
+      - "import widget"
+file_conventions:
+  - glob: "**/models/*.py"
+    entity_type: Model
+    name_from: filename
+source_patterns:
+  - pattern: "widget\\.route\\((\\w+)"
+    entity_type: Route
+    name_group: 1
+    scope: line
+    requires_framework: true
+relationship_rules:
+  - pattern: "(\\w+)\\s*->\\s*(\\w+)"
+    source_type: Route
+    target_type: Handler
+    relationship: ROUTES_TO
+    source_group: 1
+    target_group: 2
+`
+
+func loadOne(t *testing.T, name, body string) (map[string][]FrameworkRule, RuleLoadReport) {
+	t.Helper()
+	fsys := fstest.MapFS{
+		"rules/py/frameworks/" + name: {Data: []byte(body)},
+		// A known-good sibling, so "nothing loaded" cannot be mistaken for
+		// "the bad file was rejected".
+		"rules/py/frameworks/sibling.yaml": {Data: []byte(goodRuleYAML)},
+	}
+	rules, rep, err := LoadAllRulesFromFSReport(fsys, "rules")
+	if err != nil {
+		t.Fatalf("LoadAllRulesFromFSReport returned a hard error: %v", err)
+	}
+	return rules, rep
+}
+
+// Test7014_UnknownKeyInsideExecutableContainerFailsLoad is the positive
+// control: one leg per guarded container. Closes vacuity modes 3, 4 and 5.
+func Test7014_UnknownKeyInsideExecutableContainerFailsLoad(t *testing.T) {
+	cases := []struct {
+		name      string
+		container string
+		old, new  string
+		badKey    string
+	}{
+		{
+			name:      "source_patterns typo",
+			container: "source_patterns",
+			old:       "    name_group: 1", new: "    name_grup: 1",
+			badKey: "name_grup",
+		},
+		{
+			name:      "relationship_rules typo",
+			container: "relationship_rules",
+			old:       "    target_group: 2", new: "    targt_group: 2",
+			badKey: "targt_group",
+		},
+		{
+			name:      "file_conventions typo",
+			container: "file_conventions",
+			old:       "    name_from: filename", new: "    name_form: filename",
+			badKey: "name_form",
+		},
+		{
+			// The key that produced #7014, moved into an executable position.
+			name:      "unmodelled metadata key inside source_patterns",
+			container: "source_patterns",
+			old:       "    scope: line", new: "    scope: line\n    package_json_deps: [widget]",
+			badKey: "package_json_deps",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := strings.Replace(goodRuleYAML, tc.old, tc.new, 1)
+			if body == goodRuleYAML {
+				t.Fatalf("fixture did not change: %q not found in goodRuleYAML", tc.old)
+			}
+			rules, rep := loadOne(t, "typo.yaml", body)
+
+			// Mode 4: it must not merely complain — the file must not load.
+			for _, p := range rep.Loaded {
+				if strings.Contains(p, "typo.yaml") {
+					t.Errorf("typo.yaml was loaded despite an unknown key in %s[]", tc.container)
+				}
+			}
+			if got := len(rules["py"]); got != 1 {
+				t.Errorf("loaded %d py rules, want 1 (the good sibling only)", got)
+			}
+
+			if len(rep.Failures) != 1 {
+				t.Fatalf("failures = %d, want 1: %v", len(rep.Failures), rep.Failures)
+			}
+			f := rep.Failures[0]
+			msg := f.String()
+			// Mode 5: name the file AND the key, not just "something failed".
+			if !strings.Contains(f.Path, "typo.yaml") {
+				t.Errorf("failure does not name the offending file: %s", msg)
+			}
+			if !strings.Contains(msg, tc.badKey) {
+				t.Errorf("failure does not name the offending key %q: %s", tc.badKey, msg)
+			}
+			if !strings.Contains(msg, tc.container) {
+				t.Errorf("failure does not name the container %q: %s", tc.container, msg)
+			}
+		})
+	}
+}
+
+// Test7014_UnknownKeyOutsideExecutableContainersStillLoads pins the BOUNDARY.
+//
+// This is the scoping decision, and without it the next person tidying up
+// extends the guard to the top level and turns 254 of 520 rule files red. Each
+// key below is real and present in the tree today.
+func Test7014_UnknownKeyOutsideExecutableContainersStillLoads(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{"top-level metadata", "category: web\ngithub_stars_2025: 42000\nnotes: hello\n" + goodRuleYAML},
+		{"misspelled top-level container", "orms_database:\n  name: Widget\n" + goodRuleYAML},
+		{"detection_signals.package_json_deps", goodRuleYAML + "detection_signals:\n  package_json_deps:\n    - widget\n"},
+		{"unmodelled key under frameworks", strings.Replace(goodRuleYAML,
+			"  name: Widget", "  name: Widget\n  npm_packages: [widget]", 1)},
+		{"unmodelled key under frameworks.detection", strings.Replace(goodRuleYAML,
+			"  detection:", "  detection:\n    package_json_deps: [widget]", 1)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rules, rep := loadOne(t, "meta.yaml", tc.yaml)
+			if len(rep.Failures) != 0 {
+				t.Fatalf("the guard fired OUTSIDE the three executable containers, "+
+					"which turns 254 real rule files red: %v", rep.Failures)
+			}
+			if got := len(rep.Loaded); got != 2 {
+				t.Fatalf("loaded = %d, want 2: %v", got, rep.Loaded)
+			}
+			if got := len(rules["py"]); got != 2 {
+				t.Fatalf("loaded %d py rules, want 2", got)
+			}
+			// And the executable half still decoded, so "it loaded" is not
+			// "it loaded empty".
+			for _, r := range rules["py"] {
+				if len(r.SourcePatterns) != 1 || len(r.RelationshipRules) != 1 || len(r.FileConventions) != 1 {
+					t.Errorf("rule decoded with empty containers: %+v", r)
+				}
+				if r.SourcePatterns[0].NameGroup != 1 || r.SourcePatterns[0].Scope != "line" ||
+					!r.SourcePatterns[0].RequiresFramework {
+					t.Errorf("source pattern lost its modelled fields: %+v", r.SourcePatterns[0])
+				}
+				if r.RelationshipRules[0].TargetGroup != 2 || r.RelationshipRules[0].Relationship != "ROUTES_TO" {
+					t.Errorf("relationship rule lost its modelled fields: %+v", r.RelationshipRules[0])
+				}
+				if r.FileConventions[0].NameFrom != "filename" || r.FileConventions[0].EntityType != "Model" {
+					t.Errorf("file convention lost its modelled fields: %+v", r.FileConventions[0])
+				}
+			}
+		})
+	}
+}
+
+// Test7014_AllEmbeddedRuleFilesStillLoad is the 0-red measurement expressed as
+// a test rather than a one-off: every real rule file must still load under the
+// scoped strict guard. Closes vacuity modes 1 and 2.
+func Test7014_AllEmbeddedRuleFilesStillLoad(t *testing.T) {
+	rules, rep, err := LoadAllRulesReport()
+	if err != nil {
+		t.Fatalf("LoadAllRulesReport: %v", err)
+	}
+
+	// Mode 1: a guard that inspected no files proves nothing.
+	if len(rep.Candidates) < expectedMinRuleFiles {
+		t.Fatalf("only %d rule files found, want >= %d: the measurement is vacuous",
+			len(rep.Candidates), expectedMinRuleFiles)
+	}
+	if len(rep.Failures) != 0 {
+		t.Fatalf("the scoped strict guard turned %d real rule files RED, which makes it a "+
+			"migration rather than the free guard #7014 sized:\n%s",
+			len(rep.Failures), failureLines(rep))
+	}
+	if len(rep.Loaded) != len(rep.Candidates) {
+		t.Fatalf("loaded %d of %d rule files", len(rep.Loaded), len(rep.Candidates))
+	}
+
+	// Mode 2: every entry counted here was built BY the strict UnmarshalYAML —
+	// it is the only decode path into these types. A guard bypassed on the real
+	// tree cannot produce them.
+	entries := 0
+	for _, rs := range rules {
+		for _, r := range rs {
+			entries += len(r.SourcePatterns) + len(r.RelationshipRules) + len(r.FileConventions)
+		}
+	}
+	if entries < strict7014MinContainerEntries {
+		t.Fatalf("strict decoder produced only %d executable-container entries from the real "+
+			"rule tree, want >= %d: the guard is not on the real decode path",
+			entries, strict7014MinContainerEntries)
+	}
+	t.Logf("0 red: %d/%d rule files loaded, %d executable-container entries decoded strictly",
+		len(rep.Loaded), len(rep.Candidates), entries)
+}
+
+func failureLines(rep RuleLoadReport) string {
+	var b strings.Builder
+	for _, f := range rep.Failures {
+		fmt.Fprintf(&b, "  %s\n", f)
+	}
+	return b.String()
+}


### PR DESCRIPTION
## What

Unknown keys inside `source_patterns[]`, `relationship_rules[]` and `file_conventions[]` now **fail at load**, naming the file, the line, the key and the container. Unknown keys anywhere else load exactly as before.

Three `UnmarshalYAML` methods (`SourcePattern`, `RelationshipRule`, `FileConvention`) check the mapping's keys against the set the struct models — derived by reflection from the `yaml:` tags, so adding a field to the struct admits the key automatically and the guard cannot drift from what it guards. No rule YAML changed.

## The strongest evidence: the loaded rule set is byte-identical with and without the guard

From the independent review — `LoadAllRules()` dumped to canonical JSON at `5d09def56`, then again with `schema_strict.go` removed from the package:

```
with guard:    34 langs / 520 rules / 233094 bytes   sha 98703af3602bc951b9a7d0874565f68f15a3acbd
without guard: 34 langs / 520 rules / 233094 bytes   sha 98703af3602bc951b9a7d0874565f68f15a3acbd
```

That is stronger than "the ratchet stayed green": **no baseline *can* have moved**, because the extractor's input is the same bytes. The ratchet ran green anyway (see Verification).

## Why this scope and no wider

The audit on #7014 measured three prices over the 520 loader-scoped rule files:

| scope | files red |
|---|---|
| full strict `KnownFields(true)` | 515 / 520 — a migration |
| top-level key allowlist | 254 |
| **strict scoped to the three list containers** | **0** |

The executable half of the schema is exactly modelled — zero unmodelled keys occur inside those three containers — which is why the guard is free today. I re-measured the 0-red figure myself before building (520 candidates, 0 red) and it is now a test rather than a one-off.

## What this buys

A typo in an **executable** position — `name_group` misspelled, `source_group` written where `target_group` was meant — becomes a load error instead of a silently-ignored key. That is the defect class that produced #7014: `detection_signals.package_json_deps` sat unread in **59 files** for the whole life of the tree because nothing objects to a key the loader does not model.

It already earned its keep: the guard immediately failed `TestInertRuleFiles_RealRuleIsNotFlagged`, whose "relationship rules only" fixture writes **`relationship_type:`** where the modelled key is `relationship`. That fixture has been asserting "here is a real relationship rule" with a rule that decodes to an empty `Relationship`. Fixed in this PR (test-only).

To be precise about what that incident does and does not say: **#6393's guard was doing its job.** `isZeroRule` checks `len(r.RelationshipRules) == 0`, so the assertion held on list length and only the fixture's *label* over-claimed; the one-line fix neither weakens nor strengthens the leg. What it exposes is a different, pre-existing gap — **`isZeroRule` cannot tell a real rule from a present-but-garbage one** — and that is a second benefit of this PR: for the three executable containers, a garbage entry can no longer be present at all.

## What this does NOT buy

**Nothing about the metadata half.** `frameworks.name` (266 files), `source_patterns[].scope` (329 entries, declared and unread), `file_conventions[].pattern` (0 occurrences), `file_conventions[].description` (1), the 59 `package_json_deps` declarations and the **14 misspelled spellings of the top-level container** all stay exactly as they are, silently dropped as before. Extending the guard to them turns 254 files red; that is a migration with its own decision, and it is #7013's ground.

Per the issue: `source_patterns[].scope` is **not** deleted even though it has no reader. It sits inside a strict container, so it has to stay modelled to keep loading. It stays modelled and stays unread (#6916).

## Pinned

`internal/engine/strict_containers_7014_test.go`

- **Fires**: one leg per container, plus a leg putting `package_json_deps` itself into an executable position. Each asserts the file is absent from `rules` **and** from `rep.Loaded` (not merely that a failure was recorded), and that the failure names the file, the key and the container.
- **Boundary**: five real metadata shapes — top-level `category`/`github_stars_2025`/`notes`, a misspelled top-level container, `detection_signals.package_json_deps`, unmodelled keys under `frameworks` and under `frameworks.detection` — must all still load, with their modelled fields intact. This is the scoping decision; without it the next tidy-up extends the guard and turns 254 files red.
- **0-red as a test**: all 520 embedded rule files still load, zero failures.

### Vacuity — which of the five no-op modes each assertion closes

A scan-and-assert-absence guard has five independent ways to be a no-op and a count floor closes only the first:

1. *inspects no files* → candidate floor (`>= expectedMinRuleFiles`).
2. *inspects files but never reaches the containers* → **entry floor**: the real tree must yield >= 350 executable-container entries (currently **562** = 329 `source_patterns` + 155 `file_conventions` + 78 `relationship_rules`; an earlier revision of that comment said "~445 … 38 file_conventions" — 38 is the audit's *file* count, not the entry count, and is corrected). Those entries exist only because the strict `UnmarshalYAML` built them — it is the only decode path into these types — so a guard off the real decode path cannot produce them.
3. *reaches them but does not detect a bad key* → the four positive-control legs.
4. *detects but does not act* → asserting absence from `rules` and `rep.Loaded`, not just a recorded failure.
5. *acts, but the assertion is too broad* → asserting the exact key name and file path, plus the boundary test asserting the guard does **not** fire outside the three containers.

## Recorded, deliberately not fixed here

- **The reflection walk is `t.Field(i)` only**, so an embedded / `,inline` field would allow the embedded type's lowercased *name* while rejecting the keys yaml.v3 actually inlines. Nothing is embedded in the three structs today, and it **fails closed** — rule files go red, nothing is silently accepted, and `Test7014_AllEmbeddedRuleFilesStillLoad` reddens CI before it could ship. A landmine for whoever adds an embedded struct, not a hazard now; named in a comment at the walk.
- **A YAML merge key (`<<: *base`) inside a guarded entry is now rejected**, because `<<` is not a modelled field name. **Zero** rule files use one today. Recording it so the first person to hit it knows it was a decision, not an oversight.
- **YAML aliases are checked correctly** — this is the non-obvious half. An aliased entry is resolved before the guard sees it, so a typo reached through an alias *does* fire; the reviewer verified this directly.

## Mutants

Scored in a **separate checkout** (`.../impl-7014b-q9z3m/mut`, detached at `353753a31` + these three files) so the verification tree was never mutated; green baseline immediately before each score, `go vet` first, `-count=1`, each edit applied by a script that **asserts an exact occurrence count of 1** and prints `APPLIED`, restored by `cp` from a shasum-verified backup (never `git checkout --`). `git diff --stat` back to the single intended test-file change after every leg.

| mutant | result |
|---|---|
| drop strictness from `source_patterns` only | **DEAD** — `.../source_patterns_typo` + `.../unmodelled_metadata_key_inside_source_patterns`; the other two legs stayed green, so the legs are independent |
| drop strictness from `relationship_rules` only | **DEAD** — `.../relationship_rules_typo` only |
| drop strictness from `file_conventions` only | **DEAD** — `.../file_conventions_typo` only |
| make the guard vacuous (`rejectUnknownContainerKeys` returns nil before the check) | **DEAD** — all four positive-control legs |
| extend the guard to the top level (`FrameworkRule.UnmarshalYAML`) | **DEAD, loudly** — the boundary test fails on 3 legs *and* `Test7014_AllEmbeddedRuleFilesStillLoad` reports **247 real rule files RED**, **247** real rule files RED. This is the boundary assertion doing its job. |
| **case-insensitive key matching** (`allowed[key]` → `allowed[strings.ToLower(key)]`) | **DEAD** — `.../case_variant_of_a_real_key`, and *only* that leg, so the kill is precisely attributed. Was **ALIVE** on the first revision: the case sensitivity was documented and ungraded, and a future edit lowercasing keys "helpfully" would have accepted `Name_Group` / `Source_Group` — a widening in exactly the direction this guard exists to prevent. Graded now, in both directions: the variant is rejected **and** the exactly-spelled key still decodes (`NameGroup == 1`) in the same run, so a guard that rejected both would not pass. |
| take the strict decoder off the real decode path (loader nils the three containers after unmarshal) | **DEAD** — entry floor: `produced only 0 executable-container entries ... want >= 350`. This is vacuity mode 2, which the candidate floor alone does not close. |

### 247 vs 254 — different populations, both correct

Review settled this: **247** = files carrying an unmodelled top-level key, which is the cost of extending the guard to the top level and is this PR's figure. **254** = files with no top-level `frameworks:` key at all (520 − 266). The gap is exactly 7 files that have neither — `go/frameworks/{echo,gin,chi,fiber,gorm}.yaml`, `ruby/frameworks/{sidekiq,rspec}.yaml` — pure `source_patterns`/`file_conventions` files. The audit's §4 table labels 254 as the allowlist cost; that label is the error, and #7014/#7013 are being corrected to carry **247**.

## Verification

Tree measured: `/private/tmp/claude-501/-Users-jorgecajas-Projects-archigraph/c0fefed4-0195-4c81-9a94-07a7145710a4/scratchpad/impl-7014b-q9z3m/wt`, branch `lane/7014-strict-containers` off `353753a31`. macOS 25.6.0 / arm64. All `go test` runs `-count=1`; `go vet ./internal/engine/` clean; `gofmt -l` empty.

- `go test -count=1 ./internal/engine/` — **ok** (43.6s)
- `go test -count=1 ./cmd/grafel/ ./internal/quality/` with a **fresh `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`** — **ok** (176.5s / 34.0s)
- `scripts/quality/run.sh --runs 1 --ratchet` — **exit 0**, `quality ratchet OK — 38 gated fixtures held their baseline (29 at 100% must-have recall)`. **No baseline moved in either direction**, which is the check that matters here: a loader change that shifted extraction output would mean a rule stopped loading.

Review round (case-sensitivity leg, the reflection-walk and merge-key comments, and the floor-comment arithmetic): `go vet` clean, `gofmt -l` empty, `go test -count=1 ./internal/engine/` **ok** (51.7s). `./cmd/grafel/` and the ratchet were **not** re-run and do not need to be — the change is the strict decoder, its tests and comments, and the loaded rule set is byte-identical to the pre-guard decode, so neither can move. The reviewer independently ran both green at `5d09def56` (`./cmd/grafel/` 155.5s, `./internal/quality/` 34.6s, ratchet `exit 0`, 38 gated fixtures held).

Independently re-measured the 0-red claim before building, with a throwaway program outside the repo: **520 loader-scoped rule files, 0 red**. The test now reports the same from inside: `0 red: 520/520 rule files loaded, 562 executable-container entries decoded strictly`.

Refs #7014, #7013, #7007, #6916.
