### PR TITLE
fix(#7013): 52 rule files' import_markers were written correctly and unreadable — the container key was misspelled 14 ways

### DIFF
--- a/internal/engine/rule_container_key_7013_test.go
+++ b/internal/engine/rule_container_key_7013_test.go
@@ -1,0 +1,427 @@
+package engine
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"gopkg.in/yaml.v3"
+)
+
+// This file is the guard for step 1 of #7013.
+//
+// FrameworkRule models exactly one top-level container, `frameworks:`, and
+// that container is the only route by which `detection.import_markers` reaches
+// the engine (loader.go unmarshals into FrameworkRule; detector.go:153 copies
+// fr.Frameworks.Detection.ImportMarkers into the compiled rule set, and
+// frameworkPresent is the sole consumer). yaml.Unmarshal drops unknown
+// top-level keys silently, so a file that spells the container `orms_database:`
+// parses successfully and hands the engine no markers at all.
+//
+// The #7014 audit measured that: 247 of the 520 loader-scoped rule files keyed
+// their container on one of 14 misspellings — `orms_database` (121), `orms`
+// (35), `database_libraries` (14), `template_engines` (11), `orms_and_database`
+// (11), `orm_db` (10), `orm_database` (9), `frameworks_and_dialects` (9),
+// `database` (8), `orms_databases` (6), `framework_templates` (5), `mobile` (4),
+// `framework` (3), `queues` (1) — and 52 of those 247 carried real, correct
+// `detection.import_markers` the engine could not see. The markers were written;
+// they were unreadable.
+//
+// The 247 files were reconciled onto `frameworks:`. The two assertions here are
+// the artefact, not the count:
+//
+//   - specific named files' markers load through the loader's own decode path,
+//     with their exact contents; and
+//   - no loader-scoped rule file anywhere in the tree keeps `import_markers`
+//     under a container the schema does not model.
+//
+// The second is what makes the fix non-recurring: re-introducing any of the 14
+// spellings — or inventing a fifteenth — fails here by file name and key name,
+// whether it arrives as a regression or as a new rule file written to the old
+// habit.
+//
+// Deliberately out of scope: the rest of the metadata half. 465 unmodelled key
+// paths remain (`category`, `notes`, `npm_packages`, `detection_signals.*`, …)
+// and are still dropped at load; that is the tracked migration on #7014, not
+// this guard. This guard is about the ONE key that gates a live mechanism.
+
+// hiddenMarkerFile names one rule file that declares import_markers under a
+// top-level container the schema does not model.
+type hiddenMarkerFile struct {
+	path string
+	key  string
+}
+
+// importMarkerVisibility walks the loader-scoped rule files under rootDir and
+// reports, for each, whether its declared import_markers are reachable by the
+// engine.
+//
+// hidden lists files whose markers sit under an unmodelled top-level container
+// (the #7013 defect). visible counts files whose markers sit under
+// `frameworks:` and therefore load. examined counts loader-scoped files looked
+// at, so a caller can tell "nothing hidden" from "nothing scanned" — a walk
+// that finds no files would otherwise report a clean tree.
+//
+// It is a free function so the checker can be run against a synthetic tree; a
+// checker that always answers "all visible" is worth nothing on the real one.
+func importMarkerVisibility(fsys fs.FS, rootDir string) (hidden []hiddenMarkerFile, visible, examined int, err error) {
+	walkErr := fs.WalkDir(fsys, rootDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if ext := filepath.Ext(path); ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		rel, relErr := filepath.Rel(rootDir, path)
+		if relErr != nil {
+			return nil
+		}
+		// Mirror the loader: only <lang>/<subdir>/<file>.yaml, supported subdir.
+		parts := strings.Split(filepath.ToSlash(rel), "/")
+		if len(parts) != 3 || !ruleSubdirs[parts[1]] {
+			return nil
+		}
+		data, readErr := fs.ReadFile(fsys, path)
+		if readErr != nil {
+			return nil
+		}
+		var raw map[string]any
+		if yaml.Unmarshal(data, &raw) != nil {
+			// A parse failure is a different defect, caught by the #6341
+			// inventory assertion. Not hidden — absent.
+			return nil
+		}
+		examined++
+		for key, val := range raw {
+			if !declaresImportMarkers(val) {
+				continue
+			}
+			if key == "frameworks" {
+				visible++
+				continue
+			}
+			hidden = append(hidden, hiddenMarkerFile{path: filepath.ToSlash(path), key: key})
+		}
+		return nil
+	})
+	return hidden, visible, examined, walkErr
+}
+
+// declaresImportMarkers reports whether a top-level container value carries a
+// non-empty detection.import_markers list.
+func declaresImportMarkers(val any) bool {
+	container, ok := val.(map[string]any)
+	if !ok {
+		return false
+	}
+	detection, ok := container["detection"].(map[string]any)
+	if !ok {
+		return false
+	}
+	markers, ok := detection["import_markers"].([]any)
+	return ok && len(markers) > 0
+}
+
+// TestRuleTree_NoImportMarkersHiddenUnderAnUnmodelledContainer is the assertion
+// over the real embedded tree. Every rule file's import_markers must sit under
+// `frameworks:`, the one container FrameworkRule models.
+func TestRuleTree_NoImportMarkersHiddenUnderAnUnmodelledContainer(t *testing.T) {
+	hidden, visible, examined, err := importMarkerVisibility(rulesFS, "rules")
+	if err != nil {
+		t.Fatalf("walking the embedded rules tree: %v", err)
+	}
+
+	// Non-vacuity, both halves. A walk that scanned nothing, or a tree whose
+	// markers had been "reconciled" by deleting them, must not read as clean.
+	if examined < 500 {
+		t.Fatalf("examined %d loader-scoped rule files, want >= 500: the guard is "+
+			"scanning a fraction of the tree, so its verdict is not about the tree", examined)
+	}
+	if visible < 147 {
+		t.Errorf("%d rule files declare readable frameworks.detection.import_markers, want >= 147: "+
+			"95 were readable before #7013 step 1 and 52 more were recovered from misspelled "+
+			"containers; a drop means markers were deleted rather than reconciled", visible)
+	}
+
+	for _, h := range hidden {
+		t.Errorf("%s declares detection.import_markers under top-level key %q, which "+
+			"FrameworkRule does not model — the markers are dropped at load and "+
+			"requires_framework cannot evaluate against them (#7013, #7014). "+
+			"The container is spelled `frameworks:`.", h.path, h.key)
+	}
+}
+
+// reconciledContainerSpellings are the 14 top-level keys the 247 files were
+// keyed on before #7013 step 1, measured over the loader-scoped tree. They are
+// listed as the closed set they are: a file using any of them again is a
+// regression of this change, whether or not it happens to carry markers today.
+//
+// This is narrower than the strict top-level guard #7014 priced (247 red files,
+// a migration): it forbids the spellings that were actually removed, and costs
+// nothing.
+var reconciledContainerSpellings = []string{
+	"orms_database", "orms", "database_libraries", "template_engines",
+	"orms_and_database", "orm_db", "orm_database", "frameworks_and_dialects",
+	"database", "orms_databases", "framework_templates", "mobile",
+	"framework", "queues",
+}
+
+// TestRuleTree_NoReconciledContainerSpellingReturns keeps the tree at one
+// spelling. TestRuleTree_NoImportMarkersHiddenUnderAnUnmodelledContainer only
+// sees a file once it carries markers; a file re-keyed on `orms_database:` with
+// no markers yet is invisible to it, and is exactly how the next 52 would
+// accumulate.
+func TestRuleTree_NoReconciledContainerSpellingReturns(t *testing.T) {
+	banned := make(map[string]bool, len(reconciledContainerSpellings))
+	for _, k := range reconciledContainerSpellings {
+		banned[k] = true
+	}
+
+	examined := 0
+	err := fs.WalkDir(rulesFS, "rules", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		if ext := filepath.Ext(path); ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		rel, relErr := filepath.Rel("rules", path)
+		if relErr != nil {
+			return nil
+		}
+		parts := strings.Split(filepath.ToSlash(rel), "/")
+		if len(parts) != 3 || !ruleSubdirs[parts[1]] {
+			return nil
+		}
+		data, readErr := fs.ReadFile(rulesFS, path)
+		if readErr != nil {
+			return nil
+		}
+		var raw map[string]any
+		if yaml.Unmarshal(data, &raw) != nil {
+			return nil
+		}
+		examined++
+		for key := range raw {
+			if banned[key] {
+				t.Errorf("%s keys its detection metadata on %q — one of the 14 spellings "+
+					"reconciled onto `frameworks:` in #7013 step 1. The engine models "+
+					"`frameworks:` and nothing else, so everything under %q is dropped at "+
+					"load, including any import_markers added later.",
+					filepath.ToSlash(path), key, key)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the embedded rules tree: %v", err)
+	}
+	if examined < 500 {
+		t.Fatalf("examined %d loader-scoped rule files, want >= 500", examined)
+	}
+}
+
+// TestRuleTree_RecoveredImportMarkersLoad pins the artefact this change exists
+// to produce: the named files whose markers were unreadable before the
+// reconciliation now decode, with their exact contents, through the same
+// yaml.Unmarshal-into-FrameworkRule step the loader performs.
+//
+// One file per formerly-wrong spelling that carried markers.
+func TestRuleTree_RecoveredImportMarkersLoad(t *testing.T) {
+	cases := []struct {
+		path        string // embedded path
+		wasKeyedOn  string // the container spelling it used before #7013 step 1
+		name        string // frameworks.name, also unreadable before
+		wantMarkers []string
+	}{
+		{
+			path:       "rules/csharp/orms/mongodb_csharp.yaml",
+			wasKeyedOn: "orms_database",
+			name:       "MongoDB.Driver (C# official driver)",
+			wantMarkers: []string{
+				"using MongoDB.Driver",
+				"using MongoDB.Bson",
+			},
+		},
+		{
+			path:       "rules/csharp/orms/redis_stackexchange.yaml",
+			wasKeyedOn: "orms",
+			name:       "StackExchange.Redis",
+			wantMarkers: []string{
+				"using StackExchange.Redis",
+				"using ServiceStack.Redis",
+			},
+		},
+		{
+			path:       "rules/go/orms/bun.yaml",
+			wasKeyedOn: "database_libraries",
+			name:       "bun",
+			wantMarkers: []string{
+				`"github.com/uptrace/bun"`,
+				`"github.com/uptrace/bun/dialect/pgdialect"`,
+				`"github.com/uptrace/bun/dialect/mysqldialect"`,
+			},
+		},
+		{
+			path:       "rules/lua/orms/lua_resty_mysql.yaml",
+			wasKeyedOn: "database",
+			name:       "lua-resty-mysql",
+			wantMarkers: []string{
+				`require "resty.mysql"`,
+				`require("resty.mysql")`,
+				"resty.mysql",
+				"db:connect",
+				"db:query",
+				"db:close",
+				"mysql:new()",
+			},
+		},
+		{
+			path:       "rules/zig/orms/zig_sqlite.yaml",
+			wasKeyedOn: "orm_database",
+			name:       "zig-sqlite",
+			wantMarkers: []string{
+				`@import("sqlite")`,
+				`const sqlite = @import("sqlite")`,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			data, err := fs.ReadFile(rulesFS, tc.path)
+			if err != nil {
+				t.Fatalf("reading embedded rule file: %v", err)
+			}
+			var rule FrameworkRule
+			if err := yaml.Unmarshal(data, &rule); err != nil {
+				t.Fatalf("unmarshalling into FrameworkRule (the loader's own step): %v", err)
+			}
+			if rule.Frameworks.Name != tc.name {
+				t.Errorf("frameworks.name = %q, want %q (it was keyed on %q and unreadable before #7013)",
+					rule.Frameworks.Name, tc.name, tc.wasKeyedOn)
+			}
+			got := rule.Frameworks.Detection.ImportMarkers
+			if len(got) != len(tc.wantMarkers) {
+				t.Fatalf("import_markers = %q (%d), want %q (%d): these markers were "+
+					"written under %q and reached the engine as an empty slice",
+					got, len(got), tc.wantMarkers, len(tc.wantMarkers), tc.wasKeyedOn)
+			}
+			for i := range got {
+				if got[i] != tc.wantMarkers[i] {
+					t.Errorf("import_markers[%d] = %q, want %q", i, got[i], tc.wantMarkers[i])
+				}
+			}
+		})
+	}
+}
+
+// TestLoader_DoesNotAdoptAnUnmodelledContainer records the decision this change
+// made: the FILES were reconciled onto one spelling, the LOADER was not taught
+// the other fourteen.
+//
+// Aliasing was the small diff — a handful of extra yaml tags, no rule files
+// touched — and it is the one that cannot be undone, because it makes every
+// spelling correct forever and reads to the next author as an invitation to add
+// a fifteenth. Without this test that choice is unpinned: a loader that quietly
+// adopts markers from whatever container it finds passes every other assertion
+// here, since after the reconciliation no rule file offers it such a container
+// to adopt.
+func TestLoader_DoesNotAdoptAnUnmodelledContainer(t *testing.T) {
+	fsys := fstest.MapFS{
+		"rules/csharp/orms/mongodb_csharp.yaml": {Data: []byte(
+			"orms_database:\n  name: MongoDB\n  detection:\n    import_markers:\n    - \"using MongoDB.Driver\"\n")},
+	}
+	rules, err := LoadAllRulesFromFS(fsys, "rules")
+	if err != nil {
+		t.Fatalf("LoadAllRulesFromFS: %v", err)
+	}
+	got, ok := rules["csharp"]
+	if !ok || len(got) != 1 {
+		t.Fatalf("loaded %d csharp rule sets, want 1", len(got))
+	}
+	if n := len(got[0].Frameworks.Detection.ImportMarkers); n != 0 {
+		t.Errorf("the loader adopted %d import_markers from a container it does not model "+
+			"(%q): #7013 step 1 reconciled the rule files onto `frameworks:` rather than "+
+			"teaching the loader the 14 misspellings, so that the tree keeps one spelling. "+
+			"An adopting loader blesses all of them and the guards above go quiet.",
+			n, "orms_database")
+	}
+	if got[0].Frameworks.Name != "" {
+		t.Errorf("the loader adopted frameworks.name = %q from an unmodelled container",
+			got[0].Frameworks.Name)
+	}
+}
+
+// TestImportMarkerVisibility_FindsAHiddenContainer proves the checker fires.
+// Without it, an importMarkerVisibility that returned nil unconditionally would
+// make the tree assertion pass forever.
+func TestImportMarkerVisibility_FindsAHiddenContainer(t *testing.T) {
+	fsys := fstest.MapFS{
+		// The real shape of the defect, in two of the 14 spellings.
+		"rules/csharp/orms/mongodb_csharp.yaml": {Data: []byte(
+			"orms_database:\n  name: MongoDB\n  detection:\n    import_markers:\n    - \"using MongoDB.Driver\"\n")},
+		"rules/lua/orms/lsqlite3.yaml": {Data: []byte(
+			"database:\n  name: lsqlite3\n  detection:\n    import_markers:\n    - 'require \"lsqlite3\"'\n")},
+		// Reconciled: readable, and must not be flagged.
+		"rules/go/orms/bun.yaml": {Data: []byte(
+			"frameworks:\n  name: bun\n  detection:\n    import_markers:\n    - '\"github.com/uptrace/bun\"'\n")},
+		// A wrong container with no markers at all: out of this guard's scope,
+		// it is part of the #7014 metadata migration, not a hidden gate.
+		"rules/go/orms/ent.yaml": {Data: []byte(
+			"orms_database:\n  name: ent\n  category: orm\n")},
+		// Not loader-scoped: two path segments, and an unsupported subdir.
+		"rules/csharp/_manifest.yaml": {Data: []byte(
+			"orms_database:\n  detection:\n    import_markers:\n    - x\n")},
+		"rules/csharp/notes/reference.yaml": {Data: []byte(
+			"orms_database:\n  detection:\n    import_markers:\n    - x\n")},
+	}
+
+	hidden, visible, examined, err := importMarkerVisibility(fsys, "rules")
+	if err != nil {
+		t.Fatalf("importMarkerVisibility: %v", err)
+	}
+	if examined != 4 {
+		t.Errorf("examined = %d, want 4 (only <lang>/<subdir>/*.yaml in a supported subdir)", examined)
+	}
+	if visible != 1 {
+		t.Errorf("visible = %d, want 1", visible)
+	}
+	got := make([]string, 0, len(hidden))
+	for _, h := range hidden {
+		got = append(got, h.path+":"+h.key)
+	}
+	want := []string{
+		"rules/csharp/orms/mongodb_csharp.yaml:orms_database",
+		"rules/lua/orms/lsqlite3.yaml:database",
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("hidden = %v, want %v", got, want)
+	}
+}
+
+// TestImportMarkerVisibility_EmptyMarkerListIsNotHidden pins the other
+// direction. `detection.import_markers:` present but empty carries nothing for
+// the engine to lose, so flagging it would make the guard noisy about files
+// that have no gate to hide.
+func TestImportMarkerVisibility_EmptyMarkerListIsNotHidden(t *testing.T) {
+	fsys := fstest.MapFS{
+		"rules/go/orms/ent.yaml": {Data: []byte(
+			"orms_database:\n  name: ent\n  detection:\n    import_markers: []\n")},
+	}
+	hidden, visible, examined, err := importMarkerVisibility(fsys, "rules")
+	if err != nil {
+		t.Fatalf("importMarkerVisibility: %v", err)
+	}
+	if examined != 1 || visible != 0 {
+		t.Fatalf("examined = %d, visible = %d, want 1 and 0", examined, visible)
+	}
+	if len(hidden) != 0 {
+		t.Errorf("an empty import_markers list was reported hidden: %v", hidden)
+	}
+}

--- a/internal/engine/rules/clojure/frameworks/amazonica_dynamodb.yaml
+++ b/internal/engine/rules/clojure/frameworks/amazonica_dynamodb.yaml
@@ -1,4 +1,4 @@
-framework:
+frameworks:
   name: Amazonica / cognitect-labs aws-api (DynamoDB)
   category: nosql_database
   clojars_package: amazonica

--- a/internal/engine/rules/clojure/orms/clojure_java_jdbc_legacy.yaml
+++ b/internal/engine/rules/clojure/orms/clojure_java_jdbc_legacy.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: clojure.java.jdbc (legacy)
   clojars_artifact: org.clojure/java.jdbc
   category: sql_jdbc_legacy

--- a/internal/engine/rules/clojure/orms/datascript.yaml
+++ b/internal/engine/rules/clojure/orms/datascript.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: Datascript
   clojars_artifact: datascript/datascript
   category: database_in_memory_datalog

--- a/internal/engine/rules/clojure/orms/datomic.yaml
+++ b/internal/engine/rules/clojure/orms/datomic.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: Datomic
   clojars_artifact: com.datomic/datomic-free
   category: database_immutable_graph

--- a/internal/engine/rules/clojure/orms/honeysql.yaml
+++ b/internal/engine/rules/clojure/orms/honeysql.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: HoneySQL
   clojars_artifact: com.github.seancorfield/honeysql
   category: sql_dsl

--- a/internal/engine/rules/clojure/orms/korma_legacy.yaml
+++ b/internal/engine/rules/clojure/orms/korma_legacy.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: Korma (legacy)
   clojars_artifact: korma/korma
   category: sql_orm_legacy

--- a/internal/engine/rules/clojure/orms/mongodb_clojure.yaml
+++ b/internal/engine/rules/clojure/orms/mongodb_clojure.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Monger / CongoMongo (Clojure MongoDB)
   lein_dep: com.novemberain/monger
   category: nosql_driver

--- a/internal/engine/rules/clojure/orms/mysql_clojure.yaml
+++ b/internal/engine/rules/clojure/orms/mysql_clojure.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Clojure Drivers (next.jdbc, clojure.java.jdbc)
   category: relational_database
   deps_edn: com.github.seancorfield/next.jdbc

--- a/internal/engine/rules/clojure/orms/neo4j.yaml
+++ b/internal/engine/rules/clojure/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Neocons (Neo4j Clojure Driver)
   category: graph_database
   clojars_package: clojurewerkz/neocons

--- a/internal/engine/rules/clojure/orms/next_jdbc.yaml
+++ b/internal/engine/rules/clojure/orms/next_jdbc.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: next.jdbc
   clojars_artifact: com.github.seancorfield/next.jdbc
   category: sql_jdbc

--- a/internal/engine/rules/clojure/orms/next_jdbc_postgresql.yaml
+++ b/internal/engine/rules/clojure/orms/next_jdbc_postgresql.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: next.jdbc PostgreSQL (Clojure)
   category: postgres_driver
   clojars_packages:

--- a/internal/engine/rules/clojure/orms/sqlite_clojure.yaml
+++ b/internal/engine/rules/clojure/orms/sqlite_clojure.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Clojure SQLite (next.jdbc / clojure.java.jdbc with sqlite-jdbc)
   category: sqlite_driver
   deps_edn:

--- a/internal/engine/rules/cpp/orms/libpqxx.yaml
+++ b/internal/engine/rules/cpp/orms/libpqxx.yaml
@@ -1,4 +1,4 @@
-orm_db:
+frameworks:
   name: libpqxx
   category: postgresql_client
   github_stars_2025: 1100+

--- a/internal/engine/rules/cpp/orms/mysql_cpp.yaml
+++ b/internal/engine/rules/cpp/orms/mysql_cpp.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Connector/C++ (libmysqlclient)
   category: relational_database
   detection:

--- a/internal/engine/rules/cpp/orms/nanodbc.yaml
+++ b/internal/engine/rules/cpp/orms/nanodbc.yaml
@@ -1,4 +1,4 @@
-orm_db:
+frameworks:
   name: nanodbc
   category: odbc_wrapper
   github_stars_2025: 500+

--- a/internal/engine/rules/cpp/orms/odb.yaml
+++ b/internal/engine/rules/cpp/orms/odb.yaml
@@ -1,4 +1,4 @@
-orm_db:
+frameworks:
   name: ODB
   category: orm
   github_stars_2025: 400+

--- a/internal/engine/rules/cpp/orms/soci.yaml
+++ b/internal/engine/rules/cpp/orms/soci.yaml
@@ -1,4 +1,4 @@
-orm_db:
+frameworks:
   name: SOCI
   category: sql_abstraction
   github_stars_2025: 1500+

--- a/internal/engine/rules/cpp/orms/sqlite_direct_c_api.yaml
+++ b/internal/engine/rules/cpp/orms/sqlite_direct_c_api.yaml
@@ -1,4 +1,4 @@
-orm_db:
+frameworks:
   name: SQLite (direct C API)
   category: embedded_db
   detection:

--- a/internal/engine/rules/cpp/orms/sqlitecpp.yaml
+++ b/internal/engine/rules/cpp/orms/sqlitecpp.yaml
@@ -1,4 +1,4 @@
-orm_db:
+frameworks:
   name: SQLiteCpp
   category: sqlite_wrapper
   github_stars_2025: 2400+

--- a/internal/engine/rules/csharp/orms/cassandra_csharp.yaml
+++ b/internal/engine/rules/csharp/orms/cassandra_csharp.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: CassandraCSharpDriver (DataStax C# Driver)
   category: nosql_database
   nuget_package: CassandraCSharpDriver

--- a/internal/engine/rules/csharp/orms/dapper.yaml
+++ b/internal/engine/rules/csharp/orms/dapper.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Dapper
   nuget_package: Dapper
   category: micro_orm

--- a/internal/engine/rules/csharp/orms/dynamodb_csharp.yaml
+++ b/internal/engine/rules/csharp/orms/dynamodb_csharp.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: AWS DynamoDB .NET SDK (AWSSDK.DynamoDBv2)
   category: nosql_database
   nuget_package: AWSSDK.DynamoDBv2

--- a/internal/engine/rules/csharp/orms/entity_framework_core.yaml
+++ b/internal/engine/rules/csharp/orms/entity_framework_core.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Entity Framework Core
   nuget_package: Microsoft.EntityFrameworkCore
   category: full_orm

--- a/internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml
+++ b/internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: LINQPad / LINQ-to-SQL
   nuget_package: null
   category: query_language_orm

--- a/internal/engine/rules/csharp/orms/mongodb_csharp.yaml
+++ b/internal/engine/rules/csharp/orms/mongodb_csharp.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MongoDB.Driver (C# official driver)
   nuget_package: MongoDB.Driver
   category: nosql_driver

--- a/internal/engine/rules/csharp/orms/mysql_csharp.yaml
+++ b/internal/engine/rules/csharp/orms/mysql_csharp.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL .NET Drivers (MySqlConnector, MySql.Data)
   category: relational_database
   nuget_package: MySqlConnector

--- a/internal/engine/rules/csharp/orms/neo4j.yaml
+++ b/internal/engine/rules/csharp/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Neo4j .NET Driver
   category: graph_database
   nuget_package: Neo4j.Driver

--- a/internal/engine/rules/csharp/orms/nest_elasticsearch.yaml
+++ b/internal/engine/rules/csharp/orms/nest_elasticsearch.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: NEST / Elasticsearch.Net
   nuget_package: NEST
   detection:

--- a/internal/engine/rules/csharp/orms/nhibernate.yaml
+++ b/internal/engine/rules/csharp/orms/nhibernate.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: NHibernate
   nuget_package: NHibernate
   category: full_orm

--- a/internal/engine/rules/csharp/orms/npgsql.yaml
+++ b/internal/engine/rules/csharp/orms/npgsql.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Npgsql (.NET PostgreSQL Driver)
   category: postgres_driver
   nuget_package: Npgsql

--- a/internal/engine/rules/csharp/orms/redis_stackexchange.yaml
+++ b/internal/engine/rules/csharp/orms/redis_stackexchange.yaml
@@ -2,7 +2,7 @@
 #
 # Top-level `orms:` key is consumed by the modular_loader (detection).
 
-orms:
+frameworks:
   name: StackExchange.Redis
   nuget_package: StackExchange.Redis
   category: cache_client

--- a/internal/engine/rules/csharp/orms/sqlite_csharp.yaml
+++ b/internal/engine/rules/csharp/orms/sqlite_csharp.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: C# SQLite Driver (Microsoft.Data.Sqlite / System.Data.SQLite)
   category: sqlite_driver
   nuget_packages:

--- a/internal/engine/rules/dart/frameworks/dynamodb_dart.yaml
+++ b/internal/engine/rules/dart/frameworks/dynamodb_dart.yaml
@@ -1,4 +1,4 @@
-framework:
+frameworks:
   name: aws_dynamodb_api (pub.dev)
   category: nosql_database
   pub_package: aws_dynamodb_api

--- a/internal/engine/rules/dart/frameworks/flutter_desktop_macos_windows_linux.yaml
+++ b/internal/engine/rules/dart/frameworks/flutter_desktop_macos_windows_linux.yaml
@@ -1,4 +1,4 @@
-mobile:
+frameworks:
   name: Flutter Desktop (macOS / Windows / Linux)
   category: desktop
   detection:

--- a/internal/engine/rules/dart/frameworks/flutter_mobile_ios_android.yaml
+++ b/internal/engine/rules/dart/frameworks/flutter_mobile_ios_android.yaml
@@ -1,4 +1,4 @@
-mobile:
+frameworks:
   name: Flutter Mobile (iOS + Android)
   category: mobile_cross_platform
   detection:

--- a/internal/engine/rules/dart/frameworks/flutter_web_web_target.yaml
+++ b/internal/engine/rules/dart/frameworks/flutter_web_web_target.yaml
@@ -1,4 +1,4 @@
-mobile:
+frameworks:
   name: Flutter Web (web target)
   category: mobile_web
   detection:

--- a/internal/engine/rules/dart/orms/drift_formerly_moor.yaml
+++ b/internal/engine/rules/dart/orms/drift_formerly_moor.yaml
@@ -1,4 +1,4 @@
-orm_database:
+frameworks:
   name: drift (formerly moor)
   pubspec_dependency: drift
   category: orm_sqlite

--- a/internal/engine/rules/dart/orms/floor.yaml
+++ b/internal/engine/rules/dart/orms/floor.yaml
@@ -1,4 +1,4 @@
-orm_database:
+frameworks:
   name: floor
   pubspec_dependency: floor
   category: orm_sqlite

--- a/internal/engine/rules/dart/orms/hive.yaml
+++ b/internal/engine/rules/dart/orms/hive.yaml
@@ -1,4 +1,4 @@
-orm_database:
+frameworks:
   name: hive
   pubspec_dependency: hive
   category: nosql_embedded_kv

--- a/internal/engine/rules/dart/orms/isar.yaml
+++ b/internal/engine/rules/dart/orms/isar.yaml
@@ -1,4 +1,4 @@
-orm_database:
+frameworks:
   name: isar
   pubspec_dependency: isar
   category: nosql_embedded

--- a/internal/engine/rules/dart/orms/mongo_dart.yaml
+++ b/internal/engine/rules/dart/orms/mongo_dart.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: mongo_dart (Dart MongoDB driver)
   pub_package: mongo_dart
   category: nosql_driver

--- a/internal/engine/rules/dart/orms/mysql_dart.yaml
+++ b/internal/engine/rules/dart/orms/mysql_dart.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Dart Driver (mysql_client)
   category: relational_database
   pub_package: mysql_client

--- a/internal/engine/rules/dart/orms/neo4j.yaml
+++ b/internal/engine/rules/dart/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Neo4Dart (Neo4j Dart Driver)
   category: graph_database
   pub_package: neo4dart

--- a/internal/engine/rules/dart/orms/postgres_dart.yaml
+++ b/internal/engine/rules/dart/orms/postgres_dart.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: postgres (Dart PostgreSQL Driver)
   category: postgres_driver
   pub_package: postgres

--- a/internal/engine/rules/dart/orms/sqflite.yaml
+++ b/internal/engine/rules/dart/orms/sqflite.yaml
@@ -1,4 +1,4 @@
-orm_database:
+frameworks:
   name: sqflite
   pubspec_dependency: sqflite
   category: sqlite_raw

--- a/internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml
+++ b/internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml
@@ -1,4 +1,4 @@
-framework:
+frameworks:
   name: ex_aws_dynamo (ExAws.Dynamo)
   category: nosql_database
   hex_package: ex_aws_dynamo

--- a/internal/engine/rules/elixir/frameworks/postgrex.yaml
+++ b/internal/engine/rules/elixir/frameworks/postgrex.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Postgrex (Elixir PostgreSQL Driver)
   category: postgres_driver
   hex_package: postgrex

--- a/internal/engine/rules/elixir/orms/neo4j.yaml
+++ b/internal/engine/rules/elixir/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: bolt_sips (Neo4j Elixir Driver)
   category: graph_database
   hex_package: bolt_sips

--- a/internal/engine/rules/go/orms/bun.yaml
+++ b/internal/engine/rules/go/orms/bun.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: bun
   module_path: github.com/uptrace/bun
   category: orm

--- a/internal/engine/rules/go/orms/cassandra_go.yaml
+++ b/internal/engine/rules/go/orms/cassandra_go.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: gocql (Go Cassandra Driver)
   category: nosql_database
   go_module: github.com/gocql/gocql

--- a/internal/engine/rules/go/orms/dynamodb_go.yaml
+++ b/internal/engine/rules/go/orms/dynamodb_go.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: AWS DynamoDB Go SDK v2
   category: nosql_database
   go_module: github.com/aws/aws-sdk-go-v2/service/dynamodb

--- a/internal/engine/rules/go/orms/elasticsearch_go.yaml
+++ b/internal/engine/rules/go/orms/elasticsearch_go.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: go-elasticsearch
   module_path: github.com/elastic/go-elasticsearch/v8
   detection:

--- a/internal/engine/rules/go/orms/ent.yaml
+++ b/internal/engine/rules/go/orms/ent.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: ent
   module_path: entgo.io/ent
   category: orm_code_gen

--- a/internal/engine/rules/go/orms/go_redis.yaml
+++ b/internal/engine/rules/go/orms/go_redis.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: go-redis
   module_path: github.com/redis/go-redis/v9
   category: cache_client

--- a/internal/engine/rules/go/orms/golang_migrate.yaml
+++ b/internal/engine/rules/go/orms/golang_migrate.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: golang-migrate
   go_module: github.com/golang-migrate/migrate/v4
   category: migration_tool

--- a/internal/engine/rules/go/orms/gorm.yaml
+++ b/internal/engine/rules/go/orms/gorm.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: GORM
   module_path: gorm.io/gorm
   category: orm

--- a/internal/engine/rules/go/orms/mongo_driver.yaml
+++ b/internal/engine/rules/go/orms/mongo_driver.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: mongo-driver
   module_path: go.mongodb.org/mongo-driver/v2
   module_path_v1: go.mongodb.org/mongo-driver

--- a/internal/engine/rules/go/orms/mysql_go.yaml
+++ b/internal/engine/rules/go/orms/mysql_go.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Go Driver (go-sql-driver/mysql)
   category: relational_database
   go_module: github.com/go-sql-driver/mysql

--- a/internal/engine/rules/go/orms/neo4j.yaml
+++ b/internal/engine/rules/go/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Neo4j Go Driver
   category: graph_database
   module_path: github.com/neo4j/neo4j-go-driver/v5

--- a/internal/engine/rules/go/orms/pgx.yaml
+++ b/internal/engine/rules/go/orms/pgx.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: pgx
   module_path: github.com/jackc/pgx/v5
   category: postgres_driver

--- a/internal/engine/rules/go/orms/sqlc.yaml
+++ b/internal/engine/rules/go/orms/sqlc.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: sqlc
   module_path: github.com/sqlc-dev/sqlc
   category: sql_code_gen

--- a/internal/engine/rules/go/orms/sqlite_go.yaml
+++ b/internal/engine/rules/go/orms/sqlite_go.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Go SQLite Drivers (mattn/go-sqlite3 / modernc.org/sqlite)
   category: sqlite_driver
   go_modules:

--- a/internal/engine/rules/go/orms/sqlx.yaml
+++ b/internal/engine/rules/go/orms/sqlx.yaml
@@ -1,4 +1,4 @@
-database_libraries:
+frameworks:
   name: sqlx
   module_path: github.com/jmoiron/sqlx
   category: sql_toolkit

--- a/internal/engine/rules/groovy/orms/gorm_grails_object_relational_mapping.yaml
+++ b/internal/engine/rules/groovy/orms/gorm_grails_object_relational_mapping.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: GORM (Grails Object Relational Mapping)
   category: orm_active_record
   gradle_coordinates:

--- a/internal/engine/rules/groovy/orms/hibernate_groovy_grails.yaml
+++ b/internal/engine/rules/groovy/orms/hibernate_groovy_grails.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Hibernate (Groovy / Grails)
   category: orm_jpa
   gradle_coordinates:

--- a/internal/engine/rules/groovy/orms/jooq_groovy.yaml
+++ b/internal/engine/rules/groovy/orms/jooq_groovy.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: JOOQ (Groovy)
   category: orm_sql_dsl
   gradle_coordinates:

--- a/internal/engine/rules/groovy/orms/mybatis_groovy.yaml
+++ b/internal/engine/rules/groovy/orms/mybatis_groovy.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: MyBatis (Groovy)
   category: orm_sql_mapper
   gradle_coordinates:

--- a/internal/engine/rules/haskell/orms/cassandra_haskell.yaml
+++ b/internal/engine/rules/haskell/orms/cassandra_haskell.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: cql-io (Haskell Cassandra Driver)
   category: nosql_database
   hackage_package: cql-io

--- a/internal/engine/rules/haskell/orms/dynamodb_haskell.yaml
+++ b/internal/engine/rules/haskell/orms/dynamodb_haskell.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: amazonka-dynamodb (brendanhay/amazonka)
   category: nosql_database
   hackage_package: amazonka-dynamodb

--- a/internal/engine/rules/haskell/orms/mysql_haskell.yaml
+++ b/internal/engine/rules/haskell/orms/mysql_haskell.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Haskell Drivers (mysql-haskell, mysql-simple)
   category: relational_database
   hackage_package: mysql-haskell

--- a/internal/engine/rules/haskell/orms/neo4j.yaml
+++ b/internal/engine/rules/haskell/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: hasbolt (Neo4j Haskell Driver)
   category: graph_database
   hackage_package: hasbolt

--- a/internal/engine/rules/haskell/orms/postgresql_haskell.yaml
+++ b/internal/engine/rules/haskell/orms/postgresql_haskell.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: PostgreSQL Haskell Drivers (postgresql-simple, hasql)
   category: postgres_driver
   hackage_packages:

--- a/internal/engine/rules/haskell/orms/sqlite_haskell.yaml
+++ b/internal/engine/rules/haskell/orms/sqlite_haskell.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Haskell SQLite (direct-sqlite / persistent-sqlite)
   category: sqlite_driver
   hackage_packages:

--- a/internal/engine/rules/html_templates/frameworks/angular_component_templates.yaml
+++ b/internal/engine/rules/html_templates/frameworks/angular_component_templates.yaml
@@ -1,4 +1,4 @@
-framework_templates:
+frameworks:
   name: Angular Component Templates
   framework: Angular
   extensions:

--- a/internal/engine/rules/html_templates/frameworks/astro_components.yaml
+++ b/internal/engine/rules/html_templates/frameworks/astro_components.yaml
@@ -1,4 +1,4 @@
-framework_templates:
+frameworks:
   name: Astro Components
   framework: Astro
   extensions:

--- a/internal/engine/rules/html_templates/frameworks/blade.yaml
+++ b/internal/engine/rules/html_templates/frameworks/blade.yaml
@@ -1,4 +1,4 @@
-template_engines:
+frameworks:
   name: Blade
   full_name: Blade (Laravel)
   language: php

--- a/internal/engine/rules/html_templates/frameworks/ejs.yaml
+++ b/internal/engine/rules/html_templates/frameworks/ejs.yaml
@@ -1,4 +1,4 @@
-template_engines:
+frameworks:
   name: EJS
   full_name: Embedded JavaScript
   language: javascript

--- a/internal/engine/rules/html_templates/frameworks/erb.yaml
+++ b/internal/engine/rules/html_templates/frameworks/erb.yaml
@@ -1,4 +1,4 @@
-template_engines:
+frameworks:
   name: ERB
   full_name: Embedded Ruby
   language: ruby

--- a/internal/engine/rules/html_templates/frameworks/haml.yaml
+++ b/internal/engine/rules/html_templates/frameworks/haml.yaml
@@ -1,4 +1,4 @@
-template_engines:
+frameworks:
   name: HAML
   full_name: HTML Abstraction Markup Language
   language: ruby

--- a/internal/engine/rules/html_templates/frameworks/handlebars.yaml
+++ b/internal/engine/rules/html_templates/frameworks/handlebars.yaml
@@ -1,4 +1,4 @@
-template_engines:
+frameworks:
   name: Handlebars
   full_name: Handlebars.js
   language: javascript

--- a/internal/engine/rules/html_templates/frameworks/jinja2.yaml
+++ b/internal/engine/rules/html_templates/frameworks/jinja2.yaml
@@ -1,4 +1,4 @@
-template_engines:
+frameworks:
   name: Jinja2
   full_name: Jinja2 (and Jinja)
   language: python

--- a/internal/engine/rules/html_templates/frameworks/mustache.yaml
+++ b/internal/engine/rules/html_templates/frameworks/mustache.yaml
@@ -1,4 +1,4 @@
-template_engines:
+frameworks:
   name: Mustache
   full_name: Mustache
   language: polyglot

--- a/internal/engine/rules/html_templates/frameworks/nunjucks.yaml
+++ b/internal/engine/rules/html_templates/frameworks/nunjucks.yaml
@@ -1,4 +1,4 @@
-template_engines:
+frameworks:
   name: Nunjucks
   full_name: Nunjucks (Mozilla)
   language: javascript

--- a/internal/engine/rules/html_templates/frameworks/pug.yaml
+++ b/internal/engine/rules/html_templates/frameworks/pug.yaml
@@ -1,4 +1,4 @@
-template_engines:
+frameworks:
   name: Pug
   full_name: Pug (formerly Jade)
   language: javascript

--- a/internal/engine/rules/html_templates/frameworks/react_jsx_tsx_templates.yaml
+++ b/internal/engine/rules/html_templates/frameworks/react_jsx_tsx_templates.yaml
@@ -1,4 +1,4 @@
-framework_templates:
+frameworks:
   name: React JSX/TSX Templates
   framework: React / Next.js / Remix
   extensions:

--- a/internal/engine/rules/html_templates/frameworks/slim.yaml
+++ b/internal/engine/rules/html_templates/frameworks/slim.yaml
@@ -1,4 +1,4 @@
-template_engines:
+frameworks:
   name: Slim
   full_name: Slim (Ruby)
   language: ruby

--- a/internal/engine/rules/html_templates/frameworks/svelte_components.yaml
+++ b/internal/engine/rules/html_templates/frameworks/svelte_components.yaml
@@ -1,4 +1,4 @@
-framework_templates:
+frameworks:
   name: Svelte Components
   framework: Svelte / SvelteKit
   extensions:

--- a/internal/engine/rules/html_templates/frameworks/twig.yaml
+++ b/internal/engine/rules/html_templates/frameworks/twig.yaml
@@ -1,4 +1,4 @@
-template_engines:
+frameworks:
   name: Twig
   full_name: Twig (PHP)
   language: php

--- a/internal/engine/rules/html_templates/frameworks/vue_single_file_components.yaml
+++ b/internal/engine/rules/html_templates/frameworks/vue_single_file_components.yaml
@@ -1,4 +1,4 @@
-framework_templates:
+frameworks:
   name: Vue Single File Components
   framework: Vue
   extensions:

--- a/internal/engine/rules/java/orms/dynamodb_java.yaml
+++ b/internal/engine/rules/java/orms/dynamodb_java.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: AWS DynamoDB Java SDK / Spring Data DynamoDB / DynamoDB Enhanced Client
   category: nosql_database
   maven_coordinates: software.amazon.awssdk:dynamodb

--- a/internal/engine/rules/java/orms/hibernate_core.yaml
+++ b/internal/engine/rules/java/orms/hibernate_core.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Hibernate (Core)
   maven_coordinates: org.hibernate.orm:hibernate-core
   gradle_dependency: implementation 'org.hibernate.orm:hibernate-core'

--- a/internal/engine/rules/java/orms/jooq.yaml
+++ b/internal/engine/rules/java/orms/jooq.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: JOOQ
   maven_coordinates: org.jooq:jooq
   gradle_dependency: implementation 'org.jooq:jooq'

--- a/internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml
+++ b/internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: JPA (Jakarta Persistence API)
   maven_coordinates: jakarta.persistence:jakarta.persistence-api
   gradle_dependency: compileOnly 'jakarta.persistence:jakarta.persistence-api'

--- a/internal/engine/rules/java/orms/mybatis.yaml
+++ b/internal/engine/rules/java/orms/mybatis.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MyBatis
   maven_coordinates: org.mybatis:mybatis
   gradle_dependency: implementation 'org.mybatis:mybatis'

--- a/internal/engine/rules/java/orms/mysql_java.yaml
+++ b/internal/engine/rules/java/orms/mysql_java.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Connector/J (Java JDBC Driver)
   category: relational_database
   maven_coordinates: com.mysql:mysql-connector-j

--- a/internal/engine/rules/java/orms/neo4j.yaml
+++ b/internal/engine/rules/java/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Neo4j Java Driver / Spring Data Neo4j / Neo4j OGM
   category: graph_database
   maven_coordinates: org.neo4j.driver:neo4j-java-driver

--- a/internal/engine/rules/java/orms/postgresql_java.yaml
+++ b/internal/engine/rules/java/orms/postgresql_java.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: PostgreSQL Java Drivers (JDBC, HikariCP, PGSimpleDataSource)
   category: postgres_driver
   maven_coordinates:

--- a/internal/engine/rules/java/orms/spring_data_cassandra.yaml
+++ b/internal/engine/rules/java/orms/spring_data_cassandra.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Spring Data Cassandra / DataStax Java Driver
   category: nosql_database
   maven_coordinates: org.springframework.data:spring-data-cassandra

--- a/internal/engine/rules/java/orms/spring_data_elasticsearch.yaml
+++ b/internal/engine/rules/java/orms/spring_data_elasticsearch.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Spring Data Elasticsearch
   maven_coordinates: org.springframework.data:spring-data-elasticsearch
   gradle_dependency: implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'

--- a/internal/engine/rules/java/orms/spring_data_jpa.yaml
+++ b/internal/engine/rules/java/orms/spring_data_jpa.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Spring Data JPA
   maven_coordinates: org.springframework.data:spring-data-jpa
   gradle_dependency: implementation 'org.springframework.data:spring-data-jpa'

--- a/internal/engine/rules/java/orms/spring_data_mongodb.yaml
+++ b/internal/engine/rules/java/orms/spring_data_mongodb.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Spring Data MongoDB
   maven_coordinates: org.springframework.data:spring-data-mongodb
   gradle_dependency: implementation 'org.springframework.data:spring-data-mongodb'

--- a/internal/engine/rules/java/orms/spring_data_redis.yaml
+++ b/internal/engine/rules/java/orms/spring_data_redis.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Spring Data Redis
   maven_coordinates: org.springframework.data:spring-data-redis
   gradle_dependency: implementation 'org.springframework.data:spring-data-redis'

--- a/internal/engine/rules/java/orms/sqlite_java.yaml
+++ b/internal/engine/rules/java/orms/sqlite_java.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Java SQLite Driver (sqlite-jdbc / Xerial)
   category: sqlite_driver
   maven_coordinates:

--- a/internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/cassandra_js.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: cassandra-driver (DataStax Node.js Driver)
   category: nosql_database
   npm_package: cassandra-driver

--- a/internal/engine/rules/javascript_typescript/orms/drizzle.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/drizzle.yaml
@@ -1,4 +1,4 @@
-orms_and_database:
+frameworks:
   name: drizzle
   npm_packages:
   - drizzle-orm

--- a/internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/dynamodb_js.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: AWS DynamoDB JavaScript/TypeScript SDK v3
   category: nosql_database
   npm_package: "@aws-sdk/client-dynamodb"

--- a/internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/elasticsearch_js.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: "@elastic/elasticsearch"
   npm_package: "@elastic/elasticsearch"
   detection:

--- a/internal/engine/rules/javascript_typescript/orms/knex.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/knex.yaml
@@ -1,4 +1,4 @@
-orms_and_database:
+frameworks:
   name: knex
   npm_packages:
   - knex

--- a/internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml
@@ -1,4 +1,4 @@
-orms_and_database:
+frameworks:
   name: mikro-orm
   npm_packages:
   - '@mikro-orm/core'

--- a/internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/mongodb_js.yaml
@@ -1,4 +1,4 @@
-orms_and_database:
+frameworks:
   name: mongodb (official Node.js driver)
   npm_packages:
     - mongodb

--- a/internal/engine/rules/javascript_typescript/orms/mongoose.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/mongoose.yaml
@@ -1,4 +1,4 @@
-orms_and_database:
+frameworks:
   name: mongoose
   npm_packages:
   - mongoose

--- a/internal/engine/rules/javascript_typescript/orms/mysql_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/mysql_js.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL JavaScript/TypeScript Drivers (mysql2, mysql, Knex)
   category: relational_database
   npm_package: mysql2

--- a/internal/engine/rules/javascript_typescript/orms/neo4j.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Neo4j JavaScript/TypeScript Driver
   category: graph_database
   npm_package: neo4j-driver

--- a/internal/engine/rules/javascript_typescript/orms/objection.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/objection.yaml
@@ -1,4 +1,4 @@
-orms_and_database:
+frameworks:
   name: objection
   npm_packages:
   - objection

--- a/internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/postgresql_js.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: PostgreSQL JavaScript/TypeScript Drivers (pg/node-postgres, postgres.js)
   category: postgres_driver
   npm_packages:

--- a/internal/engine/rules/javascript_typescript/orms/prisma.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/prisma.yaml
@@ -1,4 +1,4 @@
-orms_and_database:
+frameworks:
   name: prisma
   npm_packages:
   - prisma

--- a/internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml
@@ -1,4 +1,4 @@
-orms_and_database:
+frameworks:
   name: prisma-client-js
   npm_packages:
   - '@prisma/client'

--- a/internal/engine/rules/javascript_typescript/orms/redis_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/redis_js.yaml
@@ -2,7 +2,7 @@
 #
 # Top-level `orms:` key is consumed by the modular_loader (detection).
 
-orms:
+frameworks:
   name: ioredis / node-redis
   npm_package: ioredis
   category: cache_client

--- a/internal/engine/rules/javascript_typescript/orms/sequelize.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/sequelize.yaml
@@ -1,4 +1,4 @@
-orms_and_database:
+frameworks:
   name: sequelize
   npm_packages:
   - sequelize

--- a/internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/sqlite_js.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: JavaScript/TypeScript SQLite Drivers (better-sqlite3 / sql.js / libsql)
   category: sqlite_driver
   npm_packages:

--- a/internal/engine/rules/javascript_typescript/orms/supabase_js.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/supabase_js.yaml
@@ -1,4 +1,4 @@
-orms_and_database:
+frameworks:
   name: supabase-js
   npm_packages:
   - '@supabase/supabase-js'

--- a/internal/engine/rules/javascript_typescript/orms/typeorm.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/typeorm.yaml
@@ -1,4 +1,4 @@
-orms_and_database:
+frameworks:
   name: typeorm
   npm_packages:
   - typeorm

--- a/internal/engine/rules/javascript_typescript/queues/bullmq.yaml
+++ b/internal/engine/rules/javascript_typescript/queues/bullmq.yaml
@@ -2,7 +2,7 @@
 # Covers: bull (v3/v4), bullmq (v1+), bull-board (producer detection only)
 # NPM: bull, bullmq
 
-queues:
+frameworks:
   name: bullmq
   category: job_queue
   npm_packages:

--- a/internal/engine/rules/kotlin/orms/cassandra_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/cassandra_kotlin.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: DataStax Java Driver (Kotlin) / Spring Data Cassandra Kotlin
   category: nosql_database
   gradle_dependency: implementation 'com.datastax.oss:java-driver-core'

--- a/internal/engine/rules/kotlin/orms/dynamodb_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/dynamodb_kotlin.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: AWS DynamoDB Kotlin SDK (aws.sdk.kotlin:dynamodb)
   category: nosql_database
   gradle_dependency: implementation("aws.sdk.kotlin:dynamodb")

--- a/internal/engine/rules/kotlin/orms/elasticsearch_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/elasticsearch_kotlin.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: elasticsearch-kotlin
   detection:
     gradle_markers:

--- a/internal/engine/rules/kotlin/orms/exposed.yaml
+++ b/internal/engine/rules/kotlin/orms/exposed.yaml
@@ -1,4 +1,4 @@
-orms_databases:
+frameworks:
   name: Exposed
   vendor: JetBrains
   gradle_coordinates:

--- a/internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml
@@ -1,4 +1,4 @@
-orms_databases:
+frameworks:
   name: Hibernate (Kotlin)
   gradle_coordinates:
   - org.hibernate.orm:hibernate-core

--- a/internal/engine/rules/kotlin/orms/ktorm.yaml
+++ b/internal/engine/rules/kotlin/orms/ktorm.yaml
@@ -1,4 +1,4 @@
-orms_databases:
+frameworks:
   name: ktorm
   gradle_coordinates:
   - org.ktorm:ktorm-core

--- a/internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: KMongo (Kotlin MongoDB driver)
   maven_coordinates: org.litote.kmongo:kmongo
   category: nosql_driver

--- a/internal/engine/rules/kotlin/orms/mysql_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/mysql_kotlin.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Kotlin Drivers (MySQL Connector/J, Exposed, R2DBC MySQL)
   category: relational_database
   maven_coordinates: com.mysql:mysql-connector-j

--- a/internal/engine/rules/kotlin/orms/neo4j.yaml
+++ b/internal/engine/rules/kotlin/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Neo4j Kotlin Driver
   category: graph_database
   maven_coordinates: org.neo4j.driver:neo4j-java-driver

--- a/internal/engine/rules/kotlin/orms/postgresql_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/postgresql_kotlin.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: PostgreSQL Kotlin Drivers (Exposed, R2DBC)
   category: postgres_driver
   maven_coordinates:

--- a/internal/engine/rules/kotlin/orms/redis_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/redis_kotlin.yaml
@@ -2,7 +2,7 @@
 #
 # Top-level `orms:` key is consumed by the modular_loader (detection).
 
-orms:
+frameworks:
   name: Lettuce / Kreds (Kotlin Redis clients)
   category: cache_client
   detection:

--- a/internal/engine/rules/kotlin/orms/room_android.yaml
+++ b/internal/engine/rules/kotlin/orms/room_android.yaml
@@ -1,4 +1,4 @@
-orms_databases:
+frameworks:
   name: Room (Android)
   gradle_coordinates:
   - androidx.room:room-runtime

--- a/internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml
@@ -1,4 +1,4 @@
-orms_databases:
+frameworks:
   name: Spring Data (Kotlin)
   gradle_coordinates:
   - org.springframework.boot:spring-boot-starter-data-jpa

--- a/internal/engine/rules/kotlin/orms/sqldelight.yaml
+++ b/internal/engine/rules/kotlin/orms/sqldelight.yaml
@@ -1,4 +1,4 @@
-orms_databases:
+frameworks:
   name: SQLDelight
   gradle_coordinates:
   - app.cash.sqldelight:android-driver

--- a/internal/engine/rules/kotlin/orms/sqlite_kotlin.yaml
+++ b/internal/engine/rules/kotlin/orms/sqlite_kotlin.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Kotlin SQLite (SQLDelight / Android Room)
   category: sqlite_driver
   gradle_dependencies:

--- a/internal/engine/rules/lua/orms/lsqlite3.yaml
+++ b/internal/engine/rules/lua/orms/lsqlite3.yaml
@@ -1,4 +1,4 @@
-database:
+frameworks:
   name: lsqlite3
   luarocks_package: lsqlite3
   category: sqlite_driver

--- a/internal/engine/rules/lua/orms/lua_resty_mysql.yaml
+++ b/internal/engine/rules/lua/orms/lua_resty_mysql.yaml
@@ -1,4 +1,4 @@
-database:
+frameworks:
   name: lua-resty-mysql
   category: mysql_driver_openresty
   detection:

--- a/internal/engine/rules/lua/orms/lua_resty_redis.yaml
+++ b/internal/engine/rules/lua/orms/lua_resty_redis.yaml
@@ -1,4 +1,4 @@
-database:
+frameworks:
   name: lua-resty-redis
   category: redis_client_openresty
   detection:

--- a/internal/engine/rules/lua/orms/pgmoon.yaml
+++ b/internal/engine/rules/lua/orms/pgmoon.yaml
@@ -1,4 +1,4 @@
-database:
+frameworks:
   name: pgmoon
   luarocks_package: pgmoon
   category: postgresql_driver

--- a/internal/engine/rules/objective_c/frameworks/platform.yaml
+++ b/internal/engine/rules/objective_c/frameworks/platform.yaml
@@ -1,4 +1,4 @@
-mobile:
+frameworks:
   platform: iOS (Legacy Objective-C)
   category: legacy_ios
   notes: 'Legacy iOS development with UIKit is the dominant Objective-C mobile pattern.

--- a/internal/engine/rules/objective_c/orms/core_data.yaml
+++ b/internal/engine/rules/objective_c/orms/core_data.yaml
@@ -1,4 +1,4 @@
-database:
+frameworks:
   name: Core Data
   type: object_graph_orm
   pod_coordinates:

--- a/internal/engine/rules/objective_c/orms/fmdb.yaml
+++ b/internal/engine/rules/objective_c/orms/fmdb.yaml
@@ -1,4 +1,4 @@
-database:
+frameworks:
   name: FMDB
   type: sqlite_wrapper
   pod_coordinates:

--- a/internal/engine/rules/objective_c/orms/realm_objective_c.yaml
+++ b/internal/engine/rules/objective_c/orms/realm_objective_c.yaml
@@ -1,4 +1,4 @@
-database:
+frameworks:
   name: Realm (Objective-C)
   type: mobile_database
   pod_coordinates:

--- a/internal/engine/rules/objective_c/orms/sqlite3_direct_c_api.yaml
+++ b/internal/engine/rules/objective_c/orms/sqlite3_direct_c_api.yaml
@@ -1,4 +1,4 @@
-database:
+frameworks:
   name: SQLite3 (direct C API)
   type: sqlite_direct
   pod_coordinates:

--- a/internal/engine/rules/perl/orms/mysql_perl.yaml
+++ b/internal/engine/rules/perl/orms/mysql_perl.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Perl Driver (DBD::mysql / DBI)
   category: relational_database
   cpan_module: DBD::mysql

--- a/internal/engine/rules/perl/orms/neo4j.yaml
+++ b/internal/engine/rules/perl/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: REST::Neo4p (Neo4j Perl Driver)
   category: graph_database
   cpan_module: REST::Neo4p

--- a/internal/engine/rules/perl/orms/postgresql_perl.yaml
+++ b/internal/engine/rules/perl/orms/postgresql_perl.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: DBD::Pg (Perl DBI PostgreSQL Driver)
   category: postgres_driver
   cpan_module: DBD::Pg

--- a/internal/engine/rules/perl/orms/sqlite_perl.yaml
+++ b/internal/engine/rules/perl/orms/sqlite_perl.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Perl SQLite Driver (DBD::SQLite via DBI)
   category: sqlite_driver
   cpan_modules:

--- a/internal/engine/rules/php/orms/cassandra_php.yaml
+++ b/internal/engine/rules/php/orms/cassandra_php.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: datastax/php-driver
   category: nosql_database
   composer_package: datastax/php-driver

--- a/internal/engine/rules/php/orms/doctrine_orm.yaml
+++ b/internal/engine/rules/php/orms/doctrine_orm.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Doctrine ORM
   package_name: doctrine/orm
   category: data_mapper_orm

--- a/internal/engine/rules/php/orms/dynamodb_php.yaml
+++ b/internal/engine/rules/php/orms/dynamodb_php.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: AWS DynamoDB PHP SDK (aws/aws-sdk-php)
   category: nosql_database
   composer_package: aws/aws-sdk-php

--- a/internal/engine/rules/php/orms/elasticsearch_php.yaml
+++ b/internal/engine/rules/php/orms/elasticsearch_php.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: elasticsearch/elasticsearch
   composer_package: elasticsearch/elasticsearch
   detection:

--- a/internal/engine/rules/php/orms/eloquent_laravel_orm.yaml
+++ b/internal/engine/rules/php/orms/eloquent_laravel_orm.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Eloquent (Laravel ORM)
   package_name: illuminate/database
   category: active_record_orm

--- a/internal/engine/rules/php/orms/mongodb_php.yaml
+++ b/internal/engine/rules/php/orms/mongodb_php.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: mongodb/mongodb (PHP driver)
   composer_package: mongodb/mongodb
   category: nosql_driver

--- a/internal/engine/rules/php/orms/mysql_php.yaml
+++ b/internal/engine/rules/php/orms/mysql_php.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL PHP Extensions (PDO::mysql, mysqli)
   category: relational_database
   detection:

--- a/internal/engine/rules/php/orms/neo4j.yaml
+++ b/internal/engine/rules/php/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: laudis/neo4j-php-client
   category: graph_database
   composer_package: laudis/neo4j-php-client

--- a/internal/engine/rules/php/orms/postgresql_php.yaml
+++ b/internal/engine/rules/php/orms/postgresql_php.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: PostgreSQL PHP Drivers (PDO::pgsql, pg_connect)
   category: postgres_driver
   php_extensions:

--- a/internal/engine/rules/php/orms/propel.yaml
+++ b/internal/engine/rules/php/orms/propel.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Propel
   package_name: propel/propel
   category: active_record_orm

--- a/internal/engine/rules/php/orms/redbeanphp.yaml
+++ b/internal/engine/rules/php/orms/redbeanphp.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: RedBeanPHP
   package_name: gabordemooij/redbeanphp
   category: zero_config_orm

--- a/internal/engine/rules/php/orms/redis_php.yaml
+++ b/internal/engine/rules/php/orms/redis_php.yaml
@@ -2,7 +2,7 @@
 #
 # Top-level `orms:` key is consumed by the modular_loader (detection).
 
-orms:
+frameworks:
   name: phpredis / Predis
   category: cache_client
   detection:

--- a/internal/engine/rules/php/orms/sqlite_php.yaml
+++ b/internal/engine/rules/php/orms/sqlite_php.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: PHP SQLite Drivers (PDO::sqlite / SQLite3 class)
   category: sqlite_driver
   detection:

--- a/internal/engine/rules/python/orms/alembic.yaml
+++ b/internal/engine/rules/python/orms/alembic.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Alembic
   pypi_package: alembic
   category: migration_tool

--- a/internal/engine/rules/python/orms/beanie.yaml
+++ b/internal/engine/rules/python/orms/beanie.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Beanie
   pypi_package: beanie
   category: document_odm_async

--- a/internal/engine/rules/python/orms/cassandra_py.yaml
+++ b/internal/engine/rules/python/orms/cassandra_py.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Cassandra Python Driver (DataStax)
   category: nosql_database
   pip_package: cassandra-driver

--- a/internal/engine/rules/python/orms/django_orm.yaml
+++ b/internal/engine/rules/python/orms/django_orm.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Django ORM
   pypi_package: django
   category: sql_orm

--- a/internal/engine/rules/python/orms/dynamodb_py.yaml
+++ b/internal/engine/rules/python/orms/dynamodb_py.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: AWS DynamoDB Python SDK (boto3)
   category: nosql_database
   pypi_package: boto3

--- a/internal/engine/rules/python/orms/elasticsearch_py.yaml
+++ b/internal/engine/rules/python/orms/elasticsearch_py.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: elasticsearch-py
   package: elasticsearch
   pypi_name: elasticsearch

--- a/internal/engine/rules/python/orms/mongoengine.yaml
+++ b/internal/engine/rules/python/orms/mongoengine.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MongoEngine
   pypi_package: mongoengine
   category: document_odm

--- a/internal/engine/rules/python/orms/mysql_py.yaml
+++ b/internal/engine/rules/python/orms/mysql_py.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Python Drivers (mysql-connector-python, PyMySQL, aiomysql)
   category: relational_database
   pypi_package: mysql-connector-python

--- a/internal/engine/rules/python/orms/neo4j.yaml
+++ b/internal/engine/rules/python/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Neo4j Python Driver / neomodel
   category: graph_database
   pip_package: neo4j

--- a/internal/engine/rules/python/orms/peewee.yaml
+++ b/internal/engine/rules/python/orms/peewee.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Peewee
   pypi_package: peewee
   category: sql_orm

--- a/internal/engine/rules/python/orms/pony_orm.yaml
+++ b/internal/engine/rules/python/orms/pony_orm.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Pony ORM
   pypi_package: pony
   category: sql_orm

--- a/internal/engine/rules/python/orms/postgresql_py.yaml
+++ b/internal/engine/rules/python/orms/postgresql_py.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: PostgreSQL Python Drivers (psycopg2/psycopg3/asyncpg)
   category: postgres_driver
   pypi_packages:

--- a/internal/engine/rules/python/orms/redis_py.yaml
+++ b/internal/engine/rules/python/orms/redis_py.yaml
@@ -2,7 +2,7 @@
 #
 # Top-level `orms_database:` key is consumed by the modular_loader (detection).
 
-orms_database:
+frameworks:
   name: redis-py
   pypi_package: redis
   category: cache_client

--- a/internal/engine/rules/python/orms/sqlalchemy.yaml
+++ b/internal/engine/rules/python/orms/sqlalchemy.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: SQLAlchemy
   pypi_package: sqlalchemy
   category: sql_orm

--- a/internal/engine/rules/python/orms/sqlite_py.yaml
+++ b/internal/engine/rules/python/orms/sqlite_py.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Python SQLite Drivers (sqlite3 / aiosqlite)
   category: sqlite_driver
   pypi_packages:

--- a/internal/engine/rules/python/orms/sqlmodel.yaml
+++ b/internal/engine/rules/python/orms/sqlmodel.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: SQLModel
   pypi_package: sqlmodel
   category: sql_orm

--- a/internal/engine/rules/python/orms/tortoise_orm.yaml
+++ b/internal/engine/rules/python/orms/tortoise_orm.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Tortoise ORM
   pypi_package: tortoise-orm
   category: sql_orm_async

--- a/internal/engine/rules/r/orms/mysql_r.yaml
+++ b/internal/engine/rules/r/orms/mysql_r.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL R Drivers (RMySQL, RMariaDB)
   category: relational_database
   cran_package: RMySQL

--- a/internal/engine/rules/r/orms/neo4j.yaml
+++ b/internal/engine/rules/r/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: neo4r (Neo4j R Driver)
   category: graph_database
   cran_package: neo4r

--- a/internal/engine/rules/r/orms/postgresql_r.yaml
+++ b/internal/engine/rules/r/orms/postgresql_r.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: RPostgres / RPostgreSQL (R PostgreSQL Drivers)
   category: postgres_driver
   cran_packages:

--- a/internal/engine/rules/r/orms/sqlite_r.yaml
+++ b/internal/engine/rules/r/orms/sqlite_r.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: R SQLite Driver (RSQLite via DBI)
   category: sqlite_driver
   cran_packages:

--- a/internal/engine/rules/ruby/orms/activerecord.yaml
+++ b/internal/engine/rules/ruby/orms/activerecord.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: ActiveRecord
   gem_name: activerecord
   category: active_record_orm

--- a/internal/engine/rules/ruby/orms/cassandra_ruby.yaml
+++ b/internal/engine/rules/ruby/orms/cassandra_ruby.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: cassandra-driver (DataStax Ruby Driver)
   category: nosql_database
   gem: cassandra-driver

--- a/internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml
+++ b/internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: DataMapper / Hanami::Model (legacy)
   gem_name: data_mapper
   category: data_mapper_legacy

--- a/internal/engine/rules/ruby/orms/dynamodb_ruby.yaml
+++ b/internal/engine/rules/ruby/orms/dynamodb_ruby.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: AWS DynamoDB Ruby SDK (aws-sdk-dynamodb)
   category: nosql_database
   gem_name: aws-sdk-dynamodb

--- a/internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml
+++ b/internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: elasticsearch-ruby
   gem_name: elasticsearch
   detection:

--- a/internal/engine/rules/ruby/orms/mongoid.yaml
+++ b/internal/engine/rules/ruby/orms/mongoid.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Mongoid
   gem_name: mongoid
   category: document_orm

--- a/internal/engine/rules/ruby/orms/mysql_ruby.yaml
+++ b/internal/engine/rules/ruby/orms/mysql_ruby.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Ruby Driver (mysql2 gem)
   category: relational_database
   gem_name: mysql2

--- a/internal/engine/rules/ruby/orms/neo4j.yaml
+++ b/internal/engine/rules/ruby/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Neo4j Ruby Driver / ActiveGraph
   category: graph_database
   gem_name: neo4j-ruby-driver

--- a/internal/engine/rules/ruby/orms/pg_ruby.yaml
+++ b/internal/engine/rules/ruby/orms/pg_ruby.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: pg Ruby gem (PostgreSQL Ruby Driver)
   category: postgres_driver
   gem_name: pg

--- a/internal/engine/rules/ruby/orms/redis_rb.yaml
+++ b/internal/engine/rules/ruby/orms/redis_rb.yaml
@@ -2,7 +2,7 @@
 #
 # Top-level `orms:` key is consumed by the modular_loader (detection).
 
-orms:
+frameworks:
   name: redis-rb
   gem: redis
   category: cache_client

--- a/internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml
+++ b/internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: ROM-rb (as ORM)
   gem_name: rom
   category: data_mapper

--- a/internal/engine/rules/ruby/orms/sequel.yaml
+++ b/internal/engine/rules/ruby/orms/sequel.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Sequel
   gem_name: sequel
   category: dataset_orm

--- a/internal/engine/rules/ruby/orms/sqlite_ruby.yaml
+++ b/internal/engine/rules/ruby/orms/sqlite_ruby.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Ruby SQLite Driver (sqlite3 gem)
   category: sqlite_driver
   rubygems_packages:

--- a/internal/engine/rules/rust/orms/cassandra_rust.yaml
+++ b/internal/engine/rules/rust/orms/cassandra_rust.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: scylla (Rust Driver — Cassandra-compatible)
   category: nosql_database
   crate: scylla

--- a/internal/engine/rules/rust/orms/diesel.yaml
+++ b/internal/engine/rules/rust/orms/diesel.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Diesel
   crate: diesel
   category: orm_sql

--- a/internal/engine/rules/rust/orms/dynamodb_rust.yaml
+++ b/internal/engine/rules/rust/orms/dynamodb_rust.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: AWS DynamoDB Rust SDK (aws-sdk-dynamodb)
   category: nosql_database
   crate_name: aws-sdk-dynamodb

--- a/internal/engine/rules/rust/orms/elasticsearch_rs.yaml
+++ b/internal/engine/rules/rust/orms/elasticsearch_rs.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: elasticsearch-rs
   crate_name: elasticsearch
   detection:

--- a/internal/engine/rules/rust/orms/mongodb_mongodb.yaml
+++ b/internal/engine/rules/rust/orms/mongodb_mongodb.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: MongoDB (mongodb)
   crate: mongodb
   category: nosql

--- a/internal/engine/rules/rust/orms/mysql_rust.yaml
+++ b/internal/engine/rules/rust/orms/mysql_rust.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Rust Drivers (mysql_async, sqlx mysql feature)
   category: relational_database
   crate_name: mysql_async

--- a/internal/engine/rules/rust/orms/neo4j.yaml
+++ b/internal/engine/rules/rust/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: neo4rs (Neo4j Rust Driver)
   category: graph_database
   crate: neo4rs

--- a/internal/engine/rules/rust/orms/postgresql_rust.yaml
+++ b/internal/engine/rules/rust/orms/postgresql_rust.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: PostgreSQL Rust Drivers (tokio-postgres, deadpool-postgres, sqlx)
   category: postgres_driver
   crates:

--- a/internal/engine/rules/rust/orms/redis_redis_rs.yaml
+++ b/internal/engine/rules/rust/orms/redis_redis_rs.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: redis (redis-rs)
   crate: redis
   category: cache_kv

--- a/internal/engine/rules/rust/orms/rusqlite.yaml
+++ b/internal/engine/rules/rust/orms/rusqlite.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: rusqlite
   crate: rusqlite
   category: embedded_sql

--- a/internal/engine/rules/rust/orms/seaorm.yaml
+++ b/internal/engine/rules/rust/orms/seaorm.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: SeaORM
   crate: sea-orm
   category: orm_async

--- a/internal/engine/rules/rust/orms/sqlite_rust.yaml
+++ b/internal/engine/rules/rust/orms/sqlite_rust.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Rust SQLite Drivers (rusqlite / sqlx sqlite)
   category: sqlite_driver
   crates:

--- a/internal/engine/rules/rust/orms/sqlx.yaml
+++ b/internal/engine/rules/rust/orms/sqlx.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: SQLx
   crate: sqlx
   category: async_sql_toolkit

--- a/internal/engine/rules/scala/orms/cassandra_scala.yaml
+++ b/internal/engine/rules/scala/orms/cassandra_scala.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: phantom / quill-cassandra (Scala Cassandra Drivers)
   category: nosql_database
   sbt_dependency: '"com.outworkers" %% "phantom-dsl" % "2.x.x"'

--- a/internal/engine/rules/scala/orms/doobie.yaml
+++ b/internal/engine/rules/scala/orms/doobie.yaml
@@ -1,4 +1,4 @@
-orm_db:
+frameworks:
   name: Doobie
   sbt_coordinates:
   - org.tpolecat::doobie-core

--- a/internal/engine/rules/scala/orms/elastic4s.yaml
+++ b/internal/engine/rules/scala/orms/elastic4s.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: elastic4s
   sbt_coordinates: com.sksamuel.elastic4s:elastic4s-core
   detection:

--- a/internal/engine/rules/scala/orms/mongodb_scala.yaml
+++ b/internal/engine/rules/scala/orms/mongodb_scala.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: mongo-scala-driver / ReactiveMongo
   maven_coordinates: org.mongodb.scala:mongo-scala-driver_2.13
   category: nosql_driver

--- a/internal/engine/rules/scala/orms/mysql_scala.yaml
+++ b/internal/engine/rules/scala/orms/mysql_scala.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Scala Drivers (MySQL Connector/J via JDBC, Slick MySQL profile)
   category: relational_database
   maven_coordinates: com.mysql:mysql-connector-j

--- a/internal/engine/rules/scala/orms/neo4j.yaml
+++ b/internal/engine/rules/scala/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: neotypes (Neo4j Scala Driver)
   category: graph_database
   sbt_dependency: "com.dimafeng %% neotypes-core"

--- a/internal/engine/rules/scala/orms/postgresql_scala.yaml
+++ b/internal/engine/rules/scala/orms/postgresql_scala.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: PostgreSQL Scala Drivers (doobie, Slick)
   category: postgres_driver
   sbt_dependencies:

--- a/internal/engine/rules/scala/orms/quill.yaml
+++ b/internal/engine/rules/scala/orms/quill.yaml
@@ -1,4 +1,4 @@
-orm_db:
+frameworks:
   name: Quill
   sbt_coordinates:
   - io.getquill::quill-jdbc

--- a/internal/engine/rules/scala/orms/scalikejdbc.yaml
+++ b/internal/engine/rules/scala/orms/scalikejdbc.yaml
@@ -1,4 +1,4 @@
-orm_db:
+frameworks:
   name: ScalikeJDBC
   sbt_coordinates:
   - org.scalikejdbc::scalikejdbc

--- a/internal/engine/rules/scala/orms/scanamo.yaml
+++ b/internal/engine/rules/scala/orms/scanamo.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Scanamo (guardian/scanamo)
   category: nosql_database
   sbt_dependency: '"org.scanamo" %% "scanamo" % "x.y.z"'

--- a/internal/engine/rules/scala/orms/slick.yaml
+++ b/internal/engine/rules/scala/orms/slick.yaml
@@ -1,4 +1,4 @@
-orm_db:
+frameworks:
   name: Slick
   sbt_coordinates:
   - com.typesafe.slick::slick

--- a/internal/engine/rules/scala/orms/sqlite_scala.yaml
+++ b/internal/engine/rules/scala/orms/sqlite_scala.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Scala SQLite (slick-sqlite / sqlite-jdbc via JDBC)
   category: sqlite_driver
   sbt_dependencies:

--- a/internal/engine/rules/sql/frameworks/dbmate.yaml
+++ b/internal/engine/rules/sql/frameworks/dbmate.yaml
@@ -1,4 +1,4 @@
-frameworks_and_dialects:
+frameworks:
   name: dbmate
   category: migration_tool
   detection:

--- a/internal/engine/rules/sql/frameworks/dbt_data_build_tool.yaml
+++ b/internal/engine/rules/sql/frameworks/dbt_data_build_tool.yaml
@@ -1,4 +1,4 @@
-frameworks_and_dialects:
+frameworks:
   name: dbt (data build tool)
   category: sql_transformation
   config_markers:

--- a/internal/engine/rules/sql/frameworks/flyway.yaml
+++ b/internal/engine/rules/sql/frameworks/flyway.yaml
@@ -1,4 +1,4 @@
-frameworks_and_dialects:
+frameworks:
   name: Flyway
   category: migration_tool
   config_markers:

--- a/internal/engine/rules/sql/frameworks/liquibase.yaml
+++ b/internal/engine/rules/sql/frameworks/liquibase.yaml
@@ -1,4 +1,4 @@
-frameworks_and_dialects:
+frameworks:
   name: Liquibase
   category: migration_tool
   config_markers:

--- a/internal/engine/rules/sql/frameworks/mysql_mariadb.yaml
+++ b/internal/engine/rules/sql/frameworks/mysql_mariadb.yaml
@@ -1,4 +1,4 @@
-frameworks_and_dialects:
+frameworks:
   name: MySQL / MariaDB
   category: rdbms_dialect
   file_extensions:

--- a/internal/engine/rules/sql/frameworks/oracle_pl_sql.yaml
+++ b/internal/engine/rules/sql/frameworks/oracle_pl_sql.yaml
@@ -1,4 +1,4 @@
-frameworks_and_dialects:
+frameworks:
   name: Oracle (PL/SQL)
   category: rdbms_dialect
   file_extensions:

--- a/internal/engine/rules/sql/frameworks/postgresql.yaml
+++ b/internal/engine/rules/sql/frameworks/postgresql.yaml
@@ -1,4 +1,4 @@
-frameworks_and_dialects:
+frameworks:
   name: PostgreSQL
   category: rdbms_dialect
   file_extensions:

--- a/internal/engine/rules/sql/frameworks/sql_server_t_sql.yaml
+++ b/internal/engine/rules/sql/frameworks/sql_server_t_sql.yaml
@@ -1,4 +1,4 @@
-frameworks_and_dialects:
+frameworks:
   name: SQL Server (T-SQL)
   category: rdbms_dialect
   file_extensions:

--- a/internal/engine/rules/sql/frameworks/sqlite.yaml
+++ b/internal/engine/rules/sql/frameworks/sqlite.yaml
@@ -1,4 +1,4 @@
-frameworks_and_dialects:
+frameworks:
   name: SQLite
   category: rdbms_dialect
   file_extensions:

--- a/internal/engine/rules/swift/orms/core_data.yaml
+++ b/internal/engine/rules/swift/orms/core_data.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Core Data
   category: orm_object_graph
   spm_product: N/A — bundled with Apple SDK

--- a/internal/engine/rules/swift/orms/dynamodb_swift.yaml
+++ b/internal/engine/rules/swift/orms/dynamodb_swift.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Soto DynamoDB (soto-project/soto)
   category: nosql_database
   spm_package: soto

--- a/internal/engine/rules/swift/orms/firebase_ios.yaml
+++ b/internal/engine/rules/swift/orms/firebase_ios.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Firebase (iOS)
   category: backend_as_a_service_client
   spm_coordinates:

--- a/internal/engine/rules/swift/orms/grdb.yaml
+++ b/internal/engine/rules/swift/orms/grdb.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: GRDB
   category: orm_sqlite
   spm_coordinates:

--- a/internal/engine/rules/swift/orms/mysql_swift.yaml
+++ b/internal/engine/rules/swift/orms/mysql_swift.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: MySQL Swift Driver (mysql-nio / vapor/mysql-kit)
   category: relational_database
   spm_package: https://github.com/vapor/mysql-kit

--- a/internal/engine/rules/swift/orms/neo4j.yaml
+++ b/internal/engine/rules/swift/orms/neo4j.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: Theo (Neo4j Swift Driver)
   category: graph_database
   swift_package: theo

--- a/internal/engine/rules/swift/orms/postgresnio.yaml
+++ b/internal/engine/rules/swift/orms/postgresnio.yaml
@@ -1,4 +1,4 @@
-orms_database:
+frameworks:
   name: PostgresNIO / postgres-kit (Swift PostgreSQL Drivers)
   category: postgres_driver
   spm_packages:

--- a/internal/engine/rules/swift/orms/realm.yaml
+++ b/internal/engine/rules/swift/orms/realm.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Realm
   category: orm_document
   spm_coordinates:

--- a/internal/engine/rules/swift/orms/sqlite_swift.yaml
+++ b/internal/engine/rules/swift/orms/sqlite_swift.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: SQLite.swift
   category: sqlite_driver
   spm_coordinates:

--- a/internal/engine/rules/swift/orms/supabase_swift.yaml
+++ b/internal/engine/rules/swift/orms/supabase_swift.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: Supabase Swift
   category: backend_as_a_service_client
   spm_coordinates:

--- a/internal/engine/rules/swift/orms/swiftdata.yaml
+++ b/internal/engine/rules/swift/orms/swiftdata.yaml
@@ -1,4 +1,4 @@
-orms:
+frameworks:
   name: SwiftData
   category: orm_declarative
   spm_product: N/A — bundled with Apple SDK (iOS 17+)

--- a/internal/engine/rules/zig/orms/libpq_postgresql_c_ffi.yaml
+++ b/internal/engine/rules/zig/orms/libpq_postgresql_c_ffi.yaml
@@ -1,4 +1,4 @@
-orm_database:
+frameworks:
   name: libpq (PostgreSQL C FFI)
   type: c_ffi_binding
   detection:

--- a/internal/engine/rules/zig/orms/no_orm_c_ffi_is_the_norm.yaml
+++ b/internal/engine/rules/zig/orms/no_orm_c_ffi_is_the_norm.yaml
@@ -1,4 +1,4 @@
-orm_database:
+frameworks:
   name: No ORM — C FFI is the norm
   type: architectural_note
   notes: 'Zig intentionally has no runtime reflection and no memory-managed strings,

--- a/internal/engine/rules/zig/orms/sqlite_via_c_ffi.yaml
+++ b/internal/engine/rules/zig/orms/sqlite_via_c_ffi.yaml
@@ -1,4 +1,4 @@
-orm_database:
+frameworks:
   name: sqlite (via C FFI)
   type: c_ffi_binding
   detection:

--- a/internal/engine/rules/zig/orms/zig_sqlite.yaml
+++ b/internal/engine/rules/zig/orms/zig_sqlite.yaml
@@ -1,4 +1,4 @@
-orm_database:
+frameworks:
   name: zig-sqlite
   type: zig_wrapper
   github: vrischmann/zig-sqlite


### PR DESCRIPTION
Step 1 of #7013's fix path, as re-ordered by the #7014 audit: make the 52 files' existing `import_markers` visible before anyone writes new ones.

**Tree measured, by absolute path:** `/private/tmp/claude-501/-Users-jorgecajas-Projects-archigraph/c0fefed4-0195-4c81-9a94-07a7145710a4/scratchpad/impl-7013a-k9x4t/wt`, branch `lane/7013-container-spellings`, parent `87106f12c`. Reference tree for the before/after comparison: a second checkout of `87106f12c` at `.../impl-7013a-k9x4t/ref`. Gate on every figure: macOS 25.6.0 / arm64 / APFS, host Go toolchain (#6966).

## Decision: reconcile the files, do not alias the loader — and pin that choice

The brief offered both. Measured before choosing, and the measurement makes the trade one-sided:

- **The rename is sufficient.** All 247 misspelled containers are YAML mappings, and **246 of 247** have a sub-shape `FrameworkMeta` already models (`name` a string in 246, `detection` a mapping in 209, `import_markers` a list of strings in all 52 that have one). Nothing else has to change for the markers to load. The one exception is **`objective_c/frameworks/platform.yaml`**, whose `mobile:` block carries neither `name` nor `detection` (it has `platform:`, `category:`, `entry_point_signals:`, `structural_signals:`): after the rename it decodes to an empty `FrameworkMeta`, which is exactly what it decoded to before — no name, no markers, nothing gated — so the rename is harmless there, and the file is now a `frameworks:` block with no modelled field in it, worth a line on #7014's metadata pass. The other unmodelled keys those files carry (`category`, `notes`, `npm_packages`, `detection_signals.*`, …) are dropped exactly as they already are under `frameworks:` in the other 266 files — that is #7014's metadata migration, untouched here.
- **No file needed merging.** **0 of 520** loader-scoped files carry both `frameworks:` and a misspelling, so this is a key rename per file, never a merge of two blocks.
- **Aliasing legitimises 14 spellings permanently** and is the one direction that cannot be walked back. `TestLoader_DoesNotAdoptAnUnmodelledContainer` now records that decision, because without it the choice is unpinned: a loader that quietly adopts markers from whatever container it finds passes every other assertion here (after the reconciliation, no rule file offers it one to adopt).

## What changed

247 files, one line each: the top-level container key → `frameworks:`. The full diff is `247 -<misspelling>:` / `247 +frameworks:` and nothing else; **0 files touched outside `internal/engine/rules/`**, **0 `source_patterns` entries touched**, and none of `go/frameworks/{chi,echo,fiber,gin}.yaml` (another lane owns those) — they carry no container key at all.

| was | files | | was | files |
|---|---:|---|---|---:|
| `orms_database` | 121 | | `orms_databases` | 6 |
| `orms` | 35 | | `framework_templates` | 5 |
| `database_libraries` | 14 | | `mobile` | 4 |
| `template_engines` | 11 | | `framework` | 3 |
| `orms_and_database` | 11 | | `queues` | 1 |
| `orm_db` | 10 | | | |
| `orm_database` | 9 | | | |
| `frameworks_and_dialects` | 9 | | | |
| `database` | 8 | | | |

After: **one spelling in the tree** — `frameworks:` in 513 files, `0` files with markers under anything else. The 5 remaining files with no container at all (`go/frameworks/{chi,echo,fiber,gin,gorm}.yaml`) and the 2 empty ruby files are out of scope; they hide nothing.

## 1. How many markers became live: 52 files, 95 → 147

**147 of 520** loader-scoped files now declare readable `frameworks.detection.import_markers`, up from **95**. The 52 recovered sit under the five misspellings that carried markers: `orms_database` 18, `orms` 15, `database_libraries` 13, `database` 4, `orm_database` 2. Named examples, with the markers that were unreadable: `csharp/orms/mongodb_csharp.yaml` (`using MongoDB.Driver`, `using MongoDB.Bson`), `go/orms/bun.yaml` (`"github.com/uptrace/bun"` + 2 dialects), `lua/orms/lua_resty_mysql.yaml` (7 markers), `zig/orms/zig_sqlite.yaml` (`@import("sqlite")`), `csharp/orms/redis_stackexchange.yaml`, `clojure/orms/datomic.yaml` (18 markers).

## 2. What regresses: nothing, and the reason is structural before it is empirical

`importMarkers` reaches the engine at `detector.go:153` and is read by exactly one thing — `frameworkPresent` — which is called only when some `source_patterns` entry **in the same rule file** sets `requires_framework` (`detector.go:394-410`). So a file's markers can only change behaviour through its own patterns.

- **All 247 renamed files compile to a wholly inert rule set.** Decoding them through `FrameworkRule` gives `sourcePatternEntries=0`, `relationshipRuleEntries=0`, `fileConventionEntries=0`, `requiresFrameworkEntries=0` — no patterns of any kind, so `frameworkGateNeeded` is false, the recovered markers are never consulted, and such a rule set cannot emit an entity or an edge whatever its markers say. (Read precisely: **89 of the 247 do carry a top-level `source_patterns:` key** — always the empty list `source_patterns: []`. "No entries" is the true statement; a `grep -l source_patterns` over the 247 will not return nothing.)
- The **10 live `requires_framework` sites in 7 files** (`ansible/frameworks/ansible_core.yaml` ×2, `cicd/frameworks/github_actions.yaml` ×3, `docker/frameworks/docker_compose.yaml`, `python/frameworks/cherrypy.yaml`, `python/frameworks/falcon.yaml`, `python/frameworks/sqlalchemy.yaml`, `vbnet/frameworks/winforms.yaml`) are **disjoint from the 247** — all seven already keyed on `frameworks:`, all ten already evaluating against visible markers. Their gating is byte-identical before and after.
- `frameworks.name` is the only other key the rename exposes, and it has no reader (#7014).

**This is a property of the 247 files, not a sample of their behaviour**, and it is checkable from the diff alone: inert rule sets cannot move extraction, whatever corpus you point them at. A before/after corpus comparison of the real `Detector` over both rule trees was also run during development and agreed — but that harness is not in the diff, so nobody can inspect its comparison key or re-run it, and an uncheckable measurement is not evidence. The structural result above is what this claim rests on.

So step 1 recovers the metadata and moves no extraction. The recall trade #7013 is holding on (`requires_framework`'s per-file gate) is untouched and still unmeasured; this change only makes it expressible for 52 more files.

## 3. Golden ratchet: unmoved

`scripts/quality/run.sh --ratchet` → exit **0**, `38 gated fixtures held their baseline (29 at 100% must-have recall)`. No constant bumped, no `--update-baseline`.

## The pin

`internal/engine/rule_container_key_7013_test.go`, asserting artefacts rather than counts:

- **`TestRuleTree_RecoveredImportMarkersLoad`** — five named files, one per formerly-wrong spelling that carried markers, must decode their **exact** marker list and framework name through the loader's own `yaml.Unmarshal`-into-`FrameworkRule` step.
- **`TestRuleTree_NoImportMarkersHiddenUnderAnUnmodelledContainer`** — no loader-scoped file anywhere may declare `import_markers` under a container the schema does not model. Non-vacuity both ways: ≥500 files examined, and ≥147 with readable markers, so "reconciled by deleting the markers" cannot read as clean.
- **`TestRuleTree_NoReconciledContainerSpellingReturns`** — the 14 spellings are a closed, named set and none may return, marker-bearing or not. This is what makes the fix non-recurring; it is **not** the strict top-level guard #7014 priced at 247 red files, and it costs 0 red today.
- **`TestLoader_DoesNotAdoptAnUnmodelledContainer`** — the loader must not learn the misspellings (see Decision).
- Two positive controls on the checker itself (it must flag a hidden container, and must not flag an empty `import_markers` list).

## Mutants, permissive direction first

Scored in a **separate checkout** (`.../impl-7013a-k9x4t/mut`, detached at the branch commit) so the verification tree was never mutated. Green baseline immediately before each, `go vet` first, `-count=1`, each edit proved landed by an exact occurrence count (`assert n==1` on the replacement, then a `grep -c` on the mutated text), and each restored by `cp` from a shasum-verified backup — never `git checkout --` — with `git diff HEAD` confirmed empty after every one.

| # | mutant | verdict |
|---|---|---|
| M1 | re-break one spelling on a marker-bearing file (`csharp/orms/mongodb_csharp.yaml` → `orms_database:`) | **DEAD** — 3 tests, by file and key name |
| M2 | reconciliation silently skips a file that has **no** markers (`clojure/frameworks/amazonica_dynamodb.yaml` → `framework:`) | **DEAD** — only by `NoReconciledContainerSpellingReturns`; without that test this mutant is alive, which is why it exists |
| M3 | make the checker permissive — treat `orms_database`/`database` as visible containers | **DEAD** — the positive control names the two files it stopped flagging |
| M4 | make the **loader** adopt markers from any container when `frameworks:` is absent (the aliasing option, applied silently) — implemented as a pre-`Unmarshal` adoption pass in `loader.go` | **ALIVE** against `./internal/engine -count=1` (ok, 77.6s) and against all three of this PR's tree guards — nothing in the tree feeds it, since the reconciliation removed every input. Killed by the new `TestLoader_DoesNotAdoptAnUnmodelledContainer` (`the loader adopted 1 import_markers from a container it does not model`). ~20 lines. |

M4 is the one worth naming: the guard and the reconciliation were mutually masking — each made the other's failure invisible — so the loader control had to be written on a synthetic FS rather than on the tree.

**Scoped precisely, because "the whole suite was green" is too strong a claim to carry unqualified.** "ALIVE" above is about *this* adopting-loader implementation against `./internal/engine` at this commit. The independent review reproduced the mutant as an `UnmarshalYAML` method on `FrameworkRule` instead, and **that variant is additionally caught by the pre-existing `TestInertRuleFiles_DetectsAnInertFile` (#6393)** — a file keyed on an unmodelled container stops parsing to the zero rule once the loader adopts its contents. So the new test is the only guard that names this defect, and the mutual-masking pair is real; it is not the only net under every possible adopting loader.

## Verification

- `go vet ./internal/engine/` clean; `gofmt -l` clean on the new file.
- `go test ./internal/engine/ -count=1` → **ok, 52.9s**, exit 0.
- `go test ./cmd/grafel/ -count=1` → **ok, 171.7s**, exit 0, in a fresh three-variable sandbox (`HOME`/`GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT` all under scratch); the real `~/.grafel` was never touched.
- `scripts/quality/run.sh --ratchet` → exit 0, same sandbox.
- **The other consumers of the rules tree**, which my original verification set omitted and the independent review ran: `go test ./internal/entkinds/ ./internal/relkinds/ ./tools/coverage/ ./internal/types/ -count=1` → all **ok** (22.2s / 16.7s / 5.2s / 14.0s). These matter here because `entkinds` and `relkinds` walk the YAML **at any depth** rather than through the schema, and the rename does shift a key path prefix for 5 files — `html_templates/frameworks/*.yaml` carry `scope_entity_mapping.entity_type: Component`, formerly under `template_engines:`. `tools/coverage` is directory- and filename-driven and never reads the container key. Green, so this is a gap in the *stated* verification rather than a defect — and a rule-tree change should name every consumer of the tree it checked (cf. "package selection is not suite selection").
- The commit is 248 files: 247 one-line renames + the new test. `git status` clean in `wt`, `mut` and the primary checkout.

## Stated limits

- **The 465 unmodelled metadata key paths are untouched**, as are the 59 `package_json_deps` declarations and every `requires_framework` setting. This change writes no new markers and sets no gate — deliberately (#7013 steps 2 and 3).
- **The no-regression result holds only while those 247 rule sets stay inert.** It is a structural property of the files as they are, not a promise about the future: a `source_patterns` entry added to one of them could change behaviour — which is the point of recovering the markers.
- **The closed 14-item spelling list has a known gap**: a *fifteenth* spelling on a *marker-less* file is invisible to both new tree guards (no markers to hide, not on the list) and stays alive. The review priced the fix — after this PR the loader-scoped tree holds exactly four distinct top-level keys, all modelled (`frameworks` 513, `source_patterns` 162, `relationship_rules` 158, `file_conventions` 154), so the strict top-level guard #7014 measured at 247 red files now **costs 0 red** and subsumes the hand-maintained list. Filed as an immediate follow-up rather than widened into this PR.
- The 5 container-less `go/frameworks/*.yaml` files still declare no detection metadata at all; #7013 step 2 has to write theirs, and now has one spelling to write it under.

Refs #7013, #7014.
