### PR TITLE
fix(#6916): Tier A — 8 `Config` rules named their entity after the whole regex match, so a file with two routers had one node

### DIFF
--- a/cmd/grafel/custom_extractor_spans_6118_test.go
+++ b/cmd/grafel/custom_extractor_spans_6118_test.go
@@ -734,6 +734,37 @@ const (
 	// components, the two /orders endpoints, the six C# hierarchy edges and the
 	// language histogram above are all unchanged.
 	gateOffDigest6809 = "acfd2bc242dc7eadee89bf94de824776d5e8fc8c60078397e569d86ba3ebeb4d"
+	// gateOffDigest6916 is the current pin. #6916 Tier A narrowed eight `Config`
+	// source_patterns from `name_group: 0` — the entity Name was the whole regex
+	// match — to the ASSIGNED VARIABLE. One of the eight is axum's
+	// `Router::new()`, and this fixture's rs/routes.rs builds its router as an
+	// unassigned expression:
+	//
+	//	pub fn app() -> Router {
+	//	    Router::new().route("/items", get(list_items))
+	//	}
+	//
+	// With no variable there is no name to give the entity, so it is no longer
+	// minted. The delta is 141/283 -> 140/282, enumerated member by member (the
+	// gate-OFF entity+relationship sets dumped before and after and diffed; NOT
+	// derived from the counts):
+	//
+	//	-E Config "Router::new()" rs/routes.rs
+	//	     the marker node itself. Its Name was the matched text, so nothing
+	//	     could ever reference it: no relationship in this fixture had it as
+	//	     an endpoint, before or after.
+	//	-R Module:span6918 -[CONTAINS]-> Config:"Router::new()"
+	//	     the module containment edge carrying the entity above; it goes with
+	//	     it, and it was the ONLY edge incident on it.
+	//
+	// That is the whole delta: a marker with no referent plus its own
+	// containment. Every positioned entity, both /orders endpoints, the six C#
+	// hierarchy edges and the language histogram are unchanged. The loss is the
+	// deliberate cost recorded on #6916 — six unassigned shapes were measured on
+	// the Tier B arm and every one lost only a marker with no edge to anchor —
+	// and it is pinned in internal/engine by
+	// TestIssue6916_TierAUnassignedConstructionMintsNoConfig.
+	gateOffDigest6916 = "9415edfea35f8254755f3b0e8505b01e43706918f201bc473d6c5fd0283537a5"
 )
 
 func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
@@ -741,8 +772,16 @@ func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
 	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
 	off := persistAndReload(t, runIndexerOn(t, fixture, "span6118", nil))
 	got := semanticDigest6118(off)
-	if got == gateOffDigest6809 {
+	if got == gateOffDigest6916 {
 		return
+	}
+	if got == gateOffDigest6809 {
+		t.Fatalf("gate-OFF graph reverted to the pre-#6916 baseline — an axum " +
+			"`Router::new()` with no assignment is minting a `Config` entity named " +
+			"after the whole regex match again. rs/routes.rs returns the router as a " +
+			"bare expression, so there is no variable to name it after; check that " +
+			"rust/frameworks/axum.yaml still anchors its Config pattern on a `let` " +
+			"binding and still uses name_group 1")
 	}
 	if got == gateOffDigest6862 {
 		t.Fatalf("gate-OFF graph reverted to the pre-#6809 baseline — a relationship_rule " +
@@ -793,8 +832,8 @@ func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
 		t.Fatalf("gate-OFF graph reverted to the pre-fix 2f0175dfc baseline — the #6118 " +
 			"span donation is no longer reaching the default path")
 	}
-	t.Fatalf("gate-OFF graph changed against ALL pinned digests\n got  %s\n post-#6809 %s\n post-#6862 %s\n post-#6742 %s\n post-#6601 %s\n post-#6485 %s\n post-#6152 %s\n post-#6138 %s\n post-#6118 %s\n 2f0175dfc %s\n"+
-		"(entities=%d relationships=%d)", got, gateOffDigest6809, gateOffDigest6862,
+	t.Fatalf("gate-OFF graph changed against ALL pinned digests\n got  %s\n post-#6916 %s\n post-#6809 %s\n post-#6862 %s\n post-#6742 %s\n post-#6601 %s\n post-#6485 %s\n post-#6152 %s\n post-#6138 %s\n post-#6118 %s\n 2f0175dfc %s\n"+
+		"(entities=%d relationships=%d)", got, gateOffDigest6916, gateOffDigest6809, gateOffDigest6862,
 		gateOffDigest6742, gateOffDigest6601, gateOffDigest6485, gateOffDigest6152,
 		gateOffDigest6138, gateOffDigest6118, gateOffDigest6118Base,
 		len(off.Entities), len(off.Relationships))
@@ -924,9 +963,16 @@ func TestCustomExtractorGateOffDeltaIsExactlyTheDocumentedSpanGain(t *testing.T)
 	// `Response` stub plus its Module:_external CONTAINS edge, which existed
 	// only to terminate that third one. Nothing that came out of a file was
 	// removed, which is why the file-component positions below are untouched.
+	//
+	// Then #6916 Tier A narrowed axum's `Config` pattern to the assigned variable
+	// (141/283 -> 140/282). rs/routes.rs builds its router as an unassigned
+	// expression, so the marker entity `Config:"Router::new()"` and the single
+	// Module CONTAINS edge that carried it are gone — enumerated member by member
+	// in the gateOffDigest6916 comment. Nothing that came out of a file was
+	// removed, so the file-component positions below are again untouched.
 	const (
-		wantEntities = 141
-		wantRels     = 283
+		wantEntities = 140
+		wantRels     = 282
 	)
 	if len(off.Entities) != wantEntities || len(off.Relationships) != wantRels {
 		t.Fatalf("gate-OFF graph size moved: entities=%d (want %d) relationships=%d (want %d) — "+

--- a/internal/engine/rules/csharp/frameworks/asp_net_core.yaml
+++ b/internal/engine/rules/csharp/frameworks/asp_net_core.yaml
@@ -87,9 +87,18 @@ source_patterns:
     scope: file
 
   # WebApplication.CreateBuilder(...) entry point
-  - pattern: "WebApplication\\.CreateBuilder\\s*\\("
+  # Named after the ASSIGNED VARIABLE (#6916): var builder = WebApplication.CreateBuilder(...)
+  # name_group 0 named this entity "WebApplication.CreateBuilder(" — a marker string with a trailing
+  # paren that no edge could bind to, one per FILE.
+  #
+  # The `(?m)^[ \\t]*` ANCHOR is load-bearing and graded: unanchored, the capture is
+  # just "the token left of the `=`", which is reachable from a commented-out
+  # example line. `(?:[\\w.<>\\[\\]]+\\s+)?` is the declarator/TYPE slot, so both
+  # `var builder =` and `WebApplicationBuilder builder =` name `builder` and neither
+  # names the type; `(?:\\w+\\.)?` keeps `this.builder =` naming `builder`.
+  - pattern: "(?m)^[ \\t]*(?:[\\w.<>\\[\\]]+\\s+)?(?:\\w+\\.)?(\\w+)\\s*=\\s*WebApplication\\.CreateBuilder\\s*\\("
     entity_type: Config
-    name_group: 0
+    name_group: 1
     scope: file
 
   # builder.Services.AddXxx(...) — DI service registration

--- a/internal/engine/rules/csharp/frameworks/net_maui.yaml
+++ b/internal/engine/rules/csharp/frameworks/net_maui.yaml
@@ -121,9 +121,18 @@ source_patterns:
     scope: file
 
   # MauiApp.CreateBuilder() — app entry point
-  - pattern: "MauiApp\\.CreateBuilder\\s*\\("
+  # Named after the ASSIGNED VARIABLE (#6916): var builder = MauiApp.CreateBuilder(...)
+  # name_group 0 named this entity "MauiApp.CreateBuilder(" — a marker string with a trailing
+  # paren that no edge could bind to, one per FILE.
+  #
+  # The `(?m)^[ \\t]*` ANCHOR is load-bearing and graded: unanchored, the capture is
+  # just "the token left of the `=`", which is reachable from a commented-out
+  # example line. `(?:[\\w.<>\\[\\]]+\\s+)?` is the declarator/TYPE slot, so both
+  # `var builder =` and `MauiAppBuilder builder =` name `builder` and neither
+  # names the type; `(?:\\w+\\.)?` keeps `this.builder =` naming `builder`.
+  - pattern: "(?m)^[ \\t]*(?:[\\w.<>\\[\\]]+\\s+)?(?:\\w+\\.)?(\\w+)\\s*=\\s*MauiApp\\.CreateBuilder\\s*\\("
     entity_type: Config
-    name_group: 0
+    name_group: 1
     scope: file
 
   # .UseMauiApp<TApp>() — application class registration

--- a/internal/engine/rules/go/frameworks/chi.yaml
+++ b/internal/engine/rules/go/frameworks/chi.yaml
@@ -36,9 +36,23 @@ source_patterns:
     scope: file
 
   # chi.NewRouter() init
-  - pattern: 'chi\.NewRouter\s*\(\s*\)'
+  # chi.NewRouter() init, named after the ASSIGNED VARIABLE (#6916): r := chi.NewRouter()
+  # name_group 0 named this entity "chi.NewRouter()" — a marker string, one per FILE, that no
+  # edge could ever bind to. Naming the variable is also what makes a PER-ROUTER
+  # anchor possible (#6914): a file building two routers now mints two entities.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded. Without it the capture is
+  # just "the token left of the `=`", which in Go is reached from inside comments
+  # and doc examples — `// r := chi.NewRouter()` would mint a plausible-looking
+  # `Config:r` in a file that builds no router at all. `(?:\w+\.)?` keeps
+  # `s.router = chi.NewRouter()` naming `router` rather than `s`; the optional
+  # `var` + type group is what lets `var r *chi.Mux = chi.NewRouter()` match at all.
+  # Measured: Go puts the type AFTER the name, so deleting that group makes an
+  # explicitly typed declaration mint NOTHING — it does not capture the type the
+  # way the TypeScript sibling did (#6916 Tier B, review ask 2).
+  - pattern: '(?m)^[ \t]*(?:var\s+)?(?:\w+\.)?(\w+)(?:\s+[\w.*\[\]]+)?\s*:?=\s*chi\.NewRouter\s*\(\s*\)'
     entity_type: Config
-    name_group: 0
+    name_group: 1
     scope: file
 
 relationship_rules:

--- a/internal/engine/rules/go/frameworks/echo.yaml
+++ b/internal/engine/rules/go/frameworks/echo.yaml
@@ -30,9 +30,23 @@ source_patterns:
     scope: file
 
   # echo.New() engine init
-  - pattern: 'echo\.New\s*\(\s*\)'
+  # echo.New() engine init, named after the ASSIGNED VARIABLE (#6916): e := echo.New()
+  # name_group 0 named this entity "echo.New()" — a marker string, one per FILE, that no
+  # edge could ever bind to. Naming the variable is also what makes a PER-ROUTER
+  # anchor possible (#6914): a file building two routers now mints two entities.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded. Without it the capture is
+  # just "the token left of the `=`", which in Go is reached from inside comments
+  # and doc examples — `// r := echo.New()` would mint a plausible-looking
+  # `Config:r` in a file that builds no router at all. `(?:\w+\.)?` keeps
+  # `s.router = echo.New()` naming `router` rather than `s`; the optional
+  # `var` + type group is what lets `var r *echo.Echo = echo.New()` match at all.
+  # Measured: Go puts the type AFTER the name, so deleting that group makes an
+  # explicitly typed declaration mint NOTHING — it does not capture the type the
+  # way the TypeScript sibling did (#6916 Tier B, review ask 2).
+  - pattern: '(?m)^[ \t]*(?:var\s+)?(?:\w+\.)?(\w+)(?:\s+[\w.*\[\]]+)?\s*:?=\s*echo\.New\s*\(\s*\)'
     entity_type: Config
-    name_group: 0
+    name_group: 1
     scope: file
 
 relationship_rules:

--- a/internal/engine/rules/go/frameworks/fiber.yaml
+++ b/internal/engine/rules/go/frameworks/fiber.yaml
@@ -30,9 +30,23 @@ source_patterns:
     scope: file
 
   # fiber.New() app init
-  - pattern: 'fiber\.New\s*\(\s*\)'
+  # fiber.New() app init, named after the ASSIGNED VARIABLE (#6916): app := fiber.New()
+  # name_group 0 named this entity "fiber.New()" — a marker string, one per FILE, that no
+  # edge could ever bind to. Naming the variable is also what makes a PER-ROUTER
+  # anchor possible (#6914): a file building two routers now mints two entities.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded. Without it the capture is
+  # just "the token left of the `=`", which in Go is reached from inside comments
+  # and doc examples — `// r := fiber.New()` would mint a plausible-looking
+  # `Config:r` in a file that builds no router at all. `(?:\w+\.)?` keeps
+  # `s.router = fiber.New()` naming `router` rather than `s`; the optional
+  # `var` + type group is what lets `var r *fiber.App = fiber.New()` match at all.
+  # Measured: Go puts the type AFTER the name, so deleting that group makes an
+  # explicitly typed declaration mint NOTHING — it does not capture the type the
+  # way the TypeScript sibling did (#6916 Tier B, review ask 2).
+  - pattern: '(?m)^[ \t]*(?:var\s+)?(?:\w+\.)?(\w+)(?:\s+[\w.*\[\]]+)?\s*:?=\s*fiber\.New\s*\(\s*\)'
     entity_type: Config
-    name_group: 0
+    name_group: 1
     scope: file
 
 relationship_rules:

--- a/internal/engine/rules/go/frameworks/gin.yaml
+++ b/internal/engine/rules/go/frameworks/gin.yaml
@@ -30,9 +30,23 @@ source_patterns:
     scope: file
 
   # gin.Default() or gin.New() engine init
-  - pattern: '(?:gin\.Default|gin\.New)\s*\(\s*\)'
+  # gin.Default() / gin.New() engine init, named after the ASSIGNED VARIABLE (#6916): r := gin.Default()
+  # name_group 0 named this entity "gin.Default()" / "gin.New()" — a marker string, one per FILE, that no
+  # edge could ever bind to. Naming the variable is also what makes a PER-ROUTER
+  # anchor possible (#6914): a file building two routers now mints two entities.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded. Without it the capture is
+  # just "the token left of the `=`", which in Go is reached from inside comments
+  # and doc examples — `// r := gin.Default()` would mint a plausible-looking
+  # `Config:r` in a file that builds no router at all. `(?:\w+\.)?` keeps
+  # `s.router = gin.Default()` naming `router` rather than `s`; the optional
+  # `var` + type group is what lets `var r *gin.Engine = gin.Default()` match at all.
+  # Measured: Go puts the type AFTER the name, so deleting that group makes an
+  # explicitly typed declaration mint NOTHING — it does not capture the type the
+  # way the TypeScript sibling did (#6916 Tier B, review ask 2).
+  - pattern: '(?m)^[ \t]*(?:var\s+)?(?:\w+\.)?(\w+)(?:\s+[\w.*\[\]]+)?\s*:?=\s*(?:gin\.Default|gin\.New)\s*\(\s*\)'
     entity_type: Config
-    name_group: 0
+    name_group: 1
     scope: file
 
 relationship_rules:

--- a/internal/engine/rules/go/frameworks/gorm.yaml
+++ b/internal/engine/rules/go/frameworks/gorm.yaml
@@ -12,9 +12,37 @@ source_patterns:
     scope: file
 
   # DB connection: gorm.Open(...)
-  - pattern: 'gorm\.Open\s*\('
+  # DB connection: gorm.Open(...), named after the ASSIGNED VARIABLE (#6916): db, err := gorm.Open(...)
+  # name_group 0 named this entity "gorm.Open(" — a marker string, one per FILE,
+  # that no edge could ever bind to. Naming the variable is also what makes a
+  # per-CONNECTION anchor possible (#6914): a file opening two databases now
+  # mints two entities instead of one.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded. Without it the capture is
+  # just "the token left of the `=`", which in Go is reached from inside comments
+  # and doc examples — `// db := gorm.Open(dsn)` would mint a plausible-looking
+  # `Config:db` in a file that opens no database at all. `(?:\w+\.)?` keeps
+  # `s.db = gorm.Open(...)` naming `db` rather than `s`; the optional
+  # `var` + type group is what lets `var db *gorm.DB = gorm.Open(...)` match at all.
+  # Measured: Go puts the type AFTER the name, so deleting that group makes an
+  # explicitly typed declaration mint NOTHING — it does not capture the type the
+  # way the TypeScript sibling did (#6916 Tier B, review ask 2).
+  #
+  # gorm.Open returns (*gorm.DB, error), so `db, err := gorm.Open(...)` is THE
+  # idiom and `(?:\s*,\s*[\w.]+)*` is here to let it through naming `db`. Go's
+  # multi-return is positional — the first name is the first return — so unlike
+  # Python's `app, env = App(), "prod"` this comma list can be read safely.
+  #
+  # MEASURED, and the reason this site is not a copy of the Tier B template: with
+  # the comma list absent AND no anchor — i.e. the Tier B Python pattern ported
+  # verbatim — this line mints `Config:err`. The ERROR value, named as though it
+  # were the database: identifier-shaped, so it reads as a real answer. That is
+  # the Tier B blocker shape (#6369) in Go. The two groups cover different halves
+  # of it and are graded separately: the comma list by this line, the anchor by a
+  # commented-out `// db := gorm.Open(dsn)`.
+  - pattern: '(?m)^[ \t]*(?:var\s+)?(?:\w+\.)?(\w+)(?:\s*,\s*[\w.]+)*(?:\s+[\w.*\[\]]+)?\s*:?=\s*gorm\.Open\s*\('
     entity_type: Config
-    name_group: 0
+    name_group: 1
     scope: file
 
   # AutoMigrate: db.AutoMigrate(&User{})

--- a/internal/engine/rules/rust/frameworks/axum.yaml
+++ b/internal/engine/rules/rust/frameworks/axum.yaml
@@ -79,9 +79,21 @@ source_patterns:
     scope: function
 
   # Router::new() — application / sub-router entry point
-  - pattern: "Router\\s*::\\s*new\\s*\\(\\s*\\)"
+  # Named after the ASSIGNED VARIABLE (#6916): let app = Router::new()
+  # name_group 0 named this entity "Router::new()" — one marker per FILE that no
+  # edge could bind to. Naming the binding is what makes a per-router anchor
+  # possible (#6914); actix's sibling shape measured 83 constructions -> 73 nodes.
+  #
+  # The `(?m)^[ \\t]*let` ANCHOR is load-bearing and graded: unanchored, the old
+  # pattern also matched inside comments and — worse — as a SUBSTRING of another
+  # type, so `MyRouter::new()` minted a Config in a crate with no axum at all.
+  # `(?:\\s*:\\s*[\\w:<>, ]+)?` is what lets `let app: Router = Router::new()` match
+  # at all. Measured: Rust puts the type AFTER the name, so deleting that group makes
+  # an annotated binding mint NOTHING rather than capture the type.
+  # A `let (app, env) = (Router::new(), "prod")` tuple binding mints nothing.
+  - pattern: "(?m)^[ \\t]*let\\s+(?:mut\\s+)?(\\w+)(?:\\s*:\\s*[\\w:<>, ]+)?\\s*=\\s*Router\\s*::\\s*new\\s*\\(\\s*\\)"
     entity_type: Config
-    name_group: 0
+    name_group: 1
     scope: file
 
   # .nest("/prefix", sub_router) — sub-router nesting

--- a/internal/engine/tier_a_config_variable_6916_test.go
+++ b/internal/engine/tier_a_config_variable_6916_test.go
@@ -1,0 +1,1340 @@
+package engine
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// #6916 Tier A — the eight `Config` source_patterns whose construction is
+// assigned to a variable on the same line:
+//
+//	go/frameworks/chi.yaml:39        chi.NewRouter()
+//	go/frameworks/echo.yaml:33       echo.New()
+//	go/frameworks/fiber.yaml:33      fiber.New()
+//	go/frameworks/gin.yaml:33        gin.Default() / gin.New()
+//	go/frameworks/gorm.yaml:15       gorm.Open(...)
+//	rust/frameworks/axum.yaml:82     Router::new()
+//	csharp/frameworks/asp_net_core.yaml:90  WebApplication.CreateBuilder(...)
+//	csharp/frameworks/net_maui.yaml:124     MauiApp.CreateBuilder()
+//
+// All eight used `name_group: 0`, so the entity Name was the whole regex match
+// — `"gin.Default()"`, `"WebApplication.CreateBuilder("`. Those are marker
+// nodes naming a call site, not a thing: nothing can bind to them, and because
+// the scope is `file` a file constructing several routers collapsed to ONE.
+// Measured on the corpus: chi 50 `chi.NewRouter()` -> 30 Config entities;
+// actix's sibling shape 83 -> 73.
+//
+// Naming the entity after the ASSIGNED VARIABLE is what makes a per-router
+// anchor possible (#6914) — `api := r.Group("/api")` can hang off `api` rather
+// than off a single per-file marker.
+//
+// These tests follow the Tier B (aws_cdk) template proven in PR #7015, which
+// found three defects on two sites. All three of its cases are carried here,
+// PER LANGUAGE, because Tier B measured its Python mutant ALIVE after the JS
+// axis was fully graded:
+//
+//  1. the unanchored capture (Tier B's blocker: a WRONG name, not a missing one),
+//  2. the type-annotated declaration (which captured the TYPE),
+//  3. the over-firing negative (every Tier B mutant moved the rule in the
+//     restrictive direction; the permissive one was ungraded).
+//
+// Note the interaction, which is why case 3 matters more after this change than
+// before it: making the Name useful also makes an over-firing hit HARDER to
+// spot. A junk entity called `gin.Default()` is visibly a marker; one called
+// `r` reads as a real router. These land in `Config`, which #7013 measures at
+// 60.5% polluted.
+//
+// Assertions are on the ARTEFACT — the emitted `<Kind>:<Name>` set — never on a
+// count, and every absence assertion carries a positive control.
+
+// tierA6916Site is one rule site. Every fixture for a site is written so the
+// ONLY difference between a leg and its control is the token under test.
+type tierA6916Site struct {
+	rule string // rule file:line, so a failure names the site to edit
+	lang string
+	path string
+
+	// marker is the Name the shipped `name_group: 0` produced. It must never
+	// come back.
+	marker string
+
+	// control is a non-Config entity every fixture below emits. Without it the
+	// absence assertions could pass on a fixture that stopped producing
+	// anything at all.
+	control string
+
+	// twoVars constructs the framework object TWICE, bound to `first` and
+	// `second`. Empty where a second construction in one file is not idiomatic.
+	twoVars       string
+	first, second string
+
+	// annotated declares the variable with an explicit type. Must still name
+	// the VARIABLE; naming `want` proves the annotation slot is not swallowing
+	// the capture.
+	annotated     string
+	annotatedWant string
+
+	// commented is the same construction inside a line comment: the shape that
+	// grades the `(?m)^[ \t]*` anchor. Must mint no Config.
+	// commentedCtl is the SAME file with the comment marker removed.
+	commented     string
+	commentedCtl  string
+	commentedWant string
+
+	// nonFramework spells the same call against another package/type; it must
+	// mint nothing. nonFrameworkCtl is the same file with the framework
+	// spelling restored.
+	nonFramework     string
+	nonFrameworkCtl  string
+	nonFrameworkWant string
+
+	// reassigned rebinds an EXISTING variable with no `let`. Only axum carries
+	// one: its pattern requires the declaration keyword, and this is the shape
+	// that grades that requirement. Must mint no Config.
+	reassigned string
+
+	// unassigned constructs the object with no binding at all — the deliberate
+	// cost of anchoring on the assignment. Must mint no Config.
+	unassigned string
+
+	// qualifier is the package/type prefix on the constructor — `chi.`,
+	// `WebApplication.`. Deleting it from nonFrameworkCtl yields the BARE call,
+	// which must mint nothing: see
+	// TestIssue6916_TierABareConstructorCallMintsNoConfig. Empty for axum,
+	// whose qualifier is the type itself (`Router::new()`); removing it leaves
+	// `::new()`, which is not Rust, so its over-firing leg is the
+	// `MyRouter::new()` substring instead.
+	qualifier string
+
+	// fieldTarget assigns the construction to a FIELD rather than to a local,
+	// which is what the `(?:\w+\.)?` receiver prefix is for: the entity must be
+	// named after the field, not after the receiver and not `recv.field`. Empty
+	// for rust, whose pattern has no such prefix (it requires a `let` binding).
+	fieldTarget     string
+	fieldTargetWant string
+}
+
+// tierA6916Sites is the whole tier. Fixtures are grouped by site rather than by
+// case so that a site's positive, its controls and its negatives are read
+// together — the Tier B review found two of its three defects by reading a
+// fixture body against the claim its name made.
+var tierA6916Sites = []tierA6916Site{
+	{
+		rule:      "go/frameworks/chi.yaml:39",
+		qualifier: "chi.",
+		lang:      "go",
+		path:      "main.go",
+		marker:    "chi.NewRouter()",
+		control:   "listUsers",
+		twoVars: `package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func listUsers(w http.ResponseWriter, r *http.Request) {}
+
+func main() {
+	r := chi.NewRouter()
+	api := chi.NewRouter()
+	r.Mount("/api", api)
+}
+`,
+		first: "r", second: "api",
+		annotated: `package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func listUsers(w http.ResponseWriter, r *http.Request) {}
+
+var mux *chi.Mux = chi.NewRouter()
+`,
+		annotatedWant: "mux",
+		commented: `package main
+
+import "net/http"
+
+func listUsers(w http.ResponseWriter, r *http.Request) {}
+
+// Historically this file built its own router:
+//	r := chi.NewRouter()
+`,
+		commentedCtl: `package main
+
+import "net/http"
+
+func listUsers(w http.ResponseWriter, r *http.Request) {}
+
+// Historically this file built its own router:
+r := chi.NewRouter()
+`,
+		commentedWant: "r",
+		nonFramework: `package main
+
+import (
+	"net/http"
+
+	"example.com/app/router"
+)
+
+func listUsers(w http.ResponseWriter, r *http.Request) {}
+
+func main() {
+	r := router.NewRouter()
+	_ = r
+}
+`,
+		nonFrameworkCtl: `package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func listUsers(w http.ResponseWriter, r *http.Request) {}
+
+func main() {
+	r := chi.NewRouter()
+	_ = r
+}
+`,
+		nonFrameworkWant: "r",
+		unassigned: `package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func listUsers(w http.ResponseWriter, r *http.Request) {}
+
+func main() {
+	http.ListenAndServe(":8080", chi.NewRouter())
+}
+`,
+		fieldTarget: `package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func listUsers(w http.ResponseWriter, r *http.Request) {}
+
+func (s *Server) setup() {
+	s.router = chi.NewRouter()
+}
+`,
+		fieldTargetWant: "router",
+	},
+	{
+		rule:      "go/frameworks/echo.yaml:33",
+		qualifier: "echo.",
+		lang:      "go",
+		path:      "main.go",
+		marker:    "echo.New()",
+		control:   "listUsers",
+		twoVars: `package main
+
+import "github.com/labstack/echo/v4"
+
+func listUsers(c echo.Context) error { return nil }
+
+func main() {
+	e := echo.New()
+	admin := echo.New()
+	_, _ = e, admin
+}
+`,
+		first: "e", second: "admin",
+		annotated: `package main
+
+import "github.com/labstack/echo/v4"
+
+func listUsers(c echo.Context) error { return nil }
+
+var srv *echo.Echo = echo.New()
+`,
+		annotatedWant: "srv",
+		commented: `package main
+
+import "github.com/labstack/echo/v4"
+
+func listUsers(c echo.Context) error { return nil }
+
+// Example from the README:
+//	e := echo.New()
+`,
+		commentedCtl: `package main
+
+import "github.com/labstack/echo/v4"
+
+func listUsers(c echo.Context) error { return nil }
+
+// Example from the README:
+e := echo.New()
+`,
+		commentedWant: "e",
+		nonFramework: `package main
+
+import (
+	"example.com/app/engine"
+	"github.com/labstack/echo/v4"
+)
+
+func listUsers(c echo.Context) error { return nil }
+
+func main() {
+	e := engine.New()
+	_ = e
+}
+`,
+		nonFrameworkCtl: `package main
+
+import (
+	"example.com/app/engine"
+	"github.com/labstack/echo/v4"
+)
+
+func listUsers(c echo.Context) error { return nil }
+
+func main() {
+	e := echo.New()
+	_ = e
+}
+`,
+		nonFrameworkWant: "e",
+		unassigned: `package main
+
+import "github.com/labstack/echo/v4"
+
+func listUsers(c echo.Context) error { return nil }
+
+func main() {
+	serve(echo.New())
+}
+`,
+		fieldTarget: `package main
+
+import "github.com/labstack/echo/v4"
+
+func listUsers(c echo.Context) error { return nil }
+
+func (s *Server) setup() {
+	s.engine = echo.New()
+}
+`,
+		fieldTargetWant: "engine",
+	},
+	{
+		rule:      "go/frameworks/fiber.yaml:33",
+		qualifier: "fiber.",
+		lang:      "go",
+		path:      "main.go",
+		marker:    "fiber.New()",
+		control:   "listUsers",
+		twoVars: `package main
+
+import "github.com/gofiber/fiber/v2"
+
+func listUsers(c *fiber.Ctx) error { return nil }
+
+func main() {
+	app := fiber.New()
+	metrics := fiber.New()
+	app.Mount("/metrics", metrics)
+}
+`,
+		first: "app", second: "metrics",
+		annotated: `package main
+
+import "github.com/gofiber/fiber/v2"
+
+func listUsers(c *fiber.Ctx) error { return nil }
+
+var app *fiber.App = fiber.New()
+`,
+		annotatedWant: "app",
+		commented: `package main
+
+import "github.com/gofiber/fiber/v2"
+
+func listUsers(c *fiber.Ctx) error { return nil }
+
+// Quickstart:
+//	app := fiber.New()
+`,
+		commentedCtl: `package main
+
+import "github.com/gofiber/fiber/v2"
+
+func listUsers(c *fiber.Ctx) error { return nil }
+
+// Quickstart:
+app := fiber.New()
+`,
+		commentedWant: "app",
+		nonFramework: `package main
+
+import (
+	"example.com/app/builder"
+	"github.com/gofiber/fiber/v2"
+)
+
+func listUsers(c *fiber.Ctx) error { return nil }
+
+func main() {
+	app := builder.New()
+	_ = app
+}
+`,
+		nonFrameworkCtl: `package main
+
+import (
+	"example.com/app/builder"
+	"github.com/gofiber/fiber/v2"
+)
+
+func listUsers(c *fiber.Ctx) error { return nil }
+
+func main() {
+	app := fiber.New()
+	_ = app
+}
+`,
+		nonFrameworkWant: "app",
+		unassigned: `package main
+
+import "github.com/gofiber/fiber/v2"
+
+func listUsers(c *fiber.Ctx) error { return nil }
+
+func main() {
+	serve(fiber.New())
+}
+`,
+		fieldTarget: `package main
+
+import "github.com/gofiber/fiber/v2"
+
+func listUsers(c *fiber.Ctx) error { return nil }
+
+func (s *Server) setup() {
+	s.app = fiber.New()
+}
+`,
+		fieldTargetWant: "app",
+	},
+	{
+		rule:      "go/frameworks/gin.yaml:33",
+		qualifier: "gin.",
+		lang:      "go",
+		path:      "main.go",
+		marker:    "gin.Default()",
+		control:   "listUsers",
+		// The #6914 shape verbatim: `api := r.Group("/api")` needs `r` to be a
+		// named entity before it can hang off anything.
+		twoVars: `package main
+
+import "github.com/gin-gonic/gin"
+
+func listUsers(c *gin.Context) {}
+
+func main() {
+	r := gin.Default()
+	admin := gin.New()
+	r.GET("/users", listUsers)
+	_ = admin
+}
+`,
+		first: "r", second: "admin",
+		annotated: `package main
+
+import "github.com/gin-gonic/gin"
+
+func listUsers(c *gin.Context) {}
+
+var engine *gin.Engine = gin.Default()
+`,
+		annotatedWant: "engine",
+		commented: `package main
+
+import "github.com/gin-gonic/gin"
+
+func listUsers(c *gin.Context) {}
+
+// The default engine ships with Logger and Recovery:
+//	r := gin.Default()
+`,
+		commentedCtl: `package main
+
+import "github.com/gin-gonic/gin"
+
+func listUsers(c *gin.Context) {}
+
+// The default engine ships with Logger and Recovery:
+r := gin.Default()
+`,
+		commentedWant: "r",
+		nonFramework: `package main
+
+import (
+	"example.com/app/engine"
+	"github.com/gin-gonic/gin"
+)
+
+func listUsers(c *gin.Context) {}
+
+func main() {
+	r := engine.Default()
+	_ = r
+}
+`,
+		nonFrameworkCtl: `package main
+
+import (
+	"example.com/app/engine"
+	"github.com/gin-gonic/gin"
+)
+
+func listUsers(c *gin.Context) {}
+
+func main() {
+	r := gin.Default()
+	_ = r
+}
+`,
+		nonFrameworkWant: "r",
+		unassigned: `package main
+
+import "github.com/gin-gonic/gin"
+
+func listUsers(c *gin.Context) {}
+
+func main() {
+	serve(gin.Default())
+}
+`,
+		fieldTarget: `package main
+
+import "github.com/gin-gonic/gin"
+
+func listUsers(c *gin.Context) {}
+
+func (s *Server) setup() {
+	s.engine = gin.Default()
+}
+`,
+		fieldTargetWant: "engine",
+	},
+	{
+		rule:      "go/frameworks/gorm.yaml:15",
+		qualifier: "gorm.",
+		lang:      "go",
+		path:      "db.go",
+		marker:    "gorm.Open(",
+		control:   "User",
+		twoVars: `package db
+
+import "gorm.io/gorm"
+
+type User struct {
+	gorm.Model
+	Name string
+}
+
+func open() {
+	primary, err := gorm.Open(pgDialector(), &gorm.Config{})
+	replica, err2 := gorm.Open(pgDialector(), &gorm.Config{})
+	_, _, _, _ = primary, replica, err, err2
+}
+`,
+		first: "primary", second: "replica",
+		annotated: `package db
+
+import "gorm.io/gorm"
+
+type User struct {
+	gorm.Model
+	Name string
+}
+
+var conn *gorm.DB = gorm.Open(pgDialector(), &gorm.Config{})
+`,
+		annotatedWant: "conn",
+		commented: `package db
+
+import "gorm.io/gorm"
+
+type User struct {
+	gorm.Model
+	Name string
+}
+
+// Connecting looks like this:
+//	db, err := gorm.Open(pgDialector(), &gorm.Config{})
+`,
+		commentedCtl: `package db
+
+import "gorm.io/gorm"
+
+type User struct {
+	gorm.Model
+	Name string
+}
+
+// Connecting looks like this:
+db, err := gorm.Open(pgDialector(), &gorm.Config{})
+`,
+		commentedWant: "db",
+		nonFramework: `package db
+
+import (
+	"database/sql"
+
+	"gorm.io/gorm"
+)
+
+type User struct {
+	gorm.Model
+	Name string
+}
+
+func open() {
+	db, err := sql.Open("postgres", dsn)
+	_, _ = db, err
+}
+`,
+		nonFrameworkCtl: `package db
+
+import (
+	"database/sql"
+
+	"gorm.io/gorm"
+)
+
+type User struct {
+	gorm.Model
+	Name string
+}
+
+func open() {
+	db, err := gorm.Open("postgres", dsn)
+	_, _ = db, err
+}
+`,
+		nonFrameworkWant: "db",
+		unassigned: `package db
+
+import "gorm.io/gorm"
+
+type User struct {
+	gorm.Model
+	Name string
+}
+
+func open() {
+	use(gorm.Open(pgDialector(), &gorm.Config{}))
+}
+`,
+		fieldTarget: `package db
+
+import "gorm.io/gorm"
+
+type User struct {
+	gorm.Model
+	Name string
+}
+
+func (s *Store) connect() {
+	s.conn = gorm.Open(pgDialector(), &gorm.Config{})
+}
+`,
+		fieldTargetWant: "conn",
+	},
+	{
+		rule:    "rust/frameworks/axum.yaml:82",
+		lang:    "rust",
+		path:    "src/main.rs",
+		marker:  "Router::new()",
+		control: "/health",
+		twoVars: `use axum::{routing::get, Router};
+
+async fn health() -> &'static str { "ok" }
+
+fn build() -> Router {
+    let api = Router::new();
+    let mut app = Router::new();
+    app = app.route("/health", get(health)).nest("/api", api);
+    app
+}
+`,
+		first: "api", second: "app",
+		annotated: `use axum::{routing::get, Router};
+
+async fn health() -> &'static str { "ok" }
+
+fn build() -> Router {
+    let app: Router = Router::new();
+    app.route("/health", get(health))
+}
+`,
+		annotatedWant: "app",
+		commented: `use axum::{routing::get, Router};
+
+async fn health() -> &'static str { "ok" }
+
+fn build() -> Router {
+    // let app = Router::new();
+    routes().route("/health", get(health))
+}
+`,
+		commentedCtl: `use axum::{routing::get, Router};
+
+async fn health() -> &'static str { "ok" }
+
+fn build() -> Router {
+    let app = Router::new();
+    routes().route("/health", get(health))
+}
+`,
+		commentedWant: "app",
+		// The old unanchored pattern matched `Router::new()` as a SUBSTRING of
+		// `MyRouter::new()`, minting a Config in a crate with no axum in it.
+		nonFramework: `use axum::routing::get;
+use crate::my_router::MyRouter;
+
+async fn health() -> &'static str { "ok" }
+
+fn build() {
+    let app = MyRouter::new();
+    app.route("/health", get(health));
+}
+`,
+		nonFrameworkCtl: `use axum::routing::get;
+use axum::Router;
+
+async fn health() -> &'static str { "ok" }
+
+fn build() {
+    let app = Router::new();
+    app.route("/health", get(health));
+}
+`,
+		nonFrameworkWant: "app",
+		unassigned: `use axum::{routing::get, Router};
+
+async fn health() -> &'static str { "ok" }
+
+fn build() -> Router {
+    Router::new().route("/health", get(health))
+}
+`,
+		reassigned: `use axum::{routing::get, Router};
+
+async fn health() -> &'static str { "ok" }
+
+fn rebuild(mut app: Router) -> Router {
+    app = Router::new();
+    app.route("/health", get(health))
+}
+`,
+	},
+	{
+		rule:      "csharp/frameworks/asp_net_core.yaml:90",
+		qualifier: "WebApplication.",
+		lang:      "csharp",
+		path:      "Program.cs",
+		marker:    "WebApplication.CreateBuilder(",
+		// app.MapGet mints Operation:"/health"; the Config rules in this file
+		// are the one under test plus none other, so "no Config" is exact.
+		control: "/health",
+		// Two builders in one C# file is legal but not idiomatic — a
+		// WebApplication has one entry point per Program.cs — so the
+		// per-variable multiplicity is graded on the six sites where a second
+		// construction is realistic, not here.
+		annotated: `var _unused = 0;
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+app.MapGet("/health", () => "ok");
+`,
+		annotatedWant: "builder",
+		commented: `// var builder = WebApplication.CreateBuilder(args);
+var app = Bootstrap();
+app.MapGet("/health", () => "ok");
+`,
+		commentedCtl: `var builder = WebApplication.CreateBuilder(args);
+var app = Bootstrap();
+app.MapGet("/health", () => "ok");
+`,
+		commentedWant: "builder",
+		nonFramework: `var builder = Host.CreateBuilder(args);
+var app = builder.Build();
+app.MapGet("/health", () => "ok");
+`,
+		nonFrameworkCtl: `var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+app.MapGet("/health", () => "ok");
+`,
+		nonFrameworkWant: "builder",
+		unassigned: `WebApplication.CreateBuilder(args).Build().Run();
+app.MapGet("/health", () => "ok");
+`,
+		fieldTarget: `public sealed class Bootstrapper
+{
+    private WebApplicationBuilder builder;
+
+    public void Setup()
+    {
+        this.builder = WebApplication.CreateBuilder(args);
+        var app = this.builder.Build();
+        app.MapGet("/health", () => "ok");
+    }
+}
+`,
+		fieldTargetWant: "builder",
+	},
+	{
+		rule:      "csharp/frameworks/net_maui.yaml:124",
+		qualifier: "MauiApp.",
+		lang:      "csharp",
+		path:      "MauiProgram.cs",
+		marker:    "MauiApp.CreateBuilder(",
+		// Routing.RegisterRoute mints Route:"orderdetail". Deliberately NOT
+		// `.UseMauiApp<App>()`, which mints a Config of its own and would make
+		// the "no Config" assertions below ambiguous.
+		control: "orderdetail",
+		annotated: `public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        MauiAppBuilder builder = MauiApp.CreateBuilder();
+        Routing.RegisterRoute("orderdetail", typeof(OrderDetailPage));
+        return builder.Build();
+    }
+}
+`,
+		annotatedWant: "builder",
+		commented: `public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        // var builder = MauiApp.CreateBuilder();
+        Routing.RegisterRoute("orderdetail", typeof(OrderDetailPage));
+        return Bootstrap();
+    }
+}
+`,
+		commentedCtl: `public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        Routing.RegisterRoute("orderdetail", typeof(OrderDetailPage));
+        return Bootstrap();
+    }
+}
+`,
+		commentedWant: "builder",
+		nonFramework: `public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = App.CreateBuilder();
+        Routing.RegisterRoute("orderdetail", typeof(OrderDetailPage));
+        return builder.Build();
+    }
+}
+`,
+		nonFrameworkCtl: `public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        Routing.RegisterRoute("orderdetail", typeof(OrderDetailPage));
+        return builder.Build();
+    }
+}
+`,
+		nonFrameworkWant: "builder",
+		unassigned: `public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        Routing.RegisterRoute("orderdetail", typeof(OrderDetailPage));
+        return MauiApp.CreateBuilder().Build();
+    }
+}
+`,
+		fieldTarget: `public sealed class Bootstrapper
+{
+    private MauiAppBuilder builder;
+
+    public void Setup()
+    {
+        this.builder = MauiApp.CreateBuilder();
+        Routing.RegisterRoute("orderdetail", typeof(OrderDetailPage));
+    }
+}
+`,
+		fieldTargetWant: "builder",
+	},
+}
+
+// configNames6916 returns the Names of every emitted Config entity.
+func configNames6916(ids []string) []string {
+	out := make([]string, 0, 2)
+	for _, id := range ids {
+		if name, ok := strings.CutPrefix(id, "Config:"); ok {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// assertControl6916 fails unless the fixture still emits its control entity, so
+// that no absence assertion in this file can pass vacuously on a fixture that
+// stopped producing anything at all.
+func assertControl6916(t *testing.T, ids []string, control string) {
+	t.Helper()
+	for _, id := range ids {
+		if _, name, ok := strings.Cut(id, ":"); ok && name == control {
+			return
+		}
+	}
+	t.Errorf("positive control missing: this fixture no longer emits an entity named %q, "+
+		"so the assertions above prove nothing. Entities:\n  %s", control, strings.Join(ids, "\n  "))
+}
+
+// TestIssue6916_TierAConfigIsNamedAfterItsVariable is the change itself: each
+// site's Config entity is named after the ASSIGNED VARIABLE, never after the
+// whole regex match.
+func TestIssue6916_TierAConfigIsNamedAfterItsVariable(t *testing.T) {
+	identifier := regexp.MustCompile(`^\w+$`)
+
+	for _, s := range tierA6916Sites {
+		t.Run(s.rule, func(t *testing.T) {
+			// Sites with a twoVars fixture are graded there; the rest use
+			// their annotated fixture, which is a single construction.
+			src, want := s.twoVars, s.first
+			if src == "" {
+				src, want = s.annotated, s.annotatedWant
+			}
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, src))
+
+			if !slices.Contains(ids, "Config:"+want) {
+				t.Errorf("%s: the Config entity is not named after its assigned variable; "+
+					"expected Config:%s among:\n  %s", s.rule, want, strings.Join(ids, "\n  "))
+			}
+			if slices.Contains(ids, "Config:"+s.marker) {
+				t.Errorf("%s: the #6916 marker Name is back: Config:%q. name_group must be the "+
+					"variable capture, not 0 (the whole match).", s.rule, s.marker)
+			}
+			for _, name := range configNames6916(ids) {
+				if !identifier.MatchString(name) {
+					t.Errorf("%s: a Config entity was minted with a non-identifier Name: %q. "+
+						"A marker string cannot be an edge endpoint — that is the whole defect.",
+						s.rule, name)
+				}
+			}
+			assertControl6916(t, ids, s.control)
+		})
+	}
+}
+
+// TestIssue6916_TierAEachConstructionGetsItsOwnEntity is the #6914 anchor, and
+// the reason this tier is worth doing at all. `scope: file` plus a constant
+// Name collapsed every construction in a file onto ONE marker node: chi's 50
+// `chi.NewRouter()` calls became 30 Config entities, and
+// `chi/middleware/throttle_test.go` built six routers and yielded one. There
+// was nothing for a per-router `Middleware REGISTERED_ON <router>` edge to
+// point at, and adding the edge rule would not have created one.
+//
+// The two C# sites are absent on purpose: a WebApplication/MauiApp builder is
+// the single entry point of its file, so a second construction there would be a
+// fixture shaped to the test rather than to the language.
+func TestIssue6916_TierAEachConstructionGetsItsOwnEntity(t *testing.T) {
+	for _, s := range tierA6916Sites {
+		if s.twoVars == "" {
+			continue
+		}
+		t.Run(s.rule, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, s.twoVars))
+			names := configNames6916(ids)
+
+			for _, want := range []string{s.first, s.second} {
+				if !slices.Contains(names, want) {
+					t.Errorf("%s: two constructions in one file must mint two entities; %q is "+
+						"missing. Config names emitted: %v", s.rule, want, names)
+				}
+			}
+			if s.first == s.second {
+				t.Fatalf("%s: fixture bug — the two variables must differ", s.rule)
+			}
+			assertControl6916(t, ids, s.control)
+		})
+	}
+}
+
+// TestIssue6916_TierAAnnotatedDeclarationNamesTheVariable is Tier B's review
+// ask 2, carried to every annotated language here. `const app: cdk.App = new
+// cdk.App()` captured the TYPE, `App`, because no fixture carried an
+// annotation. Go spells it `var mux *chi.Mux = …`, Rust `let app: Router = …`,
+// C# `WebApplicationBuilder builder = …`; each has its own slot in its own
+// pattern, so each needs its own fixture. Tier B measured its Python mutant
+// ALIVE after the JS axis was fully graded — enumerating one axis thoroughly is
+// exactly what makes its sibling look covered.
+func TestIssue6916_TierAAnnotatedDeclarationNamesTheVariable(t *testing.T) {
+	for _, s := range tierA6916Sites {
+		t.Run(s.rule, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, s.annotated))
+
+			if !slices.Contains(ids, "Config:"+s.annotatedWant) {
+				t.Errorf("%s: an explicitly typed declaration must still name the VARIABLE; "+
+					"expected Config:%s among:\n  %s", s.rule, s.annotatedWant, strings.Join(ids, "\n  "))
+			}
+			for _, name := range configNames6916(ids) {
+				if name != s.annotatedWant {
+					t.Errorf("%s: the annotation slot leaked into the capture — Config:%q. The "+
+						"type is not the entity; deleting the annotation group is what produces this.",
+						s.rule, name)
+				}
+			}
+			assertControl6916(t, ids, s.control)
+		})
+	}
+}
+
+// TestIssue6916_TierACommentedConstructionMintsNoConfig grades the
+// `(?m)^[ \t]*` ANCHOR, per language. Tier B's blocker was that an unanchored
+// capture is not "the assignment target" but "whatever token sits left of the
+// `=`" — which turned a dangling edge into one bound to the WRONG variable.
+//
+// The shape that reaches that seam differs by language. Python's was a
+// multi-target assignment; in Go, Rust and C# the production-reachable one is a
+// commented-out example line, which every real codebase carries. Unanchored,
+// `// r := chi.NewRouter()` mints `Config:r` in a file that builds no router —
+// and after this change that junk entity is called `r`, which reads as a real
+// router rather than as the visibly-broken marker it used to be.
+//
+// Each leg's control is the SAME file with the comment marker removed, so the
+// absence proves something about the anchor rather than about the fixture.
+func TestIssue6916_TierACommentedConstructionMintsNoConfig(t *testing.T) {
+	for _, s := range tierA6916Sites {
+		t.Run(s.rule, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, s.commented))
+			if names := configNames6916(ids); len(names) != 0 {
+				t.Errorf("%s: a commented-out construction minted %v. The line is a comment; "+
+					"the `(?m)^[ \\t]*` anchor is what keeps the capture off it.", s.rule, names)
+			}
+			assertControl6916(t, ids, s.control)
+
+			ctl := entityIDs6916(detect6916(t, s.path, s.lang, s.commentedCtl))
+			if !slices.Contains(ctl, "Config:"+s.commentedWant) {
+				t.Errorf("%s: positive control missing — the same file with the comment marker "+
+					"removed no longer mints Config:%s, so the absence above proves nothing about "+
+					"the comment. Entities:\n  %s", s.rule, s.commentedWant, strings.Join(ctl, "\n  "))
+			}
+		})
+	}
+}
+
+// TestIssue6916_TierAGormMultiReturnNamesTheDBNotTheError is the Go spelling of
+// Tier B's blocker, and the only site in this tier where the wrong name is
+// reachable from ordinary, idiomatic code rather than from a comment.
+//
+// `gorm.Open` returns `(*gorm.DB, error)`, so `db, err := gorm.Open(...)` is THE
+// idiom. Ported verbatim, the Tier B Python pattern — unanchored, with no comma
+// list — takes the token immediately left of the `:=` and mints `Config:err`:
+// the error value, named as though it were the database. Identifier-shaped, so
+// every other assertion in this file passes on it. Measured, not argued: that
+// compound mutant produces exactly `Config:err` here.
+//
+// The two groups cover different halves of the hazard and are graded by
+// different inputs — the comma list by THIS fixture, the anchor by the
+// commented-out construction in
+// TestIssue6916_TierACommentedConstructionMintsNoConfig. Removing the anchor
+// ALONE still names `db`, because the comma list keeps the match starting at the
+// first target; neither guard is graded by the other.
+//
+// Go's multi-return is positional — the first name is the first return — which
+// is why a comma list can be read here but not in Python, where
+// `app, env = cdk.App(), "prod"` pairs names with separate expressions.
+func TestIssue6916_TierAGormMultiReturnNamesTheDBNotTheError(t *testing.T) {
+	const src = `package db
+
+import "gorm.io/gorm"
+
+type User struct {
+	gorm.Model
+	Name string
+}
+
+func open() (*gorm.DB, error) {
+	db, err := gorm.Open(pgDialector(), &gorm.Config{})
+	return db, err
+}
+`
+	ids := entityIDs6916(detect6916(t, "db.go", "go", src))
+	names := configNames6916(ids)
+
+	if !slices.Contains(names, "db") {
+		t.Errorf("`db, err := gorm.Open(...)` must name the CONNECTION; expected Config:db "+
+			"among:\n  %s", strings.Join(ids, "\n  "))
+	}
+	if slices.Contains(names, "err") {
+		t.Errorf("the Config was named after the ERROR value: Config:err. A capture with no " +
+			"comma list takes the token left of the `:=`, which on Go's idiomatic two-value " +
+			"open is `err`. That is a confidently wrong name (#6369), not a missing one, and " +
+			"it is identifier-shaped so nothing else in this file can see it.")
+	}
+	assertControl6916(t, ids, "User")
+}
+
+// TestIssue6916_TierANonFrameworkCallMintsNoConfig grades the rule in the
+// OVER-FIRING direction — the direction every Tier B mutant missed, and the one
+// #7013 measures at 24.5% of framework entities landing in repos that do not
+// use the framework (Config specifically at 60.5%).
+//
+// Each leg is the same file as its control except for the qualifier on the
+// constructor. Two of them are pre-existing over-firing this change FIXES: the
+// old patterns were unanchored substring matches, so `MyRouter::new()` matched
+// axum's `Router\s*::\s*new` and minted a Config in a crate with no axum.
+func TestIssue6916_TierANonFrameworkCallMintsNoConfig(t *testing.T) {
+	for _, s := range tierA6916Sites {
+		t.Run(s.rule, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, s.nonFramework))
+			if names := configNames6916(ids); len(names) != 0 {
+				t.Errorf("%s: a non-framework spelling of the same call minted %v. The qualifier "+
+					"is the only thing keeping this rule off every package with a similarly named "+
+					"constructor — and the junk entity now carries a plausible variable name.",
+					s.rule, names)
+			}
+			assertControl6916(t, ids, s.control)
+
+			ctl := entityIDs6916(detect6916(t, s.path, s.lang, s.nonFrameworkCtl))
+			if !slices.Contains(ctl, "Config:"+s.nonFrameworkWant) {
+				t.Errorf("%s: positive control missing — the same file with the framework "+
+					"qualifier restored no longer mints Config:%s, so the absence above proves "+
+					"nothing about the qualifier. Entities:\n  %s",
+					s.rule, s.nonFrameworkWant, strings.Join(ctl, "\n  "))
+			}
+		})
+	}
+}
+
+// TestIssue6916_TierAUnassignedConstructionMintsNoConfig pins the DELIBERATE
+// COST of anchoring on the assignment, so it is a decision on the record rather
+// than a silent recall regression. An inline construction has no variable, so
+// there is nothing for a per-router edge to bind to; the shipped rule gave it a
+// marker node instead. Tier B measured six such shapes before and after: every
+// one lost only a marker with no edge to anchor.
+//
+// This is also the fixture that kills a mutant re-widening any of these
+// patterns to match without the assignment.
+func TestIssue6916_TierAUnassignedConstructionMintsNoConfig(t *testing.T) {
+	for _, s := range tierA6916Sites {
+		t.Run(s.rule, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, s.unassigned))
+			if names := configNames6916(ids); len(names) != 0 {
+				t.Errorf("%s: an UNASSIGNED construction minted %v. These rules are anchored on "+
+					"the assignment on purpose: with no variable there is nothing for an edge to "+
+					"bind to, which is what made the old marker nodes useless.", s.rule, names)
+			}
+			assertControl6916(t, ids, s.control)
+		})
+	}
+}
+
+// TestIssue6916_TierAChainedBuilderNamesTheAssignedVariable pins a shape the
+// "unassigned" fixture above deliberately does NOT cover, because it is not
+// unassigned: `var app = WebApplication.CreateBuilder(args).Build();` builds and
+// consumes the builder in one expression, and the variable that survives is the
+// APPLICATION, not the builder. The rule matches the prefix and names the Config
+// `app`.
+//
+// That is the intended outcome and it is recorded here rather than left to be
+// discovered: this entity stands for the framework entry point of the file, and
+// `app` is the name a reader of that file would use for it. What matters for
+// #6914 is that it is a NAME a per-router edge could bind to instead of the
+// marker string `WebApplication.CreateBuilder(`. It is pinned so that a later
+// narrowing — requiring the construction to be the whole right-hand side — is a
+// deliberate change rather than an accident.
+func TestIssue6916_TierAChainedBuilderNamesTheAssignedVariable(t *testing.T) {
+	for _, tc := range []struct{ rule, path, src, want, control string }{
+		{
+			rule: "csharp/frameworks/asp_net_core.yaml:90",
+			path: "Program.cs",
+			src: `var app = WebApplication.CreateBuilder(args).Build();
+app.MapGet("/health", () => "ok");
+`,
+			want:    "app",
+			control: "/health",
+		},
+		{
+			rule: "csharp/frameworks/net_maui.yaml:124",
+			path: "MauiProgram.cs",
+			src: `public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var app = MauiApp.CreateBuilder().Build();
+        Routing.RegisterRoute("orderdetail", typeof(OrderDetailPage));
+        return app;
+    }
+}
+`,
+			want:    "app",
+			control: "orderdetail",
+		},
+	} {
+		t.Run(tc.rule, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, tc.path, "csharp", tc.src))
+			if !slices.Contains(ids, "Config:"+tc.want) {
+				t.Errorf("%s: a chained build must still name the assigned variable; expected "+
+					"Config:%s among:\n  %s", tc.rule, tc.want, strings.Join(ids, "\n  "))
+			}
+			for _, name := range configNames6916(ids) {
+				if name != tc.want {
+					t.Errorf("%s: unexpected Config Name %q on a chained build.", tc.rule, name)
+				}
+			}
+			assertControl6916(t, ids, tc.control)
+		})
+	}
+}
+
+// TestIssue6916_TierAFieldTargetNamesTheFieldNotTheReceiver grades the
+// `(?:\w+\.)?` receiver prefix, and with it the dotted widening
+// `(?:\w+\.)?(\w+)` -> `([\w.]+)`. Building the framework object into a struct
+// field is idiomatic in both Go and C#, and there the token left of the `=` is
+// `s.router`, not `router`:
+//
+//   - without the prefix the capture starts at `s` and the entity is named
+//     after the RECEIVER — every server in a package collapses onto `s`;
+//   - with a dotted capture it is named `s.router`, which is not an identifier
+//     and so can never equal the `(\w+)` source of any relationship rule —
+//     the #6916 defect again, wearing a nicer name.
+//
+// axum has no leg here on purpose: its pattern requires a `let` binding, so a
+// field assignment is out of scope for it rather than mis-captured by it, and
+// TestIssue6916_TierAUnassignedConstructionMintsNoConfig already pins that.
+func TestIssue6916_TierAFieldTargetNamesTheFieldNotTheReceiver(t *testing.T) {
+	for _, s := range tierA6916Sites {
+		if s.fieldTarget == "" {
+			continue
+		}
+		t.Run(s.rule, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, s.fieldTarget))
+			names := configNames6916(ids)
+
+			if !slices.Contains(names, s.fieldTargetWant) {
+				t.Errorf("%s: a construction assigned to a FIELD must be named after the field; "+
+					"expected Config:%s among:\n  %s", s.rule, s.fieldTargetWant, strings.Join(ids, "\n  "))
+			}
+			for _, name := range names {
+				if name != s.fieldTargetWant {
+					t.Errorf("%s: Config:%q — the capture took the receiver or the whole dotted "+
+						"path instead of the field. A dotted name can never equal the `(\\w+)` "+
+						"source of a relationship rule.", s.rule, name)
+				}
+			}
+			assertControl6916(t, ids, s.control)
+		})
+	}
+}
+
+// TestIssue6916_TierABareConstructorCallMintsNoConfig is Tier B's review ask 3
+// — the OVER-FIRING direction — carried to every site, and it is the leg that
+// found a live mutant on seven of the eight. Making the qualifier optional
+// (`(?:chi\.)?NewRouter`, `(?:WebApplication\.)?CreateBuilder`) survived every
+// other fixture in this file, because those spell the negative with a DIFFERENT
+// qualifier — `router.NewRouter()` — which such a mutant still refuses. The
+// input that separates them is the BARE call.
+//
+// It is production-reachable and not exotic: `r := NewRouter()`, `e := New()`,
+// `db, err := Open(dsn)` and `var builder = CreateBuilder(args)` are what a
+// package's own constructor call looks like from inside that package, in any
+// repo, with no framework anywhere. Tier B's spelling of the same hazard was
+// `const app = App()` in ordinary React.
+//
+// Each leg is DERIVED from that site's own positive control by deleting exactly
+// the qualifier, so the two files cannot drift apart and the difference cannot
+// be anything else. The derivation is asserted to have changed the text —
+// an edit that silently does not land reads as a pass and argues the opposite.
+func TestIssue6916_TierABareConstructorCallMintsNoConfig(t *testing.T) {
+	for _, s := range tierA6916Sites {
+		if s.qualifier == "" {
+			continue
+		}
+		t.Run(s.rule, func(t *testing.T) {
+			// Only the qualifier ON THE CONSTRUCTION is removed — `= chi.` — not
+			// every mention of it, which would also strip `echo.Context` from
+			// the control entity's own signature and make this leg vacuous.
+			marker := "= " + s.qualifier
+			if n := strings.Count(s.nonFrameworkCtl, marker); n != 1 {
+				t.Fatalf("%s: fixture bug — %q occurs %d times in the control file; the "+
+					"derivation below must land on exactly the construction.", s.rule, marker, n)
+			}
+			bare := strings.Replace(s.nonFrameworkCtl, marker, "= ", 1)
+			if bare == s.nonFrameworkCtl {
+				t.Fatalf("%s: fixture bug — removing the qualifier %q changed nothing, so this "+
+					"leg is testing the control file, not the bare call.", s.rule, s.qualifier)
+			}
+
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, bare))
+			if names := configNames6916(ids); len(names) != 0 {
+				t.Errorf("%s: an UNQUALIFIED constructor call minted %v in a file with no "+
+					"framework qualifier anywhere. The qualifier is the only thing separating "+
+					"this rule from every package that names its own constructor the same way — "+
+					"and the junk entity now carries a plausible variable name instead of a "+
+					"visibly-broken marker string.", s.rule, names)
+			}
+			assertControl6916(t, ids, s.control)
+
+			ctl := entityIDs6916(detect6916(t, s.path, s.lang, s.nonFrameworkCtl))
+			if !slices.Contains(ctl, "Config:"+s.nonFrameworkWant) {
+				t.Errorf("%s: positive control missing — the same file WITH the qualifier no "+
+					"longer mints Config:%s, so the absence above proves nothing. Entities:\n  %s",
+					s.rule, s.nonFrameworkWant, strings.Join(ctl, "\n  "))
+			}
+		})
+	}
+}
+
+// TestIssue6916_TierAReassignmentMintsNoConfig grades axum's `let` requirement,
+// which no other fixture reaches: `app = Router::new();` — a plain rebinding of
+// an existing `mut` variable — is the only Rust shape that separates a rule
+// anchored on the DECLARATION from one that fires on any assignment.
+//
+// Minting nothing here is the intended behaviour, not an oversight. The name is
+// introduced by the `let`, and a rule that fires on every `x = Router::new()`
+// position is the unanchored capture wearing a different hat. The cost is a
+// file whose ONLY construction is a rebinding, which is what this fixture is;
+// where the `let` is also present it already mints the entity.
+func TestIssue6916_TierAReassignmentMintsNoConfig(t *testing.T) {
+	for _, s := range tierA6916Sites {
+		if s.reassigned == "" {
+			continue
+		}
+		t.Run(s.rule, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, s.reassigned))
+			if names := configNames6916(ids); len(names) != 0 {
+				t.Errorf("%s: a rebinding with no declaration keyword minted %v. The pattern is "+
+					"anchored on the `let` that introduces the name.", s.rule, names)
+			}
+			assertControl6916(t, ids, s.control)
+		})
+	}
+}


### PR DESCRIPTION
Tier A of #6916, all eight sites, following the Tier B (aws_cdk) template proven in #7015. **29 of the 39 sites remain after this** — `Refs`, not `Closes`.

| rule site | construction | was named | is named |
|---|---|---|---|
| `go/frameworks/chi.yaml:39` | `chi.NewRouter()` | `"chi.NewRouter()"` | `r` |
| `go/frameworks/echo.yaml:33` | `echo.New()` | `"echo.New()"` | `e` |
| `go/frameworks/fiber.yaml:33` | `fiber.New()` | `"fiber.New()"` | `app` |
| `go/frameworks/gin.yaml:33` | `gin.Default()` / `gin.New()` | `"gin.Default()"` | `r` |
| `go/frameworks/gorm.yaml:15` | `gorm.Open(...)` | `"gorm.Open("` | `db` |
| `rust/frameworks/axum.yaml:82` | `Router::new()` | `"Router::new()"` | `app` |
| `csharp/.../asp_net_core.yaml:90` | `WebApplication.CreateBuilder(...)` | `"WebApplication.CreateBuilder("` | `builder` |
| `csharp/.../net_maui.yaml:124` | `MauiApp.CreateBuilder()` | `"MauiApp.CreateBuilder("` | `builder` |

## Why this is the #6914 anchor

All eight used `name_group: 0`, so the Name was the whole matched text. Combined with `scope: file`, a constant Name meant every construction in a file collapsed onto **one** node — chi's 50 `chi.NewRouter()` calls measured **30** `Config` entities, actix's sibling shape **83 → 73**. There was nothing for a per-router `Middleware REGISTERED_ON <router>` edge to point at, and adding the edge rule would not have created one. Naming the variable is what makes the anchor exist.

`TestIssue6916_TierAEachConstructionGetsItsOwnEntity` pins that on the six sites where a second construction in one file is idiomatic. The two C# sites are excluded on purpose and the test says why: a `WebApplication`/`MauiApp` builder is the single entry point of its file, so a second one there would be a fixture shaped to the test rather than to the language.

## All three Tier B cases, carried per LANGUAGE

Tier B measured its Python mutant ALIVE after the JS axis was fully graded. That repeated here: **56 mutants scored across the 8 sites**, and both ALIVE families were language-shaped rather than tier-shaped.

**1 — the anchor.** Tier B's blocker was that an unanchored capture is not "the assignment target" but "whatever token sits left of the `=`". Python's reachable spelling was a multi-target assignment; in Go, Rust and C# it is a **commented-out example line**, which every real codebase carries. Unanchored, `// r := chi.NewRouter()` mints `Config:r` in a file that builds no router. Each leg's positive control is the same file with the comment marker removed.

**2 — the type annotation.** Go `var r *chi.Mux =`, Rust `let app: Router =`, C# `WebApplicationBuilder builder =` — three different slots in three different patterns, so three fixtures. Measured and now recorded in the rule comments rather than assumed from Tier B: all three put the type *after* the declarator, so deleting the group makes an annotated declaration mint **nothing**, it does not capture the type the way the TypeScript sibling did.

**3 — over-firing, and this is the one that found a live mutant on seven of the eight sites.** Making the qualifier optional (`(?:chi\.)?NewRouter`, `(?:WebApplication\.)?CreateBuilder`) survived every fixture in the first round, because those spell the negative with a *different* qualifier — `router.NewRouter()` — which such a mutant still refuses. The input that separates them is the **bare call**: `r := NewRouter()`, `db, err := Open(dsn)`, `var builder = CreateBuilder(args)`. That is what a package's own constructor call looks like from inside that package, in any repo, with no framework anywhere — Tier B's `const app = App()` in React, in three more languages. `TestIssue6916_TierABareConstructorCallMintsNoConfig` derives each leg from that site's own control by deleting exactly the qualifier, and asserts the derivation landed.

Stating the interaction #7015 asked for: **making the name useful also makes an over-firing hit harder to spot.** A junk entity called `gin.Default()` is visibly a marker; one called `r` reads as a real router. These land in `Config`, which #7013 measures at **60.5% polluted**.

## gorm is not a copy of the template, and the reason is measured

`gorm.Open` returns `(*gorm.DB, error)`, so `db, err := gorm.Open(...)` is *the* idiom. The Tier B Python pattern ported verbatim — unanchored, no comma list — mints **`Config:err`**: the error value, named as though it were the database. Identifier-shaped, so it passes every other assertion in the file. That is the Tier B blocker (#6369) in Go, and it is why the pattern carries `(?:\s*,\s*[\w.]+)*`: Go's multi-return is *positional*, so the first name is the first return and the list can be read safely — which Python's `app, env = App(), "prod"` could not.

The two guards are graded by **different** inputs and neither masks the other: the comma list by that fixture, the anchor by the commented-out line. Removing the anchor alone still names `db`. The rule comment and the test comment both say exactly that now — an earlier draft of both claimed the anchor alone produced `err`, which measurement disproved.

## Fixed in passing

The old patterns were unanchored substring matches, so axum's `Router\s*::\s*new` fired on **`MyRouter::new()`** — a `Config` minted in a crate with no axum. Pinned as `axum`'s over-firing leg.

## The deliberate cost, and the digest re-pin

An **unassigned** construction now mints nothing. `TestIssue6916_TierAUnassignedConstructionMintsNoConfig` pins it on all eight so it is a decision on the record. #6916 lifted the hold on this ground already: six unassigned shapes were measured on the Tier B arm and every one lost only a marker with no edge to anchor.

It costs exactly one entity on the `cmd/grafel` semantic-digest fixture, whose `rs/routes.rs` returns `Router::new().route(...)` as a bare expression. Re-pinned as `gateOffDigest6916`, with the delta **enumerated member by member from dumped before/after graphs, not derived from the counts**:

```
-E Config "Router::new()" rs/routes.rs      the marker itself; no relationship
                                            had it as an endpoint, before or after
-R Module:span6918 -[CONTAINS]-> that entity   the only edge incident on it
```

141/283 → 140/282. Nothing positioned moved.

**One thing to flag for the rest of the tier:** that fixture is the repo's only axum sample and it is the *unassigned* form. `Router::new().route(...)` as a function's tail expression is idiomatic axum, so axum is the site of the eight where the assignment idiom may not be the dominant one. Nothing that ever bound is lost either way — the marker had no edges — but if a per-router anchor is wanted for axum specifically, a second shape (the `-> Router` function name) is likely needed, and that is not this PR.

## Verification

Isolated `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT` + `HOME` triple, fresh per run. macOS/APFS only (#6966); no Linux or Windows figure is claimed here.

- `go vet` + `gofmt -l` clean on both touched packages.
- `./internal/engine/` full suite green (`-count=1`).
- `./cmd/grafel/` full suite green (`-count=1`).
- `scripts/quality/run.sh --ratchet` — **38 gated fixtures held their baseline**, none moved. `go-chi-mini` builds `r := chi.NewRouter()` and its recall is unchanged; no golden `expected.json` pins any of these eight marker Names (the three pinned marker names on #6916 are all sinatra, i.e. Tier C).
- **Every leg of the new file fails on the parent commit** — 8/8 sites on the naming test, and the commented-out and bare-call negatives fail there too, which is what establishes that the over-firing they assert against is real and pre-existing rather than hypothetical.
- **56 mutants, all DEAD**, scored per site with a green baseline before each and the file restored from a shasum-verified backup after each (no `git checkout --`). Restoration byte-verified at the end of the sweep. The set: `name_group: 1 → 0`, widen the capture to `(.+)`, delete the anchor, drop the constructor qualifier, delete the type/declarator group, dotted capture `([\w.]+)`, drop the `var` declarator, plus gorm's comma list and axum's `let`. Two ALIVE families (the bare call on 7 sites, axum's `let` on 1) were graded with new fixtures and the **whole set re-scored afterwards**, since a Tier B mutant went ALIVE under its author's own fix.

Refs #6916, #6914, #7013, #6906, #6369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
