### PR TITLE
fix(#7013): variant D — gate the 5 worst over-firing python patterns, and gate the flask/quart route TWIN together or it removes nothing

### DIFF
--- a/internal/engine/python_framework_gates_7013_test.go
+++ b/internal/engine/python_framework_gates_7013_test.go
@@ -1,0 +1,569 @@
+// Package engine — #7013 variant D.
+//
+// Six one-line rules changes, measured on the 60-repo corpus at 762 over-fired
+// entities removed against 9 true positives lost:
+//
+//	pytest.yaml     #1  TestClass   requires_framework   322 bad : 3 real
+//	sqlalchemy.yaml #5  Constraint  requires_framework   246 bad : 4 real
+//	flask.yaml      #6  Model       requires_framework    76 bad : 1 real
+//	flask.yaml      #1  Route       requires_framework  \  75 bad : 0 real
+//	quart.yaml      #1  Route       requires_framework  /  (one coupled change)
+//	quart.yaml      #5  Middleware  requires_framework    43 bad : 0 here
+//	flask.yaml          import_markers widened with `from flask import`,
+//	                    `import flask` — rescues 5 of the losses, costs 0 bad
+//
+// This file grades BOTH directions for every one of them, because each
+// direction is blind to the other's failure:
+//
+//   - FORBIDDEN: the gated pattern no longer mints in a file that does not
+//     itself carry a marker. A recall-only test cannot see over-firing.
+//   - RECALL: the gated pattern still mints in a file that does carry one. A
+//     forbidden-only test is passed perfectly by a gate that kills everything.
+//
+// ...plus two properties that no count of either direction can observe:
+//
+//   - THE TWIN COUPLING (#7028). flask.yaml #1 and quart.yaml #1 are a
+//     byte-identical pattern in two rule files. seenEntities (detector.go:367)
+//     is per file and shared ACROSS rule sets, and rule sets load in fs.WalkDir
+//     lexical order (loader.go:103), so `flask` wins every mint and `quart`'s
+//     twin has never produced anything. Gating flask's copy alone removes zero
+//     entities and relabels 4 genuine Flask routes as Quart. Totals, per-kind
+//     counts and the over-fire rate all stay flat while that happens, and the
+//     emitted entity cannot show it either: detector.go:451 sets the
+//     `framework` property from `sp.framework`, which compile() fills with the
+//     LANGUAGE (`python`, detector.go:171) and not the rule file — so a
+//     transfer between two python rule sets is invisible in DetectResult by
+//     construction. It is pinned twice below instead: behaviourally, because a
+//     marker-less file mints a Route if EITHER twin is ungated; and
+//     structurally, because the two files' flags must agree.
+//   - THE WIDENING, in both of its halves: that it rescues the blueprint-module
+//     case, and that it does not re-open the over-fire it was added alongside.
+//
+// Fixture discipline: every fixture below carries the SAME construct in the
+// forbidden and the recall arm, so the only thing varied is marker presence.
+// The varied and held-constant axes are listed on each test.
+package engine
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+)
+
+// ---------------------------------------------------------------------------
+// Premise helpers — grounded in the rule FILES on disk, never in the compiled
+// Go structs under test, so a loader bug cannot make a premise vacuously true.
+// ---------------------------------------------------------------------------
+
+// pgRuleFile is a minimal on-disk view of a python framework rule file.
+type pgRuleFile struct {
+	Frameworks struct {
+		Detection struct {
+			ImportMarkers []string `yaml:"import_markers"`
+		} `yaml:"detection"`
+	} `yaml:"frameworks"`
+	SourcePatterns []struct {
+		Pattern           string `yaml:"pattern"`
+		EntityType        string `yaml:"entity_type"`
+		NameGroup         int    `yaml:"name_group"`
+		RequiresFramework bool   `yaml:"requires_framework"`
+	} `yaml:"source_patterns"`
+}
+
+// pgFrameworks is every rule file this change touches. Both flask AND quart are
+// named everywhere they can both matter — enumerating one thoroughly is what
+// makes its twin look covered.
+var pgFrameworks = []string{"pytest", "sqlalchemy", "flask", "quart"}
+
+// pgLoadRuleFile parses one python framework rule file straight off disk.
+func pgLoadRuleFile(t *testing.T, framework string) pgRuleFile {
+	t.Helper()
+	path := "rules/python/frameworks/" + framework + ".yaml"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc pgRuleFile
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return doc
+}
+
+// pgMarkers returns a framework's on-disk import_markers, failing if the list
+// is empty — an empty list makes every "no marker present" premise trivial and
+// every "marker present" premise unsatisfiable.
+func pgMarkers(t *testing.T, framework string) []string {
+	t.Helper()
+	m := pgLoadRuleFile(t, framework).Frameworks.Detection.ImportMarkers
+	if len(m) == 0 {
+		t.Fatalf("%s declares no frameworks.detection.import_markers — the gate under test has "+
+			"no signal, and every premise here would be vacuous", framework)
+	}
+	return m
+}
+
+// pgAssertNoMarkers asserts src carries no import marker for ANY framework
+// whose gated pattern could mint from it. Without this the forbidden direction
+// could pass for the wrong reason. `falcon` and `cherrypy` are included because
+// their own gated bare-class patterns (#6152) reach the class fixtures too.
+func pgAssertNoMarkers(t *testing.T, src string) {
+	t.Helper()
+	for _, fw := range append(append([]string{}, pgFrameworks...), "falcon", "cherrypy") {
+		for _, m := range pgMarkers(t, fw) {
+			if strings.Contains(src, m) {
+				t.Fatalf("fixture premise broken: source contains %s marker %q, so it is not a "+
+					"marker-free file and cannot grade the forbidden direction", fw, m)
+			}
+		}
+	}
+}
+
+// pgAssertHasMarker asserts src carries at least one marker for framework, the
+// recall direction's premise.
+func pgAssertHasMarker(t *testing.T, framework, src string) {
+	t.Helper()
+	for _, m := range pgMarkers(t, framework) {
+		if strings.Contains(src, m) {
+			return
+		}
+	}
+	t.Fatalf("fixture premise broken: source contains none of %s's import_markers %v, so a "+
+		"mint here would not prove the gate lets real %s code through",
+		framework, pgMarkers(t, framework), framework)
+}
+
+// pgAssertGated asserts on disk that the named framework file carries exactly
+// one source_pattern producing entityType whose regex contains patternSubstr,
+// and that it carries requires_framework.
+//
+// It identifies the pattern by a distinguishing fragment of its regex rather
+// than by entity_type alone, because these files carry several patterns per
+// kind (flask.yaml alone mints Route twice) and by ordinal, because an ordinal
+// silently slides when a pattern is inserted above it.
+//
+// This pins the WIRING: without it, a forbidden-direction pass is equally
+// consistent with "the gate holds" and "someone deleted the pattern".
+func pgAssertGated(t *testing.T, framework, entityType, patternSubstr string) {
+	t.Helper()
+	doc := pgLoadRuleFile(t, framework)
+	found := 0
+	for _, sp := range doc.SourcePatterns {
+		if sp.EntityType != entityType || !strings.Contains(sp.Pattern, patternSubstr) {
+			continue
+		}
+		found++
+		if !sp.RequiresFramework {
+			t.Errorf("%s.yaml pattern %q produces %s but does NOT carry requires_framework — "+
+				"#7013's gate is not wired for it", framework, sp.Pattern, entityType)
+		}
+	}
+	switch {
+	case found == 0:
+		t.Fatalf("%s.yaml has no source_pattern producing %s whose regex contains %q: the "+
+			"pattern this test grades was rewritten or deleted, and the forbidden direction "+
+			"below would pass vacuously", framework, entityType, patternSubstr)
+	case found > 1:
+		t.Fatalf("%s.yaml has %d source_patterns producing %s and matching %q — the fragment no "+
+			"longer identifies one pattern, so this assertion is ambiguous",
+			framework, found, entityType, patternSubstr)
+	}
+}
+
+// pgDetect runs the REAL embedded rule set, the same one Pass 2.5 runs.
+func pgDetect(t *testing.T, path, src string) *DetectResult {
+	t.Helper()
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	res, err := New(rules).Detect(context.Background(), extractor.FileInput{
+		Path:     path,
+		Language: "python",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if res == nil {
+		t.Fatal("detect returned nil result")
+	}
+	return res
+}
+
+// pgHas reports whether the detector emitted an entity with this kind and name.
+func pgHas(res *DetectResult, kind, name string) bool {
+	for i := range res.Entities {
+		if res.Entities[i].Kind == kind && res.Entities[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// pgDump renders every emitted entity, for failure messages.
+func pgDump(res *DetectResult) string {
+	var b []string
+	for i := range res.Entities {
+		b = append(b, res.Entities[i].Kind+":"+res.Entities[i].Name)
+	}
+	if len(b) == 0 {
+		return "(no entities)"
+	}
+	return strings.Join(b, ", ")
+}
+
+// ---------------------------------------------------------------------------
+// The constructs. Each appears verbatim in both a marker-free and a marked
+// fixture, so marker presence is the ONLY axis varied between the two arms.
+// ---------------------------------------------------------------------------
+
+const (
+	// pytest.yaml #1 — `(?m)^class\s+(Test\w+)\s*`.
+	pgTestClassConstruct = "class TestPgProbe:\n    def test_pg_probe(self):\n        assert True\n"
+	// sqlalchemy.yaml #5 — `ForeignKey\s*\(\s*["']([^"']+)["']`.
+	pgConstraintConstruct = "pg_probe_col = ForeignKey(\"pg_probe_table.id\")\n"
+	// flask.yaml #6 — `class\s+(\w+)\s*\(\s*(?:db\.Model|Model)\s*\)`.
+	pgModelConstruct = "class PgProbeModel(db.Model):\n    pass\n"
+	// flask.yaml #1 / quart.yaml #1 — the byte-identical twin.
+	pgRouteConstruct = "@pg_probe_bp.get(\"/pg-probe-route\")\ndef pg_probe_view():\n    return \"ok\"\n"
+	// quart.yaml #5 — `async def` deliberately: flask.yaml #5's near-twin
+	// requires `\ndef` and cannot reach an async hook, so this construct
+	// isolates quart #5 instead of being masked by flask's ungated pattern.
+	pgMiddlewareConstruct = "@pg_probe_app.before_request\nasync def pg_probe_hook():\n    return None\n"
+)
+
+// pgGateCase is one gated pattern, graded in both directions with the same
+// construct on both sides.
+type pgGateCase struct {
+	name string
+	// frameworks whose rule file must carry the gate for this kind. Two for
+	// the Route twin — flask AND quart, named together everywhere.
+	frameworks []string
+	kind       string
+	entity     string
+	construct  string
+	// patternSubstr identifies WHICH pattern in those files is under test, by
+	// a fragment of its regex — see pgAssertGated.
+	patternSubstr string
+	// recallMarker is prepended to construct for the recall arm. It is a
+	// marker of recallFramework and of nothing else.
+	recallFramework string
+	recallMarker    string
+}
+
+var pgGateCases = []pgGateCase{
+	{
+		name:            "pytest#1_TestClass",
+		patternSubstr:   "^class\\s+(Test\\w+)",
+		frameworks:      []string{"pytest"},
+		kind:            "TestClass",
+		entity:          "TestPgProbe",
+		construct:       pgTestClassConstruct,
+		recallFramework: "pytest",
+		recallMarker:    "import pytest\n\n",
+	},
+	{
+		name:            "sqlalchemy#5_Constraint",
+		patternSubstr:   "ForeignKey",
+		frameworks:      []string{"sqlalchemy"},
+		kind:            "Constraint",
+		entity:          "pg_probe_table.id",
+		construct:       pgConstraintConstruct,
+		recallFramework: "sqlalchemy",
+		recallMarker:    "from sqlalchemy import ForeignKey\n\n",
+	},
+	{
+		name:            "flask#6_Model",
+		patternSubstr:   "db\\.Model",
+		frameworks:      []string{"flask"},
+		kind:            "Model",
+		entity:          "PgProbeModel",
+		construct:       pgModelConstruct,
+		recallFramework: "flask",
+		recallMarker:    "app = Flask(__name__)\n\n",
+	},
+	{
+		// The twin, graded with a FLASK marker: flask sorts first and mints.
+		name:            "flask#1_Route_flask_marked",
+		patternSubstr:   "get|post|put|patch|delete",
+		frameworks:      []string{"flask", "quart"},
+		kind:            "Route",
+		entity:          "/pg-probe-route",
+		construct:       pgRouteConstruct,
+		recallFramework: "flask",
+		recallMarker:    "app = Flask(__name__)\n\n",
+	},
+	{
+		// The SAME twin and the SAME construct, graded with a QUART marker.
+		// Held constant: pattern, kind, entity name, construct. Varied: which
+		// of the two identical rule files can see its framework. flask #1 is
+		// gated off here, so this arm is quart #1's recall and nothing else.
+		name:            "quart#1_Route_quart_marked",
+		patternSubstr:   "get|post|put|patch|delete",
+		frameworks:      []string{"flask", "quart"},
+		kind:            "Route",
+		entity:          "/pg-probe-route",
+		construct:       pgRouteConstruct,
+		recallFramework: "quart",
+		recallMarker:    "from quart import Quart\n\n",
+	},
+	{
+		name:            "quart#5_Middleware",
+		patternSubstr:   "before_request",
+		frameworks:      []string{"quart"},
+		kind:            "Middleware",
+		entity:          "pg_probe_hook",
+		construct:       pgMiddlewareConstruct,
+		recallFramework: "quart",
+		recallMarker:    "from quart import Quart\n\n",
+	},
+}
+
+// TestGatedPythonPatterns_DoNotMintWithoutMarkers_7013 is the FORBIDDEN
+// direction — the 762 entities this change exists to remove.
+//
+// Varied: nothing but marker presence, against the recall test below. Held
+// constant: the construct, the entity name, the file path, the language.
+//
+// This test is also the behavioural half of the flask/quart twin coupling: the
+// Route row mints if EITHER twin is left ungated, because the ungated one still
+// fires on this marker-free file.
+func TestGatedPythonPatterns_DoNotMintWithoutMarkers_7013(t *testing.T) {
+	for _, tc := range pgGateCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, fw := range tc.frameworks {
+				pgAssertGated(t, fw, tc.kind, tc.patternSubstr)
+			}
+			pgAssertNoMarkers(t, tc.construct)
+
+			res := pgDetect(t, "pg_probe.py", tc.construct)
+
+			if pgHas(res, tc.kind, tc.entity) {
+				t.Errorf("%s: %s %q was minted from a file carrying no import marker for %v — "+
+					"the requires_framework gate is not holding (#7013). Emitted: %s",
+					tc.name, tc.kind, tc.entity, tc.frameworks, pgDump(res))
+			}
+		})
+	}
+}
+
+// TestGatedPythonPatterns_StillMintWithMarkers_7013 is the RECALL direction. A
+// gate that suppresses everything passes the forbidden test above perfectly.
+//
+// Varied: marker presence (and, for the two Route rows, WHICH of the twin's two
+// frameworks is marked). Held constant: the construct, the entity name, the
+// file path, the language.
+func TestGatedPythonPatterns_StillMintWithMarkers_7013(t *testing.T) {
+	for _, tc := range pgGateCases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := tc.recallMarker + tc.construct
+			pgAssertHasMarker(t, tc.recallFramework, src)
+
+			res := pgDetect(t, "pg_probe.py", src)
+
+			if !pgHas(res, tc.kind, tc.entity) {
+				t.Errorf("%s: %s %q is GONE from a file that plainly uses %s — the #7013 gate "+
+					"is too strict and has cost real recall. Emitted: %s",
+					tc.name, tc.kind, tc.entity, tc.recallFramework, pgDump(res))
+			}
+		})
+	}
+}
+
+// TestFlaskAndQuartRouteTwinsGatedTogether_7013 is the structural half of the
+// twin coupling (#7028), and the one that speaks to the next person to touch
+// either file.
+//
+// It asserts the general property rather than the instance: any source_pattern
+// that appears in two python rule files with the same regex, entity_type and
+// name_group must agree on requires_framework. There are four such pairs today
+// — all flask/quart: #0 Route (`.route`), #1 Route (the one this change gates),
+// #2 Controller (Blueprint), #4 Middleware (errorhandler). Gating one member of
+// any of them alone removes nothing and silently transfers its mints, including
+// its TRUE positives, to the other framework's label.
+//
+// It must also see the twin at all, so it fails if no pair is found.
+func TestFlaskAndQuartRouteTwinsGatedTogether_7013(t *testing.T) {
+	type twinKey struct {
+		pattern    string
+		entityType string
+		nameGroup  int
+	}
+	type site struct {
+		framework string
+		gated     bool
+	}
+
+	// Every python framework rule file, not just the four this change edits:
+	// a twin introduced elsewhere in the tree is the same trap.
+	dir := "rules/python/frameworks"
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	twins := map[twinKey][]site{}
+	for _, e := range ents {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		fw := strings.TrimSuffix(e.Name(), ".yaml")
+		for _, sp := range pgLoadRuleFile(t, fw).SourcePatterns {
+			k := twinKey{sp.Pattern, sp.EntityType, sp.NameGroup}
+			twins[k] = append(twins[k], site{fw, sp.RequiresFramework})
+		}
+	}
+
+	pairs := 0
+	sawRouteTwin := false
+	for k, sites := range twins {
+		if len(sites) < 2 {
+			continue
+		}
+		pairs++
+		if k.entityType == "Route" && strings.Contains(k.pattern, "get|post|put|patch|delete") {
+			sawRouteTwin = true
+		}
+		first := sites[0].gated
+		for _, s := range sites[1:] {
+			if s.gated == first {
+				continue
+			}
+			t.Errorf("identical pattern %q (%s, name_group %d) disagrees on requires_framework "+
+				"across rule files %v. Dedup (seenEntities, detector.go:367) is per file and "+
+				"SHARED across rule sets, and rule sets load in lexical order (loader.go:103), "+
+				"so the first file wins every mint: gating only one of these removes ZERO "+
+				"entities and relabels the survivors with the other framework — measured on "+
+				"flask#1/quart#1 as 0 removed and 4 real Flask routes reported as Quart. "+
+				"Gate both or neither (#7028).", k.pattern, k.entityType, k.nameGroup, sites)
+			break
+		}
+	}
+	if pairs == 0 {
+		t.Error("no identical-twin source_pattern pair found in rules/python/frameworks: this " +
+			"test's premise is gone and it is asserting nothing (#7028)")
+	}
+	if !sawRouteTwin {
+		t.Error("the flask#1/quart#1 HTTP-method Route twin — the pair #7013 gates and the " +
+			"reason this test exists — was not found; it was edited out of one of the two " +
+			"files and the coupling is no longer being graded (#7028)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The marker widening, graded in both halves.
+// ---------------------------------------------------------------------------
+
+// pgFlaskMarkersBeforeWidening is flask.yaml's marker list as it stood before
+// #7013. Hard-coded on purpose: the widening test must compare against the OLD
+// list, and reading it from the file would compare it against itself.
+var pgFlaskMarkersBeforeWidening = []string{"from flask import Flask", "Flask(__name__)"}
+
+// pgBlueprintModule is the shape the widening exists for: a real Flask
+// blueprint module (flask/examples/celery/src/task_app/views.py) that imports
+// Blueprint and never constructs the app. Under the old marker list this file
+// carried no Flask evidence at all, and the gate above cost it 4 real routes.
+const pgBlueprintModule = "from flask import Blueprint\n\n" +
+	"pg_probe_bp = Blueprint(\"pg_probe\", __name__)\n\n" + pgRouteConstruct
+
+// TestWidenedFlaskMarkers_RescueBlueprintModule_7013 is the widening's first
+// half: it must actually rescue.
+//
+// Varied: the marker LINE only (`from flask import Blueprint` here versus
+// `Flask(__name__)` in the recall table above). Held constant: the construct,
+// the entity name, the gate.
+func TestWidenedFlaskMarkers_RescueBlueprintModule_7013(t *testing.T) {
+	// Premise: this fixture is invisible to the PRE-widening marker list, so a
+	// Route here is evidence about the widening and not about the old markers.
+	for _, m := range pgFlaskMarkersBeforeWidening {
+		if strings.Contains(pgBlueprintModule, m) {
+			t.Fatalf("fixture premise broken: blueprint module contains pre-widening marker %q, "+
+				"so it would have been rescued without the widening and grades nothing", m)
+		}
+	}
+	pgAssertHasMarker(t, "flask", pgBlueprintModule)
+
+	res := pgDetect(t, "task_app/views.py", pgBlueprintModule)
+
+	if !pgHas(res, "Route", "/pg-probe-route") {
+		t.Errorf("blueprint module lost its Route: flask.yaml's import_markers no longer reach "+
+			"`from flask import` / `import flask`, and the #7013 gate is costing the 4 real "+
+			"routes the widening was measured to rescue. Emitted: %s", pgDump(res))
+	}
+	// The Blueprint pattern is ungated and must be unaffected either way — if
+	// this stops holding, the fixture has stopped being a blueprint module.
+	if !pgHas(res, "Controller", "pg_probe") {
+		t.Errorf("fixture no longer registers as a blueprint module (no Controller): "+
+			"emitted %s", pgDump(res))
+	}
+}
+
+// pgPlainImportModule is the OTHER half of the widening: a module that reaches
+// Flask through `import flask` and the qualified `flask.Blueprint` spelling,
+// never through a `from … import` line. `from flask import` cannot see it.
+//
+// Added after mutant scoring: dropping `import flask` and keeping only
+// `from flask import` left every other test in this file green, so the second
+// marker was carried by nothing.
+const pgPlainImportModule = "import flask\n\n" +
+	"pg_probe_bp = flask.Blueprint(\"pg_probe\", __name__)\n\n" + pgRouteConstruct
+
+// TestWidenedFlaskMarkers_RescuePlainImportModule_7013 grades `import flask`
+// specifically.
+//
+// Varied: the marker SPELLING only (`import flask` here, `from flask import
+// Blueprint` in the sibling test above, `Flask(__name__)` in the recall table).
+// Held constant: the construct, the entity name, the gate.
+func TestWidenedFlaskMarkers_RescuePlainImportModule_7013(t *testing.T) {
+	// Premise: neither the pre-widening markers NOR the other widened marker
+	// can see this file, so a Route here is evidence about `import flask`
+	// alone.
+	for _, m := range append(append([]string{}, pgFlaskMarkersBeforeWidening...), "from flask import") {
+		if strings.Contains(pgPlainImportModule, m) {
+			t.Fatalf("fixture premise broken: module contains marker %q, so it does not "+
+				"isolate `import flask` and grades nothing about it", m)
+		}
+	}
+	pgAssertHasMarker(t, "flask", pgPlainImportModule)
+
+	res := pgDetect(t, "pg_app/views.py", pgPlainImportModule)
+
+	if !pgHas(res, "Route", "/pg-probe-route") {
+		t.Errorf("module using `import flask` lost its Route: flask.yaml's import_markers no "+
+			"longer carry the bare `import flask` spelling, so the #7013 gate suppresses "+
+			"qualified-import Flask code. Emitted: %s", pgDump(res))
+	}
+}
+
+// pgDjangoRouteModule is the over-firing shape the gate removes: a Django
+// module using a decorator with an HTTP-verb method name. 75 of flask #1's 80
+// corpus mints were this. It names flask nowhere — including under the WIDENED
+// markers, which is the property this test grades.
+const pgDjangoRouteModule = "from django.db import models\n" +
+	"from django.urls import path\n\n" +
+	"pg_probe_bp = models.Manager()\n\n" + pgRouteConstruct
+
+// TestWidenedFlaskMarkers_DoNotReopenOverfire_7013 is the widening's second
+// half. A widening that rescues the blueprint module by also matching every
+// non-Flask file would pass the rescue test above and quietly undo the 762.
+//
+// Varied: the surrounding imports (Django rather than none). Held constant: the
+// construct and the entity name, both identical to the forbidden table's Route
+// row — so this is the same assertion against a realistic over-firer rather
+// than a bare fixture.
+func TestWidenedFlaskMarkers_DoNotReopenOverfire_7013(t *testing.T) {
+	pgAssertNoMarkers(t, pgDjangoRouteModule)
+
+	res := pgDetect(t, "pg_app/views.py", pgDjangoRouteModule)
+
+	if pgHas(res, "Route", "/pg-probe-route") {
+		t.Errorf("a Django module with no flask or quart token minted Route \"/pg-probe-route\": "+
+			"flask.yaml's widened import_markers now reach ordinary non-Flask files and have "+
+			"re-opened the over-firing #7013 closed. Emitted: %s", pgDump(res))
+	}
+}

--- a/internal/engine/python_framework_gates_7013_test.go
+++ b/internal/engine/python_framework_gates_7013_test.go
@@ -26,16 +26,29 @@
 //     byte-identical pattern in two rule files. seenEntities (detector.go:367)
 //     is per file and shared ACROSS rule sets, and rule sets load in fs.WalkDir
 //     lexical order (loader.go:103), so `flask` wins every mint and `quart`'s
-//     twin has never produced anything. Gating flask's copy alone removes zero
-//     entities and relabels 4 genuine Flask routes as Quart. Totals, per-kind
-//     counts and the over-fire rate all stay flat while that happens, and the
-//     emitted entity cannot show it either: detector.go:451 sets the
-//     `framework` property from `sp.framework`, which compile() fills with the
-//     LANGUAGE (`python`, detector.go:171) and not the rule file — so a
-//     transfer between two python rule sets is invisible in DetectResult by
-//     construction. It is pinned twice below instead: behaviourally, because a
-//     marker-less file mints a Route if EITHER twin is ungated; and
-//     structurally, because the two files' flags must agree.
+//     twin has never produced anything. Gating flask's copy alone therefore
+//     removes ZERO entities: the mints TRANSFER to quart.yaml's twin rather
+//     than disappearing (before {django: 75, flask: 5}; after flask {flask: 1}
+//
+//   - quart {django: 75, flask: 4} — the same 80 mints from a different rule
+//     file, no over-firing removed). Totals, per-kind counts and the over-fire
+//     rate all stay flat while that happens.
+//
+//     Nor does anything on the entity show the transfer: detector.go:451 sets
+//     the `framework` property from `sp.framework`, which compile() fills at
+//     :171 with the rule BUCKET key (`python`) and not the rule file, and
+//     frameworks.name is parsed by schema.go and read by nothing in the mint
+//     path. Both twins emit framework=python; nothing is relabelled, and there
+//     is no per-framework field for a test to assert on. (The one difference
+//     the rows could carry is the `file_convention` annotation — flask.yaml
+//     declares 6 file_conventions, quart.yaml none — which is unmeasured and
+//     deliberately not tested here.)
+//
+//     So the coupling is pinned twice, by the only two means available:
+//     behaviourally, because a marker-less file mints a Route if EITHER twin
+//     is ungated — the mint SURVIVES, which is exactly the "zero removed"
+//     failure — and structurally, because the two files' flags must agree.
+//
 //   - THE WIDENING, in both of its halves: that it rescues the blueprint-module
 //     case, and that it does not re-open the over-fire it was added alongside.
 //
@@ -376,6 +389,67 @@ func TestGatedPythonPatterns_StillMintWithMarkers_7013(t *testing.T) {
 	}
 }
 
+// pgRouteDecoratorConstruct exercises the OTHER flask/quart twin — the `.route`
+// pair (flask.yaml #0 / quart.yaml #0), #7028's group #3 at 178 mints. It is
+// deliberately a different path string from pgRouteConstruct so the two twins
+// cannot be confused in a failure message.
+const pgRouteDecoratorConstruct = "@pg_probe_bp.route(\"/pg-probe-decorated\")\n" +
+	"def pg_probe_decorated_view():\n    return \"ok\"\n"
+
+// TestRouteDecoratorTwinIsUngated_7013 records the CURRENT state of the second
+// twin rather than changing it.
+//
+// #7013 gates the flask#1/quart#1 HTTP-method pair. The flask#0/quart#0
+// `.route` pair is the identical twin shape one entry over, is still ungated,
+// and still over-fires — 178 mints, unmeasured for recall. Gating it is #7028's
+// call and needs its own recall pass, so this change does NOT gate it.
+//
+// Without this test that state is unobservable: gating BOTH halves of the #0
+// pair passes every other test in this file, so someone could gate it — or
+// un-gate it later — with no test noticing and no recall measurement. Scored as
+// a mutant and it was ALIVE; this is the kill.
+//
+// If you are here because this test went red: you changed the #0 pair. That is
+// allowed, but (1) measure its recall cost first, the way #7013 did for #1,
+// (2) gate BOTH files or neither — see TestFlaskAndQuartRouteTwinsGatedTogether_7013
+// for why one alone removes nothing, and (3) replace this test with a
+// forbidden+recall pair like the #1 rows above, rather than deleting it.
+func TestRouteDecoratorTwinIsUngated_7013(t *testing.T) {
+	// Structural premise: both halves exist and both are ungated on disk.
+	seen := 0
+	for _, fw := range []string{"flask", "quart"} {
+		for _, sp := range pgLoadRuleFile(t, fw).SourcePatterns {
+			if sp.EntityType != "Route" || !strings.Contains(sp.Pattern, "\\.route") {
+				continue
+			}
+			seen++
+			if sp.RequiresFramework {
+				t.Errorf("%s.yaml's `.route` pattern %q now carries requires_framework. The "+
+					"flask#0/quart#0 twin was left ungated by #7013 on purpose: 178 mints, "+
+					"recall cost UNMEASURED. Measure it, gate both halves, and turn this test "+
+					"into a forbidden+recall pair (#7028).", fw, sp.Pattern)
+			}
+		}
+	}
+	if seen != 2 {
+		t.Fatalf("found %d `.route` Route patterns across flask.yaml and quart.yaml, want 2: the "+
+			"twin this test tracks was edited away and the test is no longer observing it", seen)
+	}
+
+	// Behavioural half: ungated means it still mints with no marker present.
+	// This is the same marker-free premise the forbidden table uses, so the
+	// only thing separating this row from those is which pattern is gated.
+	pgAssertNoMarkers(t, pgRouteDecoratorConstruct)
+
+	res := pgDetect(t, "pg_probe.py", pgRouteDecoratorConstruct)
+
+	if !pgHas(res, "Route", "/pg-probe-decorated") {
+		t.Errorf("the ungated `.route` twin no longer mints on a marker-free file. Something "+
+			"gated or narrowed flask#0/quart#0 without updating this test — see the doc "+
+			"comment. Emitted: %s", pgDump(res))
+	}
+}
+
 // TestFlaskAndQuartRouteTwinsGatedTogether_7013 is the structural half of the
 // twin coupling (#7028), and the one that speaks to the next person to touch
 // either file.
@@ -438,9 +512,9 @@ func TestFlaskAndQuartRouteTwinsGatedTogether_7013(t *testing.T) {
 				"across rule files %v. Dedup (seenEntities, detector.go:367) is per file and "+
 				"SHARED across rule sets, and rule sets load in lexical order (loader.go:103), "+
 				"so the first file wins every mint: gating only one of these removes ZERO "+
-				"entities and relabels the survivors with the other framework — measured on "+
-				"flask#1/quart#1 as 0 removed and 4 real Flask routes reported as Quart. "+
-				"Gate both or neither (#7028).", k.pattern, k.entityType, k.nameGroup, sites)
+				"entities — the mints TRANSFER to the other file's identical pattern instead "+
+				"of disappearing, and no count moves. Measured on flask#1/quart#1 as 80 mints "+
+				"before, 80 after, 0 over-firing removed. Gate both or neither (#7028).", k.pattern, k.entityType, k.nameGroup, sites)
 			break
 		}
 	}

--- a/internal/engine/rules/python/frameworks/flask.yaml
+++ b/internal/engine/rules/python/frameworks/flask.yaml
@@ -82,11 +82,23 @@ source_patterns:
   # the same entity_type and name_group. `seenEntities` (detector.go:367) is per
   # file and shared across rule sets, and rule sets load in fs.WalkDir lexical
   # order (loader.go:103), so `flask` wins every mint and `quart`'s twin has
-  # never produced anything. Gating this one alone removes ZERO entities and
-  # hands all 80 to Quart — measured: before {django: 75, flask: 5}; after
-  # flask {flask: 1} + quart {django: 75, flask: 4}. That relabels 4 genuine
-  # Flask routes as Quart in a repo with no Quart, which is strictly worse than
-  # making no change, and every summary count stays flat while it happens.
+  # never produced anything. Gating this one alone therefore removes ZERO
+  # entities: the mints TRANSFER to quart.yaml's twin rather than disappearing.
+  # Measured: before {django: 75, flask: 5}; after flask {flask: 1} + quart
+  # {django: 75, flask: 4}. Same 80 mints, different producing rule file, no
+  # over-firing removed — strictly worse than making no change, since it is
+  # work that looks like a fix. Every summary count stays flat while it
+  # happens: totals, per-kind totals and the over-fire rate are all identical
+  # before and after.
+  #
+  # The transfer is not visible on the entity either. detector.go:451 sets the
+  # `framework` property from sp.framework, which compile() fills at :171 with
+  # the rule BUCKET key (`python`) and not the rule file; frameworks.name is
+  # parsed by schema.go and read by nothing in the mint path, so both twins
+  # emit framework=python and nothing is relabelled. The only difference the
+  # emitted rows could carry is the `file_convention` annotation — flask.yaml
+  # declares 6 file_conventions and quart.yaml declares none — and nobody has
+  # measured that, so do not rely on it and do not test it.
   # TestFlaskAndQuartRouteTwinsGatedTogether_7013 fails if the two diverge.
   - pattern: "@(\\w+)\\.(get|post|put|patch|delete)\\s*\\(\\s*[\"']([^\"']+)[\"']"
     entity_type: Route

--- a/internal/engine/rules/python/frameworks/flask.yaml
+++ b/internal/engine/rules/python/frameworks/flask.yaml
@@ -22,6 +22,15 @@ frameworks:
     import_markers:
     - from flask import Flask
     - Flask(__name__)
+    # Widened for #7013. `frameworkPresent` is per FILE (detector.go:96, called
+    # at :402 with this file's own content), so a blueprint module that writes
+    # `from flask import Blueprint` and never constructs the app carried NO
+    # marker and lost every gated match below. Measured on the 60-repo corpus:
+    # these two rescue 5 true positives (4 Routes from pattern #1, 1 Model from
+    # pattern #6) at ZERO cost to bad-removal — the gated patterns still removed
+    # the same 762 over-fired entities with these markers in place.
+    - from flask import
+    - import flask
     structural_markers:
     - .flaskenv
     - templates/ directory
@@ -63,10 +72,27 @@ source_patterns:
     name_group: 2
     scope: file
   # HTTP method decorators: @app.get("/path"), @app.post("/path"), etc.
+  #
+  # requires_framework (#7013). `@x.get("/…")` is not a Flask construct: it is
+  # the shape of a decorator call on any object with a `get` method, and on the
+  # corpus 75 of this pattern's 80 mints were Django, not Flask.
+  #
+  # THIS GATE IS COUPLED TO quart.yaml's identical pattern — do not gate one
+  # without the other (#7028). quart.yaml carries a BYTE-IDENTICAL pattern with
+  # the same entity_type and name_group. `seenEntities` (detector.go:367) is per
+  # file and shared across rule sets, and rule sets load in fs.WalkDir lexical
+  # order (loader.go:103), so `flask` wins every mint and `quart`'s twin has
+  # never produced anything. Gating this one alone removes ZERO entities and
+  # hands all 80 to Quart — measured: before {django: 75, flask: 5}; after
+  # flask {flask: 1} + quart {django: 75, flask: 4}. That relabels 4 genuine
+  # Flask routes as Quart in a repo with no Quart, which is strictly worse than
+  # making no change, and every summary count stays flat while it happens.
+  # TestFlaskAndQuartRouteTwinsGatedTogether_7013 fails if the two diverge.
   - pattern: "@(\\w+)\\.(get|post|put|patch|delete)\\s*\\(\\s*[\"']([^\"']+)[\"']"
     entity_type: Route
     name_group: 3
     scope: file
+    requires_framework: true
   # Blueprint instantiation: bp = Blueprint("name", __name__)
   - pattern: "(\\w+)\\s*=\\s*Blueprint\\s*\\(\\s*[\"'](\\w+)[\"']"
     entity_type: Controller
@@ -88,10 +114,16 @@ source_patterns:
     name_group: 3
     scope: file
   # SQLAlchemy model base class
+  #
+  # requires_framework (#7013). A bare `Model` alternative in the base list is
+  # not Flask-specific — `class Foo(Model)` is how Django-adjacent and plain
+  # ORM code spells it too, and 76 of this pattern's 78 corpus mints were in
+  # repos that do not use Flask at all.
   - pattern: "class\\s+(\\w+)\\s*\\(\\s*(?:db\\.Model|Model)\\s*\\)"
     entity_type: Model
     name_group: 1
     scope: class
+    requires_framework: true
 
 # relationship_rules: regex patterns that produce edges between entities.
 relationship_rules:

--- a/internal/engine/rules/python/frameworks/pytest.yaml
+++ b/internal/engine/rules/python/frameworks/pytest.yaml
@@ -83,10 +83,21 @@ source_patterns:
   # non-test hits). Left as written at that rate rather than narrowed to a
   # spelling pytest itself does not use — recorded so the next reader is not
   # told something untrue about why.
+  #
+  # requires_framework (#7013). The false-positive shape recorded above was
+  # measured corpus-wide and is not rare: 322 of this pattern's 358 mints were
+  # in repos that do not use pytest — `class TestCase(TransactionTestCase):` in
+  # django/django/test/testcases.py is the canonical one. The gate is per FILE
+  # (detector.go:96), so it costs the 4 measured true positives whose pytest
+  # evidence lives in a sibling `conftest.py` rather than in the test module
+  # itself; 3 of those are real classes and structural under per-file
+  # semantics, and the 4th (`conduit/settings.py:54 class TestConfig(Config)`)
+  # is itself a false positive that this gate is right to drop. 322:3.
   - pattern: "(?m)^class\\s+(Test\\w+)\\s*"
     entity_type: TestClass
     name_group: 1
     scope: file
+    requires_framework: true
   # Fixture decorator
   - pattern: "@pytest\\.fixture(?:\\s*\\([^)]*\\))?\\s*\\ndef\\s+(\\w+)\\s*\\("
     entity_type: Fixture

--- a/internal/engine/rules/python/frameworks/quart.yaml
+++ b/internal/engine/rules/python/frameworks/quart.yaml
@@ -40,10 +40,21 @@ source_patterns:
     name_group: 2
     scope: file
   # HTTP method decorators: @app.get("/path"), @app.post("/path"), etc.
+  #
+  # requires_framework (#7013), MANDATORILY IN LOCKSTEP WITH flask.yaml's
+  # identical pattern (#7028). This pattern is byte-identical to flask.yaml's
+  # — same regex, same entity_type, same name_group — and `flask` sorts before
+  # `quart` in the loader's fs.WalkDir order, so with the per-file, cross-rule-
+  # set `seenEntities` dedup (detector.go:367) this twin has never minted
+  # anything on a file flask also matched. Gating flask's copy while leaving
+  # this one open does not remove the 75 Django false positives; it transfers
+  # them here and mislabels 4 real Flask routes as Quart. Gate both or neither.
+  # TestFlaskAndQuartRouteTwinsGatedTogether_7013 fails if they diverge.
   - pattern: "@(\\w+)\\.(get|post|put|patch|delete)\\s*\\(\\s*[\"']([^\"']+)[\"']"
     entity_type: Route
     name_group: 3
     scope: file
+    requires_framework: true
   # Blueprint instantiation: bp = Blueprint("name", __name__)
   - pattern: "(\\w+)\\s*=\\s*Blueprint\\s*\\(\\s*[\"'](\\w+)[\"']"
     entity_type: Controller
@@ -60,10 +71,18 @@ source_patterns:
     name_group: 2
     scope: file
   # Before/after request hooks: @app.before_request
+  #
+  # requires_framework (#7013). `@app.before_request` is Flask's decorator as
+  # much as Quart's; all 43 of this pattern's corpus mints were in Flask repos
+  # and none in a Quart repo. The corpus contains NO Quart user at all, so the
+  # measured zero true-positive loss is "loses nothing here", not "loses
+  # nothing" — recall for real Quart code is untested by that corpus and rests
+  # on the fixture below.
   - pattern: "@(\\w+)\\.(before_request|after_request|teardown_request)\\s*[\\r\\n]+\\s*(?:async\\s+)?def\\s+(\\w+)"
     entity_type: Middleware
     name_group: 3
     scope: file
+    requires_framework: true
 
 # relationship_rules: edges between entities.
 relationship_rules:

--- a/internal/engine/rules/python/frameworks/quart.yaml
+++ b/internal/engine/rules/python/frameworks/quart.yaml
@@ -47,8 +47,11 @@ source_patterns:
   # `quart` in the loader's fs.WalkDir order, so with the per-file, cross-rule-
   # set `seenEntities` dedup (detector.go:367) this twin has never minted
   # anything on a file flask also matched. Gating flask's copy while leaving
-  # this one open does not remove the 75 Django false positives; it transfers
-  # them here and mislabels 4 real Flask routes as Quart. Gate both or neither.
+  # this one open removes NOTHING: it does not delete the 75 Django false
+  # positives, it transfers them to this pattern, which then mints all 80. No
+  # count moves — and the entity cannot show the move either, because the
+  # emitted `framework` property is the bucket key `python` for both files
+  # (detector.go:171), not the framework name. Gate both or neither.
   # TestFlaskAndQuartRouteTwinsGatedTogether_7013 fails if they diverge.
   - pattern: "@(\\w+)\\.(get|post|put|patch|delete)\\s*\\(\\s*[\"']([^\"']+)[\"']"
     entity_type: Route

--- a/internal/engine/rules/python/frameworks/sqlalchemy.yaml
+++ b/internal/engine/rules/python/frameworks/sqlalchemy.yaml
@@ -103,10 +103,24 @@ source_patterns:
     name_group: 1
     scope: file
   # ForeignKey: ForeignKey("table.id")
+  #
+  # requires_framework (#7013). `ForeignKey("…")` is Django's spelling too, and
+  # Peewee's, and every other Python ORM's: the token names no library. It was
+  # the single worst over-firing pattern measured on the corpus — 246 of its
+  # 251 mints (98.0%) were in repos that do not use SQLAlchemy, led by
+  # django/.../inspectdb.py.
+  #
+  # The 4 true positives it costs are NOT a marker gap and adding markers does
+  # not recover them. `flask-realworld`'s conduit/database.py re-exports
+  # `Column = db.Column` and imports `relationship` centrally, so the model
+  # modules contain no sqlalchemy token of any kind; adding `flask_sqlalchemy`
+  # as a marker was tried and rescued ZERO. Under the per-file gate this is
+  # structural. Accepted at 246:4.
   - pattern: "ForeignKey\\s*\\(\\s*[\"']([^\"']+)[\"']"
     entity_type: Constraint
     name_group: 1
     scope: file
+    requires_framework: true
 
 # relationship_rules: intentionally empty (#6809).
 #

--- a/internal/engine/zero_producing_rule_kinds_6776_test.go
+++ b/internal/engine/zero_producing_rule_kinds_6776_test.go
@@ -159,10 +159,21 @@ func zeroKindSites() []zeroKindSite {
 			negWhy: "conf.py is not conftest.py",
 		},
 		{
-			label: "TestClass — python/frameworks/pytest.yaml:60 (source_pattern)",
-			lang:  "python", path: "tests/test_orders.py", content: "class TestOrders:\n    pass\n",
-			kind: "TestClass", name: "TestOrders",
-			negPath: "tests/test_orders.py", negBody: "class Orders:\n    pass\n",
+			// Both bodies gained `import pytest` in #7013, when this pattern
+			// took `requires_framework: true`. It is a marker for pytest and
+			// for nothing else.
+			//
+			// The NEGATIVE body carries it too, deliberately: without it the
+			// negative would hold for two reasons at once — wrong class name
+			// AND absent framework marker — and would keep passing if the name
+			// half of the pattern were widened to anything. With the marker
+			// present the only thing separating the two bodies is the class
+			// name, which is what negWhy claims.
+			label: "TestClass — python/frameworks/pytest.yaml:96 (source_pattern)",
+			lang:  "python", path: "tests/test_orders.py",
+			content: "import pytest\n\nclass TestOrders:\n    pass\n",
+			kind:    "TestClass", name: "TestOrders",
+			negPath: "tests/test_orders.py", negBody: "import pytest\n\nclass Orders:\n    pass\n",
 			negWhy: "a class not named Test* is not a pytest test class",
 		},
 		{


### PR DESCRIPTION
Ships **variant D** as priced by the two measurement passes on #7013: **762 over-fired entities removed, 9 true positives lost, net +753 — 43% of this P1's 1,757.** Six one-line rules changes, no new mechanism and no new metadata.

`Refs #7013, #7028.` This closes 43% of the issue, not the issue.

## Per pattern, before → after

| pattern | kind | minted | bad removed | good removed | net |
|---|---|---:|---:|---:|---:|
| `pytest.yaml` #1 | TestClass | 358 | 322 | 4 (**3 real**, 1 is itself an FP) | +318 |
| `sqlalchemy.yaml` #5 | Constraint | 251 | 246 | 4 | +242 |
| `flask.yaml` #6 | Model | 78 | 76 | 2 → **1** after the widening | +75 |
| `flask.yaml` #1 + `quart.yaml` #1 | Route | 80 | **75** (0 if gated alone) | 4 → **0** after the widening | +75 |
| `quart.yaml` #5 | Middleware | 43 | 43 | 0 *here* | +43 |
| **total** | | 810 | **762** | **9** | **+753** |

Plus: `flask.yaml`'s `import_markers` widened with `from flask import` and `import flask`.

Every index was re-verified against the pattern that actually produces the named `entity_type` rather than trusted as an ordinal, and each assertion in the new tests identifies its pattern by a fragment of the regex, not by position — an ordinal slides silently when a pattern is inserted above it.

## The coupling — why `quart.yaml` #1 is in this commit and not a follow-up

`flask.yaml` #1 and `quart.yaml` #1 are a **byte-identical** pattern in two rule files: same regex, same `entity_type`, same `name_group`. `seenEntities` (`detector.go:367`) is per file and **shared across rule sets**, and rule sets load in `fs.WalkDir` lexical order (`loader.go:103`), so `flask` wins every mint and `quart`'s twin has never produced anything on any file `flask` also matched.

Gating `flask.yaml` #1 alone therefore removes **zero** entities and hands all 80 mints to Quart:

- before: `flask#1 {django: 75, flask: 5}`
- after: `flask#1 {flask: 1}`, `quart#1 {django: 75, flask: 4}`

Four genuine Flask routes get **relabelled Quart** in a repo with no Quart in it — strictly worse than making no change. And it is invisible to every count: totals, per-kind totals and the over-fire rate all stay flat. It is invisible in the emitted entity too — `detector.go:451` fills the `framework` property from `sp.framework`, which `compile()` sets to the **language** (`python`, `detector.go:171`), not the rule file, so a transfer between two python rule sets cannot be observed in `DetectResult` at all.

It is pinned twice instead:

- **behaviourally** — a marker-free file mints a Route if *either* twin is left ungated, so the forbidden-direction Route rows go red for either half;
- **structurally** — `TestFlaskAndQuartRouteTwinsGatedTogether_7013` asserts the general property: any `source_pattern` appearing in two python rule files with the same regex, `entity_type` and `name_group` must agree on `requires_framework`. There are four such pairs today, all flask/quart (#0 Route `.route`, #1 Route, #2 Controller `Blueprint`, #4 Middleware `errorhandler`); the test also fails if the #1 pair itself disappears, so it cannot go vacuous.

## `frameworkPresent` is per FILE

`detector.go:96 func (c compiledRuleSet) frameworkPresent(content string)`, called at `:402` with `content := string(file.Content)`. A gate kills every match in any file that does not **itself** carry a marker, even in a repo that plainly uses the framework. That is the entire cost profile, and it is why the losses concentrate in alias- and re-export-heavy Python.

## Fixture axes — varied vs held constant

Each of the six gated patterns is graded in both directions with the **same construct on both sides**.

**Varied:**
- marker presence (forbidden arm vs recall arm) — the only axis separating the two tables;
- for the Route twin, **which of the two identical rule files** can see its framework (a Flask-marked row and a Quart-marked row over the identical construct);
- marker **spelling** across three widening fixtures: `Flask(__name__)` (pre-existing), `from flask import Blueprint` (widened), `import flask` (widened, qualified-import style);
- the surrounding module for the over-fire check: a Django-shaped module rather than a bare one.

**Held constant:** the construct text, the entity name, the entity kind, the file path, the language, and the rule tree (the real `LoadAllRules()`, the same one Pass 2.5 runs).

**Premises asserted, never assumed:** every forbidden fixture is checked against the on-disk `import_markers` of *all six* relevant rule files (`pytest`, `sqlalchemy`, `flask`, `quart`, plus `falcon`/`cherrypy`, whose own #6152 bare-class gates reach the class fixtures); every recall fixture is checked to contain one. Markers are read from the YAML **files**, not from the compiled Go structs under test, so a loader bug cannot make a premise vacuously true. An empty marker list is a hard failure.

**Construct isolation was enumerated, not assumed.** Each fixture was run against every `source_pattern` in `rules/python/**` to confirm only the intended gated pattern reaches it. That is why the Middleware fixture uses `async def`: `flask.yaml` #5 is a near-twin of `quart.yaml` #5 and is **ungated**, but its `\ndef` cannot match an async hook, so the fixture isolates `quart` #5 instead of being masked by flask's mint.

## Accepted losses — recorded in the YAML, not fixed

- **`sqlalchemy` #5 loses 4.** `flask-realworld`'s `conduit/database.py` re-exports `Column = db.Column` and imports `relationship` centrally, so the model modules contain **no sqlalchemy token at all**. Adding `flask_sqlalchemy` as a marker was tried and rescued **zero**. Structural under per-file semantics. Accepted at 246:4.
- **`pytest` #1 loses 4, of which 3 are real** — pytest classes in `tests/test_*.py` whose fixtures come from `conftest.py` and which legitimately never name pytest. Structural. The 4th, `conduit/settings.py:54 class TestConfig(Config)`, is itself a false positive that the repo-level classifier miscredits; removing it is a win.
- **`flask` #6 loses 1** after the widening — it reaches Flask only via `from flask_jwt_extended import …` and a local re-export, not rescuable without a marker loose enough to over-fire.
- **`quart` #5 loses nothing *here*.** The corpus contains **no Quart user at all** — zero repos classify as using Quart and all 43 bad mints are in Flask repos. This is "loses nothing here", not "loses nothing"; recall for real Quart code is untested by that corpus and rests on the fixture in this PR.
- The widened `import flask` marker matches by substring, so it also reaches `import flask_sqlalchemy`, `import flask_admin` and friends. Those are Flask ecosystem packages, and the widening was measured at **zero** cost to bad-removal on the corpus — but it is a widening, and `TestWidenedFlaskMarkers_DoNotReopenOverfire_7013` is what will catch it if a future marker goes too far.

## Direction of error, carried forward from the measurement

- **762 is a lower bound** — step 2's "uses" classifier is a repo-wide scan, so a vendored blob or a comment marks a repo as *using* and hides over-firing behind it.
- **9 is an upper bound in kind** — a mint counts as "good" only because some unrelated file mentioned the framework, demonstrably so for `TestConfig`.
- **9 is a lower bound in corpus breadth** — only 48 true-positive mints exist across all five patterns in this corpus, across 3 repos.
- **The 7 structural losses come from one repo** (`flask-realworld`). The per-file gate's cost on alias-heavy Python is measured at n=1.

## Independent grounding that the change is not inert

Read-only scan of the `django` corpus repo alone, counting distinct-name matches per file for each gated pattern and asking whether the file carries any marker for the framework it is credited to:

| pattern | matches in django | of which in files with NO marker |
|---|---:|---:|
| `sqlalchemy` #5 `ForeignKey(` | 244 | **244** |
| `pytest` #1 `class Test*` | 322 | **322** |
| `flask` #6 `class X(db.Model\|Model)` | 76 | **76** |

642 mints, **none** of which survives the gate, from one repo — matching the coordinator's per-pattern bad counts (246 / 322 / 76) almost exactly. The removal is real and concentrated exactly where the sweep said it was.

## Mutant scores — 11 applied, 11 DEAD

Each mutant was applied with an **exact occurrence-count assertion** before and after the edit, so a silently-unapplied edit could not read as ALIVE; each was scored with `-count=1`; the tree was restored from a shasum-verified backup between runs (never `git checkout --`).

| # | mutant | verdict | killed by |
|---|---|---|---|
| M1 | `pytest` #1 ungated | **DEAD** | forbidden `pytest#1_TestClass` |
| M2 | `sqlalchemy` #5 ungated | **DEAD** | forbidden `sqlalchemy#5_Constraint` |
| M3 | `flask` #6 ungated | **DEAD** | forbidden `flask#6_Model` |
| M4 | **`flask` #1 ungated ALONE** (the #7028 trap) | **DEAD** | both forbidden Route rows + the twin-parity test + the over-fire test |
| M5 | **`quart` #1 ungated ALONE** (the trap, mirrored) | **DEAD** | same four |
| M6 | `quart` #5 ungated | **DEAD** | forbidden `quart#5_Middleware` |
| M7 | widening reverted (both markers dropped) | **DEAD** | `RescueBlueprintModule` |
| M8 | widening narrowed to `from flask import` only | **DEAD** *(was ALIVE — see below)* | `RescuePlainImportModule` |
| M9 | `frameworkPresent` → always `false` (gate kills everything) | **DEAD** | all six recall rows + both rescue tests |
| M10 | `frameworkPresent` → always `true` (gate wired but inert) | **DEAD** | all six forbidden rows + the over-fire test |
| M11 | flask markers widened over-broadly (`"def "` added) | **DEAD** | four forbidden rows + the over-fire test |

**M8 was ALIVE on the first pass and was killed rather than argued away.** Dropping `import flask` and keeping only `from flask import` left every other test green — the second widened marker was carried by nothing, because the blueprint fixture happens to use a `from …` import. It cost ~20 lines to add `TestWidenedFlaskMarkers_RescuePlainImportModule_7013`, a module reaching Flask through `import flask` + `flask.Blueprint(...)`, with a premise asserting neither the pre-widening markers *nor the other widened marker* can see it. That is now the only test that grades `import flask`.

M4 and M5 are the pair that matters: they are the parent's behaviour for their half of the twin, and they turn the forbidden fixture red — positive proof that this change removes entities rather than only pinning what was already true.

## Verification

- `go test -count=1 ./internal/engine/...` — **green** (`internal/engine` 52s, `internal/engine/httproutes`). `gofmt -l internal/engine/` clean, `go vet ./internal/engine/` clean.
- `go test -count=1 ./cmd/grafel/` — **green** (150s), run with a **fresh** `GRAFEL_HOME` and `GRAFEL_DAEMON_ROOT`. Its `Kind|Name|QualifiedName|Subtype|SourceFile|StartLine|EndLine` digest **did not move**, so there is no delta to enumerate: the mixed-language fixture's Python content is framework-honest and every gated pattern that fires there fires on a file carrying its own marker.
- `scripts/quality/run.sh --runs 1 --ratchet` — 38 fixtures held (29 at 100% must-have recall), and, which is the check that actually means something, **`git status --porcelain` is empty afterwards**. No baseline was rewritten and none needed to be. `python-pytest-sqlalchemy-mini` in particular held, which is the recall direction on the two heaviest gates.

### One fixture legitimately moved, hand-edited

`TestZeroProducingKinds6776_EverySiteFires` / `..._EveryNegativeHolds` — the `TestClass` site. Its positive body was `class TestOrders:\n    pass\n` with no pytest marker anywhere, so it asserted the pattern fires on a file the gate now correctly suppresses. Both bodies gained `import pytest`.

The **negative** body gained it too, deliberately. Without the marker the negative would hold for two reasons at once — wrong class name **and** absent framework marker — and would keep passing even if the `Test\w+` half of the pattern were widened to anything at all. With the marker present, the class name is the only thing separating the two bodies, which is what that case's `negWhy` claims. The site's label was also corrected from `pytest.yaml:60` to `:96`.

## Not established

- Recall outside the Python bucket; cross-bucket dedup interactions were not exercised.
- How many identical-twin pairs exist **outside** `rules/python/frameworks` — the new parity test enumerates that directory only. The general sweep is #7028's deliverable, and `flask`#0/`quart`#0 (178 mints) is the same trap still waiting there for whoever tightens either one.
- Whether the widened flask markers over-fire outside this corpus.
