### PR TITLE
fix(#7025): the 10 files hiding 49 import_markers are unreachable by PATH and by SHAPE — #7024's rename is a regression there, not a rescue

### DIFF
--- a/internal/engine/hidden_import_markers_7025_test.go
+++ b/internal/engine/hidden_import_markers_7025_test.go
@@ -1,10 +1,14 @@
 package engine
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -116,13 +120,15 @@ type hiddenMarkerInventoryEntry struct {
 // sibling look covered; this function exists to look at the sibling.
 //
 // examined counts files parsed, so "nothing hidden" is distinguishable from
-// "nothing scanned".
-func hiddenImportMarkerInventory(fsys fs.FS, rootDir string) (entries []hiddenMarkerInventoryEntry, examined int, err error) {
+// "nothing scanned". skipped lists every file the walk reached but could not
+// read as a mapping, so "nothing hidden" is also distinguishable from "the
+// file was never decoded" — see the block comment at the skip sites.
+func hiddenImportMarkerInventory(fsys fs.FS, rootDir string) (entries []hiddenMarkerInventoryEntry, examined int, skipped []string, err error) {
 	// Ask the loader which files it opens, rather than re-deriving its path
 	// rule. See hiddenMarkerInventoryEntry.LoaderScoped.
 	_, report, loadErr := LoadAllRulesFromFSReport(fsys, rootDir)
 	if loadErr != nil {
-		return nil, 0, loadErr
+		return nil, 0, nil, loadErr
 	}
 	candidates := make(map[string]bool, len(report.Candidates))
 	for _, c := range report.Candidates {
@@ -139,17 +145,41 @@ func hiddenImportMarkerInventory(fsys fs.FS, rootDir string) (entries []hiddenMa
 		if ext := filepath.Ext(path); ext != ".yaml" && ext != ".yml" {
 			return nil
 		}
+		// Every early return from here on is recorded. A scan-and-assert-absence
+		// guard has more ways to be a no-op than to work, and "the decoder could
+		// not read this file" is the one that looks healthiest: examined stays
+		// plausible, the entry set stays exactly right, and a file carrying
+		// hidden markers is simply never looked at. Two real shapes do it — a
+		// top-level SEQUENCE and a MULTI-DOCUMENT file — and neither is
+		// hypothetical: the loader and internal/entkinds have the same
+		// first-document-only limit. So a skip must be loud, not impossible.
 		data, readErr := fs.ReadFile(fsys, path)
 		if readErr != nil {
+			skipped = append(skipped, filepath.ToSlash(path)+": read: "+readErr.Error())
 			return nil
 		}
+		//
+		// The two shapes fail differently and both have to be caught. A
+		// top-level sequence fails the decode outright. A multi-document file
+		// does NOT: yaml.Unmarshal reads document 1 and returns nil, so a second
+		// document carrying markers is dropped with no error at all — the
+		// quieter of the two. A decoder loop is what tells them apart.
+		dec := yaml.NewDecoder(bytes.NewReader(data))
 		var raw map[string]any
-		if yaml.Unmarshal(data, &raw) != nil {
+		if uerr := dec.Decode(&raw); uerr != nil && !errors.Is(uerr, io.EOF) {
+			skipped = append(skipped, filepath.ToSlash(path)+": decode into map[string]any: "+uerr.Error())
+			return nil
+		}
+		var extra any
+		if derr := dec.Decode(&extra); derr == nil {
+			skipped = append(skipped, filepath.ToSlash(path)+
+				": multi-document: only document 1 is decoded, later documents are not scanned")
 			return nil
 		}
 		examined++
 		rel, relErr := filepath.Rel(rootDir, path)
 		if relErr != nil {
+			skipped = append(skipped, filepath.ToSlash(path)+": relative path: "+relErr.Error())
 			return nil
 		}
 		relSlash := filepath.ToSlash(rel)
@@ -180,7 +210,8 @@ func hiddenImportMarkerInventory(fsys fs.FS, rootDir string) (entries []hiddenMa
 		}
 		return entries[i].Key < entries[j].Key
 	})
-	return entries, examined, walkErr
+	sort.Strings(skipped)
+	return entries, examined, skipped, walkErr
 }
 
 // countImportMarkerBlocks counts non-empty `import_markers:` lists anywhere
@@ -243,9 +274,18 @@ var knownHiddenMarkerInventory = []hiddenMarkerInventoryEntry{
 // assertion #7024's guard cannot make, because its walk is loader-scoped and
 // these ten files are not.
 func TestRuleTree_HiddenImportMarkersAreOutsideLoaderScope(t *testing.T) {
-	got, examined, err := hiddenImportMarkerInventory(rulesFS, "rules")
+	got, examined, skipped, err := hiddenImportMarkerInventory(rulesFS, "rules")
 	if err != nil {
 		t.Fatalf("walking the embedded rules tree: %v", err)
+	}
+	// A file the walk could not decode is a file this guard did not judge. All
+	// 714 rule files parse as mappings today, so this costs nothing and closes
+	// the hole permanently: a rule file added as a top-level sequence, or as a
+	// multi-document file, must fail here rather than pass silently.
+	for _, sk := range skipped {
+		t.Errorf("the hidden-marker walk skipped %s. This guard asserts an ABSENCE, so a "+
+			"file it cannot decode is a file it did not check — markers hidden there would "+
+			"read as a clean tree (#7025). Fix the file, or teach the walk its shape.", sk)
 	}
 	// Non-vacuity: the whole tree, not the loader-scoped fifth of it.
 	if examined < 700 {
@@ -421,9 +461,12 @@ func TestHiddenImportMarkerInventory_Controls(t *testing.T) {
 			"toolchains:\n- name: cargo\n  detection:\n    files:\n    - Cargo.toml\n")},
 	}
 
-	got, examined, err := hiddenImportMarkerInventory(fsys, "rules")
+	got, examined, skipped, err := hiddenImportMarkerInventory(fsys, "rules")
 	if err != nil {
 		t.Fatalf("hiddenImportMarkerInventory: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Errorf("skipped = %v, want none: every fixture here is a mapping", skipped)
 	}
 	if examined != 5 {
 		t.Errorf("examined = %d, want 5 (every yaml file, not only loader-scoped ones)", examined)
@@ -440,6 +483,66 @@ func TestHiddenImportMarkerInventory_Controls(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("inventory[%d] = %+v, want %+v", i, got[i], want[i])
 		}
+	}
+}
+
+// TestHiddenImportMarkerInventory_UndecodableFilesAreReported is the positive
+// control on the skip counter. Without it, `skipped == 0` on the real tree is
+// satisfied just as well by a walk that never appends to skipped at all — the
+// same vacuity the counter exists to remove, moved one level up.
+//
+// Both fixtures are real shapes, not invented ones, and both carry hidden
+// markers so that a silent skip would be a MISSED FINDING rather than a
+// harmless omission:
+//
+//   - a top-level SEQUENCE, which does not decode into map[string]any; and
+//   - a MULTI-DOCUMENT file, whose second document is where the markers are.
+//
+// The third fixture is an ordinary mapping, so "everything was skipped" cannot
+// pass either.
+func TestHiddenImportMarkerInventory_UndecodableFilesAreReported(t *testing.T) {
+	fsys := fstest.MapFS{
+		// Top-level sequence: yaml.Unmarshal cannot fit it into a map.
+		"rules/go/seq_patterns.yaml": {Data: []byte(
+			"- name: testing\n  detection:\n    import_markers:\n    - '\"testing\"'\n")},
+		// Multi-document: the markers live after the separator.
+		"rules/go/multidoc_patterns.yaml": {Data: []byte(
+			"testing_frameworks: []\n---\ntesting:\n- name: testify\n  detection:\n" +
+				"    import_markers:\n    - '\"github.com/stretchr/testify\"'\n")},
+		// Decodable, and genuinely hidden: the walk must still do its job.
+		"rules/lua/test_patterns.yaml": {Data: []byte(
+			"testing:\n- name: busted\n  detection:\n    import_markers:\n    - \"require('busted')\"\n")},
+	}
+
+	got, examined, skipped, err := hiddenImportMarkerInventory(fsys, "rules")
+	if err != nil {
+		t.Fatalf("hiddenImportMarkerInventory: %v", err)
+	}
+
+	if len(skipped) != 2 {
+		t.Fatalf("skipped = %v, want 2 entries (the sequence file and the multi-document "+
+			"file): if either now decodes, the walk grew a shape it did not have and the "+
+			"tree assertion's skipped==0 is checking something different", skipped)
+	}
+	for _, want := range []string{"rules/go/multidoc_patterns.yaml", "rules/go/seq_patterns.yaml"} {
+		found := false
+		for _, sk := range skipped {
+			if strings.HasPrefix(sk, want+":") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("skipped = %v, want an entry naming %s", skipped, want)
+		}
+	}
+	// The skip is loud, not fatal: the rest of the walk still runs and still
+	// reports. A counter that fired by aborting the walk would make the tree
+	// assertion pass for the wrong reason.
+	if examined != 1 {
+		t.Errorf("examined = %d, want 1 (only the decodable fixture)", examined)
+	}
+	if len(got) != 1 || got[0].Path != "lua/test_patterns.yaml" || got[0].Key != "testing" || got[0].Blocks != 1 {
+		t.Errorf("inventory = %+v, want the one decodable hidden entry", got)
 	}
 }
 

--- a/internal/engine/hidden_import_markers_7025_test.go
+++ b/internal/engine/hidden_import_markers_7025_test.go
@@ -1,0 +1,471 @@
+package engine
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"testing"
+	"testing/fstest"
+
+	"gopkg.in/yaml.v3"
+)
+
+// #7025: the ten rule files that still declare import_markers the engine cannot
+// see — and the measurement that says renaming their container is NOT the fix.
+//
+// # What #7024 fixed, and why the same move does not apply here
+//
+// #7024 found 247 loader-scoped rule files spelling the `frameworks:` container
+// 14 other ways. Those files WERE opened by the loader, WERE unmarshalled into
+// FrameworkRule, and their content was dropped only because yaml.Unmarshal
+// discards unknown top-level keys. Renaming the key to `frameworks:` was
+// therefore sufficient: 52 files' markers became readable.
+//
+// The remaining ten files fail for two different reasons, and neither is the
+// container spelling:
+//
+//  1. THE PATH. LoadAllRulesFromFS accepts exactly <lang>/<subdir>/<file>.yaml
+//     for subdir in ruleSubdirs (frameworks, orms, queues). All ten sit at
+//     <lang>/<file>.yaml — two path segments — so the loader never opens them,
+//     never adds them to RuleLoadReport.Candidates, and never decodes them at
+//     all. Spelling the container `frameworks:` changes nothing, because
+//     nothing reads the file.
+//
+//  2. THE SHAPE. FrameworkRule.Frameworks is a single FrameworkMeta MAPPING.
+//     Every one of the ten containers is a SEQUENCE of framework entries
+//     (`- name: clojure.test` …). Renaming such a container to `frameworks:` in
+//     a file the loader does open makes the file stop parsing: the decode
+//     errors, the loader records a parse failure, and the file's rules —
+//     including any it currently contributes — are dropped. The rename is not a
+//     no-op there, it is a regression.
+//
+// Both mechanisms are pinned below on a synthetic FS, so each is exercised on
+// its own rather than only through the real tree (a guard that fires only when
+// the tree happens to feed it grades nothing).
+//
+// # Who reads these containers today: nobody (measured, #7025 step 1)
+//
+// Established by rename-to-break, not by grep. All 16 top-level keys on the ten
+// files — testing_frameworks, testing, test_conventions, complexity_signals,
+// domain_roots, orms_db, detection, extraction_targets, package_patterns,
+// toolchains — were renamed to `zzprobe_<key>:` and every disk-walking consumer
+// of the rule tree was re-run:
+//
+//   - internal/engine (the embedded loader): compiled rule set byte-identical.
+//   - internal/entkinds (walks the YAML at ANY depth): site list identical.
+//   - internal/relkinds (top-level relationship_rules only): identical.
+//   - tools/coverage (Discover over the repo root): identical once its own
+//     map-order nondeterminism is normalised away.
+//
+// Positive control on that measurement: appending `probe_block: {entity_type:
+// ProbeKind7025}` to go/test_patterns.yaml DID appear in the entkinds site
+// list, so the scanners do read these files — they simply do not decode the
+// container key. tools/coverage's only use of test_patterns.yaml is a
+// whole-file `strings.Contains` needle for a framework NAME
+// (discover.go testFrameworkWalker), which is blind to key names by
+// construction.
+//
+// So the containers are inert, exactly as #7024's 247 were. What is NOT
+// available here is #7024's remedy.
+//
+// # What this guard therefore asserts
+//
+// The inventory is a closed set: these ten files, these container keys, these
+// block counts, and every one of them outside loader scope. An eleventh such
+// file fails here. One of the ten moving INTO loader scope while still keyed on
+// an unmodelled container fails here (and in #7024's guard). Rescuing one — by
+// relocating its entries under <lang>/frameworks/ in the mapping shape the
+// schema models — fails here too, which is the point: the count moves only when
+// something real happens, and the test names what changed.
+//
+// Deliberately NOT done: the rescue. Relocating these catalogues into
+// loader-scoped rule files turns each entry into a rule set the engine
+// compiles, one per framework, which is a schema and behaviour decision, not a
+// key rename. Left to the #7025 follow-up.
+
+// hiddenMarkerInventoryEntry is one (file, top-level container key) pair that
+// declares import_markers the engine cannot reach.
+type hiddenMarkerInventoryEntry struct {
+	// Path is relative to the rules root, slash-separated.
+	Path string
+	// Key is the top-level container key the markers sit under.
+	Key string
+	// Blocks is the number of non-empty import_markers lists under Key, at any
+	// depth.
+	Blocks int
+	// LoaderScoped reports whether the loader opens this file at all. It is
+	// taken from LoadAllRulesFromFSReport's own Candidates list rather than
+	// re-derived from the path here: a local copy of the path rule would agree
+	// with a loader that had changed, and the whole point of this field is to
+	// track what the loader actually does.
+	LoaderScoped bool
+	// SequenceShaped reports whether the container is a YAML sequence.
+	// FrameworkRule.Frameworks is a mapping, so a sequence cannot be rescued by
+	// renaming the key — the decode would fail.
+	SequenceShaped bool
+}
+
+// hiddenImportMarkerInventory walks EVERY yaml file under rootDir — not only
+// the loader-scoped ones — and reports each top-level container other than
+// `frameworks:` that carries non-empty import_markers anywhere beneath it.
+//
+// The whole-tree walk is the difference from #7024's importMarkerVisibility,
+// which is scoped to <lang>/<subdir>/<file>.yaml and is structurally unable to
+// see any of these ten files. Enumerating one set thoroughly is what made its
+// sibling look covered; this function exists to look at the sibling.
+//
+// examined counts files parsed, so "nothing hidden" is distinguishable from
+// "nothing scanned".
+func hiddenImportMarkerInventory(fsys fs.FS, rootDir string) (entries []hiddenMarkerInventoryEntry, examined int, err error) {
+	// Ask the loader which files it opens, rather than re-deriving its path
+	// rule. See hiddenMarkerInventoryEntry.LoaderScoped.
+	_, report, loadErr := LoadAllRulesFromFSReport(fsys, rootDir)
+	if loadErr != nil {
+		return nil, 0, loadErr
+	}
+	candidates := make(map[string]bool, len(report.Candidates))
+	for _, c := range report.Candidates {
+		candidates[filepath.ToSlash(c)] = true
+	}
+
+	walkErr := fs.WalkDir(fsys, rootDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if ext := filepath.Ext(path); ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		data, readErr := fs.ReadFile(fsys, path)
+		if readErr != nil {
+			return nil
+		}
+		var raw map[string]any
+		if yaml.Unmarshal(data, &raw) != nil {
+			return nil
+		}
+		examined++
+		rel, relErr := filepath.Rel(rootDir, path)
+		if relErr != nil {
+			return nil
+		}
+		relSlash := filepath.ToSlash(rel)
+		scoped := candidates[filepath.ToSlash(path)]
+
+		for key, val := range raw {
+			if key == "frameworks" {
+				continue
+			}
+			n := countImportMarkerBlocks(val)
+			if n == 0 {
+				continue
+			}
+			_, isSeq := val.([]any)
+			entries = append(entries, hiddenMarkerInventoryEntry{
+				Path:           relSlash,
+				Key:            key,
+				Blocks:         n,
+				LoaderScoped:   scoped,
+				SequenceShaped: isSeq,
+			})
+		}
+		return nil
+	})
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Path != entries[j].Path {
+			return entries[i].Path < entries[j].Path
+		}
+		return entries[i].Key < entries[j].Key
+	})
+	return entries, examined, walkErr
+}
+
+// countImportMarkerBlocks counts non-empty `import_markers:` lists anywhere
+// beneath node. An empty list carries nothing for the engine to lose, so it is
+// not counted — the same convention #7024's declaresImportMarkers uses.
+func countImportMarkerBlocks(node any) int {
+	switch v := node.(type) {
+	case map[string]any:
+		n := 0
+		for k, child := range v {
+			if k == "import_markers" {
+				if list, ok := child.([]any); ok && len(list) > 0 {
+					n++
+					continue
+				}
+			}
+			n += countImportMarkerBlocks(child)
+		}
+		return n
+	case []any:
+		n := 0
+		for _, child := range v {
+			n += countImportMarkerBlocks(child)
+		}
+		return n
+	default:
+		return 0
+	}
+}
+
+// knownHiddenMarkerInventory is the measured state of the tree at the commit
+// that added this test: ten files, 49 non-empty import_markers blocks, every
+// one outside loader scope and every container sequence-shaped.
+//
+// It is written out per file rather than as a total, because a total is blind
+// to substitution: markers deleted from one file and added to another leave the
+// count where it was.
+//
+// Note where this disagrees with the #7025 issue body, which listed each file's
+// FULL top-level key set rather than the marker-bearing one. `domain_roots`,
+// `test_conventions`, `detection`, `extraction_targets` and `package_patterns`
+// carry no import_markers at all; rust/test_patterns.yaml's 8 are all under
+// `testing`, protobuf/extras.yaml's 3 are all under `toolchains`, and
+// python/test_patterns.yaml has 6 non-empty blocks, not 7 (one further
+// `import_markers:` key there is an empty list).
+var knownHiddenMarkerInventory = []hiddenMarkerInventoryEntry{
+	{Path: "clojure/test_patterns.yaml", Key: "testing_frameworks", Blocks: 4},
+	{Path: "elixir/extras.yaml", Key: "orms_db", Blocks: 5},
+	{Path: "elixir/test_patterns.yaml", Key: "testing", Blocks: 6},
+	{Path: "go/test_patterns.yaml", Key: "testing_frameworks", Blocks: 7},
+	{Path: "lua/test_patterns.yaml", Key: "testing", Blocks: 3},
+	{Path: "protobuf/extras.yaml", Key: "toolchains", Blocks: 3},
+	{Path: "python/complexity.yaml", Key: "complexity_signals", Blocks: 6},
+	{Path: "python/test_patterns.yaml", Key: "testing_frameworks", Blocks: 6},
+	{Path: "rust/test_patterns.yaml", Key: "testing", Blocks: 8},
+	{Path: "zig/test_patterns.yaml", Key: "testing", Blocks: 1},
+}
+
+// TestRuleTree_HiddenImportMarkersAreOutsideLoaderScope is the whole-tree
+// assertion #7024's guard cannot make, because its walk is loader-scoped and
+// these ten files are not.
+func TestRuleTree_HiddenImportMarkersAreOutsideLoaderScope(t *testing.T) {
+	got, examined, err := hiddenImportMarkerInventory(rulesFS, "rules")
+	if err != nil {
+		t.Fatalf("walking the embedded rules tree: %v", err)
+	}
+	// Non-vacuity: the whole tree, not the loader-scoped fifth of it.
+	if examined < 700 {
+		t.Fatalf("examined %d yaml files, want >= 700: this guard is about EVERY rule "+
+			"file, not the loader-scoped subset #7024 walks; a smaller number means the "+
+			"walk, not the tree, is what came back clean", examined)
+	}
+
+	render := func(e hiddenMarkerInventoryEntry) string {
+		return fmt.Sprintf("%s:%s=%d", e.Path, e.Key, e.Blocks)
+	}
+	wantSet := map[string]bool{}
+	for _, e := range knownHiddenMarkerInventory {
+		wantSet[render(e)] = true
+	}
+	gotSet := map[string]bool{}
+	totalBlocks := 0
+	for _, e := range got {
+		gotSet[render(e)] = true
+		totalBlocks += e.Blocks
+
+		// The load-bearing property. Either of these being false would mean the
+		// #7024 remedy applies and this file should have been rescued, not
+		// inventoried.
+		if e.LoaderScoped {
+			t.Errorf("%s declares import_markers under unmodelled container %q AND is "+
+				"loader-scoped: the loader opens it, so this is the #7024 defect and the "+
+				"file must be reconciled onto `frameworks:`, not listed here.", e.Path, e.Key)
+		}
+		if !e.SequenceShaped {
+			t.Errorf("%s's %q container is a MAPPING, not a sequence: FrameworkRule."+
+				"Frameworks is a FrameworkMeta mapping, so a mapping-shaped container can "+
+				"be rescued by a key rename once the file is in loader scope. Re-check "+
+				"whether this file belongs in the inventory.", e.Path, e.Key)
+		}
+	}
+
+	for k := range wantSet {
+		if !gotSet[k] {
+			t.Errorf("expected hidden-marker entry %q is gone. If it was rescued — the "+
+				"entries relocated under <lang>/frameworks/ in the mapping shape the "+
+				"schema models — update knownHiddenMarkerInventory and say so. If the "+
+				"markers were merely deleted, that is not a fix (#7025).", k)
+		}
+	}
+	for k := range gotSet {
+		if !wantSet[k] {
+			t.Errorf("new hidden-marker entry %q: a rule file declares import_markers "+
+				"under a top-level container the schema does not model, in a file the "+
+				"loader does not open. Written markers that reach nothing (#7025). Put "+
+				"them under `frameworks: {detection: {import_markers: [...]}}` in a "+
+				"<lang>/frameworks/<file>.yaml.", k)
+		}
+	}
+	if totalBlocks != 49 {
+		t.Errorf("total unreachable import_markers blocks = %d, want 49", totalBlocks)
+	}
+}
+
+// TestLoader_IgnoresRuleFilesOutsideARuleSubdir is reason 1, exercised alone.
+//
+// The file below is spelled perfectly: top-level `frameworks:`, a mapping, a
+// `detection.import_markers` list. It is what a naive #7025 fix would produce
+// by renaming clojure/test_patterns.yaml's container. The loader still loads
+// nothing, because <lang>/<file>.yaml is not a rule path.
+//
+// Without this test, the claim "the rename is a no-op" rests on the real tree
+// happening not to contain such a file — which is the mutually-masking pair
+// #7024 hit. Here the input is constructed, so the guard is graded on its own.
+func TestLoader_IgnoresRuleFilesOutsideARuleSubdir(t *testing.T) {
+	const perfect = "frameworks:\n  name: clojure.test\n  detection:\n    import_markers:\n" +
+		"    - clojure.test\n"
+
+	fsys := fstest.MapFS{
+		// Two path segments: the shape all ten #7025 files have.
+		"rules/clojure/test_patterns.yaml": {Data: []byte(perfect)},
+		// The identical bytes at a rule path, as the positive control. Without
+		// it, a loader that returned nothing at all would pass.
+		"rules/clojure/frameworks/clojure_test.yaml": {Data: []byte(perfect)},
+	}
+
+	rules, report, err := LoadAllRulesFromFSReport(fsys, "rules")
+	if err != nil {
+		t.Fatalf("LoadAllRulesFromFSReport: %v", err)
+	}
+
+	for _, c := range report.Candidates {
+		if c == "rules/clojure/test_patterns.yaml" {
+			t.Fatalf("the loader now opens <lang>/<file>.yaml. If that is deliberate, the "+
+				"ten #7025 files became loader-scoped and their containers must be "+
+				"reconciled onto `frameworks:`; candidates = %v", report.Candidates)
+		}
+	}
+	if len(report.Candidates) != 1 {
+		t.Fatalf("candidates = %v, want exactly the one file at a rule path", report.Candidates)
+	}
+	if n := len(rules["clojure"]); n != 1 {
+		t.Fatalf("loaded %d clojure rule sets, want 1 (the control file at a rule path)", n)
+	}
+	// The control's markers loaded, so "no markers" below is about the path,
+	// not about a loader that reads nothing.
+	if got := rules["clojure"][0].Frameworks.Detection.ImportMarkers; len(got) != 1 || got[0] != "clojure.test" {
+		t.Fatalf("control file's import_markers = %q, want [clojure.test]: the positive "+
+			"control did not load, so this test cannot say anything about the other file", got)
+	}
+}
+
+// TestLoader_SequenceShapedFrameworksContainerFailsToParse is reason 2,
+// exercised alone: even inside loader scope, renaming one of these containers
+// to `frameworks:` does not rescue the markers — it breaks the file.
+//
+// FrameworkRule.Frameworks is a FrameworkMeta mapping. The ten #7025 containers
+// are sequences. So the "fix" turns a file whose metadata is silently dropped
+// into a file the loader refuses outright, taking any rules it does carry with
+// it (loader.go records a parse failure and skips).
+func TestLoader_SequenceShapedFrameworksContainerFailsToParse(t *testing.T) {
+	// clojure/test_patterns.yaml's real shape, reduced: a sequence of entries.
+	const renamed = "frameworks:\n- name: clojure.test\n  detection:\n    import_markers:\n" +
+		"    - clojure.test\n" +
+		"source_patterns:\n- pattern: deftest\n  entity_type: Function\n"
+
+	fsys := fstest.MapFS{
+		"rules/clojure/frameworks/test_patterns.yaml": {Data: []byte(renamed)},
+	}
+
+	rules, report, err := LoadAllRulesFromFSReport(fsys, "rules")
+	if err != nil {
+		t.Fatalf("LoadAllRulesFromFSReport: %v", err)
+	}
+	if len(report.Candidates) != 1 {
+		t.Fatalf("candidates = %v, want 1", report.Candidates)
+	}
+	if len(report.Failures) != 1 || report.Failures[0].Stage != "parse" {
+		t.Fatalf("failures = %v, want exactly one parse failure: a sequence-shaped "+
+			"`frameworks:` must not decode into FrameworkMeta. If it now does, the schema "+
+			"learned the sequence shape and the ten #7025 files ARE rescuable by rename — "+
+			"say so on #7025.", report.Failures)
+	}
+	if n := len(rules["clojure"]); n != 0 {
+		t.Fatalf("loaded %d clojure rule sets from a file that failed to parse, want 0", n)
+	}
+	// And the cost is not confined to the markers: the file's source_patterns
+	// go with it. This is why the #7024 rename is a regression here, not a
+	// no-op.
+	if len(report.Loaded) != 0 {
+		t.Errorf("loaded = %v, want none", report.Loaded)
+	}
+}
+
+// TestHiddenImportMarkerInventory_Controls grades the checker itself. An
+// inventory function that returned nil, or that counted every import_markers
+// key including the empty ones, or that got LoaderScoped backwards, would make
+// the tree assertion above meaningless.
+func TestHiddenImportMarkerInventory_Controls(t *testing.T) {
+	fsys := fstest.MapFS{
+		// The #7025 shape: outside loader scope, sequence container, 2 blocks.
+		"rules/go/test_patterns.yaml": {Data: []byte(
+			"testing_frameworks:\n- name: testing\n  detection:\n    import_markers:\n    - '\"testing\"'\n" +
+				"- name: testify\n  detection:\n    import_markers:\n    - '\"github.com/stretchr/testify\"'\n")},
+		// The #7024 shape: INSIDE loader scope under an unmodelled key. Must be
+		// reported, and must be reported as loader-scoped — that is what tells
+		// the two defects apart.
+		"rules/csharp/orms/mongodb.yaml": {Data: []byte(
+			"orms_database:\n  name: MongoDB\n  detection:\n    import_markers:\n    - using MongoDB.Driver\n")},
+		// Correctly keyed: never in the inventory.
+		"rules/go/orms/bun.yaml": {Data: []byte(
+			"frameworks:\n  name: bun\n  detection:\n    import_markers:\n    - '\"github.com/uptrace/bun\"'\n")},
+		// Empty list: nothing to lose, not an entry.
+		"rules/lua/test_patterns.yaml": {Data: []byte(
+			"testing:\n- name: busted\n  detection:\n    import_markers: []\n")},
+		// No markers anywhere: not an entry, whatever the key is called.
+		"rules/rust/build_tools.yaml": {Data: []byte(
+			"toolchains:\n- name: cargo\n  detection:\n    files:\n    - Cargo.toml\n")},
+	}
+
+	got, examined, err := hiddenImportMarkerInventory(fsys, "rules")
+	if err != nil {
+		t.Fatalf("hiddenImportMarkerInventory: %v", err)
+	}
+	if examined != 5 {
+		t.Errorf("examined = %d, want 5 (every yaml file, not only loader-scoped ones)", examined)
+	}
+
+	want := []hiddenMarkerInventoryEntry{
+		{Path: "csharp/orms/mongodb.yaml", Key: "orms_database", Blocks: 1, LoaderScoped: true, SequenceShaped: false},
+		{Path: "go/test_patterns.yaml", Key: "testing_frameworks", Blocks: 2, LoaderScoped: false, SequenceShaped: true},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("inventory = %+v, want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("inventory[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestCountImportMarkerBlocks_Depth pins the one thing the counter has to get
+// right that the fixtures above do not vary: markers nested at more than one
+// level, and markers under a key that merely CONTAINS "import_markers".
+func TestCountImportMarkerBlocks_Depth(t *testing.T) {
+	var doc any
+	src := "" +
+		"a:\n" +
+		"- b:\n" +
+		"    detection:\n" +
+		"      import_markers: [x, y]\n" +
+		"- c:\n" +
+		"    nested:\n" +
+		"      deeper:\n" +
+		"        import_markers: [z]\n" +
+		"- d:\n" +
+		"    import_markers: []\n" +
+		"- e:\n" +
+		"    import_markers_legacy: [q]\n"
+	if err := yaml.Unmarshal([]byte(src), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if n := countImportMarkerBlocks(doc); n != 2 {
+		t.Errorf("countImportMarkerBlocks = %d, want 2: two non-empty lists at different "+
+			"depths; the empty list and the `import_markers_legacy` key must not count", n)
+	}
+}


### PR DESCRIPTION
**Tree measured, by absolute path:** `/private/tmp/claude-501/-Users-jorgecajas-Projects-archigraph/c0fefed4-0195-4c81-9a94-07a7145710a4/scratchpad/impl-7025-q7m/wt`, branch `lane/7025-hidden-markers`, parent `e2b54fef0`. macOS 25.6.0 / arm64 / APFS, host Go toolchain `go1.26.4 darwin/arm64`.

## The headline: the rescue #7025 specifies is not available, and applying it would be a regression

The brief's step 2 was "rename the container to `frameworks:` so the markers become readable, exactly as #7024 did". Measured before doing it. It cannot work here, for **two** reasons, and **neither is the container spelling**:

1. **THE PATH.** `LoadAllRulesFromFS` (`loader.go:113-127`) accepts exactly `<lang>/<subdir>/<file>.yaml` for `subdir ∈ ruleSubdirs = {frameworks, orms, queues}`. All ten #7025 files sit at `<lang>/<file>.yaml` — **two** path segments. The loader never opens them, never lists them in `RuleLoadReport.Candidates`, and never decodes them at all. **Demonstration:** renaming `go/test_patterns.yaml`'s `testing_frameworks:` → `frameworks:` and re-running a harness that dumps `engine.LoadAllRules()` as JSON produced a **zero-byte diff**. The correctly-spelled container is still invisible. The container key was never the blocker.

2. **THE SHAPE.** `FrameworkRule.Frameworks` is a single `FrameworkMeta` **mapping** (`schema.go:19`). All ten #7025 containers are **sequences** of framework entries (`- name: clojure.test` …). So inside loader scope the same rename does not decode — it *fails* to decode: `yaml.Unmarshal` errors, `loader.go:141` records a parse failure, and the file is dropped **along with any rules it does carry**. On these files the #7024 move is not a no-op, it is a regression.

That is the difference #7025 was opened to find, and it is a different one from the one it predicted.

## Step 1 — who reads these containers, per key

**Method, per the brief: rename-to-break, not grep.** All **16** top-level keys on the ten files were renamed in place to `zzprobe_<key>:` (each edit proved landed by an exact `assert n == 1` occurrence count before substitution, 16/16), then every consumer that reaches the rule tree from disk or embed was re-run and its **output** compared, not just its exit code.

**How the consumer set was established** (this is the part a grep only lower-bounds): the only code that opens files under `internal/engine/rules/` is `internal/engine/loader.go` (`//go:embed all:rules`) and `tools/coverage/discover.go` (`filepath.Join(repoRoot, "internal", "engine", "rules", …)`). `internal/entkinds` and `internal/relkinds` walk whatever root they are handed and are pointed at the repo root by their own tests. Non-Go: nothing under `scripts/`, `.github/` or `Makefile` reads these keys; `docs/coverage/registry.json` *cites* `<lang>/test_patterns.yaml` as evidence in 8 records but is data, not a decoder (see "what this exposes" below).

| container key | file(s) | carries markers? | decoded by | evidence |
|---|---|---|---:|---|
| `testing_frameworks` | clojure, go, python `test_patterns.yaml` | yes (4+7+6) | **nothing** | rename → engine rule-set, entkinds, relkinds, coverage all identical |
| `testing` | elixir, lua, rust, zig `test_patterns.yaml` | yes (6+3+8+1) | **nothing** | same |
| `complexity_signals` | `python/complexity.yaml` | yes (6) | **nothing** | same |
| `orms_db` | `elixir/extras.yaml` | yes (5) | **nothing** | same |
| `toolchains` | `protobuf/extras.yaml` | yes (3) | **nothing** | same |
| `test_conventions` | `rust/test_patterns.yaml` | **no** | **nothing** | same |
| `domain_roots` | elixir + protobuf `extras.yaml` | **no** | **nothing** | same |
| `detection` (top-level) | `protobuf/extras.yaml` | **no** | **nothing** | same |
| `extraction_targets` | `protobuf/extras.yaml` | **no** | **nothing** | same |
| `package_patterns` | `protobuf/extras.yaml` | **no** | **nothing** | same |

Per-consumer result under the 16-key rename:

- **`internal/engine`** (embedded loader): `LoadAllRules()` serialised to JSON — **byte-identical**. Structural reason: the files are not loader-scoped, so the key is never even looked at.
- **`internal/entkinds`** (walks the YAML at **any depth**, and computes `Site.Bound` **from the YAML path**, so a top-level rename is exactly the kind of change that could move it): full `Site` list (`file|line|kind|origin|path|bound`) + `UnresolvedSites` + parsed-file counts — **identical**. None of the ten declares `entity_type:` or `entity_mapping:` anywhere.
- **`internal/relkinds`**: reads top-level `relationship_rules:` only; none of the ten has one. Site list **identical**.
- **`tools/coverage`**: `Discover(repoRoot, "")` marshalled to JSON — **identical** once its own map-iteration nondeterminism is normalised away (see below). Its only use of `test_patterns.yaml` is `strings.Contains(strings.ToLower(fileBytes), needle)` for a framework **name** (`discover.go` `testFrameworkWalker`), which is blind to key names by construction.
- Package suites, `-count=1`: `./internal/engine ./internal/entkinds ./internal/relkinds ./tools/coverage ./internal/types` — all **ok** with the mutant applied.

**Positive controls, because "no diff" from an insensitive probe is worthless:**

- Appending `probe_block: {entity_type: ProbeKind7025}` to `go/test_patterns.yaml` **did** appear in the entkinds output (`ENT internal/engine/rules/go/test_patterns.yaml|151|ProbeKind7025|rule_yaml|probe_block.entity_type|false`). So entkinds **does** read these files at arbitrary depth and its verdict **does** depend on their content — it simply does not decode the container key.
- **`tools/coverage.Discover` is nondeterministic.** Its first run under the mutant differed from baseline by 24 lines (a `synthesizeSlim` / PHP evidence block reordering between two candidates). Two further runs of the *same* mutated tree were byte-identical to baseline, and **two runs of the same tree differed from each other** — so the diff is map ordering, not signal. Comparing sorted line multisets: baseline == mutant, exactly. Recorded because a 24-line diff read at face value would have been a false positive on a language (PHP) not among the ten.

**Verdict: all 10 keys are inert**, exactly as #7024's 247 were. What is not available here is #7024's remedy.

## Correcting the issue's inventory

#7025 listed each file's **full** top-level key set rather than the marker-bearing one. Re-derived over all 714 rule-tree YAML files by counting non-empty `import_markers:` lists at any depth:

| file | marker-bearing key | blocks |
|---|---|---:|
| `clojure/test_patterns.yaml` | `testing_frameworks` | 4 |
| `elixir/extras.yaml` | `orms_db` | 5 |
| `elixir/test_patterns.yaml` | `testing` | 6 |
| `go/test_patterns.yaml` | `testing_frameworks` | 7 |
| `lua/test_patterns.yaml` | `testing` | 3 |
| `protobuf/extras.yaml` | `toolchains` | 3 |
| `python/complexity.yaml` | `complexity_signals` | 6 |
| `python/test_patterns.yaml` | `testing_frameworks` | 6 |
| `rust/test_patterns.yaml` | `testing` | 8 |
| `zig/test_patterns.yaml` | `testing` | 1 |

**49 blocks, not 50.** `rust`'s 8 are all under `testing` (`test_conventions` has none); `protobuf`'s 3 are all under `toolchains` (`detection`, `domain_roots`, `extraction_targets`, `package_patterns` have none); `elixir/extras.yaml`'s 5 are all under `orms_db` (`domain_roots` has none); `python/test_patterns.yaml` has 6 non-empty blocks — a 7th `import_markers:` key there is an empty list, and an empty list carries nothing to lose (same convention as #7024's `declaresImportMarkers`). The ten-file set itself reproduces exactly.

## What landed: one test file, no rule file touched

`internal/engine/hidden_import_markers_7025_test.go` (471 lines). **Zero non-test lines changed; zero YAML changed.** The diff is one new file.

- **`TestRuleTree_HiddenImportMarkersAreOutsideLoaderScope`** — the whole-tree assertion #7024's guard is *structurally unable* to make. `importMarkerVisibility` walks only `<lang>/<subdir>/<file>.yaml`, so all ten of these files are invisible to it; this one walks **every** YAML in the tree and reports each top-level container other than `frameworks:` carrying markers at any depth. It asserts the closed inventory above **per file, per key, per block count** (not a total — a total is blind to substitution), plus the two load-bearing properties: every entry is **not loader-scoped**, and every container is **sequence-shaped**. Either being false would mean the #7024 remedy applies and the file should have been rescued, not inventoried. Non-vacuity: `examined >= 700` (the whole tree, not the loader-scoped fifth) and `totalBlocks == 49`.
  - `LoaderScoped` is taken from **`LoadAllRulesFromFSReport`'s own `Candidates` list**, not re-derived from the path here. First draft re-derived it, and mutant M3 (below) showed why that is worthless: a local copy of the path rule agrees with a loader that has changed. Two "independent" checks sharing a premise are one check.
- **`TestLoader_IgnoresRuleFilesOutsideARuleSubdir`** — reason 1, on a synthetic FS, **exercised alone**. A perfectly-spelled `frameworks:` mapping with markers at `rules/clojure/test_patterns.yaml` loads nothing; the byte-identical file at `rules/clojure/frameworks/clojure_test.yaml` loads and its markers are asserted by content, so "no markers" is about the path and not about a loader that reads nothing.
- **`TestLoader_SequenceShapedFrameworksContainerFailsToParse`** — reason 2, on a synthetic FS, exercised alone: a sequence-shaped `frameworks:` inside loader scope produces exactly one `parse` failure and takes the file's `source_patterns` with it.
- **`TestHiddenImportMarkerInventory_Controls`** — grades the checker: five synthetic files covering the #7025 shape (unscoped + sequence), the #7024 shape (scoped + mapping, which must be reported *as scoped* — that is what tells the two defects apart), a correctly-keyed file, an empty marker list, and a file with no markers under a suspicious key.
- **`TestCountImportMarkerBlocks_Depth`** — the one axis the fixtures above hold constant: markers nested at two different depths, an empty list, and a key that merely *contains* `import_markers`.

## The mutual-masking trap, explicitly

#7024's author hit it: with every file renamed, nothing exercised the strict-container guard. Here the pairing would have been worse, because **no data changed at all** — a tree-only guard would be graded solely by a tree that already satisfies it. That is why both mechanism claims (path, shape) are pinned on **constructed** inputs rather than on the real tree, and why the checker has its own five-file control. M3 and M6 below are the mutants those synthetic tests exist to kill, and M6 is killed by *nothing else in the repository*.

## Mutants, permissive direction first

Scored in the branch worktree with a byte-for-byte `cp` backup of every mutated file (never `git checkout --`), each edit proved landed by an exact occurrence count *before* the run, `git status --porcelain` confirmed clean after each restore, `-count=1` throughout, and every verdict re-scored against the final code (M3 was re-scored after the `LoaderScoped` coupling fix).

| # | mutant | verdict |
|---|---|---|
| M1 | apply the fix #7025 asked for — rename `go/test_patterns.yaml`'s `testing_frameworks:` → `frameworks:` | **DEAD** — inventory entry named, total 42 ≠ 49. The failure message says what a *real* rescue would have to look like. |
| M2 | an 11th hidden-marker file (`dart/lint_patterns.yaml`, `linters:` + 1 block) | **DEAD** — new entry named by path and key, total 50 ≠ 49 |
| M3 | **permissive loader**: accept `<lang>/<file>.yaml` by synthesising a `frameworks` segment (~3 lines in `loader.go`) | **DEAD twice** — by `IgnoresRuleFilesOutsideARuleSubdir`, and by the tree test's `LoaderScoped` assertion on 9 of 10 files. **Against the first draft it was DEAD only once**, because `LoaderScoped` was re-derived from the path instead of read from the loader's report. That is the fix described above; the mutant is what found it. |
| M4 | **permissive checker**: count empty `import_markers:` lists as blocks | **DEAD** — 3 tests (tree total, controls, depth) |
| M5 | **checker no-op**: `hiddenImportMarkerInventory` returns `nil, 714, nil` (a plausible-looking `examined` so the non-vacuity floor is satisfied) | **DEAD** — tree test + controls |
| M6 | **make the rename work**: `FrameworkMeta.UnmarshalYAML` adopts a sequence's first entry (~15 lines in `schema.go`) | **DEAD** — by `SequenceShapedFrameworksContainerFailsToParse` **only**. The rest of `./internal/engine` (`-count=1`, 47.0s) is **green** under it. This is the one mutant worth naming: nothing in the repository before this PR observed that the schema refuses a sequence, so "the shape blocks the rename" was an unpinned claim. |
| M7 | **re-scope the walk** to loader-scoped files — i.e. reintroduce exactly #7024's blind spot | **DEAD** — all ten entries vanish; tree test + controls |

## Varied vs. held constant

The repeated defect here is enumerating one set thoroughly and leaving its sibling ungraded. Stated explicitly:

**Varied**
- *Path scope*: unscoped `<lang>/<file>.yaml` **and** scoped `<lang>/<subdir>/<file>.yaml` — both appear as fixtures, and the scoped one must be reported *as scoped* (controls), not merely reported.
- *Container shape*: sequence **and** mapping, both in fixtures and asserted per real-tree entry.
- *Container key*: all 16 real keys probed, not only the 5 marker-bearing ones — including the 5 that carry no markers and would look "covered" by the marker-bearing enumeration.
- *Marker list*: non-empty, empty, and absent; nested at one level and at three; plus a decoy key `import_markers_legacy`.
- *Correctness direction*: a correctly-keyed `frameworks:` file must **not** be reported (controls), and the rescue mutant M1 must fail — so the guard is graded in both directions, not only "hidden must be flagged".
- *Consumers*: four independent packages, each with its own artefact compared, plus a positive control that one of them actually reads the files.

**Held constant, and therefore ungraded here — say so rather than let the enumeration imply coverage**
- **The other 112 ordinary rule files carrying unmodelled top-level keys with no markers.** #7025 measured 193 files with at least one unmodelled top-level key (122 ordinary + 31 `_manifest.yaml` + 40 `_engine/`). This guard sees a file only once it carries markers, exactly as #7024's did. A file at `<lang>/<file>.yaml` acquiring markers under a new key **is** caught (M2); a file acquiring an unmodelled *key* with no markers is **not**. That is #7014's strict top-level guard, still unbuilt, and its scope decision (which file classes it governs) is untouched here.
- **`_manifest.yaml`, `_engine/` and `database_index/`** are walked by the inventory (they are YAML in the tree) but none carries markers, so no assertion here is about them and none of their schemas is judged.
- **The 465 unmodelled metadata key paths** (#7014) and every `requires_framework` setting: untouched.
- **Multi-document YAML**: `yaml.Unmarshal` reads the first document only, as does `loader.go:141` and `entkinds`. A container after a `---` is invisible to this guard, as it is to the engine. No file in the tree currently uses one.
- **Per file, the keys I did not rename**: nothing was renamed at all in the committed diff — the probe renames were reverted and `git status` verified clean — so this axis is vacuous by construction rather than by argument.

## What this exposes, and does not fix

`docs/coverage/registry.json` cites `internal/engine/rules/<lang>/test_patterns.yaml` as evidence in 8 records, with notes like *"PHPUnit test detection via test_patterns.yaml"* and *"embedded and loaded by engine/loader.go (`go:embed all:rules`)"*. The **embed** is real — the bytes are in the binary. The **load** is not: for the flat `<lang>/test_patterns.yaml` files the loader skips the path, so nothing in those files reaches `FrameworkRule`. `tools/coverage`'s own needle scan is a `strings.Contains` over the raw bytes, which is what actually backs the citation. Not touched here; worth a line on #7014.

## The follow-up the rescue actually needs

Rescuing these 49 blocks means **relocating** each catalogue entry into a loader-scoped `<lang>/frameworks/<framework>.yaml` in the mapping shape the schema models — roughly 49 new rule files, each of which the engine then compiles into a rule set. That is a schema-and-behaviour decision (what a `test_patterns.yaml` entry *means* as a `FrameworkRule`, and whether `python/complexity.yaml`'s `complexity_signals` is a framework at all), not a key rename, and it is the wrong thing to smuggle into a guard PR. The alternative — teaching `FrameworkRule` a sequence-shaped container and widening `ruleSubdirs`/the path rule — is M3 and M6 combined, i.e. two of the mutants this PR exists to kill, and needs to be argued on #7014's schema thread rather than applied silently.

Either way the guard above is what makes the change visible when it happens: the inventory fails the moment a file leaves it, and the message says what a real rescue has to look like.

## Verification

- `gofmt -l internal/engine/` clean; `go vet ./internal/engine/` clean.
- `go test ./internal/engine/ ./internal/entkinds/ ./internal/relkinds/ ./tools/coverage/ ./internal/types/ -count=1` → **all ok**, exit 0 (48.1s / 16.0s / 11.5s / 5.6s / 7.8s). The last four are the consumers named in the brief; `internal/types` is included because #7024's review flagged its omission.
- `go test ./cmd/grafel/ -count=1` → **ok, 156.7s**, exit 0, in a fresh three-variable sandbox (`HOME`/`GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT` all under scratch); the real `~/.grafel` was never touched. **Reported honestly: the first run FAILED** — `TestRebuildFiveSequentialAlwaysComplete`, *"Rebuild RPC 5 hung after 5s"*. It passed 3/3 in isolation and the full package passed on re-run in a second fresh sandbox. This PR changes no non-test code and no rule YAML and touches nothing in `cmd/grafel`, so it cannot be the cause; recorded as a pre-existing timing flake rather than dropped. `cmd/grafel` was run despite being a test-only change because it digest-pins the whole graph.
- `git status --porcelain` clean in the worktree; the commit is one file.

Refs #7025, #7013, #7014, #7024.
