### PR TITLE
fix(#6990): the relational-target scan ran 400 bytes forward regardless of where the declaration ended, so a field bound to the NEXT field's model

### DIFF
--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -157,13 +157,30 @@ var (
 	// but it drops `TreeForeignKey(Category, ...)` with it — measured, not
 	// assumed: see TestIssue6988_RegexBoundaryRejected_WouldDropSubclasses.
 	// This regex extracts a target; it is NOT the constructor filter.
-	// `isDjangoRelationalField` decides which constructors are PROCESSED — but it
-	// does not bound what this regex READS. The caller hands it a 400-char
-	// forward window (`fullRHS` below) that can span later lines, so a
-	// legitimate `ForeignKey` whose own argument this regex cannot parse
-	// (`models.ForeignKey(settings.AUTH_USER_MODEL, ...)`) can still match a
-	// string belonging to a constructor the gate REJECTED. That residue survives
-	// #6988 and is zero-incidence on the measured corpus; it is filed separately.
+	// `isDjangoRelationalField` decides which constructors are PROCESSED. It does
+	// not bound what this regex READS — the CALLER's window does, and until
+	// #6990 that window was a raw 400-byte forward slice from the matched field,
+	// unbounded by the declaration it belonged to. A legitimate `ForeignKey`
+	// whose own argument this regex cannot parse
+	// (`models.ForeignKey(settings.AUTH_USER_MODEL, ...)` — dotted and
+	// lowercase-initial, so the `[A-Z]` symbol alternative correctly rejects it)
+	// therefore ran on into the NEXT field's declaration and captured ITS target.
+	// django/contrib/admin/models.py's `LogEntry.user` did exactly that and came
+	// out targeting `ContentType`: a real model, a bound edge, the wrong thing.
+	//
+	// CORRECTION (#6990): an earlier version of this comment called that residue
+	// "zero-incidence on the measured corpus". That was a measurement of the
+	// snake_case target population (chosen for #6988's `content_type` shape)
+	// stated over a wider one. `ContentType` is CamelCase and a genuine model
+	// name, so no shape filter could see it. The general population was never
+	// counted — it is UNMEASURED, not zero.
+	//
+	// The window is now bounded by the field's OWN call parentheses
+	// (`djangoDeclEnd`), so this regex can no longer read text belonging to a
+	// constructor the gate rejected — or to any other declaration. The regex
+	// itself is UNCHANGED: adding a left `\b` here would close the same case but
+	// drop `TreeForeignKey(Category, ...)` with it (#6988), and two guards that
+	// only fire together grade neither.
 	djangoModelRelTargetRe = regexp.MustCompile(
 		`(?:ForeignKey|OneToOneField|ManyToManyField)\s*\(\s*(?:to\s*=\s*)?(?:["']([^"']+)["']|([A-Z][A-Za-z0-9_]*))`)
 
@@ -715,7 +732,19 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 			if attr == "" || !isDjangoRelationalField(rhs) {
 				continue
 			}
-			fullRHS := body[fIdx[0]:min(fIdx[0]+400, len(body))]
+			// #6990 — bound the target scan to THIS field's own declaration.
+			// fIdx[1] is one past the match, whose last byte is the `(` of the
+			// constructor call (djangoModelFieldRe ends `\s*\(`), so the slice
+			// runs from the start of the assignment line to the matching `)`.
+			// Multi-line declarations are covered by construction: the scan
+			// follows parens, not bytes or lines. The 400-byte cap survives ONLY
+			// as the unbalanced-source fallback, where it is exactly the old
+			// behaviour — never wider.
+			end := djangoDeclEnd(body, fIdx[1]-1)
+			if end < 0 {
+				end = min(fIdx[0]+400, len(body))
+			}
+			fullRHS := body[fIdx[0]:end]
 			if target, rawFKString, isSelf := djangoRelTargetDetail(fullRHS, className); target != "" {
 				rel := referencesClassEdge(file.Path, className+"."+attr, target, "django", attr)
 				// #6986 — carry the RELATION-SHAPE properties the core
@@ -1042,6 +1071,79 @@ func djangoRelTargetDetail(rhs, ownerClass string) (target, rawFKString string, 
 func djangoRelTarget(rhs, ownerClass string) string {
 	target, _, _ := djangoRelTargetDetail(rhs, ownerClass)
 	return target
+}
+
+// djangoDeclEnd returns the index one past the `)` that closes the call whose
+// opening `(` sits at openPos, or -1 when the source is unbalanced within body.
+//
+// #6990 — this is what bounds a relational field's target scan to the field's
+// OWN declaration. A byte window cannot do that: Django field declarations
+// legitimately span lines, so any fixed count is either too short for a real
+// multi-line `ForeignKey(\n  "app.Model",\n  on_delete=...\n)` or long enough to
+// reach the NEXT field's constructor. Following the parentheses is exact in
+// both directions.
+//
+// It counts parenthesis depth only — a `)` cannot appear inside `[...]` or
+// `{...}` without its own `(` — and it skips the two places a `)` can appear
+// without closing anything: string literals (single, double, and triple-quoted,
+// honouring backslash escapes) and `#` comments. An unterminated single-quoted
+// string or comment yields -1 rather than a guess, so the caller falls back to
+// the pre-#6990 byte window instead of over-reading further than it used to.
+func djangoDeclEnd(body string, openPos int) int {
+	if openPos < 0 || openPos >= len(body) || body[openPos] != '(' {
+		return -1
+	}
+	depth := 0
+	for i := openPos; i < len(body); i++ {
+		switch body[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		case '#':
+			nl := strings.IndexByte(body[i:], '\n')
+			if nl < 0 {
+				return -1
+			}
+			i += nl
+		case '\'', '"':
+			j := skipPyStringLiteral(body, i)
+			if j < 0 {
+				return -1
+			}
+			i = j - 1
+		}
+	}
+	return -1
+}
+
+// skipPyStringLiteral returns the index one past the string literal that starts
+// at i (which must hold a quote byte), or -1 if it is unterminated. Triple
+// quotes are handled first so a `)` inside a docstring-style default cannot be
+// mistaken for a closing paren.
+func skipPyStringLiteral(s string, i int) int {
+	q := s[i]
+	if i+2 < len(s) && s[i+1] == q && s[i+2] == q {
+		quote := s[i : i+3]
+		if end := strings.Index(s[i+3:], quote); end >= 0 {
+			return i + 3 + end + 3
+		}
+		return -1
+	}
+	for j := i + 1; j < len(s); j++ {
+		switch s[j] {
+		case '\\':
+			j++
+		case '\n':
+			return -1
+		case q:
+			return j + 1
+		}
+	}
+	return -1
 }
 
 // extractBalancedBrackets returns the content of a [...] list starting at openPos.

--- a/internal/custom/python/django_decl_window_6990_test.go
+++ b/internal/custom/python/django_decl_window_6990_test.go
@@ -1,0 +1,306 @@
+package python
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6990, residue 2 — the relational-target scan ran forward a raw 400
+// BYTES from the matched field, unbounded by the declaration it belonged to. A
+// field whose own target argument the regex cannot parse therefore captured the
+// NEXT field's target. `LogEntry.user`, declared
+// `models.ForeignKey(settings.AUTH_USER_MODEL, ...)`, came out targeting
+// `ContentType` — a real model, a bound edge, the wrong thing.
+//
+// The window is now bounded by the field's OWN call parentheses
+// (`djangoDeclEnd`). The regex is UNCHANGED: this ships ONE guard, so it stays
+// graded (#6988's lesson — two guards that only fire together grade neither).
+//
+// SCOPE. Residue 1 of #6990 — `class CTForeignKey(GenericForeignKey)` passing
+// `isDjangoRelationalField`'s suffix check at django.go — is NOT touched here.
+// It is a policy decision (deny-list vs allow-list) that #6988/#6989 settled
+// once, and it is pinned by TestIssue6988_RegexBoundaryRejected_WouldDropSubclasses.
+//
+// GATE (#6966): every edge below exists only with the custom Python lane ON.
+// It is off by default (`WithCustomExtractors`), so default-index baselines are
+// untouched. Graph-level incidence of the defect on the real django corpus is
+// NOT ESTABLISHED and is not claimed anywhere in this file; what is graded here
+// is extractor-level behaviour.
+
+// ---------------------------------------------------------------------------
+// The bound itself: djangoDeclEnd.
+// ---------------------------------------------------------------------------
+
+// TestIssue6990_DeclEnd_FindsTheCallsOwnCloser grades every place a `)` can
+// appear without closing the call. Only the unit level can observe these: the
+// target is the FIRST argument, so an EARLY close still contains it and is
+// invisible end-to-end. A LATE close is the bug.
+func TestIssue6990_DeclEnd_FindsTheCallsOwnCloser(t *testing.T) {
+	cases := []struct {
+		name string
+		body string // `|` marks the expected end (one past the closing paren)
+	}{
+		{"flat", `f(A)|`},
+		{"nested call", `f(A, on_delete=models.CASCADE)|`},
+		{"double nested", `f(A, default=(1, (2, 3)))|`},
+		{"paren in double-quoted string", `f(A, help_text="see (the docs)")|`},
+		{"paren in single-quoted string", `f(A, help_text='see (the docs)')|`},
+		{"paren in triple-quoted string", `f(A, help_text="""see (the
+docs)""")|`},
+		{"paren in comment", `f(A,  # a ) here
+    on_delete=CASCADE)|`},
+		{"hash inside string is not a comment", `f(A, default="#)")|`},
+		{"apostrophe inside comment is not a string", `f(A,  # don't ) do this
+    x=1)|`},
+		{"escaped quote inside string", `f(A, default="a\")b")|`},
+		{"multi-line with trailing comma", `f(
+    "catalog.Author",
+    on_delete=models.CASCADE,
+)|`},
+		{"stops at its OWN closer, not a later one", `f(A)| g(B)`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			want := strings.IndexByte(c.body, '|')
+			if want < 0 {
+				t.Fatalf("fixture %q has no `|` end marker", c.body)
+			}
+			body := strings.Replace(c.body, "|", "", 1)
+			if got := djangoDeclEnd(body, 1); got != want {
+				t.Errorf("djangoDeclEnd(%q, 1) = %d, want %d (slice %q, want %q) (#6990)",
+					body, got, want, body[:max(got, 0)], body[:want])
+			}
+		})
+	}
+}
+
+// TestIssue6990_DeclEnd_RefusesToGuess pins the -1 side. The caller falls back
+// to the pre-#6990 400-byte window there, which is EXACTLY the old behaviour —
+// never wider. A guess (end-of-body, say) would be strictly worse than the bug
+// this fixes, so "unbalanced" must be reported, not papered over.
+func TestIssue6990_DeclEnd_RefusesToGuess(t *testing.T) {
+	cases := []struct{ name, body string }{
+		{"never closed", `f(A, on_delete=CASCADE`},
+		{"unterminated string", `f(A, help_text="oops)`},
+		{"unterminated triple-quoted string", `f(A, help_text="""oops)`},
+		{"unterminated trailing comment", `f(A,  # oops`},
+		{"depth never returns to zero", `f((A)`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := djangoDeclEnd(c.body, 1); got != -1 {
+				t.Errorf("djangoDeclEnd(%q, 1) = %d, want -1 — an unbalanced source must fall back "+
+					"to the byte window, not guess an end (#6990)", c.body, got)
+			}
+		})
+	}
+	// openPos must actually name a `(`.
+	for _, pos := range []int{-1, 0, 99} {
+		if got := djangoDeclEnd(`f(A)`, pos); got != -1 {
+			t.Errorf("djangoDeclEnd(%q, %d) = %d, want -1", `f(A)`, pos, got)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End to end. Two axes crossed: DECLARATION LAYOUT x TARGET FORM.
+// ---------------------------------------------------------------------------
+
+// declLayout6990 renders one field declaration three ways. The argument text is
+// identical in all three; only the line structure varies. RE2's `\s` matches
+// `\n`, so multi-line coverage in this package has been INCIDENTAL and never
+// asserted — which is exactly how a narrowing walks through a pin.
+type declLayout6990 struct {
+	name   string
+	render func(attr, ctor, args string) string
+}
+
+var declLayouts6990 = []declLayout6990{
+	{"single-line", func(attr, ctor, args string) string {
+		return fmt.Sprintf("    %s = %s(%s, on_delete=models.CASCADE)", attr, ctor, args)
+	}},
+	{"multi-line", func(attr, ctor, args string) string {
+		return fmt.Sprintf("    %s = %s(\n        %s,\n        on_delete=models.CASCADE)", attr, ctor, args)
+	}},
+	{"multi-line-trailing-comma", func(attr, ctor, args string) string {
+		return fmt.Sprintf("    %s = %s(\n        %s,\n        on_delete=models.CASCADE,\n    )", attr, ctor, args)
+	}},
+}
+
+// TestIssue6990_TargetFormsSurviveEveryDeclarationLayout crosses the two axes.
+//
+// VARIED: declaration layout (single-line / multi-line / multi-line with a
+// trailing comma) x target form (dotted lowercase `settings.AUTH_USER_MODEL`,
+// bare CamelCase symbol, quoted `"app.Model"`, quoted `'self'`).
+//
+// HELD CONSTANT and graded elsewhere: the constructor (`models.ForeignKey`
+// throughout — the constructor gate is #6988's and is pinned by
+// TestIssue6988_GateKeepsRelationalConstructors); the regex's left boundary
+// (unchanged by #6990, pinned by TestIssue6988_RegexBoundaryRejected_WouldDropSubclasses);
+// and the `[A-Z]` symbol anchor (pinned by
+// TestIssue6988_RegexRejectsLowercaseInitialSymbol).
+//
+// EVERY case carries a SENTINEL sibling declared immediately after it with a
+// different target. That is what makes the negative rows non-vacuous: if the
+// window still ran past the declaration it would capture `Sentinel`, and the
+// "want no target" rows would fail LOUDLY rather than pass by producing nothing.
+func TestIssue6990_TargetFormsSurviveEveryDeclarationLayout(t *testing.T) {
+	targetForms := []struct {
+		name string
+		args string
+		want string // "" = no target edge at all
+	}{
+		{"dotted-lowercase-settings", "settings.AUTH_USER_MODEL", ""},
+		{"bare-CamelCase-symbol", "Profile", "Profile"},
+		{"quoted-app-dot-Model", `"catalog.Author"`, "Author"},
+		{"quoted-self", `'self'`, "Owner"},
+	}
+	for _, layout := range declLayouts6990 {
+		for _, form := range targetForms {
+			t.Run(layout.name+"/"+form.name, func(t *testing.T) {
+				src := "from django.conf import settings\nfrom django.db import models\n\n\n" +
+					"class Owner(models.Model):\n" +
+					layout.render("subject", "models.ForeignKey", form.args) + "\n" +
+					layout.render("sentinel", "models.ForeignKey", "Sentinel") + "\n"
+				rels := djangoEdges6988(t, src)
+
+				got := fieldTargetEdgesFrom6988(rels, "Owner.subject")
+				if form.want == "" {
+					if len(got) != 0 {
+						t.Errorf("Owner.subject emitted %d field_target_type edge(s), want 0; first ToID=%q. "+
+							"A target here is the scan reading past this declaration's own `)` (#6990)",
+							len(got), got[0].ToID)
+					}
+				} else {
+					if len(got) != 1 {
+						t.Fatalf("Owner.subject emitted %d field_target_type edge(s), want exactly 1 "+
+							"-> %s. The #6990 window bound must not cost a legitimate target (source:\n%s)",
+							len(got), form.want, src)
+					}
+					if want := fieldTargetRef6988(form.want); got[0].ToID != want {
+						t.Errorf("Owner.subject -> %q, want %q (#6990)", got[0].ToID, want)
+					}
+				}
+
+				// POSITIVE CONTROL on every single row, including the negative
+				// ones: the sentinel is the field whose target an over-reading
+				// window would steal, and it must resolve on its own.
+				sent := fieldTargetEdgesFrom6988(rels, "Owner.sentinel")
+				if len(sent) != 1 || sent[0].ToID != fieldTargetRef6988("Sentinel") {
+					t.Fatalf("Owner.sentinel did not resolve to Sentinel (%d edge(s)) — the control is "+
+						"gone, so the assertion above proves nothing (source:\n%s)", len(sent), src)
+				}
+			})
+		}
+	}
+}
+
+// TestIssue6990_NamedResidue2_RealFieldFollowedByGFK is the issue's named
+// shape, as a forbidden row: a legitimate relational field whose target the
+// regex cannot parse, sitting directly above the `GenericForeignKey` whose
+// `ct_field` STRING the old window captured. This is the #6988 case seen from
+// the other side — the gate rejects the GFK constructor, but until #6990 it did
+// not stop the regex READING the GFK's text on a neighbouring field's behalf.
+func TestIssue6990_NamedResidue2_RealFieldFollowedByGFK(t *testing.T) {
+	const src = `from django.conf import settings
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.db import models
+
+
+class Note(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    object_id = models.PositiveIntegerField()
+    content_object = GenericForeignKey("content_type", "object_id")
+`
+	rels := djangoEdges6988(t, src)
+
+	if got := fieldTargetEdgesFrom6988(rels, "Note.user"); len(got) != 0 {
+		t.Errorf("Note.user emitted %d field_target_type edge(s), want 0; first ToID=%q. Its own "+
+			"declaration names settings.AUTH_USER_MODEL and nothing else (#6990 residue 2)",
+			len(got), got[0].ToID)
+	}
+	// #6988's row, restated here because #6990 must not reopen it.
+	if got := fieldTargetEdgesFrom6988(rels, "Note.content_object"); len(got) != 0 {
+		t.Errorf("Note.content_object emitted %d field_target_type edge(s), want 0; first ToID=%q (#6988)",
+			len(got), got[0].ToID)
+	}
+	// Controls: the two fields that SHOULD resolve, still do.
+	if got := fieldTargetEdgesFrom6988(rels, "Note.content_type"); len(got) != 1 ||
+		got[0].ToID != fieldTargetRef6988("ContentType") {
+		t.Fatalf("Note.content_type did not resolve to ContentType (%d edge(s)) — the negatives above "+
+			"are vacuous without it", len(got))
+	}
+	if !hasEdge6988(rels, pyClassRef("Note"), "Note.content_object", string(types.RelationshipKindContains)) {
+		t.Error("Note CONTAINS content_object missing: #6990 bounds the target scan, it does not drop fields")
+	}
+}
+
+// TestIssue6990_TheBoundIsTheSoleGuard shows that the WINDOW is what rejects the
+// bad match, not the regex — so the shipped guard is graded on its own. Handed
+// the OLD over-reading text, the unchanged regex still happily captures
+// `ContentType`; handed the bounded text, there is nothing to capture.
+func TestIssue6990_TheBoundIsTheSoleGuard(t *testing.T) {
+	const twoFields = `    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)`
+
+	// The pre-#6990 window (byte-counted, spanning both declarations).
+	if got := djangoRelTarget(twoFields, "LogEntry"); got != "ContentType" {
+		t.Fatalf("djangoRelTarget over the OLD unbounded window = %q, want \"ContentType\": this test's "+
+			"premise is that the regex is unchanged and still reads the next field (#6990)", got)
+	}
+
+	// The post-#6990 window: the first declaration, bounded at its own `)`.
+	open := strings.IndexByte(twoFields, '(')
+	end := djangoDeclEnd(twoFields, open)
+	if end < 0 {
+		t.Fatal("djangoDeclEnd failed on a balanced declaration")
+	}
+	if got := djangoRelTarget(twoFields[:end], "LogEntry"); got != "" {
+		t.Errorf("djangoRelTarget over the BOUNDED window = %q, want \"\" — the bound alone must be "+
+			"what rejects the over-read (#6990)", got)
+	}
+}
+
+// TestIssue6990_UnbalancedSourceFallsBackToTheOldByteWindow_NotWider grades the
+// `end < 0` branch — the one path where a byte count survives #6990. When
+// `djangoDeclEnd` cannot find the declaration's closer (a truncated or
+// syntactically broken file), the scan reverts to the pre-#6990 400-byte
+// window. That is deliberately EXACTLY the old behaviour: a fallback of
+// `len(body)` would make an unbalanced file read WIDER than the bug this fixes.
+//
+// The distinguishing input: an unterminated declaration, then more than 400
+// bytes of filler, then a parseable target. Under the 400-byte fallback the
+// later target is out of reach; under any wider fallback it is captured.
+func TestIssue6990_UnbalancedSourceFallsBackToTheOldByteWindow_NotWider(t *testing.T) {
+	filler := strings.Repeat("    # padding to push the next declaration past 400 bytes\n", 10)
+	if len(filler) <= 400 {
+		t.Fatalf("filler is %d bytes, need >400 for this test to distinguish the two fallbacks", len(filler))
+	}
+	src := "from django.conf import settings\nfrom django.db import models\n\n\n" +
+		"class Owner(models.Model):\n" +
+		"    subject = models.ForeignKey(settings.AUTH_USER_MODEL,\n" + // never closed
+		filler +
+		"    sentinel = models.ForeignKey(Sentinel, on_delete=models.CASCADE)\n"
+
+	// Premise control: this really is the unbalanced path.
+	body := src[strings.Index(src, "    subject"):]
+	if got := djangoDeclEnd(body, strings.IndexByte(body, '(')); got != -1 {
+		t.Fatalf("djangoDeclEnd = %d, want -1: the fixture is not exercising the fallback branch", got)
+	}
+
+	rels := djangoEdges6988(t, src)
+	if got := fieldTargetEdgesFrom6988(rels, "Owner.subject"); len(got) != 0 {
+		t.Errorf("Owner.subject emitted %d field_target_type edge(s), want 0; first ToID=%q. The "+
+			"unbalanced-source fallback must stay at the pre-#6990 400-byte window, never wider",
+			len(got), got[0].ToID)
+	}
+	if got := fieldTargetEdgesFrom6988(rels, "Owner.sentinel"); len(got) != 1 ||
+		got[0].ToID != fieldTargetRef6988("Sentinel") {
+		t.Fatalf("Owner.sentinel did not resolve to Sentinel (%d edge(s)) — the negative above is vacuous",
+			len(got))
+	}
+}

--- a/internal/custom/python/django_decl_window_6990_test.go
+++ b/internal/custom/python/django_decl_window_6990_test.go
@@ -265,42 +265,83 @@ func TestIssue6990_TheBoundIsTheSoleGuard(t *testing.T) {
 	}
 }
 
-// TestIssue6990_UnbalancedSourceFallsBackToTheOldByteWindow_NotWider grades the
+// TestIssue6990_UnbalancedSourceFallsBackToTheOldByteWindow grades the
 // `end < 0` branch — the one path where a byte count survives #6990. When
 // `djangoDeclEnd` cannot find the declaration's closer (a truncated or
 // syntactically broken file), the scan reverts to the pre-#6990 400-byte
-// window. That is deliberately EXACTLY the old behaviour: a fallback of
-// `len(body)` would make an unbalanced file read WIDER than the bug this fixes.
+// window, which is deliberately EXACTLY the old behaviour.
 //
-// The distinguishing input: an unterminated declaration, then more than 400
-// bytes of filler, then a parseable target. Under the 400-byte fallback the
-// later target is out of reach; under any wider fallback it is captured.
-func TestIssue6990_UnbalancedSourceFallsBackToTheOldByteWindow_NotWider(t *testing.T) {
+// "Exactly the old behaviour" has TWO halves and this test asserts BOTH,
+// because the fallback's whole reason to exist is that it PRESERVES prior
+// behaviour rather than dropping edges:
+//
+//   - NOT WIDER. A target more than 400 bytes past the field must NOT be
+//     captured — a fallback of `len(body)` would make an unbalanced file read
+//     wider than the bug #6990 fixes.
+//   - NOT NARROWER. A target WITHIN 400 bytes must still BE captured — a
+//     fallback of `fIdx[0]` (an empty window) silently drops every target in
+//     an unbalanced file, and until this half was asserted that build was
+//     indistinguishable from this one.
+//
+// Both halves run on genuinely unbalanced declarations, each with its own
+// `djangoDeclEnd == -1` premise control, so neither is quietly grading the
+// normal path instead.
+func TestIssue6990_UnbalancedSourceFallsBackToTheOldByteWindow(t *testing.T) {
 	filler := strings.Repeat("    # padding to push the next declaration past 400 bytes\n", 10)
 	if len(filler) <= 400 {
 		t.Fatalf("filler is %d bytes, need >400 for this test to distinguish the two fallbacks", len(filler))
 	}
 	src := "from django.conf import settings\nfrom django.db import models\n\n\n" +
+		// FAR: the target the window must NOT reach. Unterminated declaration,
+		// then >400 bytes of filler, then a parseable `ForeignKey(Sentinel`.
 		"class Owner(models.Model):\n" +
 		"    subject = models.ForeignKey(settings.AUTH_USER_MODEL,\n" + // never closed
 		filler +
-		"    sentinel = models.ForeignKey(Sentinel, on_delete=models.CASCADE)\n"
+		"    sentinel = models.ForeignKey(Sentinel, on_delete=models.CASCADE)\n" +
+		"\n\n" +
+		// NEAR: the target the window MUST still reach. Equally unterminated,
+		// so it takes the same fallback branch — but its own target sits
+		// immediately after its own `(`, well inside 400 bytes.
+		"class NearOwner(models.Model):\n" +
+		"    near = models.ForeignKey(Nearby,\n" // never closed
 
-	// Premise control: this really is the unbalanced path.
-	body := src[strings.Index(src, "    subject"):]
-	if got := djangoDeclEnd(body, strings.IndexByte(body, '(')); got != -1 {
-		t.Fatalf("djangoDeclEnd = %d, want -1: the fixture is not exercising the fallback branch", got)
+	// Premise controls, one per half: both declarations really do take the
+	// `end < 0` fallback, so neither assertion is grading the normal path.
+	for _, decl := range []string{"    subject", "    near"} {
+		body := src[strings.Index(src, decl):]
+		if got := djangoDeclEnd(body, strings.IndexByte(body, '(')); got != -1 {
+			t.Fatalf("djangoDeclEnd for %q = %d, want -1: that half of the fixture is not "+
+				"exercising the fallback branch", strings.TrimSpace(decl), got)
+		}
 	}
 
 	rels := djangoEdges6988(t, src)
+
+	// NOT WIDER.
 	if got := fieldTargetEdgesFrom6988(rels, "Owner.subject"); len(got) != 0 {
 		t.Errorf("Owner.subject emitted %d field_target_type edge(s), want 0; first ToID=%q. The "+
-			"unbalanced-source fallback must stay at the pre-#6990 400-byte window, never wider",
+			"unbalanced-source fallback must stay at the pre-#6990 400-byte window, never WIDER",
 			len(got), got[0].ToID)
 	}
+	// NOT NARROWER. Without this row, a fallback of `end = fIdx[0]` — an empty
+	// window that finds nothing at all on any unbalanced file — passes every
+	// other assertion in this package.
+	if got := fieldTargetEdgesFrom6988(rels, "NearOwner.near"); len(got) != 1 ||
+		got[0].ToID != fieldTargetRef6988("Nearby") {
+		ids := make([]string, 0, len(got))
+		for _, r := range got {
+			ids = append(ids, r.ToID)
+		}
+		t.Errorf("NearOwner.near emitted %d field_target_type edge(s) %v, want exactly 1 -> %q. Its "+
+			"own target is inside the 400-byte fallback window, so the fallback must still find it — "+
+			"it exists to PRESERVE the old behaviour, not to drop every target on an unbalanced file",
+			len(got), ids, fieldTargetRef6988("Nearby"))
+	}
+	// Control on the FAR half: the field whose target an over-reading fallback
+	// would steal resolves on its own, so the negative above is not vacuous.
 	if got := fieldTargetEdgesFrom6988(rels, "Owner.sentinel"); len(got) != 1 ||
 		got[0].ToID != fieldTargetRef6988("Sentinel") {
-		t.Fatalf("Owner.sentinel did not resolve to Sentinel (%d edge(s)) — the negative above is vacuous",
-			len(got))
+		t.Fatalf("Owner.sentinel did not resolve to Sentinel (%d edge(s)) — the NOT-WIDER negative "+
+			"above is vacuous", len(got))
 	}
 }

--- a/internal/custom/python/django_decl_window_6990_test.go
+++ b/internal/custom/python/django_decl_window_6990_test.go
@@ -44,7 +44,8 @@ func TestIssue6990_DeclEnd_FindsTheCallsOwnCloser(t *testing.T) {
 		body string // `|` marks the expected end (one past the closing paren)
 	}{
 		{"flat", `f(A)|`},
-		{"nested call", `f(A, on_delete=models.CASCADE)|`},
+		{"nested call", `f(A, default=make())|`},
+		{"call with a dotted kwarg, no nesting", `f(A, on_delete=models.CASCADE)|`},
 		{"double nested", `f(A, default=(1, (2, 3)))|`},
 		{"paren in double-quoted string", `f(A, help_text="see (the docs)")|`},
 		{"paren in single-quoted string", `f(A, help_text='see (the docs)')|`},
@@ -87,6 +88,13 @@ func TestIssue6990_DeclEnd_RefusesToGuess(t *testing.T) {
 		{"unterminated string", `f(A, help_text="oops)`},
 		{"unterminated triple-quoted string", `f(A, help_text="""oops)`},
 		{"unterminated trailing comment", `f(A,  # oops`},
+		// Grades `case '\n': return -1` in skipPyStringLiteral on its own. The
+		// quote is closed, but only on a LATER line — a Python string literal
+		// cannot span a newline unless it is triple-quoted, so this one is
+		// unterminated and the scan must refuse. Without the newline rule the
+		// skipper runs to the second line's quote and then reports the `)`
+		// after it as this call's closer.
+		{"quote closed only on a later line", "f(A, x=\"oops\ny = \")"},
 		{"depth never returns to zero", `f((A)`},
 	}
 	for _, c := range cases {
@@ -174,6 +182,12 @@ func TestIssue6990_TargetFormsSurviveEveryDeclarationLayout(t *testing.T) {
 							"A target here is the scan reading past this declaration's own `)` (#6990)",
 							len(got), got[0].ToID)
 					}
+					// The field must still EXIST. A negative that passes
+					// because the field vanished passes for the wrong reason.
+					if !hasEdge6988(rels, pyClassRef("Owner"), "Owner.subject", string(types.RelationshipKindContains)) {
+						t.Error("Owner CONTAINS subject missing — the negative above passed because the " +
+							"FIELD is gone, not because its target scan was bounded (#6990)")
+					}
 				} else {
 					if len(got) != 1 {
 						t.Fatalf("Owner.subject emitted %d field_target_type edge(s), want exactly 1 "+
@@ -222,6 +236,11 @@ class Note(models.Model):
 		t.Errorf("Note.user emitted %d field_target_type edge(s), want 0; first ToID=%q. Its own "+
 			"declaration names settings.AUTH_USER_MODEL and nothing else (#6990 residue 2)",
 			len(got), got[0].ToID)
+	}
+	// Both negatives in this test need the field to still exist, or they pass
+	// for the wrong reason.
+	if !hasEdge6988(rels, pyClassRef("Note"), "Note.user", string(types.RelationshipKindContains)) {
+		t.Error("Note CONTAINS user missing — the negative above passed because the FIELD is gone (#6990)")
 	}
 	// #6988's row, restated here because #6990 must not reopen it.
 	if got := fieldTargetEdgesFrom6988(rels, "Note.content_object"); len(got) != 0 {
@@ -275,57 +294,110 @@ func TestIssue6990_TheBoundIsTheSoleGuard(t *testing.T) {
 // because the fallback's whole reason to exist is that it PRESERVES prior
 // behaviour rather than dropping edges:
 //
-//   - NOT WIDER. A target more than 400 bytes past the field must NOT be
-//     captured — a fallback of `len(body)` would make an unbalanced file read
-//     wider than the bug #6990 fixes.
-//   - NOT NARROWER. A target WITHIN 400 bytes must still BE captured — a
-//     fallback of `fIdx[0]` (an empty window) silently drops every target in
-//     an unbalanced file, and until this half was asserted that build was
-//     indistinguishable from this one.
+//   - NOT WIDER. A target 401 bytes past the field must NOT be captured — a
+//     fallback of `len(body)` would make an unbalanced file read wider than
+//     the bug #6990 fixes.
+//   - NOT NARROWER. A target 400 bytes past the field MUST be captured, and so
+//     must a field's own target sitting right after its own `(` — a fallback
+//     of `fIdx[0]` (an empty window) silently drops every target in an
+//     unbalanced file.
 //
-// Both halves run on genuinely unbalanced declarations, each with its own
-// `djangoDeclEnd == -1` premise control, so neither is quietly grading the
-// normal path instead.
+// The two byte-exact rows pin the constant by MAGNITUDE, not just by sign:
+// together they admit exactly one window width. Grading only the direction
+// left ~300 bytes of slack either side (`+120` and `+600` both survived), so
+// "exactly the old behaviour" — the fallback's entire justification — was not
+// what was being asserted.
+//
+// WHY THE FALLBACK IS KEPT AT ALL. On every `-1` input it is byte-identical to
+// main, so it cannot regress anything; and one `-1` path is reachable from
+// VALID Python, because `extractClassBody`'s indent cut can truncate a body
+// mid-declaration. That is a pre-existing condition and preserving the old
+// window is the correct behaviour there.
+//
+// Every row runs on a genuinely unbalanced declaration and carries its own
+// `djangoDeclEnd == -1` premise control, so none is quietly grading the normal
+// path instead.
 func TestIssue6990_UnbalancedSourceFallsBackToTheOldByteWindow(t *testing.T) {
-	filler := strings.Repeat("    # padding to push the next declaration past 400 bytes\n", 10)
-	if len(filler) <= 400 {
-		t.Fatalf("filler is %d bytes, need >400 for this test to distinguish the two fallbacks", len(filler))
+	// boundaryClass renders a class whose FIRST field is UNTERMINATED — so its
+	// scan takes the `end < 0` fallback — followed by padding and a second,
+	// well-formed field whose target ends EXACTLY matchEnd bytes after the
+	// start of the first field's line.
+	//
+	// The target is the single character `Q` on purpose. A longer name would
+	// still match as a TRUNCATED PREFIX when the window cuts through it
+	// (`[A-Z][A-Za-z0-9_]*` is happy with `Boundar`), which would make the
+	// boundary fuzzy by the length of the name. One character makes "the match
+	// fits" and "the match does not fit" adjacent.
+	boundaryClass := func(class, field string, matchEnd int) string {
+		head := "    " + field + " = models.ForeignKey(settings.AUTH_USER_MODEL,\n" // never closed
+		tail := "    following = models.ForeignKey(Q, on_delete=models.CASCADE)\n"
+		targetEnd := strings.Index(tail, "(Q") + len("(Q") // one past `Q`
+		padLen := matchEnd - len(head) - targetEnd
+		if padLen < 6 {
+			t.Fatalf("matchEnd %d leaves no room for padding (need >= 6, got %d)", matchEnd, padLen)
+		}
+		pad := "    #" + strings.Repeat("p", padLen-6) + "\n"
+		if len(pad) != padLen {
+			t.Fatalf("padding is %d bytes, want %d — the byte-exact boundary is not what it claims",
+				len(pad), padLen)
+		}
+		return "class " + class + "(models.Model):\n" + head + pad + tail
 	}
+
 	src := "from django.conf import settings\nfrom django.db import models\n\n\n" +
-		// FAR: the target the window must NOT reach. Unterminated declaration,
-		// then >400 bytes of filler, then a parseable `ForeignKey(Sentinel`.
-		"class Owner(models.Model):\n" +
-		"    subject = models.ForeignKey(settings.AUTH_USER_MODEL,\n" + // never closed
-		filler +
-		"    sentinel = models.ForeignKey(Sentinel, on_delete=models.CASCADE)\n" +
-		"\n\n" +
-		// NEAR: the target the window MUST still reach. Equally unterminated,
-		// so it takes the same fallback branch — but its own target sits
-		// immediately after its own `(`, well inside 400 bytes.
+		// JUST OUTSIDE: `Q` ends 401 bytes in. Must NOT be captured.
+		boundaryClass("FarOwner", "subject", 401) + "\n\n" +
+		// JUST INSIDE: `Q` ends exactly 400 bytes in. MUST be captured — this
+		// is the pre-#6990 window preserved verbatim, which is the whole point
+		// of the fallback.
+		boundaryClass("EdgeOwner", "subject", 400) + "\n\n" +
+		// A field's OWN target, right after its own `(`, on an equally
+		// unterminated declaration. Simplest form of "not narrower".
 		"class NearOwner(models.Model):\n" +
 		"    near = models.ForeignKey(Nearby,\n" // never closed
 
-	// Premise controls, one per half: both declarations really do take the
-	// `end < 0` fallback, so neither assertion is grading the normal path.
-	for _, decl := range []string{"    subject", "    near"} {
-		body := src[strings.Index(src, decl):]
-		if got := djangoDeclEnd(body, strings.IndexByte(body, '(')); got != -1 {
-			t.Fatalf("djangoDeclEnd for %q = %d, want -1: that half of the fixture is not "+
-				"exercising the fallback branch", strings.TrimSpace(decl), got)
+	// Premise controls, one per row: each really does take the `end < 0`
+	// fallback, so none is quietly grading the normal path.
+	for _, decl := range []string{"    subject = models.ForeignKey(settings", "    near"} {
+		for from := 0; ; {
+			i := strings.Index(src[from:], decl)
+			if i < 0 {
+				break
+			}
+			body := src[from+i:]
+			if got := djangoDeclEnd(body, strings.IndexByte(body, '(')); got != -1 {
+				t.Fatalf("djangoDeclEnd for %q = %d, want -1: that row of the fixture is not "+
+					"exercising the fallback branch", strings.TrimSpace(decl), got)
+			}
+			from += i + len(decl)
 		}
 	}
 
 	rels := djangoEdges6988(t, src)
 
-	// NOT WIDER.
-	if got := fieldTargetEdgesFrom6988(rels, "Owner.subject"); len(got) != 0 {
-		t.Errorf("Owner.subject emitted %d field_target_type edge(s), want 0; first ToID=%q. The "+
-			"unbalanced-source fallback must stay at the pre-#6990 400-byte window, never WIDER",
-			len(got), got[0].ToID)
+	// NOT WIDER — by exactly one byte.
+	if got := fieldTargetEdgesFrom6988(rels, "FarOwner.subject"); len(got) != 0 {
+		t.Errorf("FarOwner.subject emitted %d field_target_type edge(s), want 0; first ToID=%q. Its "+
+			"following field's target ends 401 bytes in, one past the pre-#6990 window: the "+
+			"unbalanced-source fallback must never read WIDER than 400", len(got), got[0].ToID)
 	}
-	// NOT NARROWER. Without this row, a fallback of `end = fIdx[0]` — an empty
-	// window that finds nothing at all on any unbalanced file — passes every
-	// other assertion in this package.
+	// The field must still EXIST. A negative row that passes because the field
+	// vanished is passing for the wrong reason.
+	if !hasEdge6988(rels, pyClassRef("FarOwner"), "FarOwner.subject", string(types.RelationshipKindContains)) {
+		t.Error("FarOwner CONTAINS subject missing — the negative above passed because the FIELD is " +
+			"gone, not because its target scan was bounded (#6990)")
+	}
+	// NOT NARROWER — by exactly one byte, and this row is the pre-#6990
+	// behaviour the fallback exists to preserve.
+	if got := fieldTargetEdgesFrom6988(rels, "EdgeOwner.subject"); len(got) != 1 ||
+		got[0].ToID != fieldTargetRef6988("Q") {
+		t.Errorf("EdgeOwner.subject emitted %d field_target_type edge(s), want exactly 1 -> %q. Its "+
+			"following field's target ends exactly 400 bytes in, INSIDE the pre-#6990 window: the "+
+			"fallback must be that window exactly, not a narrower one", len(got), fieldTargetRef6988("Q"))
+	}
+	// NOT NARROWER, simplest form. Without this row a fallback of
+	// `end = fIdx[0]` — an empty window finding nothing on any unbalanced file
+	// — passes every other assertion in this package.
 	if got := fieldTargetEdgesFrom6988(rels, "NearOwner.near"); len(got) != 1 ||
 		got[0].ToID != fieldTargetRef6988("Nearby") {
 		ids := make([]string, 0, len(got))
@@ -333,15 +405,16 @@ func TestIssue6990_UnbalancedSourceFallsBackToTheOldByteWindow(t *testing.T) {
 			ids = append(ids, r.ToID)
 		}
 		t.Errorf("NearOwner.near emitted %d field_target_type edge(s) %v, want exactly 1 -> %q. Its "+
-			"own target is inside the 400-byte fallback window, so the fallback must still find it — "+
-			"it exists to PRESERVE the old behaviour, not to drop every target on an unbalanced file",
+			"own target sits right after its own `(`, so the fallback must still find it — it exists "+
+			"to PRESERVE the old behaviour, not to drop every target on an unbalanced file",
 			len(got), ids, fieldTargetRef6988("Nearby"))
 	}
-	// Control on the FAR half: the field whose target an over-reading fallback
-	// would steal resolves on its own, so the negative above is not vacuous.
-	if got := fieldTargetEdgesFrom6988(rels, "Owner.sentinel"); len(got) != 1 ||
-		got[0].ToID != fieldTargetRef6988("Sentinel") {
-		t.Fatalf("Owner.sentinel did not resolve to Sentinel (%d edge(s)) — the NOT-WIDER negative "+
-			"above is vacuous", len(got))
+	// Control: the following fields, whose targets the rows above are measured
+	// against, resolve on their own.
+	for _, owner := range []string{"FarOwner.following", "EdgeOwner.following"} {
+		if got := fieldTargetEdgesFrom6988(rels, owner); len(got) != 1 ||
+			got[0].ToID != fieldTargetRef6988("Q") {
+			t.Fatalf("%s did not resolve to Q (%d edge(s)) — the boundary rows above are vacuous", owner, len(got))
+		}
 	}
 }

--- a/internal/custom/python/field_target_address_6986_test.go
+++ b/internal/custom/python/field_target_address_6986_test.go
@@ -547,4 +547,16 @@ class ContentType(models.Model):
 		t.Fatal("LogEntry.content_type emitted no field_target_type edge at all — the positive control " +
 			"is gone, so the LogEntry.user negative above proves nothing (#6990)")
 	}
+	// The field under the NEGATIVE must still exist. A negative row that passes
+	// because the field vanished entirely is passing for the wrong reason.
+	var sawUserField bool
+	for i := range ents {
+		if ents[i].Name == "LogEntry.user" {
+			sawUserField = true
+		}
+	}
+	if !sawUserField {
+		t.Error("no LogEntry.user entity — the negative above passed because the FIELD is gone, not " +
+			"because its target scan was bounded (#6990)")
+	}
 }

--- a/internal/custom/python/field_target_address_6986_test.go
+++ b/internal/custom/python/field_target_address_6986_test.go
@@ -452,38 +452,45 @@ class Vendor(models.Model):
 }
 
 // ---------------------------------------------------------------------------
-// KNOWN-WRONG, pinned deliberately. A fix to #6990 is EXPECTED to break this.
+// #6990 — FIXED. This was a known-wrong pin; it is now a positive assertion.
 // ---------------------------------------------------------------------------
 
-// TestPythonFieldTargetType_KnownWrong_6990_OverReadBindsToTheNextFieldsTarget
-// pins a wrong BOUND edge that this address change creates, and that the PR
-// body originally denied existed.
+// TestPythonFieldTargetType_6990_NoOverReadIntoTheNextFieldsTarget was, until
+// #6990 shipped, a KNOWN-WRONG pin: it asserted that `LogEntry.user` came out
+// bound to `ContentType`, and carried a t.Skip telling the fixer to delete it.
+// It is converted rather than deleted, because deleting it would leave the
+// defect's own named shape unobserved — and the correct behaviour is a
+// NEGATIVE, which nothing else in this file grades.
 //
-// #6990's mechanism: `djangoModelRelTargetRe` has no left word boundary and the
-// producer hands it a 400-char `fullRHS` window. For
-// `user = models.ForeignKey(settings.AUTH_USER_MODEL, …)` the dotted target is
-// correctly REJECTED by the `[A-Z]` symbol alternative — and the window then
-// runs on into the NEXT field's `ForeignKey(ContentType`, capturing that. The
-// field's target_type becomes a class it does not reference.
+// The mechanism that was fixed: `djangoModelRelTargetRe` has no left word
+// boundary and the producer handed it a raw 400-BYTE forward window, unbounded
+// by the declaration it started in. For
+// `user = models.ForeignKey(settings.AUTH_USER_MODEL, …)` the dotted,
+// lowercase-initial target is correctly REJECTED by the `[A-Z]` symbol
+// alternative — and the window then ran on into the NEXT field's
+// `ForeignKey(ContentType`, capturing that. The field's target_type became a
+// class it does not reference: django/contrib/admin/models.py, verbatim.
 //
-// Under the old `Class:<Target>` address that wrong edge could not bind, so it
-// surfaced as one more dangling stub. Under the structural address it binds
-// whenever the wrong name has a unique in-tree declaration — which is exactly
-// #6369's hazard, a confident wrong edge that no dangling count can see.
+// That made it strictly worse than #6988's case. `ContentType` is CamelCase and
+// a genuine model, so the edge BOUND, to a legitimate node, in the declaring
+// file. Neither `NeverBindsToANonDeclaringFile` nor a dangling count could see
+// it: the FILE was right, the NAME was wrong, and no control here observes that
+// dimension.
 //
-// THIS IS NOT COVERED BY THE OVER-FIRE CONTROLS IN THIS FILE, and that is the
-// point of pinning it separately: `NeverBindsToANonDeclaringFile` and the
-// corpus "0 bound to a non-declaring file" figure both grade the FILE the
-// resolver picked. Here the file is right — `ContentType` really is declared
-// there. The wrongness is in the NAME the extractor chose, a dimension neither
-// control observes.
+// The window is now bounded by the field's own call parentheses
+// (`djangoDeclEnd`), so the correct target for `LogEntry.user` is NONE: the
+// declaration names `settings.AUTH_USER_MODEL`, a settings indirection this
+// extractor does not resolve, and emitting nothing is what "does not resolve"
+// looks like. Asserted as "no field_target_type edge AT ALL" rather than "not
+// ContentType", so a re-broadened window cannot pass by capturing a different
+// wrong target.
 //
-// On the django corpus this particular edge stays dangling, but for a reason
-// that lives elsewhere: the `ext:django:` external-synthesis pass intercepts
-// first. The guarantee is that pass's, not this address's. Fixing #6990 (either
-// anchoring the regex or bounding the window at the field's own call) should
-// make this test fail with `Class:` / no edge at all — delete it then.
-func TestPythonFieldTargetType_KnownWrong_6990_OverReadBindsToTheNextFieldsTarget(t *testing.T) {
+// GRAPH-LEVEL INCIDENCE IS NOT ESTABLISHED. An earlier comment here claimed
+// that on the real django corpus this edge stays dangling anyway because the
+// `ext:django:` external-synthesis pass intercepts first. Nobody verified that,
+// and it is not asserted. What this test grades is EXTRACTOR-LEVEL behaviour,
+// end to end through the merge and resolve path, which it does prove.
+func TestPythonFieldTargetType_6990_NoOverReadIntoTheNextFieldsTarget(t *testing.T) {
 	files := map[string]string{
 		"admin/models.py": `from django.conf import settings
 from django.db import models
@@ -505,57 +512,39 @@ class ContentType(models.Model):
 	for i := range ents {
 		byID[ents[i].ID] = ents[i]
 	}
-
-	// Control on the premise, through the production path: the SAME field with
-	// no sibling behind it emits NO edge at all. So the capture below is the
-	// 400-char window running on into the next field, not the symbol
-	// alternative accepting `settings.AUTH_USER_MODEL`.
-	lone := mergedFor6986(t, map[string]string{
-		"admin/models.py": `from django.conf import settings
-from django.db import models
-
-
-class LogEntry(models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-`,
-	})
-	for _, e := range fieldTargetEdges6986(lone) {
-		if edgeKey6986(e.Owner, e.Rel) == "LogEntry.user" {
-			t.Fatalf("LogEntry.user emits a target edge (%q) with NO sibling field behind it — this "+
-				"test's premise (the window over-reads into the NEXT field) is not what is happening",
-				propOf6986(e.Rel.Properties, "target_type"))
-		}
-	}
-
 	idx := resolve.BuildIndex(ents)
 	resolve.ReferencesEmbedded(ents, idx)
 
-	var userEdge *types.RelationshipRecord
+	var sawContentType bool
 	for _, e := range fieldTargetEdges6986(ents) {
-		if edgeKey6986(e.Owner, e.Rel) == "LogEntry.user" {
-			r := e.Rel
-			userEdge = &r
+		switch edgeKey6986(e.Owner, e.Rel) {
+		case "LogEntry.user":
+			// THE FORBIDDEN ROW.
+			t.Errorf("LogEntry.user emitted a field_target_type edge (target_type=%q, ToID=%q); want "+
+				"NONE. The declaration names settings.AUTH_USER_MODEL — any target here came from "+
+				"reading past the end of this field's own declaration (#6990)",
+				propOf6986(e.Rel.Properties, "target_type"), e.Rel.ToID)
+		case "LogEntry.content_type":
+			// POSITIVE CONTROL, and the specific sibling whose target was
+			// stolen. Without it the negative above could pass vacuously —
+			// "this fixture produced nothing" reads identically.
+			sawContentType = true
+			if got := propOf6986(e.Rel.Properties, "target_type"); got != "ContentType" {
+				t.Errorf("LogEntry.content_type target_type = %q, want \"ContentType\" — the #6990 "+
+					"window bound dropped a target that was always correct", got)
+			}
+			target, bound := byID[e.Rel.ToID]
+			if !bound {
+				t.Errorf("LogEntry.content_type did NOT bind (ToID %q): the narrowing cost a real edge",
+					e.Rel.ToID)
+			} else if target.Name != "ContentType" || target.SourceFile != "contenttypes/models.py" {
+				t.Errorf("LogEntry.content_type bound to %s@%s, want ContentType@contenttypes/models.py",
+					target.Name, target.SourceFile)
+			}
 		}
 	}
-	if userEdge == nil {
-		t.Skip("LogEntry.user emits no target edge — #6990 appears fixed; delete this known-wrong pin")
+	if !sawContentType {
+		t.Fatal("LogEntry.content_type emitted no field_target_type edge at all — the positive control " +
+			"is gone, so the LogEntry.user negative above proves nothing (#6990)")
 	}
-	if got := propOf6986(userEdge.Properties, "target_type"); got != "ContentType" {
-		t.Fatalf("LogEntry.user target_type = %q, want \"ContentType\" — #6990's over-read shape has "+
-			"changed and this pin no longer describes it", got)
-	}
-	target, bound := byID[userEdge.ToID]
-	if !bound {
-		t.Fatalf("LogEntry.user did NOT bind (ToID %q). If #6990 or the address changed so this "+
-			"wrong edge can no longer bind, that is an improvement — delete this known-wrong pin",
-			userEdge.ToID)
-	}
-	if target.Name != "ContentType" || target.SourceFile != "contenttypes/models.py" {
-		t.Fatalf("LogEntry.user bound to %s@%s, want the known-wrong ContentType@contenttypes/models.py",
-			target.Name, target.SourceFile)
-	}
-	t.Logf("KNOWN WRONG (#6990, pinned by #6986): LogEntry.user -[REFERENCES field_target_type]-> "+
-		"%s@%s. The field references settings.AUTH_USER_MODEL; the 400-char window captured the "+
-		"NEXT field's target. Dangling under the old address, BOUND under this one.",
-		target.Name, target.SourceFile)
 }


### PR DESCRIPTION
Fixes #6990 (residue 2 only — see Scope).

## What was wrong

`internal/custom/python/django.go` handed `djangoModelRelTargetRe` a **raw 400-byte forward slice** from the matched field, unbounded by the declaration it belonged to:

```go
fullRHS := body[fIdx[0]:min(fIdx[0]+400, len(body))]
```

`models.ForeignKey(settings.AUTH_USER_MODEL, ...)` — dotted and lowercase-initial — is *correctly* rejected by the regex's `[A-Z]` symbol alternative. The regex then kept scanning inside that oversized window and matched the **next field's** `ForeignKey(ContentType`. django/contrib/admin/models.py's `LogEntry.user` came out targeting `ContentType`: a real model, a bound edge, the wrong thing.

## What bounds the window now

`djangoDeclEnd(body, fIdx[1]-1)` — `djangoModelFieldRe` ends `\s*\(`, so `fIdx[1]-1` is the constructor's own `(`. The scan follows **parenthesis depth**, not bytes and not lines, so:

- multi-line declarations are covered *by construction*, not incidentally;
- it skips the two places a `)` can appear without closing anything: string literals (single, double, **triple**-quoted, honouring `\` escapes) and `#` comments — and does not mistake a `#` inside a string for a comment, nor an apostrophe inside a comment for a string;
- on an **unbalanced** source it returns `-1` rather than guessing, and the caller falls back to the pre-#6990 400-byte window.

**Why the fallback is kept.** On every `-1` input it is byte-identical to `main`, so it cannot regress anything — and one `-1` path is reachable from **valid** Python, because `extractClassBody`'s indent cut can truncate a class body mid-declaration. That is a pre-existing condition, and preserving the old window is the correct behaviour there. (Better justification than the "never wider" one this body originally gave; thanks to the review for it.) The fallback width is now pinned by **magnitude**, not just sign: a target ending at byte 400 must be captured and one ending at byte 401 must not, which together admit exactly one window width.

**The regex is unchanged.** A left `\b` would close the same case but drops `TreeForeignKey(Category, ...)` with it (#6988). Shipping the bound alone keeps it graded — two guards that only fire together grade neither. `TestIssue6990_TheBoundIsTheSoleGuard` shows the distinguishing input directly: handed the old two-declaration text the unchanged regex still captures `ContentType`; handed the bounded text it captures nothing.

## Axes: varied vs held constant

`TestIssue6990_TargetFormsSurviveEveryDeclarationLayout` is a full 3x4 cross.

**Varied**
- **Declaration layout**: single-line · multi-line · multi-line with a trailing comma.
- **Target form**: `settings.AUTH_USER_MODEL` (dotted lowercase → *no* target) · bare CamelCase symbol `Profile` · quoted `"catalog.Author"` · quoted `'self'`.
- **Window bound vs byte count**: declaration-end (normal path) and the 400-byte fallback (unbalanced path), each with its own test.
- **`)` placement**: flat · nested call · dotted kwarg with no nesting · doubly nested · inside `"`/`'`/`"""` strings · inside a `#` comment · `#` inside a string · escaped quote · unterminated (all six ways, including a quote closed only on a later line).
- **Fallback width**: byte 400 (captured) vs byte 401 (not), plus a field's own target right after its own `(`.

**Held constant, and graded elsewhere**
- The constructor: `models.ForeignKey` throughout. The constructor gate is #6988's — `TestIssue6988_GateKeepsRelationalConstructors` / `TestIssue6988_GateRejectsGenericForeignKey`.
- The regex's left boundary — `TestIssue6988_RegexBoundaryRejected_WouldDropSubclasses` (unchanged, still green).
- The `[A-Z]` symbol anchor — `TestIssue6988_RegexRejectsLowercaseInitialSymbol`.

**Every** row, including every negative one, carries a **sentinel sibling** declared immediately after the field under test with a different target, asserted to resolve. That is what stops "want no target" passing vacuously: if the window still over-read, the sentinel's target is what it would steal.

Named forbidden rows: `TestIssue6990_NamedResidue2_RealFieldFollowedByGFK` (the issue's shape — a real FK directly above a `GenericForeignKey`, asserting *no* edge at all rather than "not `content_type`", so a re-broadened window cannot pass by picking a different wrong target).

## The known-wrong pin

`TestPythonFieldTargetType_KnownWrong_6990_OverReadBindsToTheNextFieldsTarget` asserted today's wrong behaviour and carried a `t.Skip` telling the fixer to delete it. Confirmed it fires with the fix in place, then **converted it** into `TestPythonFieldTargetType_6990_NoOverReadIntoTheNextFieldsTarget` rather than deleting it: the correct behaviour for `LogEntry.user` is a **negative** (the declaration names a settings indirection this extractor does not resolve, so it emits nothing), and nothing else in that file grades it. It keeps the same fixture, the same end-to-end merge+resolve path, and gains `LogEntry.content_type` as the positive control — the specific sibling whose target was being stolen. Its stale prose is rewritten.

## Mutants

Applied to `django.go` one at a time; each edit asserted to land by exact occurrence count + shasum before/after, restored by `cp` from a byte-for-byte backup with the shasum re-verified and `git diff HEAD` empty. Scored with `-count=1`.

| # | Mutant | Verdict |
|---|---|---|
| 1 | Revert the bound: `end = min(fIdx[0]+400, len(body))` unconditionally | **DEAD** — 5 tests, incl. all three layouts of the `settings.AUTH_USER_MODEL` row, the named GFK row, and the converted pin |
| 2 | Widen the fallback: `end = len(body)` on `-1` | **DEAD** — `TestIssue6990_UnbalancedSourceFallsBackToTheOldByteWindow` |
| CU-2 | Empty the fallback: `end = fIdx[0]` | **DEAD** (was ALIVE; killed in `aa220a250`) |
| C-120 / C-600 / C-700 | Fallback constant `400` → `120` / `600` / `700` | **DEAD** (120 and 600 were ALIVE — the constant was graded by sign, not magnitude) |
| 8 | Delete `case '\n': return -1` in the string skipper | **DEAD** (was ALIVE; a quote closed only on a later line) |
| 3 | Delete the string-literal skip | **DEAD** — 4 subtests |
| 4 | Delete the `#`-comment skip | **DEAD** — 2 subtests |
| 5 | Off-by-one on the closer: `return i` | **DEAD** — 12 subtests |
| 6 | Delete the triple-quote branch | **DEAD** — 1 subtest |
| 7 | Delete the backslash-escape case | **DEAD** — 1 subtest |

12/12 dead, all re-scored against the final tests. No equivalent-under-the-suite and no ungraded survivors.

**Non-vacuity of the negatives.** Every "want no target" row now asserts *both* that no `field_target_type` edge exists **and** that the field itself still does (a `CONTAINS` edge, or the entity in the merged set for the converted pin) — a negative that passes because the field vanished is passing for the wrong reason.

## Scope — residue 1 is deliberately NOT touched

`class CTForeignKey(GenericForeignKey)` still passes `isDjangoRelationalField`'s suffix check at `django.go`. That is a **policy decision** (deny-list vs allow-list) that #6988/#6989 settled once on measured merit, and it is pinned by `TestIssue6988_RegexBoundaryRejected_WouldDropSubclasses`. It is left alone here on purpose; #6990 stays open for it if the board wants it.

## Incidence — what is and is not claimed

- **Extractor-level behaviour is proven**, end to end through merge + `resolve.BuildIndex` / `ReferencesEmbedded`.
- **Graph-level incidence on the real django corpus is NOT ESTABLISHED and is not claimed.** An in-repo comment asserted that this edge stays dangling anyway because the `ext:django:` external-synthesis pass intercepts first; nobody has verified that, so it is neither repeated nor contradicted. No "fixes N edges" number appears anywhere in this PR — a number nobody measured is worse than none.
- **Gate (#6966)**: these edges exist only with the custom Python lane ON. It is off by default (`WithCustomExtractors`, `cmd/grafel/index.go`), so default-index baselines are untouched.

## Stale prose fixed

`django.go`'s comment above `djangoModelRelTargetRe` asserted this residue was *"zero-incidence on the measured corpus"*. The issue's own correction comment contradicts that: the measurement covered the **snake_case** target population and was stated over a wider one — `ContentType` is CamelCase and a genuine model, invisible to any shape filter. The comment now says the general population is **unmeasured, not zero**, and records what actually bounds the read. That sentence is how the bug survived once already.

## Verification

- `go test -count=1 ./internal/custom/python/` — green.
- `go test -count=1 ./internal/custom/... ./internal/extractors/python/... ./internal/resolve/...` — green.
- `gofmt -l` clean, `go vet` clean.
- **`./cmd/grafel/` was NOT run, deliberately — and the original reason given here was wrong.** Two `cmd/grafel` tests *do* drive the django extractor: `inproc_custom_extractors_5989_test.go:93` and `generated_seam_6329_test.go:51`. The conclusion holds for a different reason: **both fixtures are single-line, balanced, with the target as the first argument**, so `djangoDeclEnd` returns the same slice the 400-byte window did and the bound is a no-op on them. Verified by reading both, not inferred from the diff's package set. "No consumer reaches this" has been wrong on this board before.
