### PR TITLE
fix(#7022): a statement keyword reached the `Config` capture — three entries per Go site, so no type slot sits behind a bare `\w+`

### DIFF
--- a/internal/engine/rules/go/frameworks/chi.yaml
+++ b/internal/engine/rules/go/frameworks/chi.yaml
@@ -40,32 +40,53 @@ source_patterns:
   # edge could ever bind to. Naming the variable is also what makes a PER-ROUTER
   # anchor possible (#6914): a file building two routers now mints two entities.
   #
-  # TWO entries, not one (#7022). A SINGLE entry with an optional `var` AND an
-  # optional trailing type slot let `if r := chi.NewRouter(); …` match with the keyword `if`
-  # in the name slot and the real variable in the type slot — minting `Config:if`,
-  # a node named after a syntax token, which is the exact defect class #6916
-  # exists to remove. Confirmed through the real detector on all four Go sites;
-  # gorm was immune because its comma list takes a different path. Splitting the
-  # forms puts the type slot BEHIND a literal `var`, so nothing but a declared
-  # name can reach the capture.
+  # THREE entries, not one (#7022). A SINGLE entry with an optional `var` AND an
+  # optional trailing type slot let `if r := chi.NewRouter(); …` match with the keyword
+  # `if` in the name slot and the real variable in the type slot — minting
+  # `Config:if`, a node named after a syntax token, which is the exact defect
+  # class #6916 exists to remove. `for`/`switch`/`go` initialisers minted
+  # `Config:for` / `Config:switch` / `Config:go` the same way. All confirmed
+  # through the real detector; gorm was immune because its comma list takes a
+  # different path, and is deliberately left as one entry.
   #
-  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded on BOTH entries. Without it
-  # the capture is just "the token left of the `=`", which in Go is reached from
-  # inside comments and doc examples — `// r := chi.NewRouter()` would mint a
-  # plausible-looking `Config:` in a file that builds nothing at all. `(?:\w+\.)?`
-  # on the short form keeps `s.router = chi.NewRouter()` naming the field rather than the
-  # receiver.
+  # The three entries carve the Go declaration forms so that NO entry offers a
+  # free type slot after a bare `\w+` — that slot is what a keyword walks into:
+  #
+  #   1. short form   `r := chi.NewRouter()`, `s.router = chi.NewRouter()` — no type slot at all.
+  #   2. `var` form   `var mux *chi.Mux = chi.NewRouter()` — the type slot exists
+  #      only BEHIND a literal `var`, which no keyword can spell.
+  #   3. grouped form `var (` … `r *chi.Mux = chi.NewRouter()` … `)` — inside a
+  #      grouped declaration the `var` is on its own line, so entry 2 cannot
+  #      reach it and entry 1 has no type slot. This entry restores it (it
+  #      matched the pre-split pattern, and dropping it would have been a
+  #      REGRESSION), and it stays keyword-proof by requiring the type to be
+  #      chi-QUALIFIED: `if r = chi.NewRouter()` cannot match, because `r` is not
+  #      spelled `chi.Something`. The cost is a grouped declaration whose type is
+  #      a dot-imported or aliased name; that is narrower than the pre-split
+  #      pattern and is the deliberate price of keeping keywords out.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing on ALL THREE entries and graded on
+  # all three by the `commented` fixture, which carries the short, the `var` and
+  # the grouped spelling. Without it the capture is just "the token left of the
+  # `=`", which in Go is reached from inside comments and doc examples — a
+  # commented `r := chi.NewRouter()` would mint a plausible-looking `Config:` in a file
+  # that builds nothing at all. `(?:\w+\.)?` on the short form keeps
+  # `s.router = chi.NewRouter()` naming the field rather than the receiver.
+  #
+  # Measured: Go puts the type AFTER the name, so entries 2 and 3 are what let an
+  # explicitly typed declaration match at all — neither captures the TYPE the way
+  # the TypeScript sibling did (#6916 Tier B, review ask 2).
   - pattern: '(?m)^[ \t]*(?:\w+\.)?(\w+)\s*:?=\s*chi\.NewRouter\s*\(\s*\)'
     entity_type: Config
     name_group: 1
     scope: file
 
-  # Declaration form: `var mux *chi.Mux = chi.NewRouter()`. Measured: Go puts the
-  # type AFTER the name, so deleting this entry's type slot makes an explicitly
-  # typed declaration mint NOTHING — it does not capture the type the way the
-  # TypeScript sibling did (#6916 Tier B, review ask 2). The type slot lives here
-  # rather than on the short form so it cannot swallow a keyword (#7022).
   - pattern: '(?m)^[ \t]*var\s+(\w+)(?:\s+[\w.*\[\]]+)?\s*=\s*chi\.NewRouter\s*\(\s*\)'
+    entity_type: Config
+    name_group: 1
+    scope: file
+
+  - pattern: '(?m)^[ \t]*(\w+)\s+[*\[\]]*chi\.\w+\s*=\s*chi\.NewRouter\s*\(\s*\)'
     entity_type: Config
     name_group: 1
     scope: file

--- a/internal/engine/rules/go/frameworks/chi.yaml
+++ b/internal/engine/rules/go/frameworks/chi.yaml
@@ -35,22 +35,37 @@ source_patterns:
     name_group: 1
     scope: file
 
-  # chi.NewRouter() init
   # chi.NewRouter() init, named after the ASSIGNED VARIABLE (#6916): r := chi.NewRouter()
   # name_group 0 named this entity "chi.NewRouter()" — a marker string, one per FILE, that no
   # edge could ever bind to. Naming the variable is also what makes a PER-ROUTER
   # anchor possible (#6914): a file building two routers now mints two entities.
   #
-  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded. Without it the capture is
-  # just "the token left of the `=`", which in Go is reached from inside comments
-  # and doc examples — `// r := chi.NewRouter()` would mint a plausible-looking
-  # `Config:r` in a file that builds no router at all. `(?:\w+\.)?` keeps
-  # `s.router = chi.NewRouter()` naming `router` rather than `s`; the optional
-  # `var` + type group is what lets `var r *chi.Mux = chi.NewRouter()` match at all.
-  # Measured: Go puts the type AFTER the name, so deleting that group makes an
-  # explicitly typed declaration mint NOTHING — it does not capture the type the
-  # way the TypeScript sibling did (#6916 Tier B, review ask 2).
-  - pattern: '(?m)^[ \t]*(?:var\s+)?(?:\w+\.)?(\w+)(?:\s+[\w.*\[\]]+)?\s*:?=\s*chi\.NewRouter\s*\(\s*\)'
+  # TWO entries, not one (#7022). A SINGLE entry with an optional `var` AND an
+  # optional trailing type slot let `if r := chi.NewRouter(); …` match with the keyword `if`
+  # in the name slot and the real variable in the type slot — minting `Config:if`,
+  # a node named after a syntax token, which is the exact defect class #6916
+  # exists to remove. Confirmed through the real detector on all four Go sites;
+  # gorm was immune because its comma list takes a different path. Splitting the
+  # forms puts the type slot BEHIND a literal `var`, so nothing but a declared
+  # name can reach the capture.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded on BOTH entries. Without it
+  # the capture is just "the token left of the `=`", which in Go is reached from
+  # inside comments and doc examples — `// r := chi.NewRouter()` would mint a
+  # plausible-looking `Config:` in a file that builds nothing at all. `(?:\w+\.)?`
+  # on the short form keeps `s.router = chi.NewRouter()` naming the field rather than the
+  # receiver.
+  - pattern: '(?m)^[ \t]*(?:\w+\.)?(\w+)\s*:?=\s*chi\.NewRouter\s*\(\s*\)'
+    entity_type: Config
+    name_group: 1
+    scope: file
+
+  # Declaration form: `var mux *chi.Mux = chi.NewRouter()`. Measured: Go puts the
+  # type AFTER the name, so deleting this entry's type slot makes an explicitly
+  # typed declaration mint NOTHING — it does not capture the type the way the
+  # TypeScript sibling did (#6916 Tier B, review ask 2). The type slot lives here
+  # rather than on the short form so it cannot swallow a keyword (#7022).
+  - pattern: '(?m)^[ \t]*var\s+(\w+)(?:\s+[\w.*\[\]]+)?\s*=\s*chi\.NewRouter\s*\(\s*\)'
     entity_type: Config
     name_group: 1
     scope: file

--- a/internal/engine/rules/go/frameworks/echo.yaml
+++ b/internal/engine/rules/go/frameworks/echo.yaml
@@ -34,32 +34,53 @@ source_patterns:
   # edge could ever bind to. Naming the variable is also what makes a PER-ROUTER
   # anchor possible (#6914): a file building two routers now mints two entities.
   #
-  # TWO entries, not one (#7022). A SINGLE entry with an optional `var` AND an
-  # optional trailing type slot let `if e := echo.New(); …` match with the keyword `if`
-  # in the name slot and the real variable in the type slot — minting `Config:if`,
-  # a node named after a syntax token, which is the exact defect class #6916
-  # exists to remove. Confirmed through the real detector on all four Go sites;
-  # gorm was immune because its comma list takes a different path. Splitting the
-  # forms puts the type slot BEHIND a literal `var`, so nothing but a declared
-  # name can reach the capture.
+  # THREE entries, not one (#7022). A SINGLE entry with an optional `var` AND an
+  # optional trailing type slot let `if e := echo.New(); …` match with the keyword
+  # `if` in the name slot and the real variable in the type slot — minting
+  # `Config:if`, a node named after a syntax token, which is the exact defect
+  # class #6916 exists to remove. `for`/`switch`/`go` initialisers minted
+  # `Config:for` / `Config:switch` / `Config:go` the same way. All confirmed
+  # through the real detector; gorm was immune because its comma list takes a
+  # different path, and is deliberately left as one entry.
   #
-  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded on BOTH entries. Without it
-  # the capture is just "the token left of the `=`", which in Go is reached from
-  # inside comments and doc examples — `// e := echo.New()` would mint a
-  # plausible-looking `Config:` in a file that builds nothing at all. `(?:\w+\.)?`
-  # on the short form keeps `s.engine = echo.New()` naming the field rather than the
-  # receiver.
+  # The three entries carve the Go declaration forms so that NO entry offers a
+  # free type slot after a bare `\w+` — that slot is what a keyword walks into:
+  #
+  #   1. short form   `e := echo.New()`, `s.engine = echo.New()` — no type slot at all.
+  #   2. `var` form   `var srv *echo.Echo = echo.New()` — the type slot exists
+  #      only BEHIND a literal `var`, which no keyword can spell.
+  #   3. grouped form `var (` … `e *echo.Echo = echo.New()` … `)` — inside a
+  #      grouped declaration the `var` is on its own line, so entry 2 cannot
+  #      reach it and entry 1 has no type slot. This entry restores it (it
+  #      matched the pre-split pattern, and dropping it would have been a
+  #      REGRESSION), and it stays keyword-proof by requiring the type to be
+  #      echo-QUALIFIED: `if r = echo.New()` cannot match, because `r` is not
+  #      spelled `echo.Something`. The cost is a grouped declaration whose type is
+  #      a dot-imported or aliased name; that is narrower than the pre-split
+  #      pattern and is the deliberate price of keeping keywords out.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing on ALL THREE entries and graded on
+  # all three by the `commented` fixture, which carries the short, the `var` and
+  # the grouped spelling. Without it the capture is just "the token left of the
+  # `=`", which in Go is reached from inside comments and doc examples — a
+  # commented `e := echo.New()` would mint a plausible-looking `Config:` in a file
+  # that builds nothing at all. `(?:\w+\.)?` on the short form keeps
+  # `s.engine = echo.New()` naming the field rather than the receiver.
+  #
+  # Measured: Go puts the type AFTER the name, so entries 2 and 3 are what let an
+  # explicitly typed declaration match at all — neither captures the TYPE the way
+  # the TypeScript sibling did (#6916 Tier B, review ask 2).
   - pattern: '(?m)^[ \t]*(?:\w+\.)?(\w+)\s*:?=\s*echo\.New\s*\(\s*\)'
     entity_type: Config
     name_group: 1
     scope: file
 
-  # Declaration form: `var srv *echo.Echo = echo.New()`. Measured: Go puts the
-  # type AFTER the name, so deleting this entry's type slot makes an explicitly
-  # typed declaration mint NOTHING — it does not capture the type the way the
-  # TypeScript sibling did (#6916 Tier B, review ask 2). The type slot lives here
-  # rather than on the short form so it cannot swallow a keyword (#7022).
   - pattern: '(?m)^[ \t]*var\s+(\w+)(?:\s+[\w.*\[\]]+)?\s*=\s*echo\.New\s*\(\s*\)'
+    entity_type: Config
+    name_group: 1
+    scope: file
+
+  - pattern: '(?m)^[ \t]*(\w+)\s+[*\[\]]*echo\.\w+\s*=\s*echo\.New\s*\(\s*\)'
     entity_type: Config
     name_group: 1
     scope: file

--- a/internal/engine/rules/go/frameworks/echo.yaml
+++ b/internal/engine/rules/go/frameworks/echo.yaml
@@ -29,22 +29,37 @@ source_patterns:
     name_group: 1
     scope: file
 
-  # echo.New() engine init
-  # echo.New() engine init, named after the ASSIGNED VARIABLE (#6916): e := echo.New()
+  # echo.New() init, named after the ASSIGNED VARIABLE (#6916): e := echo.New()
   # name_group 0 named this entity "echo.New()" — a marker string, one per FILE, that no
   # edge could ever bind to. Naming the variable is also what makes a PER-ROUTER
   # anchor possible (#6914): a file building two routers now mints two entities.
   #
-  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded. Without it the capture is
-  # just "the token left of the `=`", which in Go is reached from inside comments
-  # and doc examples — `// r := echo.New()` would mint a plausible-looking
-  # `Config:r` in a file that builds no router at all. `(?:\w+\.)?` keeps
-  # `s.router = echo.New()` naming `router` rather than `s`; the optional
-  # `var` + type group is what lets `var r *echo.Echo = echo.New()` match at all.
-  # Measured: Go puts the type AFTER the name, so deleting that group makes an
-  # explicitly typed declaration mint NOTHING — it does not capture the type the
-  # way the TypeScript sibling did (#6916 Tier B, review ask 2).
-  - pattern: '(?m)^[ \t]*(?:var\s+)?(?:\w+\.)?(\w+)(?:\s+[\w.*\[\]]+)?\s*:?=\s*echo\.New\s*\(\s*\)'
+  # TWO entries, not one (#7022). A SINGLE entry with an optional `var` AND an
+  # optional trailing type slot let `if e := echo.New(); …` match with the keyword `if`
+  # in the name slot and the real variable in the type slot — minting `Config:if`,
+  # a node named after a syntax token, which is the exact defect class #6916
+  # exists to remove. Confirmed through the real detector on all four Go sites;
+  # gorm was immune because its comma list takes a different path. Splitting the
+  # forms puts the type slot BEHIND a literal `var`, so nothing but a declared
+  # name can reach the capture.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded on BOTH entries. Without it
+  # the capture is just "the token left of the `=`", which in Go is reached from
+  # inside comments and doc examples — `// e := echo.New()` would mint a
+  # plausible-looking `Config:` in a file that builds nothing at all. `(?:\w+\.)?`
+  # on the short form keeps `s.engine = echo.New()` naming the field rather than the
+  # receiver.
+  - pattern: '(?m)^[ \t]*(?:\w+\.)?(\w+)\s*:?=\s*echo\.New\s*\(\s*\)'
+    entity_type: Config
+    name_group: 1
+    scope: file
+
+  # Declaration form: `var srv *echo.Echo = echo.New()`. Measured: Go puts the
+  # type AFTER the name, so deleting this entry's type slot makes an explicitly
+  # typed declaration mint NOTHING — it does not capture the type the way the
+  # TypeScript sibling did (#6916 Tier B, review ask 2). The type slot lives here
+  # rather than on the short form so it cannot swallow a keyword (#7022).
+  - pattern: '(?m)^[ \t]*var\s+(\w+)(?:\s+[\w.*\[\]]+)?\s*=\s*echo\.New\s*\(\s*\)'
     entity_type: Config
     name_group: 1
     scope: file

--- a/internal/engine/rules/go/frameworks/fiber.yaml
+++ b/internal/engine/rules/go/frameworks/fiber.yaml
@@ -34,32 +34,53 @@ source_patterns:
   # edge could ever bind to. Naming the variable is also what makes a PER-APP
   # anchor possible (#6914): a file building two apps now mints two entities.
   #
-  # TWO entries, not one (#7022). A SINGLE entry with an optional `var` AND an
-  # optional trailing type slot let `if app := fiber.New(); …` match with the keyword `if`
-  # in the name slot and the real variable in the type slot — minting `Config:if`,
-  # a node named after a syntax token, which is the exact defect class #6916
-  # exists to remove. Confirmed through the real detector on all four Go sites;
-  # gorm was immune because its comma list takes a different path. Splitting the
-  # forms puts the type slot BEHIND a literal `var`, so nothing but a declared
-  # name can reach the capture.
+  # THREE entries, not one (#7022). A SINGLE entry with an optional `var` AND an
+  # optional trailing type slot let `if app := fiber.New(); …` match with the keyword
+  # `if` in the name slot and the real variable in the type slot — minting
+  # `Config:if`, a node named after a syntax token, which is the exact defect
+  # class #6916 exists to remove. `for`/`switch`/`go` initialisers minted
+  # `Config:for` / `Config:switch` / `Config:go` the same way. All confirmed
+  # through the real detector; gorm was immune because its comma list takes a
+  # different path, and is deliberately left as one entry.
   #
-  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded on BOTH entries. Without it
-  # the capture is just "the token left of the `=`", which in Go is reached from
-  # inside comments and doc examples — `// app := fiber.New()` would mint a
-  # plausible-looking `Config:` in a file that builds nothing at all. `(?:\w+\.)?`
-  # on the short form keeps `s.app = fiber.New()` naming the field rather than the
-  # receiver.
+  # The three entries carve the Go declaration forms so that NO entry offers a
+  # free type slot after a bare `\w+` — that slot is what a keyword walks into:
+  #
+  #   1. short form   `app := fiber.New()`, `s.app = fiber.New()` — no type slot at all.
+  #   2. `var` form   `var app *fiber.App = fiber.New()` — the type slot exists
+  #      only BEHIND a literal `var`, which no keyword can spell.
+  #   3. grouped form `var (` … `app *fiber.App = fiber.New()` … `)` — inside a
+  #      grouped declaration the `var` is on its own line, so entry 2 cannot
+  #      reach it and entry 1 has no type slot. This entry restores it (it
+  #      matched the pre-split pattern, and dropping it would have been a
+  #      REGRESSION), and it stays keyword-proof by requiring the type to be
+  #      fiber-QUALIFIED: `if r = fiber.New()` cannot match, because `r` is not
+  #      spelled `fiber.Something`. The cost is a grouped declaration whose type is
+  #      a dot-imported or aliased name; that is narrower than the pre-split
+  #      pattern and is the deliberate price of keeping keywords out.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing on ALL THREE entries and graded on
+  # all three by the `commented` fixture, which carries the short, the `var` and
+  # the grouped spelling. Without it the capture is just "the token left of the
+  # `=`", which in Go is reached from inside comments and doc examples — a
+  # commented `app := fiber.New()` would mint a plausible-looking `Config:` in a file
+  # that builds nothing at all. `(?:\w+\.)?` on the short form keeps
+  # `s.app = fiber.New()` naming the field rather than the receiver.
+  #
+  # Measured: Go puts the type AFTER the name, so entries 2 and 3 are what let an
+  # explicitly typed declaration match at all — neither captures the TYPE the way
+  # the TypeScript sibling did (#6916 Tier B, review ask 2).
   - pattern: '(?m)^[ \t]*(?:\w+\.)?(\w+)\s*:?=\s*fiber\.New\s*\(\s*\)'
     entity_type: Config
     name_group: 1
     scope: file
 
-  # Declaration form: `var app *fiber.App = fiber.New()`. Measured: Go puts the
-  # type AFTER the name, so deleting this entry's type slot makes an explicitly
-  # typed declaration mint NOTHING — it does not capture the type the way the
-  # TypeScript sibling did (#6916 Tier B, review ask 2). The type slot lives here
-  # rather than on the short form so it cannot swallow a keyword (#7022).
   - pattern: '(?m)^[ \t]*var\s+(\w+)(?:\s+[\w.*\[\]]+)?\s*=\s*fiber\.New\s*\(\s*\)'
+    entity_type: Config
+    name_group: 1
+    scope: file
+
+  - pattern: '(?m)^[ \t]*(\w+)\s+[*\[\]]*fiber\.\w+\s*=\s*fiber\.New\s*\(\s*\)'
     entity_type: Config
     name_group: 1
     scope: file

--- a/internal/engine/rules/go/frameworks/fiber.yaml
+++ b/internal/engine/rules/go/frameworks/fiber.yaml
@@ -29,22 +29,37 @@ source_patterns:
     name_group: 1
     scope: file
 
-  # fiber.New() app init
-  # fiber.New() app init, named after the ASSIGNED VARIABLE (#6916): app := fiber.New()
+  # fiber.New() init, named after the ASSIGNED VARIABLE (#6916): app := fiber.New()
   # name_group 0 named this entity "fiber.New()" — a marker string, one per FILE, that no
-  # edge could ever bind to. Naming the variable is also what makes a PER-ROUTER
-  # anchor possible (#6914): a file building two routers now mints two entities.
+  # edge could ever bind to. Naming the variable is also what makes a PER-APP
+  # anchor possible (#6914): a file building two apps now mints two entities.
   #
-  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded. Without it the capture is
-  # just "the token left of the `=`", which in Go is reached from inside comments
-  # and doc examples — `// r := fiber.New()` would mint a plausible-looking
-  # `Config:r` in a file that builds no router at all. `(?:\w+\.)?` keeps
-  # `s.router = fiber.New()` naming `router` rather than `s`; the optional
-  # `var` + type group is what lets `var r *fiber.App = fiber.New()` match at all.
-  # Measured: Go puts the type AFTER the name, so deleting that group makes an
-  # explicitly typed declaration mint NOTHING — it does not capture the type the
-  # way the TypeScript sibling did (#6916 Tier B, review ask 2).
-  - pattern: '(?m)^[ \t]*(?:var\s+)?(?:\w+\.)?(\w+)(?:\s+[\w.*\[\]]+)?\s*:?=\s*fiber\.New\s*\(\s*\)'
+  # TWO entries, not one (#7022). A SINGLE entry with an optional `var` AND an
+  # optional trailing type slot let `if app := fiber.New(); …` match with the keyword `if`
+  # in the name slot and the real variable in the type slot — minting `Config:if`,
+  # a node named after a syntax token, which is the exact defect class #6916
+  # exists to remove. Confirmed through the real detector on all four Go sites;
+  # gorm was immune because its comma list takes a different path. Splitting the
+  # forms puts the type slot BEHIND a literal `var`, so nothing but a declared
+  # name can reach the capture.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded on BOTH entries. Without it
+  # the capture is just "the token left of the `=`", which in Go is reached from
+  # inside comments and doc examples — `// app := fiber.New()` would mint a
+  # plausible-looking `Config:` in a file that builds nothing at all. `(?:\w+\.)?`
+  # on the short form keeps `s.app = fiber.New()` naming the field rather than the
+  # receiver.
+  - pattern: '(?m)^[ \t]*(?:\w+\.)?(\w+)\s*:?=\s*fiber\.New\s*\(\s*\)'
+    entity_type: Config
+    name_group: 1
+    scope: file
+
+  # Declaration form: `var app *fiber.App = fiber.New()`. Measured: Go puts the
+  # type AFTER the name, so deleting this entry's type slot makes an explicitly
+  # typed declaration mint NOTHING — it does not capture the type the way the
+  # TypeScript sibling did (#6916 Tier B, review ask 2). The type slot lives here
+  # rather than on the short form so it cannot swallow a keyword (#7022).
+  - pattern: '(?m)^[ \t]*var\s+(\w+)(?:\s+[\w.*\[\]]+)?\s*=\s*fiber\.New\s*\(\s*\)'
     entity_type: Config
     name_group: 1
     scope: file

--- a/internal/engine/rules/go/frameworks/gin.yaml
+++ b/internal/engine/rules/go/frameworks/gin.yaml
@@ -29,22 +29,37 @@ source_patterns:
     name_group: 1
     scope: file
 
-  # gin.Default() or gin.New() engine init
-  # gin.Default() / gin.New() engine init, named after the ASSIGNED VARIABLE (#6916): r := gin.Default()
-  # name_group 0 named this entity "gin.Default()" / "gin.New()" — a marker string, one per FILE, that no
+  # gin.Default() init, named after the ASSIGNED VARIABLE (#6916): r := gin.Default()
+  # name_group 0 named this entity "gin.Default()" — a marker string, one per FILE, that no
   # edge could ever bind to. Naming the variable is also what makes a PER-ROUTER
-  # anchor possible (#6914): a file building two routers now mints two entities.
+  # anchor possible (#6914): a file building two engines now mints two entities.
   #
-  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded. Without it the capture is
-  # just "the token left of the `=`", which in Go is reached from inside comments
-  # and doc examples — `// r := gin.Default()` would mint a plausible-looking
-  # `Config:r` in a file that builds no router at all. `(?:\w+\.)?` keeps
-  # `s.router = gin.Default()` naming `router` rather than `s`; the optional
-  # `var` + type group is what lets `var r *gin.Engine = gin.Default()` match at all.
-  # Measured: Go puts the type AFTER the name, so deleting that group makes an
-  # explicitly typed declaration mint NOTHING — it does not capture the type the
-  # way the TypeScript sibling did (#6916 Tier B, review ask 2).
-  - pattern: '(?m)^[ \t]*(?:var\s+)?(?:\w+\.)?(\w+)(?:\s+[\w.*\[\]]+)?\s*:?=\s*(?:gin\.Default|gin\.New)\s*\(\s*\)'
+  # TWO entries, not one (#7022). A SINGLE entry with an optional `var` AND an
+  # optional trailing type slot let `if r := gin.Default(); …` match with the keyword `if`
+  # in the name slot and the real variable in the type slot — minting `Config:if`,
+  # a node named after a syntax token, which is the exact defect class #6916
+  # exists to remove. Confirmed through the real detector on all four Go sites;
+  # gorm was immune because its comma list takes a different path. Splitting the
+  # forms puts the type slot BEHIND a literal `var`, so nothing but a declared
+  # name can reach the capture.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded on BOTH entries. Without it
+  # the capture is just "the token left of the `=`", which in Go is reached from
+  # inside comments and doc examples — `// r := gin.Default()` would mint a
+  # plausible-looking `Config:` in a file that builds nothing at all. `(?:\w+\.)?`
+  # on the short form keeps `s.router = gin.Default()` naming the field rather than the
+  # receiver.
+  - pattern: '(?m)^[ \t]*(?:\w+\.)?(\w+)\s*:?=\s*(?:gin\.Default|gin\.New)\s*\(\s*\)'
+    entity_type: Config
+    name_group: 1
+    scope: file
+
+  # Declaration form: `var r *gin.Engine = gin.Default()`. Measured: Go puts the
+  # type AFTER the name, so deleting this entry's type slot makes an explicitly
+  # typed declaration mint NOTHING — it does not capture the type the way the
+  # TypeScript sibling did (#6916 Tier B, review ask 2). The type slot lives here
+  # rather than on the short form so it cannot swallow a keyword (#7022).
+  - pattern: '(?m)^[ \t]*var\s+(\w+)(?:\s+[\w.*\[\]]+)?\s*=\s*(?:gin\.Default|gin\.New)\s*\(\s*\)'
     entity_type: Config
     name_group: 1
     scope: file

--- a/internal/engine/rules/go/frameworks/gin.yaml
+++ b/internal/engine/rules/go/frameworks/gin.yaml
@@ -34,32 +34,53 @@ source_patterns:
   # edge could ever bind to. Naming the variable is also what makes a PER-ROUTER
   # anchor possible (#6914): a file building two engines now mints two entities.
   #
-  # TWO entries, not one (#7022). A SINGLE entry with an optional `var` AND an
-  # optional trailing type slot let `if r := gin.Default(); …` match with the keyword `if`
-  # in the name slot and the real variable in the type slot — minting `Config:if`,
-  # a node named after a syntax token, which is the exact defect class #6916
-  # exists to remove. Confirmed through the real detector on all four Go sites;
-  # gorm was immune because its comma list takes a different path. Splitting the
-  # forms puts the type slot BEHIND a literal `var`, so nothing but a declared
-  # name can reach the capture.
+  # THREE entries, not one (#7022). A SINGLE entry with an optional `var` AND an
+  # optional trailing type slot let `if r := gin.Default(); …` match with the keyword
+  # `if` in the name slot and the real variable in the type slot — minting
+  # `Config:if`, a node named after a syntax token, which is the exact defect
+  # class #6916 exists to remove. `for`/`switch`/`go` initialisers minted
+  # `Config:for` / `Config:switch` / `Config:go` the same way. All confirmed
+  # through the real detector; gorm was immune because its comma list takes a
+  # different path, and is deliberately left as one entry.
   #
-  # The `(?m)^[ \t]*` ANCHOR is load-bearing and graded on BOTH entries. Without it
-  # the capture is just "the token left of the `=`", which in Go is reached from
-  # inside comments and doc examples — `// r := gin.Default()` would mint a
-  # plausible-looking `Config:` in a file that builds nothing at all. `(?:\w+\.)?`
-  # on the short form keeps `s.router = gin.Default()` naming the field rather than the
-  # receiver.
+  # The three entries carve the Go declaration forms so that NO entry offers a
+  # free type slot after a bare `\w+` — that slot is what a keyword walks into:
+  #
+  #   1. short form   `r := gin.Default()`, `s.router = gin.Default()` — no type slot at all.
+  #   2. `var` form   `var r *gin.Engine = gin.Default()` — the type slot exists
+  #      only BEHIND a literal `var`, which no keyword can spell.
+  #   3. grouped form `var (` … `r *gin.Engine = gin.Default()` … `)` — inside a
+  #      grouped declaration the `var` is on its own line, so entry 2 cannot
+  #      reach it and entry 1 has no type slot. This entry restores it (it
+  #      matched the pre-split pattern, and dropping it would have been a
+  #      REGRESSION), and it stays keyword-proof by requiring the type to be
+  #      gin-QUALIFIED: `if r = gin.Default()` cannot match, because `r` is not
+  #      spelled `gin.Something`. The cost is a grouped declaration whose type is
+  #      a dot-imported or aliased name; that is narrower than the pre-split
+  #      pattern and is the deliberate price of keeping keywords out.
+  #
+  # The `(?m)^[ \t]*` ANCHOR is load-bearing on ALL THREE entries and graded on
+  # all three by the `commented` fixture, which carries the short, the `var` and
+  # the grouped spelling. Without it the capture is just "the token left of the
+  # `=`", which in Go is reached from inside comments and doc examples — a
+  # commented `r := gin.Default()` would mint a plausible-looking `Config:` in a file
+  # that builds nothing at all. `(?:\w+\.)?` on the short form keeps
+  # `s.router = gin.Default()` naming the field rather than the receiver.
+  #
+  # Measured: Go puts the type AFTER the name, so entries 2 and 3 are what let an
+  # explicitly typed declaration match at all — neither captures the TYPE the way
+  # the TypeScript sibling did (#6916 Tier B, review ask 2).
   - pattern: '(?m)^[ \t]*(?:\w+\.)?(\w+)\s*:?=\s*(?:gin\.Default|gin\.New)\s*\(\s*\)'
     entity_type: Config
     name_group: 1
     scope: file
 
-  # Declaration form: `var r *gin.Engine = gin.Default()`. Measured: Go puts the
-  # type AFTER the name, so deleting this entry's type slot makes an explicitly
-  # typed declaration mint NOTHING — it does not capture the type the way the
-  # TypeScript sibling did (#6916 Tier B, review ask 2). The type slot lives here
-  # rather than on the short form so it cannot swallow a keyword (#7022).
   - pattern: '(?m)^[ \t]*var\s+(\w+)(?:\s+[\w.*\[\]]+)?\s*=\s*(?:gin\.Default|gin\.New)\s*\(\s*\)'
+    entity_type: Config
+    name_group: 1
+    scope: file
+
+  - pattern: '(?m)^[ \t]*(\w+)\s+[*\[\]]*gin\.\w+\s*=\s*(?:gin\.Default|gin\.New)\s*\(\s*\)'
     entity_type: Config
     name_group: 1
     scope: file

--- a/internal/engine/tier_a_config_variable_6916_test.go
+++ b/internal/engine/tier_a_config_variable_6916_test.go
@@ -10,10 +10,10 @@ import (
 // #6916 Tier A — the eight `Config` source_patterns whose construction is
 // assigned to a variable on the same line:
 //
-//	go/frameworks/chi.yaml:39        chi.NewRouter()
-//	go/frameworks/echo.yaml:33       echo.New()
-//	go/frameworks/fiber.yaml:33      fiber.New()
-//	go/frameworks/gin.yaml:33        gin.Default() / gin.New()
+//	go/frameworks/chi.yaml:58        chi.NewRouter()
+//	go/frameworks/echo.yaml:52       echo.New()
+//	go/frameworks/fiber.yaml:52      fiber.New()
+//	go/frameworks/gin.yaml:52        gin.Default() / gin.New()
 //	go/frameworks/gorm.yaml:15       gorm.Open(...)
 //	rust/frameworks/axum.yaml:82     Router::new()
 //	csharp/frameworks/asp_net_core.yaml:90  WebApplication.CreateBuilder(...)
@@ -90,6 +90,16 @@ type tierA6916Site struct {
 	nonFrameworkCtl  string
 	nonFrameworkWant string
 
+	// ifInit constructs the object inside Go's if-with-initialiser, where a
+	// KEYWORD sits in the position the pattern reads as the variable name.
+	// Must mint no Config named after the keyword; ifInitWant is the variable
+	// that a correct rule may still name (empty where the shape mints nothing
+	// at all). Go-only: rust's pattern requires a line-initial `let` and C#
+	// has no if-initialiser, and both were probed through the real detector
+	// and mint nothing here — see the test below.
+	ifInit     string
+	ifInitWant string
+
 	// reassigned rebinds an EXISTING variable with no `let`. Only axum carries
 	// one: its pattern requires the declaration keyword, and this is the shape
 	// that grades that requirement. Must mint no Config.
@@ -122,7 +132,7 @@ type tierA6916Site struct {
 // fixture body against the claim its name made.
 var tierA6916Sites = []tierA6916Site{
 	{
-		rule:      "go/frameworks/chi.yaml:39",
+		rule:      "go/frameworks/chi.yaml:58",
 		qualifier: "chi.",
 		lang:      "go",
 		path:      "main.go",
@@ -145,6 +155,23 @@ func main() {
 }
 `,
 		first: "r", second: "api",
+		ifInit: `package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func listUsers(w http.ResponseWriter, r *http.Request) {}
+
+func main() {
+	if r := chi.NewRouter(); r != nil {
+		_ = r
+	}
+}
+`,
+		ifInitWant: "r",
 		annotated: `package main
 
 import (
@@ -239,7 +266,7 @@ func (s *Server) setup() {
 		fieldTargetWant: "router",
 	},
 	{
-		rule:      "go/frameworks/echo.yaml:33",
+		rule:      "go/frameworks/echo.yaml:52",
 		qualifier: "echo.",
 		lang:      "go",
 		path:      "main.go",
@@ -258,6 +285,19 @@ func main() {
 }
 `,
 		first: "e", second: "admin",
+		ifInit: `package main
+
+import "github.com/labstack/echo/v4"
+
+func listUsers(c echo.Context) error { return nil }
+
+func main() {
+	if e := echo.New(); e != nil {
+		_ = e
+	}
+}
+`,
+		ifInitWant: "e",
 		annotated: `package main
 
 import "github.com/labstack/echo/v4"
@@ -338,7 +378,7 @@ func (s *Server) setup() {
 		fieldTargetWant: "engine",
 	},
 	{
-		rule:      "go/frameworks/fiber.yaml:33",
+		rule:      "go/frameworks/fiber.yaml:52",
 		qualifier: "fiber.",
 		lang:      "go",
 		path:      "main.go",
@@ -357,6 +397,19 @@ func main() {
 }
 `,
 		first: "app", second: "metrics",
+		ifInit: `package main
+
+import "github.com/gofiber/fiber/v2"
+
+func listUsers(c *fiber.Ctx) error { return nil }
+
+func main() {
+	if app := fiber.New(); app != nil {
+		_ = app
+	}
+}
+`,
+		ifInitWant: "app",
 		annotated: `package main
 
 import "github.com/gofiber/fiber/v2"
@@ -437,7 +490,7 @@ func (s *Server) setup() {
 		fieldTargetWant: "app",
 	},
 	{
-		rule:      "go/frameworks/gin.yaml:33",
+		rule:      "go/frameworks/gin.yaml:52",
 		qualifier: "gin.",
 		lang:      "go",
 		path:      "main.go",
@@ -459,6 +512,19 @@ func main() {
 }
 `,
 		first: "r", second: "admin",
+		ifInit: `package main
+
+import "github.com/gin-gonic/gin"
+
+func listUsers(c *gin.Context) {}
+
+func main() {
+	if r := gin.Default(); r != nil {
+		_ = r
+	}
+}
+`,
+		ifInitWant: "r",
 		annotated: `package main
 
 import "github.com/gin-gonic/gin"
@@ -561,6 +627,21 @@ func open() {
 }
 `,
 		first: "primary", second: "replica",
+		ifInit: `package db
+
+import "gorm.io/gorm"
+
+type User struct {
+	gorm.Model
+	Name string
+}
+
+func open() {
+	if db, err := gorm.Open(pgDialector(), &gorm.Config{}); err == nil {
+		_, _ = db, err
+	}
+}
+`,
 		annotated: `package db
 
 import "gorm.io/gorm"
@@ -761,9 +842,17 @@ fn rebuild(mut app: Router) -> Router {
 		// are the one under test plus none other, so "no Config" is exact.
 		control: "/health",
 		// Two builders in one C# file is legal but not idiomatic — a
-		// WebApplication has one entry point per Program.cs — so the
-		// per-variable multiplicity is graded on the six sites where a second
-		// construction is realistic, not here.
+		// WebApplication has one entry point per Program.cs. It is graded here
+		// anyway (#7022): an argument about idiom does not fail a build, and
+		// leaving the multiplicity axis ungraded on two of eight sites is the
+		// asymmetry this PR family keeps filing. Measured through the real
+		// detector before it was pinned: [first second].
+		twoVars: `var first = WebApplication.CreateBuilder(args);
+var second = WebApplication.CreateBuilder(args);
+var app = first.Build();
+app.MapGet("/health", () => "ok");
+`,
+		first: "first", second: "second",
 		annotated: `var _unused = 0;
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
@@ -815,6 +904,21 @@ app.MapGet("/health", () => "ok");
 		// `.UseMauiApp<App>()`, which mints a Config of its own and would make
 		// the "no Config" assertions below ambiguous.
 		control: "orderdetail",
+		// As on asp_net_core above: one MauiApp builder per MauiProgram.cs is
+		// the idiom, but the multiplicity is graded anyway (#7022). Measured
+		// through the real detector before it was pinned: [firstApp secondApp].
+		twoVars: `public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var firstApp = MauiApp.CreateBuilder();
+        var secondApp = MauiApp.CreateBuilder();
+        Routing.RegisterRoute("orderdetail", typeof(OrderDetailPage));
+        return firstApp.Build();
+    }
+}
+`,
+		first: "firstApp", second: "secondApp",
 		annotated: `public static class MauiProgram
 {
     public static MauiApp CreateMauiApp()
@@ -961,9 +1065,11 @@ func TestIssue6916_TierAConfigIsNamedAfterItsVariable(t *testing.T) {
 // was nothing for a per-router `Middleware REGISTERED_ON <router>` edge to
 // point at, and adding the edge rule would not have created one.
 //
-// The two C# sites are absent on purpose: a WebApplication/MauiApp builder is
-// the single entry point of its file, so a second construction there would be a
-// fixture shaped to the test rather than to the language.
+// All EIGHT sites are graded here. The two C# sites were originally left out on
+// the argument that one builder per Program.cs is the idiom; #7022 put them
+// back, because an idiom argument does not fail a build and a tightening that
+// reintroduced per-file collapsing would have been caught by six sites and
+// missed by two.
 func TestIssue6916_TierAEachConstructionGetsItsOwnEntity(t *testing.T) {
 	for _, s := range tierA6916Sites {
 		if s.twoVars == "" {
@@ -1308,6 +1414,66 @@ func TestIssue6916_TierABareConstructorCallMintsNoConfig(t *testing.T) {
 				t.Errorf("%s: positive control missing — the same file WITH the qualifier no "+
 					"longer mints Config:%s, so the absence above proves nothing. Entities:\n  %s",
 					s.rule, s.nonFrameworkWant, strings.Join(ctl, "\n  "))
+			}
+		})
+	}
+}
+
+// TestIssue6916_TierAIfInitialiserMintsNoKeywordConfig grades the #7022 split.
+//
+// A SINGLE Go entry with an optional `var` AND an optional trailing type slot
+// let `if r := chi.NewRouter(); …` match with the keyword `if` in the name slot
+// and `r` in the type slot, minting `Config:if` — a node named after a syntax
+// token, which is the defect class #6916 exists to remove. Splitting each Go
+// site into a short form (no type slot) and a `var` form (type slot behind a
+// literal `var`) closes it without touching gorm, whose comma list already made
+// it immune.
+//
+// Both directions are scored: the keyword must never be a Name, AND the
+// ordinary `r := chi.NewRouter()` form must still mint its variable — a fix that
+// simply stops minting is not a fix, so every leg re-runs the site's own
+// single-construction control and requires the entity back.
+//
+// The other two language families were probed through the real detector and
+// mint nothing for their nearest shapes — rust `if let Some(app) = Router::new()`
+// (the pattern requires a line-initial `let`) and C# `if (x) builder =
+// WebApplication.CreateBuilder(args)` (no if-initialiser exists) — so they carry
+// no fixture here. One language family is not a population: that is a measured
+// absence for two of them, not an assumption about the rest.
+func TestIssue6916_TierAIfInitialiserMintsNoKeywordConfig(t *testing.T) {
+	for _, s := range tierA6916Sites {
+		if s.ifInit == "" {
+			continue
+		}
+		t.Run(s.rule, func(t *testing.T) {
+			if !strings.Contains(s.ifInit, "if ") {
+				t.Fatalf("%s: fixture bug — the ifInit fixture carries no if-initialiser, so "+
+					"this leg is not testing the shape its name claims.", s.rule)
+			}
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, s.ifInit))
+			names := configNames6916(ids)
+			for _, name := range names {
+				if name != s.ifInitWant {
+					t.Errorf("%s: an if-with-initialiser minted Config:%q. The only names this "+
+						"shape may produce are the declared variable (%q, or none); a keyword in "+
+						"the name slot means the type slot is reachable without `var`.",
+						s.rule, name, s.ifInitWant)
+				}
+			}
+			if s.ifInitWant != "" && !slices.Contains(names, s.ifInitWant) {
+				t.Logf("%s: the if-initialiser mints nothing (names: %v). That is the accepted "+
+					"cost of the split, not a failure.", s.rule, names)
+			}
+			assertControl6916(t, ids, s.control)
+
+			// Positive control: the ORDINARY assignment form on the same site
+			// must still mint its variable. Without this, a rule that stopped
+			// firing altogether would pass every assertion above.
+			ctl := entityIDs6916(detect6916(t, s.path, s.lang, s.nonFrameworkCtl))
+			if !slices.Contains(ctl, "Config:"+s.nonFrameworkWant) {
+				t.Errorf("%s: positive control missing — the plain `x := %s(...)` form no longer "+
+					"mints Config:%s, so the absence above proves nothing. Entities:\n  %s",
+					s.rule, s.qualifier, s.nonFrameworkWant, strings.Join(ctl, "\n  "))
 			}
 		})
 	}

--- a/internal/engine/tier_a_config_variable_6916_test.go
+++ b/internal/engine/tier_a_config_variable_6916_test.go
@@ -10,10 +10,12 @@ import (
 // #6916 Tier A — the eight `Config` source_patterns whose construction is
 // assigned to a variable on the same line:
 //
-//	go/frameworks/chi.yaml:58        chi.NewRouter()
-//	go/frameworks/echo.yaml:52       echo.New()
-//	go/frameworks/fiber.yaml:52      fiber.New()
-//	go/frameworks/gin.yaml:52        gin.Default() / gin.New()
+// The four Go sites are THREE entries each after #7022 (short / `var` /
+// grouped); the line below is the short form, the other two follow it.
+//	go/frameworks/chi.yaml:79        chi.NewRouter()
+//	go/frameworks/echo.yaml:73       echo.New()
+//	go/frameworks/fiber.yaml:73      fiber.New()
+//	go/frameworks/gin.yaml:73        gin.Default() / gin.New()
 //	go/frameworks/gorm.yaml:15       gorm.Open(...)
 //	rust/frameworks/axum.yaml:82     Router::new()
 //	csharp/frameworks/asp_net_core.yaml:90  WebApplication.CreateBuilder(...)
@@ -79,9 +81,17 @@ type tierA6916Site struct {
 	// commented is the same construction inside a line comment: the shape that
 	// grades the `(?m)^[ \t]*` anchor. Must mint no Config.
 	// commentedCtl is the SAME file with the comment marker removed.
-	commented     string
-	commentedCtl  string
-	commentedWant string
+	//
+	// On the four Go sites the fixture carries the short, the single-line `var`
+	// and the GROUPED spelling, because #7022 split those sites into three
+	// entries and the anchor has to be graded on each one separately: with the
+	// anchor dropped from the `var` entry alone the whole suite stayed green
+	// while `// var mux *chi.Mux = chi.NewRouter()` minted `Config:mux`.
+	// commentedExtraWant lists the additional names the control must mint.
+	commented          string
+	commentedCtl       string
+	commentedWant      string
+	commentedExtraWant []string
 
 	// nonFramework spells the same call against another package/type; it must
 	// mint nothing. nonFrameworkCtl is the same file with the framework
@@ -90,15 +100,25 @@ type tierA6916Site struct {
 	nonFrameworkCtl  string
 	nonFrameworkWant string
 
-	// ifInit constructs the object inside Go's if-with-initialiser, where a
-	// KEYWORD sits in the position the pattern reads as the variable name.
-	// Must mint no Config named after the keyword; ifInitWant is the variable
-	// that a correct rule may still name (empty where the shape mints nothing
-	// at all). Go-only: rust's pattern requires a line-initial `let` and C#
-	// has no if-initialiser, and both were probed through the real detector
-	// and mint nothing here — see the test below.
-	ifInit     string
-	ifInitWant string
+	// keywordInit puts a KEYWORD where the pattern reads the variable name:
+	// Go's if/switch/go statement heads, in BOTH the `:=` and the plain `=`
+	// spelling. Measured at `87106f12c`, these minted `Config:if`,
+	// `Config:switch` and `Config:go`; the whole fixture must now mint NOTHING.
+	// Go-only: rust's pattern requires a line-initial `let` and C# has no
+	// if-initialiser, and both were probed through the real detector and mint
+	// nothing here — see the test below.
+	keywordInit string
+
+	// groupedVar declares the construction inside a `var (…)` block WITH an
+	// explicit type — the shape that falls between a short form with no type
+	// slot and a `var` form whose type slot sits behind a literal `var`, since
+	// inside the block the `var` is on its own line. It matched before the
+	// split and must keep matching: losing a working binding is worse than the
+	// junk name the split removed. groupedVarWant is asserted; the block also
+	// carries a SECOND declarator, so a per-line entry is graded rather than a
+	// once-per-block one.
+	groupedVar                      string
+	groupedVarWant, groupedVarWant2 string
 
 	// reassigned rebinds an EXISTING variable with no `let`. Only axum carries
 	// one: its pattern requires the declaration keyword, and this is the shape
@@ -132,7 +152,7 @@ type tierA6916Site struct {
 // fixture body against the claim its name made.
 var tierA6916Sites = []tierA6916Site{
 	{
-		rule:      "go/frameworks/chi.yaml:58",
+		rule:      "go/frameworks/chi.yaml:79",
 		qualifier: "chi.",
 		lang:      "go",
 		path:      "main.go",
@@ -155,7 +175,7 @@ func main() {
 }
 `,
 		first: "r", second: "api",
-		ifInit: `package main
+		keywordInit: `package main
 
 import (
 	"net/http"
@@ -169,9 +189,34 @@ func main() {
 	if r := chi.NewRouter(); r != nil {
 		_ = r
 	}
+
+	var api *chi.Mux
+	if api = chi.NewRouter(); api != nil {
+		_ = api
+	}
+
+	switch api = chi.NewRouter(); {
+	default:
+		_ = api
+	}
 }
 `,
-		ifInitWant: "r",
+		groupedVar: `package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func listUsers(w http.ResponseWriter, r *http.Request) {}
+
+var (
+	grouped *chi.Mux = chi.NewRouter()
+	secondary *chi.Mux = chi.NewRouter()
+)
+`,
+		groupedVarWant: "grouped", groupedVarWant2: "secondary",
 		annotated: `package main
 
 import (
@@ -193,6 +238,10 @@ func listUsers(w http.ResponseWriter, r *http.Request) {}
 
 // Historically this file built its own router:
 //	r := chi.NewRouter()
+//	var mux *chi.Mux = chi.NewRouter()
+//	var (
+//		grouped *chi.Mux = chi.NewRouter()
+//	)
 `,
 		commentedCtl: `package main
 
@@ -202,8 +251,12 @@ func listUsers(w http.ResponseWriter, r *http.Request) {}
 
 // Historically this file built its own router:
 r := chi.NewRouter()
+var mux *chi.Mux = chi.NewRouter()
+var (
+	grouped *chi.Mux = chi.NewRouter()
+)
 `,
-		commentedWant: "r",
+		commentedWant: "r", commentedExtraWant: []string{"mux", "grouped"},
 		nonFramework: `package main
 
 import (
@@ -266,7 +319,7 @@ func (s *Server) setup() {
 		fieldTargetWant: "router",
 	},
 	{
-		rule:      "go/frameworks/echo.yaml:52",
+		rule:      "go/frameworks/echo.yaml:73",
 		qualifier: "echo.",
 		lang:      "go",
 		path:      "main.go",
@@ -285,7 +338,7 @@ func main() {
 }
 `,
 		first: "e", second: "admin",
-		ifInit: `package main
+		keywordInit: `package main
 
 import "github.com/labstack/echo/v4"
 
@@ -295,9 +348,30 @@ func main() {
 	if e := echo.New(); e != nil {
 		_ = e
 	}
+
+	var admin *echo.Echo
+	if admin = echo.New(); admin != nil {
+		_ = admin
+	}
+
+	switch admin = echo.New(); {
+	default:
+		_ = admin
+	}
 }
 `,
-		ifInitWant: "e",
+		groupedVar: `package main
+
+import "github.com/labstack/echo/v4"
+
+func listUsers(c echo.Context) error { return nil }
+
+var (
+	grouped *echo.Echo = echo.New()
+	secondary *echo.Echo = echo.New()
+)
+`,
+		groupedVarWant: "grouped", groupedVarWant2: "secondary",
 		annotated: `package main
 
 import "github.com/labstack/echo/v4"
@@ -315,6 +389,10 @@ func listUsers(c echo.Context) error { return nil }
 
 // Example from the README:
 //	e := echo.New()
+//	var srv *echo.Echo = echo.New()
+//	var (
+//		grouped *echo.Echo = echo.New()
+//	)
 `,
 		commentedCtl: `package main
 
@@ -324,8 +402,12 @@ func listUsers(c echo.Context) error { return nil }
 
 // Example from the README:
 e := echo.New()
+var srv *echo.Echo = echo.New()
+var (
+	grouped *echo.Echo = echo.New()
+)
 `,
-		commentedWant: "e",
+		commentedWant: "e", commentedExtraWant: []string{"srv", "grouped"},
 		nonFramework: `package main
 
 import (
@@ -378,7 +460,7 @@ func (s *Server) setup() {
 		fieldTargetWant: "engine",
 	},
 	{
-		rule:      "go/frameworks/fiber.yaml:52",
+		rule:      "go/frameworks/fiber.yaml:73",
 		qualifier: "fiber.",
 		lang:      "go",
 		path:      "main.go",
@@ -397,7 +479,7 @@ func main() {
 }
 `,
 		first: "app", second: "metrics",
-		ifInit: `package main
+		keywordInit: `package main
 
 import "github.com/gofiber/fiber/v2"
 
@@ -407,9 +489,30 @@ func main() {
 	if app := fiber.New(); app != nil {
 		_ = app
 	}
+
+	var metrics *fiber.App
+	if metrics = fiber.New(); metrics != nil {
+		_ = metrics
+	}
+
+	switch metrics = fiber.New(); {
+	default:
+		_ = metrics
+	}
 }
 `,
-		ifInitWant: "app",
+		groupedVar: `package main
+
+import "github.com/gofiber/fiber/v2"
+
+func listUsers(c *fiber.Ctx) error { return nil }
+
+var (
+	grouped *fiber.App = fiber.New()
+	secondary *fiber.App = fiber.New()
+)
+`,
+		groupedVarWant: "grouped", groupedVarWant2: "secondary",
 		annotated: `package main
 
 import "github.com/gofiber/fiber/v2"
@@ -427,6 +530,10 @@ func listUsers(c *fiber.Ctx) error { return nil }
 
 // Quickstart:
 //	app := fiber.New()
+//	var srv *fiber.App = fiber.New()
+//	var (
+//		grouped *fiber.App = fiber.New()
+//	)
 `,
 		commentedCtl: `package main
 
@@ -436,8 +543,12 @@ func listUsers(c *fiber.Ctx) error { return nil }
 
 // Quickstart:
 app := fiber.New()
+var srv *fiber.App = fiber.New()
+var (
+	grouped *fiber.App = fiber.New()
+)
 `,
-		commentedWant: "app",
+		commentedWant: "app", commentedExtraWant: []string{"srv", "grouped"},
 		nonFramework: `package main
 
 import (
@@ -490,7 +601,7 @@ func (s *Server) setup() {
 		fieldTargetWant: "app",
 	},
 	{
-		rule:      "go/frameworks/gin.yaml:52",
+		rule:      "go/frameworks/gin.yaml:73",
 		qualifier: "gin.",
 		lang:      "go",
 		path:      "main.go",
@@ -512,7 +623,7 @@ func main() {
 }
 `,
 		first: "r", second: "admin",
-		ifInit: `package main
+		keywordInit: `package main
 
 import "github.com/gin-gonic/gin"
 
@@ -522,9 +633,30 @@ func main() {
 	if r := gin.Default(); r != nil {
 		_ = r
 	}
+
+	var admin *gin.Engine
+	if admin = gin.Default(); admin != nil {
+		_ = admin
+	}
+
+	switch admin = gin.Default(); {
+	default:
+		_ = admin
+	}
 }
 `,
-		ifInitWant: "r",
+		groupedVar: `package main
+
+import "github.com/gin-gonic/gin"
+
+func listUsers(c *gin.Context) {}
+
+var (
+	grouped *gin.Engine = gin.Default()
+	secondary *gin.Engine = gin.Default()
+)
+`,
+		groupedVarWant: "grouped", groupedVarWant2: "secondary",
 		annotated: `package main
 
 import "github.com/gin-gonic/gin"
@@ -542,6 +674,10 @@ func listUsers(c *gin.Context) {}
 
 // The default engine ships with Logger and Recovery:
 //	r := gin.Default()
+//	var engine *gin.Engine = gin.Default()
+//	var (
+//		grouped *gin.Engine = gin.Default()
+//	)
 `,
 		commentedCtl: `package main
 
@@ -551,8 +687,12 @@ func listUsers(c *gin.Context) {}
 
 // The default engine ships with Logger and Recovery:
 r := gin.Default()
+var engine *gin.Engine = gin.Default()
+var (
+	grouped *gin.Engine = gin.Default()
+)
 `,
-		commentedWant: "r",
+		commentedWant: "r", commentedExtraWant: []string{"engine", "grouped"},
 		nonFramework: `package main
 
 import (
@@ -627,7 +767,9 @@ func open() {
 }
 `,
 		first: "primary", second: "replica",
-		ifInit: `package db
+		// gorm is the control for the whole #7022 split: it was NOT split, its
+		// comma list already made it immune, and it must stay immune.
+		keywordInit: `package db
 
 import "gorm.io/gorm"
 
@@ -1147,10 +1289,12 @@ func TestIssue6916_TierACommentedConstructionMintsNoConfig(t *testing.T) {
 			assertControl6916(t, ids, s.control)
 
 			ctl := entityIDs6916(detect6916(t, s.path, s.lang, s.commentedCtl))
-			if !slices.Contains(ctl, "Config:"+s.commentedWant) {
-				t.Errorf("%s: positive control missing — the same file with the comment marker "+
-					"removed no longer mints Config:%s, so the absence above proves nothing about "+
-					"the comment. Entities:\n  %s", s.rule, s.commentedWant, strings.Join(ctl, "\n  "))
+			for _, want := range append([]string{s.commentedWant}, s.commentedExtraWant...) {
+				if !slices.Contains(ctl, "Config:"+want) {
+					t.Errorf("%s: positive control missing — the same file with the comment marker "+
+						"removed no longer mints Config:%s, so the absence above proves nothing about "+
+						"the comment. Entities:\n  %s", s.rule, want, strings.Join(ctl, "\n  "))
+				}
 			}
 		})
 	}
@@ -1419,50 +1563,53 @@ func TestIssue6916_TierABareConstructorCallMintsNoConfig(t *testing.T) {
 	}
 }
 
-// TestIssue6916_TierAIfInitialiserMintsNoKeywordConfig grades the #7022 split.
+// TestIssue6916_TierAKeywordInitialiserMintsNoConfig grades the #7022 split.
 //
 // A SINGLE Go entry with an optional `var` AND an optional trailing type slot
-// let `if r := chi.NewRouter(); …` match with the keyword `if` in the name slot
-// and `r` in the type slot, minting `Config:if` — a node named after a syntax
-// token, which is the defect class #6916 exists to remove. Splitting each Go
-// site into a short form (no type slot) and a `var` form (type slot behind a
-// literal `var`) closes it without touching gorm, whose comma list already made
-// it immune.
+// let a STATEMENT KEYWORD match in the name slot and the real variable in the
+// type slot. Measured at `87106f12c` through the real detector, on all four Go
+// sites:
 //
-// Both directions are scored: the keyword must never be a Name, AND the
-// ordinary `r := chi.NewRouter()` form must still mint its variable — a fix that
-// simply stops minting is not a fix, so every leg re-runs the site's own
-// single-construction control and requires the entity back.
+//	if r := chi.NewRouter(); …      -> Config:if
+//	if r = chi.NewRouter(); …       -> Config:if
+//	switch r = chi.NewRouter(); …   -> Config:switch
+//	go r = chi.NewRouter()          -> Config:go
+//	for r := chi.NewRouter(); …     -> Config:for
+//	const r = chi.NewRouter()       -> Config:const
+//
+// Every one of those is a node named after a syntax token, which is the defect
+// class #6916 exists to remove. The fixture carries BOTH the `:=` and the plain
+// `=` spelling on purpose: a first cut pinned only `:=`, and a mutant making
+// `var` optional on the declaration entry then survived the whole suite while
+// the `=` twins came straight back. Pinning one spelling and leaving its legal
+// sibling open is the failure this PR family keeps repeating.
+//
+// gorm carries the fixture too, as the control for the split itself: it was NOT
+// split, and it must stay immune.
 //
 // The other two language families were probed through the real detector and
 // mint nothing for their nearest shapes — rust `if let Some(app) = Router::new()`
 // (the pattern requires a line-initial `let`) and C# `if (x) builder =
 // WebApplication.CreateBuilder(args)` (no if-initialiser exists) — so they carry
-// no fixture here. One language family is not a population: that is a measured
-// absence for two of them, not an assumption about the rest.
-func TestIssue6916_TierAIfInitialiserMintsNoKeywordConfig(t *testing.T) {
+// no fixture here. Two of three families measured, not assumed.
+func TestIssue6916_TierAKeywordInitialiserMintsNoConfig(t *testing.T) {
 	for _, s := range tierA6916Sites {
-		if s.ifInit == "" {
+		if s.keywordInit == "" {
 			continue
 		}
 		t.Run(s.rule, func(t *testing.T) {
-			if !strings.Contains(s.ifInit, "if ") {
-				t.Fatalf("%s: fixture bug — the ifInit fixture carries no if-initialiser, so "+
-					"this leg is not testing the shape its name claims.", s.rule)
-			}
-			ids := entityIDs6916(detect6916(t, s.path, s.lang, s.ifInit))
-			names := configNames6916(ids)
-			for _, name := range names {
-				if name != s.ifInitWant {
-					t.Errorf("%s: an if-with-initialiser minted Config:%q. The only names this "+
-						"shape may produce are the declared variable (%q, or none); a keyword in "+
-						"the name slot means the type slot is reachable without `var`.",
-						s.rule, name, s.ifInitWant)
+			for _, kw := range []string{"if ", "= "} {
+				if !strings.Contains(s.keywordInit, kw) {
+					t.Fatalf("%s: fixture bug — the keywordInit fixture carries no %q, so it is "+
+						"not testing the shape its name claims.", s.rule, kw)
 				}
 			}
-			if s.ifInitWant != "" && !slices.Contains(names, s.ifInitWant) {
-				t.Logf("%s: the if-initialiser mints nothing (names: %v). That is the accepted "+
-					"cost of the split, not a failure.", s.rule, names)
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, s.keywordInit))
+			if names := configNames6916(ids); len(names) != 0 {
+				t.Errorf("%s: a statement keyword reached the name slot and minted %v. A type "+
+					"slot is only safe BEHIND a literal `var` (or behind a qualified type); an "+
+					"entity named after a keyword is the #6916 defect wearing a new spelling.",
+					s.rule, names)
 			}
 			assertControl6916(t, ids, s.control)
 
@@ -1475,6 +1622,62 @@ func TestIssue6916_TierAIfInitialiserMintsNoKeywordConfig(t *testing.T) {
 					"mints Config:%s, so the absence above proves nothing. Entities:\n  %s",
 					s.rule, s.qualifier, s.nonFrameworkWant, strings.Join(ctl, "\n  "))
 			}
+		})
+	}
+}
+
+// TestIssue6916_TierAGroupedVarDeclarationNamesEachVariable pins the shape that
+// the #7022 split first LOST, and that review caught before it shipped.
+//
+// Splitting one pattern into several is how gaps open. The first cut had two
+// entries — a short form with no type slot, and a `var` form whose type slot sat
+// behind a literal `var` — and a grouped declaration matched NEITHER, because
+// inside `var (…)` the keyword is on its own line:
+//
+//	var (
+//	        r *chi.Mux = chi.NewRouter()
+//	)
+//
+// `Config=[r]` at `87106f12c`, `Config=[]` after the first cut, on all four
+// sites. Losing a binding that worked is worse than the junk name the split was
+// removing, so a third entry restores it — and stays keyword-proof by requiring
+// the type to be package-QUALIFIED, since `if r = chi.NewRouter(); …` cannot
+// spell `r` as `chi.Something`. (Making `var` merely optional, the obvious fix,
+// reopens the whole keyword hole for the plain-`=` forms above; that was
+// measured, not assumed.)
+//
+// The block carries TWO declarators so that a once-per-block entry is graded,
+// not just a once-per-file one.
+//
+// The residual, measured and accepted: a grouped declarator whose type is
+// UNQUALIFIED — `var ( r Mux = chi.NewRouter() )`, reachable only via a
+// dot-import or a local alias — minted `[r]` at the parent and mints nothing
+// now. That is the deliberate price of keeping keywords out, and it is stated
+// here rather than left for the next reader to rediscover.
+func TestIssue6916_TierAGroupedVarDeclarationNamesEachVariable(t *testing.T) {
+	for _, s := range tierA6916Sites {
+		if s.groupedVar == "" {
+			continue
+		}
+		t.Run(s.rule, func(t *testing.T) {
+			if !strings.Contains(s.groupedVar, "var (") {
+				t.Fatalf("%s: fixture bug — the groupedVar fixture has no `var (` block, so it "+
+					"is testing the single-line declaration the `var` entry already covers.", s.rule)
+			}
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, s.groupedVar))
+			names := configNames6916(ids)
+			if s.groupedVarWant == s.groupedVarWant2 {
+				t.Fatalf("%s: fixture bug — the two declarators must differ", s.rule)
+			}
+			for _, want := range []string{s.groupedVarWant, s.groupedVarWant2} {
+				if !slices.Contains(names, want) {
+					t.Errorf("%s: a grouped `var (…)` declaration with an explicit type must name "+
+						"EACH declarator; %q is missing. This shape matched before #7022 split the "+
+						"rule — dropping it is a regression, not a tightening. Config names "+
+						"emitted: %v", s.rule, want, names)
+				}
+			}
+			assertControl6916(t, ids, s.control)
 		})
 	}
 }


### PR DESCRIPTION
Closes #7022. Both Tier A residuals from #6916 / PR #7020, in the same eight rule sites.

**Updated after review (`209d60c9d`)** — the first cut had a regression and two ALIVE mutants. Both are fixed and every mutant has been re-scored against **this** head. Changes since `644b3f0e5` are called out inline.

## 1. A statement keyword reached the capture

The four Go `Config` patterns carried an optional `var` **and** an optional trailing type slot in **one** entry, so a keyword matched in the name slot and the real variable in the type slot. Measured at `87106f12c` through the real detector — this is **wider than the first version of this body claimed**:

```
if r := chi.NewRouter(); …     -> Config:if
if r = chi.NewRouter(); …      -> Config:if
if s.router = chi.NewRouter()  -> Config:if      (qualified LHS)
switch r = chi.NewRouter(); …  -> Config:switch
go r = chi.NewRouter()         -> Config:go
for r := chi.NewRouter(); …    -> Config:for
const r = chi.NewRouter()      -> Config:const
```

All seven mint **nothing** at head, on chi, echo, fiber and gin. `gorm` was already immune (its comma list takes a different path) and is deliberately left as a single entry — it is the control for the split.

### Three entries, not two

Each of the four sites is now three entries, carved so that **no entry offers a free type slot after a bare `\w+`** — that slot is what a keyword walks into:

1. **short form** — `r := chi.NewRouter()`, `s.router = chi.NewRouter()`. No type slot at all.
2. **`var` form** — `var mux *chi.Mux = chi.NewRouter()`. The type slot exists only behind a literal `var`, which no keyword can spell.
3. **grouped form** — `var (` … `r *chi.Mux = chi.NewRouter()` … `)`. **New since review**; see below.

### The blocker review caught: the split lost a working binding

Inside `var (…)` the keyword is on its own line, so entry 2's literal `var` is unreachable and entry 1 has no type slot. A grouped declaration **with an explicit type** matched the pre-split pattern and matched neither new entry:

| fixture | `87106f12c` | first cut | head |
|---|---|---|---|
| `var (\n\tr *chi.Mux = chi.NewRouter()\n)` | `[r]` | **`[]`** | `[r]` |
| `var (\n\tr chi.Router = chi.NewRouter()\n)` | `[r]` | **`[]`** | `[r]` |
| `var (\n\trs []*chi.Mux = …\n)` | `[rs]` | **`[]`** | `[rs]` |
| two declarators in one block | `[api r]` | **`[]`** | `[api r]` |

Losing a binding that worked is worse than the junk name the split removed. Entry 3 restores it.

The obvious fix — making `var` merely optional on entry 2, as review suggested — was **measured and rejected**: it reopens the hole for every plain-`=` keyword head above (review's own MU2 shows this, which is why entry 3 takes a different route). Entry 3 instead requires the type to be **package-qualified** (`[*\[\]]*chi\.\w+`), which no statement keyword can spell, so it is keyword-proof by construction rather than by absence of a counter-example.

**Measured residual, accepted and documented in the test:** a grouped declarator whose type is *unqualified* — `var ( r Mux = chi.NewRouter() )`, reachable only via a dot-import or a local alias — minted `[r]` at the parent and mints nothing now. That is the price of keeping keywords out. Every other real binding shape is preserved; the earlier claim that the union "covers every Go shape that is legal at statement level" is **withdrawn** and replaced by this measurement.

### Neighbours re-probed around the new boundary

Parent vs head, same probe, through the real detector: grouped typed (pointer / qualified / slice), grouped untyped, grouped multi-declarator, grouped unqualified, single-line `var` typed and untyped, short declaration, field assignment, `const` grouped and single, six keyword heads, three commented spellings, bare constructor, foreign package. Only the two rows above changed direction, and only in the intended one.

### Immunity of the other two language families (unchanged, independently reproduced)

`if let Some(app) = Router::new()` → `[]`, `if x { let app = Router::new(); }` → `[]` (rust's pattern requires a line-initial `let`); `if (x) builder = WebApplication.CreateBuilder(args)` → `[]`, same for MauiApp (C# has no if-initialiser). Recorded in the test's doc comment. Two of three families measured, not assumed.

## 2. The two C# sites had no `twoVars` fixture

Tier A's per-variable multiplicity claim was graded on 6 of 8 sites. The behaviour was already correct — `[first second]` and `[firstApp secondApp]` — but the axis had no direct pin. Both shapes are now in the sites' `twoVars` slots, and the two comments arguing the multiplicity was deliberately ungraded there are rewritten rather than left contradicting the fixtures.

**Claim corrected:** the earlier body said the new fixtures "are what kills" a per-file collapse. That does not follow — review showed MU5 is DEAD at `87106f12c` too, via five pre-existing legs. The fixtures add a **direct** pin on an axis that genuinely was ungraded on those two sites; they are not the only thing catching a collapse.

## 3. Two ALIVE mutants closed, one dead assertion removed

- **The anchor was graded on the short form only**, while all four files claimed it was graded on "BOTH" entries — a prose claim no test observed, inside a PR whose parent issue is about exactly that. The `commented` fixture now carries the short, the single-line `var` **and** the grouped spelling, so all three anchors are graded, and the control asserts all three names.
- **`ifInit` pinned only the `:=` spelling.** Renamed `keywordInit` and extended with the plain-`=` `if` and `switch` heads, so the legal sibling of the shape being fixed is graded too.
- **`ifInitWant` is gone.** Head mints nothing for these shapes and its check was a `t.Logf`, not an assertion. The fixture now asserts an empty `Config` set outright, backed by the site's own plain-assignment positive control.

## Mutants — 9 applied, 9 DEAD, all re-scored against `209d60c9d`

Separate detached checkout, green baseline (`./internal/engine/` `ok` 49.6s) immediately before, `-count=1`, `go vet` clean, each edit an exact-occurrence-count replacement (`assert count == 1`) against a **specific one of the three similar entries**, each restore by `cp` from a shasum-verified backup with `git status --porcelain` empty.

| # | Mutant | Verdict |
|---|---|---|
| MU1 | chi entry 1: restore the optional type slot (the original defect) | **DEAD** — `KeywordInitialiser…/chi.yaml:79` |
| MU2 | chi entry 2: `var\s+` → `(?:var\s+)?` (permissive; was ALIVE) | **DEAD** — `KeywordInitialiser…/chi.yaml:79` |
| MU3 | gin: fold all three entries back into the pre-split single entry | **DEAD** — `KeywordInitialiser…/gin.yaml:73` |
| MU4 | chi entry 2: drop the anchor (permissive; was ALIVE) | **DEAD** — `CommentedConstruction…/chi.yaml:79` |
| MU5 | both C# sites: capture the constant qualifier → per-file collapse | **DEAD** — incl. both new `twoVars` legs |
| MU6 | chi entry 3: drop the anchor (permissive) | **DEAD** — `CommentedConstruction…/chi.yaml:79` |
| MU7 | chi entry 3: delete it — i.e. re-introduce the regression | **DEAD** — `GroupedVarDeclaration…` + `CommentedConstruction…` |
| MU8 | chi entry 3: allow ANY type, not just a qualified one (permissive) | **DEAD** — `KeywordInitialiser…/chi.yaml:79` |
| MU9 | chi entry 3: match only the FIRST declarator of a block | **DEAD** — `GroupedVarDeclaration…` (the second declarator) |

MU1/MU2/MU8 score the **over-firing** direction, MU3/MU7 the **regression** direction, MU4/MU6 the anchors, MU9 the per-line grain. Every leg that grades an absence re-runs the site's own plain-assignment control, so a rule that simply stopped firing cannot pass.

## Verification — macOS/APFS (#6966)

- `./internal/engine/` — `ok` 53.1s, `-count=1`
- `./cmd/grafel/` — `ok` 167.2s, `-count=1`, under a **fresh** `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`. The whole-graph digest pin did not move.
- `scripts/quality/run.sh --runs 1 --ratchet` — exit 0, *38 gated fixtures held their baseline (29 at 100% must-have recall)*, and `git status --porcelain` empty afterwards, so **no baseline moved** (not inferred from the summary line).
- `gofmt -l` clean, `go vet ./internal/engine/` clean.

Refs #6916, #6914, #7013, #7020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
