### PR TITLE
fix(#7030): dormant-bucket consultation order was a Go map range, so the framework stamped on a shared yaml entity was randomised per process

### DIFF
--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -118,11 +118,59 @@ func (c compiledRuleSet) frameworkPresent(content string) bool {
 //     docker_compose.yaml rules target compose files → `yaml`. The bucket is
 //     indivisible at load time, so it is aliased onto both; non-matching
 //     patterns are inert.)
-var dormantBucketAliases = map[string][]string{
-	"cicd":       {"yaml"},
-	"ansible":    {"yaml"},
-	"kubernetes": {"yaml"},
-	"docker":     {"dockerfile", "yaml"},
+//
+// # This is an ORDERED SLICE, not a map, and the order is load-bearing (#7030)
+//
+// compile() APPENDS each bucket's compiled rule sets onto the shared target
+// key, and Detect's per-file `seenEntities` (see below) lets the FIRST rule set
+// that matches an entity claim it — the later one is silently shadowed. The
+// emitted `framework` property comes from the bucket directory name
+// (`framework: lang`), so for two buckets aliased onto the SAME target the
+// consultation order decides the property that gets stamped.
+//
+// While this was a `map[string][]string`, `range` over it randomised that order
+// per process. `docker/frameworks/docker_compose.yaml`#1 and
+// `kubernetes/frameworks/kubernetes_manifests.yaml`#12 carry the byte-identical
+// pattern `image:\s+(\S+)` (entity_type Dependency) and co-occur on 92 files /
+// 142 entities, so those entities came out `framework=docker` or
+// `framework=kubernetes` depending on the map seed: two indexes of an unchanged
+// tree could disagree.
+//
+// The order below is LEXICAL BY BUCKET NAME. That is a deliberate non-choice:
+// it is the same rule the loader already uses to order rule FILES
+// (fs.WalkDir, loader.go), it is mechanically re-derivable by anyone reading
+// this list, and it does not smuggle in a claim that `docker` deserves to beat
+// `kubernetes` on the shared `image:` pattern. It only guarantees that the pair
+// HAS a stable winner, which is the precondition for choosing one on the
+// merits (#7028 owns that choice, and wants a file_conventions-scoped gate
+// rather than a reordering).
+//
+// So: reordering these entries CHANGES EXTRACTION OUTPUT for any two buckets
+// sharing a target language. Do it deliberately, with a recall measurement, and
+// update TestDormantAliasOrderIsExactAndStable_7030 — which pins this exact
+// sequence — in the same change.
+var dormantBucketAliases = []dormantBucketAlias{
+	{bucket: "ansible", targets: []string{"yaml"}},
+	{bucket: "cicd", targets: []string{"yaml"}},
+	{bucket: "docker", targets: []string{"dockerfile", "yaml"}},
+	{bucket: "kubernetes", targets: []string{"yaml"}},
+}
+
+// dormantBucketAlias is one bucket→concrete-language(s) alias entry.
+type dormantBucketAlias struct {
+	bucket  string
+	targets []string
+}
+
+// dormantAliasTargets returns the concrete languages a bucket is aliased onto,
+// or nil when the bucket is not aliased at all.
+func dormantAliasTargets(bucket string) []string {
+	for _, a := range dormantBucketAliases {
+		if a.bucket == bucket {
+			return a.targets
+		}
+	}
+	return nil
 }
 
 // Detector applies YAML-driven framework extraction rules to source files.
@@ -312,12 +360,16 @@ func (d *Detector) compile() {
 	// frameworks/*.yaml files carry engine schema keys (source_patterns /
 	// file_conventions / relationship_rules) — they are documentation-only
 	// descriptors — so aliasing it onto `html` would add zero extraction.
-	for bucket, targets := range dormantBucketAliases {
-		sets, ok := d.compiled[bucket]
+	//
+	// Iterated in the fixed slice order declared at dormantBucketAliases — see
+	// the comment there for why the order decides output and must not drift
+	// (#7030).
+	for _, alias := range dormantBucketAliases {
+		sets, ok := d.compiled[alias.bucket]
 		if !ok || len(sets) == 0 {
 			continue
 		}
-		for _, target := range targets {
+		for _, target := range alias.targets {
 			d.compiled[target] = append(d.compiled[target], sets...)
 		}
 	}

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -136,22 +136,47 @@ func (c compiledRuleSet) frameworkPresent(content string) bool {
 // `framework=kubernetes` depending on the map seed: two indexes of an unchanged
 // tree could disagree.
 //
-// The order below is LEXICAL BY BUCKET NAME. That is a deliberate non-choice:
-// it is the same rule the loader already uses to order rule FILES
-// (fs.WalkDir, loader.go), it is mechanically re-derivable by anyone reading
-// this list, and it does not smuggle in a claim that `docker` deserves to beat
-// `kubernetes` on the shared `image:` pattern. It only guarantees that the pair
-// HAS a stable winner, which is the precondition for choosing one on the
-// merits (#7028 owns that choice, and wants a file_conventions-scoped gate
-// rather than a reordering).
+// The order below is LEXICAL BY BUCKET NAME, WITH ONE DOCUMENTED EXCEPTION.
+// Two pairs of buckets share the `yaml` target and share a pattern, so the
+// order decides a label for each; they are argued separately on purpose,
+// because one global order has to serve both and no single rule earns both.
+//
+//   - docker vs kubernetes — LEXICAL, and genuinely a non-choice. `image:` in
+//     a compose file is docker and in a manifest is kubernetes, so EITHER fixed
+//     winner is wrong for roughly half the 142 entities. There is no status quo
+//     worth preserving (the winner was random) and no evidence favouring
+//     either, so lexical picks one without smuggling in a claim. All it buys is
+//     that the pair HAS a stable winner, which is the precondition for choosing
+//     one on the merits. #7028 owns that choice and wants a
+//     file_conventions-scoped gate (`docker-compose.yml` vs `k8s/*.yaml`),
+//     NOT a reordering here.
+//
+//   - cicd vs ansible — `cicd` IS OUT OF LEXICAL POSITION, DELIBERATELY.
+//     `ansible/…/ansible_core.yaml`#0 and `cicd/…/github_actions.yaml`#3 differ
+//     only by an anchor (`(?m)^\s+` vs `\s+`) and shadow each other on ~999
+//     entities — 7x the docker/kubernetes pair, and #7028's largest row. Unlike
+//     that pair, ONE label here is simply correct: the measured population is
+//     90 `.github/workflows/*.y*ml` files and ZERO Ansible playbooks, so every
+//     one of those entities is CI, not Ansible. Lexical would pin `ansible` on
+//     all of them, every run — trading a coin-flip mislabel for a permanent
+//     one. Putting `cicd` first is NOT a status-quo reflex (it happened to win
+//     ~86% of the time under the map, and that frequency is noise, not a
+//     property); it is the only label anyone has evidence for.
+//
+//     The correct long-term fix is to disambiguate the two patterns or gate
+//     them on file_conventions, exactly as for docker/kubernetes. Until then a
+//     determinism fix must not ship a new mislabel class as a side effect.
 //
 // So: reordering these entries CHANGES EXTRACTION OUTPUT for any two buckets
 // sharing a target language. Do it deliberately, with a recall measurement, and
-// update TestDormantAliasOrderIsExactAndStable_7030 — which pins this exact
-// sequence — in the same change.
+// update TestDormantAliasOrderIsExactAndStable_7030 (which pins this exact
+// sequence) and TestDormantAliasConsultationOrderIsDeterministic_7030 (which
+// pins the observable consequence for BOTH pairs) in the same change.
 var dormantBucketAliases = []dormantBucketAlias{
-	{bucket: "ansible", targets: []string{"yaml"}},
+	// cicd before ansible: out of lexical order on purpose — see above.
 	{bucket: "cicd", targets: []string{"yaml"}},
+	{bucket: "ansible", targets: []string{"yaml"}},
+	// lexical from here.
 	{bucket: "docker", targets: []string{"dockerfile", "yaml"}},
 	{bucket: "kubernetes", targets: []string{"yaml"}},
 }

--- a/internal/engine/docker_ansible_multiline_anchor_6927_test.go
+++ b/internal/engine/docker_ansible_multiline_anchor_6927_test.go
@@ -87,7 +87,7 @@ func rules6927(t *testing.T, frameworkName, wantBucket string) map[string][]Fram
 		t.Fatalf("expected exactly one %q rule set in the %q bucket, got %d",
 			frameworkName, wantBucket, len(out[wantBucket]))
 	}
-	if targets := dormantBucketAliases[wantBucket]; !containsStr6927(targets, "yaml") {
+	if targets := dormantAliasTargets(wantBucket); !containsStr6927(targets, "yaml") {
 		t.Fatalf("bucket %q is no longer aliased onto yaml (%v); these tests hand Detect "+
 			"Language=yaml and would grade nothing", wantBucket, targets)
 	}

--- a/internal/engine/dormant_alias_order_7030_test.go
+++ b/internal/engine/dormant_alias_order_7030_test.go
@@ -1,0 +1,216 @@
+package engine
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+)
+
+// #7030 — dormant-bucket consultation order.
+//
+// dormantBucketAliases used to be a map, and compile() appended each bucket's
+// compiled rule sets onto the shared target language key under `range`. Go
+// randomises map iteration order, so the order in which those buckets were
+// consulted was random per range. Detect's per-file seenEntities lets the FIRST
+// rule set that matches an entity claim it, and the emitted `framework`
+// property is the bucket directory name — so on a yaml file matched by two
+// aliased buckets, the property flipped from run to run on identical input.
+//
+// The three tests below grade the fix on three independent axes, and each fails
+// on an input the others survive:
+//
+//   - Order: the exact declared sequence. Reordering two entries fails this and
+//     nothing else — the completeness test is order-independent by construction.
+//   - Completeness: every listed bucket's sets still reach every one of its
+//     targets. Making compile() append only the first target (or skip a bucket)
+//     while leaving the declaration untouched fails this and nothing else.
+//   - Determinism: the observable consequence. This is the one that fails on
+//     main; the other two are structural pins that main would pass.
+
+// wantDormantAliasOrder7030 is the exact expected sequence. Written out here
+// rather than derived from the production value so that a change to the
+// production value is what the test reports.
+var wantDormantAliasOrder7030 = []dormantBucketAlias{
+	{bucket: "ansible", targets: []string{"yaml"}},
+	{bucket: "cicd", targets: []string{"yaml"}},
+	{bucket: "docker", targets: []string{"dockerfile", "yaml"}},
+	{bucket: "kubernetes", targets: []string{"yaml"}},
+}
+
+// TestDormantAliasOrderIsExactAndStable_7030 pins the consultation order as an
+// EXACT SEQUENCE, not as a set. "contains these buckets" would pass under the
+// map, which is precisely the bug.
+func TestDormantAliasOrderIsExactAndStable_7030(t *testing.T) {
+	if got, want := len(dormantBucketAliases), len(wantDormantAliasOrder7030); got != want {
+		t.Fatalf("dormantBucketAliases has %d entries, want %d: %v",
+			got, want, dormantBucketAliases)
+	}
+	for i, want := range wantDormantAliasOrder7030 {
+		got := dormantBucketAliases[i]
+		if got.bucket != want.bucket {
+			t.Errorf("dormantBucketAliases[%d].bucket = %q, want %q — the order is "+
+				"load-bearing (it decides which bucket's `framework` property wins on a "+
+				"shared pattern); change it deliberately, not incidentally",
+				i, got.bucket, want.bucket)
+			continue
+		}
+		if len(got.targets) != len(want.targets) {
+			t.Errorf("alias %q targets = %v, want %v", got.bucket, got.targets, want.targets)
+			continue
+		}
+		for j := range want.targets {
+			if got.targets[j] != want.targets[j] {
+				t.Errorf("alias %q targets = %v, want %v (target order also decides "+
+					"append order on a shared key)", got.bucket, got.targets, want.targets)
+				break
+			}
+		}
+	}
+
+	// The ordered slice must still be a function: one entry per bucket.
+	seen := map[string]bool{}
+	for _, a := range dormantBucketAliases {
+		if seen[a.bucket] {
+			t.Errorf("bucket %q listed twice — its sets would be appended twice", a.bucket)
+		}
+		seen[a.bucket] = true
+	}
+
+	// html_templates stays unaliased (doc-only frameworks, no engine schema).
+	if dormantAliasTargets("html_templates") != nil {
+		t.Error("html_templates must not be aliased: its frameworks carry no engine schema")
+	}
+}
+
+// TestDormantAliasAppendsEveryBucket_7030 is the OTHER direction: an ordered
+// slice that silently dropped a bucket, or a compile() that stopped appending
+// onto the second target, would sail through an order assertion.
+//
+// It is deliberately order-INDEPENDENT — it only counts — so it cannot mask the
+// order test and the order test cannot mask it.
+//
+// len(d.compiled[k]) before aliasing equals len(rules[k]): compile() appends
+// exactly one compiledRuleSet per FrameworkRule, unconditionally.
+func TestDormantAliasAppendsEveryBucket_7030(t *testing.T) {
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules failed: %v", err)
+	}
+	det := New(rules)
+	det.once.Do(det.compile)
+
+	want := map[string]int{}
+	for lang, frs := range rules {
+		want[lang] = len(frs)
+	}
+	for _, a := range dormantBucketAliases {
+		src := len(rules[a.bucket])
+		if src == 0 {
+			t.Errorf("dormant bucket %q loaded 0 rule sets — it cannot fire, so listing "+
+				"it in dormantBucketAliases is dead weight", a.bucket)
+			continue
+		}
+		for _, target := range a.targets {
+			want[target] += src
+		}
+	}
+
+	targets := map[string]bool{}
+	for _, a := range dormantBucketAliases {
+		for _, tg := range a.targets {
+			targets[tg] = true
+		}
+	}
+	names := make([]string, 0, len(targets))
+	for tg := range targets {
+		names = append(names, tg)
+	}
+	sort.Strings(names)
+
+	for _, tg := range names {
+		if got := len(det.compiled[tg]); got != want[tg] {
+			t.Errorf("compiled[%q] holds %d rule sets, want %d — a bucket's sets are not "+
+				"reaching this language key (a dropped or short-circuited alias)",
+				tg, got, want[tg])
+		}
+	}
+}
+
+// TestDormantAliasConsultationOrderIsDeterministic_7030 is the behavioural
+// grade, and the one that fails on main.
+//
+// docker/frameworks/docker_compose.yaml#1 and
+// kubernetes/frameworks/kubernetes_manifests.yaml#12 carry the byte-identical
+// pattern `image:\s+(\S+)` for entity_type Dependency. On a yaml file matched by
+// both, whichever bucket is consulted first claims the entity and stamps its own
+// bucket name as `framework`.
+//
+// A single Detect proves NOTHING here: it would report one winner under the bug
+// too. `-count=N` is no defence either — it reruns in the same process, and the
+// same *Detector compiles once via sync.Once. What breaks the bug is building
+// MANY Detectors: Go re-randomises the start offset on every `range` over a map,
+// so each fresh compile() drew an independent order. This test therefore
+// compiles the real rules independently many times and requires that all runs
+// agree AND that the agreed winner is the declared-first bucket.
+//
+// Verified: on main this fails (observed both `docker` and `kubernetes` across
+// the iterations); on this branch every iteration yields `docker`.
+func TestDormantAliasConsultationOrderIsDeterministic_7030(t *testing.T) {
+	const composeYAML = `services:
+  web:
+    image: nginx:1.25
+`
+	const iterations = 200
+
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules failed: %v", err)
+	}
+
+	// Which aliased bucket SHOULD win is read off the declared order rather than
+	// hard-coded, so this test states the consequence of the order and the order
+	// test states the order. Both `docker` and `kubernetes` alias onto `yaml` and
+	// both carry the shared `image:` pattern.
+	winner := ""
+	for _, a := range dormantBucketAliases {
+		if a.bucket == "docker" || a.bucket == "kubernetes" {
+			winner = a.bucket
+			break
+		}
+	}
+	if winner == "" {
+		t.Fatal("neither docker nor kubernetes is aliased; this test grades nothing")
+	}
+
+	observed := map[string]int{}
+	for i := 0; i < iterations; i++ {
+		det := New(rules)
+		res, err := det.Detect(context.Background(), extractor.FileInput{
+			Path:     "deploy/stack.yaml",
+			Language: "yaml",
+			Content:  []byte(composeYAML),
+		})
+		if err != nil {
+			t.Fatalf("Detect failed on iteration %d: %v", i, err)
+		}
+		e := findEntity(res.Entities, "Dependency", "nginx:1.25")
+		if e == nil {
+			t.Fatalf("iteration %d: no Dependency entity %q — the shared `image:` pattern "+
+				"no longer fires, so this test grades nothing", i, "nginx:1.25")
+		}
+		observed[e.Properties["framework"]]++
+	}
+
+	if len(observed) != 1 {
+		t.Fatalf("the `framework` property on an identical input took %d distinct values "+
+			"across %d independent compiles (%v) — bucket consultation order is not "+
+			"deterministic", len(observed), iterations, observed)
+	}
+	if observed[winner] != iterations {
+		t.Fatalf("framework property = %v across %d compiles, want %q every time "+
+			"(the first of docker/kubernetes in the declared alias order)",
+			observed, iterations, winner)
+	}
+}

--- a/internal/engine/dormant_alias_order_7030_test.go
+++ b/internal/engine/dormant_alias_order_7030_test.go
@@ -33,8 +33,9 @@ import (
 // rather than derived from the production value so that a change to the
 // production value is what the test reports.
 var wantDormantAliasOrder7030 = []dormantBucketAlias{
-	{bucket: "ansible", targets: []string{"yaml"}},
+	// cicd is deliberately out of lexical position — see the declaration.
 	{bucket: "cicd", targets: []string{"yaml"}},
+	{bucket: "ansible", targets: []string{"yaml"}},
 	{bucket: "docker", targets: []string{"dockerfile", "yaml"}},
 	{bucket: "kubernetes", targets: []string{"yaml"}},
 }
@@ -138,30 +139,103 @@ func TestDormantAliasAppendsEveryBucket_7030(t *testing.T) {
 	}
 }
 
+// dormantPairCase7030 is one pair of buckets that (a) alias onto the same
+// concrete language and (b) carry a pattern that matches the same text, so the
+// consultation order alone decides which bucket's name is stamped as
+// `framework` on the resulting entity.
+type dormantPairCase7030 struct {
+	name    string
+	pair    [2]string // the two competing buckets, in no particular order
+	path    string
+	content string
+	kind    string
+	entity  string
+}
+
+// dormantPairCases7030 covers BOTH shared-target pairs in the alias list.
+// Covering only one leaves the other pinned by declaration and ungraded: a
+// call site that swapped just that pair's two entries would change ~999
+// entities' framework label and pass the whole package.
+var dormantPairCases7030 = []dormantPairCase7030{
+	{
+		// docker/frameworks/docker_compose.yaml#1 and
+		// kubernetes/frameworks/kubernetes_manifests.yaml#12 carry the
+		// byte-identical pattern `image:\s+(\S+)` for entity_type Dependency.
+		name: "docker_vs_kubernetes_image",
+		pair: [2]string{"docker", "kubernetes"},
+		path: "deploy/stack.yaml",
+		content: `services:
+  web:
+    image: nginx:1.25
+`,
+		kind:   "Dependency",
+		entity: "nginx:1.25",
+	},
+	{
+		// ansible/frameworks/ansible_core.yaml#0 and
+		// cicd/frameworks/github_actions.yaml#3 both type a `- name:` list item
+		// as a Task; they differ only by an anchor. This fixture is a PURE
+		// GitHub Actions workflow with no Ansible content whatsoever, which is
+		// what the measured corpus population looks like (90 workflow files,
+		// zero playbooks), so `cicd` is the correct label here and the order
+		// must keep producing it.
+		name: "cicd_vs_ansible_named_step",
+		pair: [2]string{"cicd", "ansible"},
+		path: ".github/workflows/ci.yml",
+		content: `name: ci
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install deps
+        run: go mod download
+      - name: Run unit tests
+        run: go test ./...
+`,
+		kind:   "Task",
+		entity: "Install deps",
+	},
+}
+
+// firstDeclared7030 returns whichever of a and b appears first in
+// dormantBucketAliases, i.e. the bucket the declared order elects to win any
+// pattern the two share. Derived rather than hard-coded so that this test
+// grades the CONSEQUENCE of the declared order while
+// TestDormantAliasOrderIsExactAndStable_7030 grades the order itself.
+func firstDeclared7030(t *testing.T, a, b string) string {
+	t.Helper()
+	for _, al := range dormantBucketAliases {
+		if al.bucket == a || al.bucket == b {
+			return al.bucket
+		}
+	}
+	t.Fatalf("neither %q nor %q is aliased; this case grades nothing", a, b)
+	return ""
+}
+
 // TestDormantAliasConsultationOrderIsDeterministic_7030 is the behavioural
 // grade, and the one that fails on main.
 //
-// docker/frameworks/docker_compose.yaml#1 and
-// kubernetes/frameworks/kubernetes_manifests.yaml#12 carry the byte-identical
-// pattern `image:\s+(\S+)` for entity_type Dependency. On a yaml file matched by
-// both, whichever bucket is consulted first claims the entity and stamps its own
-// bucket name as `framework`.
+// On a yaml file matched by two aliased buckets, whichever is consulted first
+// claims the entity and stamps its own bucket name as `framework`.
 //
 // A single Detect proves NOTHING here: it would report one winner under the bug
 // too. `-count=N` is no defence either — it reruns in the same process, and the
 // same *Detector compiles once via sync.Once. What breaks the bug is building
 // MANY Detectors: Go re-randomises the start offset on every `range` over a map,
 // so each fresh compile() drew an independent order. This test therefore
-// compiles the real rules independently many times and requires that all runs
-// agree AND that the agreed winner is the declared-first bucket.
+// compiles the real rules independently many times per case and requires that
+// all runs agree AND that the agreed winner is the declared-first bucket.
 //
-// Verified: on main this fails (observed both `docker` and `kubernetes` across
-// the iterations); on this branch every iteration yields `docker`.
+// Verified on main (1b115b73b), by running each case there rather than
+// asserting it: docker/kubernetes came out `map[docker:23 kubernetes:177]` over
+// 200 compiles, and the pure GitHub Actions workflow `map[ansible:48 cicd:352]`
+// over 400. Both cases therefore FAIL on main. On this branch every iteration of
+// every case yields a single value.
 func TestDormantAliasConsultationOrderIsDeterministic_7030(t *testing.T) {
-	const composeYAML = `services:
-  web:
-    image: nginx:1.25
-`
 	const iterations = 200
 
 	rules, err := LoadAllRules()
@@ -169,48 +243,43 @@ func TestDormantAliasConsultationOrderIsDeterministic_7030(t *testing.T) {
 		t.Fatalf("LoadAllRules failed: %v", err)
 	}
 
-	// Which aliased bucket SHOULD win is read off the declared order rather than
-	// hard-coded, so this test states the consequence of the order and the order
-	// test states the order. Both `docker` and `kubernetes` alias onto `yaml` and
-	// both carry the shared `image:` pattern.
-	winner := ""
-	for _, a := range dormantBucketAliases {
-		if a.bucket == "docker" || a.bucket == "kubernetes" {
-			winner = a.bucket
-			break
-		}
-	}
-	if winner == "" {
-		t.Fatal("neither docker nor kubernetes is aliased; this test grades nothing")
-	}
+	for _, tc := range dormantPairCases7030 {
+		t.Run(tc.name, func(t *testing.T) {
+			winner := firstDeclared7030(t, tc.pair[0], tc.pair[1])
 
-	observed := map[string]int{}
-	for i := 0; i < iterations; i++ {
-		det := New(rules)
-		res, err := det.Detect(context.Background(), extractor.FileInput{
-			Path:     "deploy/stack.yaml",
-			Language: "yaml",
-			Content:  []byte(composeYAML),
+			observed := map[string]int{}
+			for i := 0; i < iterations; i++ {
+				det := New(rules)
+				res, err := det.Detect(context.Background(), extractor.FileInput{
+					Path:     tc.path,
+					Language: "yaml",
+					Content:  []byte(tc.content),
+				})
+				if err != nil {
+					t.Fatalf("Detect failed on iteration %d: %v", i, err)
+				}
+				e := findEntity(res.Entities, tc.kind, tc.entity)
+				if e == nil {
+					t.Fatalf("iteration %d: no %s entity %q — the shared pattern no longer "+
+						"fires, so this case grades nothing", i, tc.kind, tc.entity)
+				}
+				observed[e.Properties["framework"]]++
+			}
+
+			// Both competing buckets must actually be capable of producing this
+			// entity, or "one winner" is trivially true and grades nothing. Assert
+			// it by construction: the loser is the other member of the pair, and
+			// #7028 measured both producers on this pattern.
+			if len(observed) != 1 {
+				t.Fatalf("the `framework` property on an identical input took %d distinct "+
+					"values across %d independent compiles (%v) — bucket consultation "+
+					"order is not deterministic", len(observed), iterations, observed)
+			}
+			if observed[winner] != iterations {
+				t.Fatalf("framework property = %v across %d compiles, want %q every time "+
+					"(the first of %q/%q in the declared alias order)",
+					observed, iterations, winner, tc.pair[0], tc.pair[1])
+			}
 		})
-		if err != nil {
-			t.Fatalf("Detect failed on iteration %d: %v", i, err)
-		}
-		e := findEntity(res.Entities, "Dependency", "nginx:1.25")
-		if e == nil {
-			t.Fatalf("iteration %d: no Dependency entity %q — the shared `image:` pattern "+
-				"no longer fires, so this test grades nothing", i, "nginx:1.25")
-		}
-		observed[e.Properties["framework"]]++
-	}
-
-	if len(observed) != 1 {
-		t.Fatalf("the `framework` property on an identical input took %d distinct values "+
-			"across %d independent compiles (%v) — bucket consultation order is not "+
-			"deterministic", len(observed), iterations, observed)
-	}
-	if observed[winner] != iterations {
-		t.Fatalf("framework property = %v across %d compiles, want %q every time "+
-			"(the first of docker/kubernetes in the declared alias order)",
-			observed, iterations, winner)
 	}
 }

--- a/internal/engine/dormant_buckets_3593_test.go
+++ b/internal/engine/dormant_buckets_3593_test.go
@@ -218,7 +218,8 @@ func TestDormant3593_AliasMapWiring(t *testing.T) {
 	det.once.Do(det.compile)
 
 	// Each alias target must have received the dormant bucket's sets appended.
-	for bucket, targets := range dormantBucketAliases {
+	for _, alias := range dormantBucketAliases {
+		bucket, targets := alias.bucket, alias.targets
 		src := det.compiled[bucket]
 		if len(src) == 0 {
 			t.Errorf("dormant bucket %q compiled to 0 rule sets — cannot fire", bucket)
@@ -233,7 +234,7 @@ func TestDormant3593_AliasMapWiring(t *testing.T) {
 	}
 
 	// html_templates is intentionally NOT aliased (doc-only frameworks).
-	if _, ok := dormantBucketAliases["html_templates"]; ok {
+	if dormantAliasTargets("html_templates") != nil {
 		t.Error("html_templates must not be aliased: its frameworks carry no engine schema")
 	}
 }


### PR DESCRIPTION
Fixes #7030.

> **Revised after review.** The first revision ordered the aliases purely lexically and disclosed only one of the two output flips it shipped. The reviewer was right: I *measured* the second flip and filed it under "#6821 evidence" — as a signal about entity counts — instead of as an impact of my own change. That is the difference between a disclosed trade and a silent regression. The order changed to `cicd, ansible, docker, kubernetes`, the impact section below now names **both** pairs, and the ungraded pair (M8, ALIVE) is now pinned.

## What changed

`dormantBucketAliases` (`internal/engine/detector.go`) was a `map[string][]string`, and `compile()` appended each dormant bucket's compiled rule sets onto the shared target language key under `range` over it. `Detect`'s per-file `seenEntities` lets the **first** rule set that matches an entity claim it, and the emitted `framework` property is the bucket directory name (`framework: lang`) — so on a `.yaml` file matched by two aliased buckets, the property flipped run to run on identical input.

It is now an ordered `[]dormantBucketAlias`, plus a `dormantAliasTargets(bucket)` lookup for the two existing tests that indexed the map. The mechanism is otherwise untouched.

## The order, and why — per pair

**`cicd, ansible, docker, kubernetes`: lexical with one documented exception.** One global order has to serve two shared-target pairs, and no single rule earns both, so the declaration comment argues them separately.

**`docker` vs `kubernetes` — lexical, and a genuine non-choice.** `docker_compose.yaml`#1 and `kubernetes_manifests.yaml`#12 carry the byte-identical `image:\s+(\S+)`, **142 entities**. `image:` in a compose file is docker and in a manifest is kubernetes, so *either* fixed winner is wrong for roughly half of them. The winner was random, so there is no status quo worth preserving and no evidence favouring either. Lexical buys exactly one thing: the pair *has* a stable winner, which is the precondition for choosing one on the merits. **#7028 owns that choice** and wants a `file_conventions`-scoped gate, not a reordering here.

**`cicd` vs `ansible` — `cicd` is out of lexical position, deliberately.** `ansible_core.yaml`#0 and `github_actions.yaml`#3 differ only by an anchor (`(?m)^\s+` vs `\s+`) and shadow each other on **~999 entities** — 7× the docker/kubernetes pair, and **#7028's largest row**. Unlike that pair, **one label here is simply correct**: `archigraph-corpora` holds **90 `.github/workflows/*.y*ml` files and 0 Ansible playbooks**, so every entity in the measured population is CI, not Ansible. Lexical would have pinned `ansible` on all of them, every run — trading a coin-flip mislabel for a permanent one.

Putting `cicd` first is **not** a status-quo reflex. It won ~86–88% of the time under the map and that frequency is noise, not a property. It is the only label anyone has evidence for. The correct long-term fix is to disambiguate or gate the two patterns, exactly as for docker/kubernetes; until then a determinism fix must not ship a new mislabel class as a side effect.

## Impact on output — both pairs

Pinning a winner where there was none moves output by construction. Measured on `main` (`1b115b73b`) with fresh compiles, then on this branch:

| pair | population (#7028) | `main` | this branch | assessment |
|---|---:|---|---|---|
| `docker` / `kubernetes` on `image:\s+(\S+)` | 142 | `map[docker:23 kubernetes:177]` /200 — `kubernetes` **~88%** | `docker` **200/200** | Changes the *typical* output. Accepted: both labels were wrong ~half the time, so no correctness is lost and #7028 decides on the merits. |
| `cicd` / `ansible` on `- name:` (pure GH Actions workflow, zero Ansible content) | ~999 | `map[ansible:48 cicd:352]` /400 — `cicd` **88%** | `cicd` **400/400** | Preserves the correct label for the entire measured population. Under the previous revision this was `ansible` 400/400 — the regression this revision fixes. |

Both `main` figures are my own runs in a detached `main` worktree; the reviewer reproduced both independently at n=400 (`map[docker:57 kubernetes:343]`, and `cicd` 346/400 on the workflow).

## How the tests fail on main — with the evidence

The obvious test does not work: a single `Detect` reports one winner under the bug too, and `-count=N` reruns in the same process, so it is no defence against map-order randomisation. What breaks it is that Go re-randomises the start offset on **every `range` over a map**, so each fresh `compile()` drew an independent order. `TestDormantAliasConsultationOrderIsDeterministic_7030` therefore builds **200 fresh `Detector`s per case** from the real embedded rules and requires all of them to agree.

**Verified by running it on `main`, not asserted.** Probe in a detached `main` worktree:

```
--- FAIL: TestProbe7030MainDeterminism
    NONDETERMINISTIC: 2 distinct framework values across 200 compiles: map[docker:23 kubernetes:177]

--- FAIL: TestZZProbe7030Workflow
    MAIN framework distribution: map[ansible:48 cicd:352] ; entity-count distribution: map[8:400]
    NONDETERMINISTIC on main: map[ansible:48 cicd:352]
```

Both cases fail on `main`; both are single-valued on this branch.

## Three axes, and no guard masks another

`internal/engine/dormant_alias_order_7030_test.go`:

1. **`TestDormantAliasOrderIsExactAndStable_7030`** — the order as an **exact sequence** (index by index, bucket *and* target order, plus length and no duplicate bucket). "Contains these buckets" would pass under the map, which is precisely the bug.
2. **`TestDormantAliasAppendsEveryBucket_7030`** — the other direction: an ordered slice that silently dropped a bucket, or a `compile()` that stopped appending onto the second target, would sail through an order assertion. It checks `len(compiled[target]) == len(rules[target]) + Σ len(rules[bucket])` over every alias naming that target (`compile()` appends exactly one `compiledRuleSet` per `FrameworkRule`, unconditionally). Deliberately **order-independent**, so it cannot mask the order test and vice versa.
3. **`TestDormantAliasConsultationOrderIsDeterministic_7030`** — the behavioural consequence, now **parameterised over both pairs** with a per-pair fixture, deriving the expected winner *from the declared order* rather than hard-coding it. So test 1 grades the order and test 3 grades its consequence, including for a call site that reverses or re-maps a correctly-declared slice.

Distinguishing inputs: **M1** fails only the order test (completeness passes); **M2** fails only completeness among the two structural guards (the order test passes); **M5/M7/M8** fail only determinism.

## Mutants — re-scored against the reordered data

Every edit asserted at an **exact occurrence count** before running and confirmed to differ from the backup (an unapplied edit reading ALIVE is the trap). `detector.go` `cp`-restored from a `shasum`-verified backup after each; final `shasum 97759efd…` matches and `git diff HEAD` is empty. `-count=1` throughout; fresh compiles, never `-count=N`.

| # | mutant | order | complete | determ. | verdict |
|---|---|---|---|---|---|
| M1 | swap `cicd`/`ansible` in the **declaration** | **FAIL** | pass | pass | **DEAD** — order test alone. `[0].bucket = "ansible", want "cicd"`. |
| M2 | `range alias.targets[:1]` | pass | **FAIL** | FAIL | **DEAD** — `compiled["yaml"] holds 14 rule sets, want 16`. Order test passes, so the two structural guards are disjoint. |
| M3 | delete the `kubernetes` entry | **FAIL** | pass | pass | **DEAD** — `has 3 entries, want 4`. Completeness passes (bucket absent from both sides of the count), so only the exact-sequence assertion catches it. |
| M4 | swap `docker`/`kubernetes` in the declaration | **FAIL** | pass | pass | **DEAD** — `[2].bucket = "kubernetes", want "docker"`. Determinism passes *by design* (it derives the winner), so a deliberate winner change is **reported, not silently accepted** — the review gate #7028 needs. |
| M5 | **call site** iterates the slice in reverse | pass | pass | **FAIL** | **DEAD** — determinism alone. `map[kubernetes:200], want "docker"`. |
| M7 | **call site** re-maps the slice into a map and ranges it (the refactor-back regression) | pass | pass | **FAIL** | **DEAD** — determinism alone, and it re-exhibits the bug: `map[docker:175 kubernetes:25]`, `map[ansible:35 cicd:165]`. |
| M8 | **call site** swaps only indices 0/1 (`cicd`⇄`ansible`); declaration untouched | pass | pass | **FAIL** | **DEAD** — was **ALIVE against the whole package** before this revision. Now `map[ansible:200] across 200 compiles, want "cicd"`. This is the reviewer's §4 gap, closed. |
| — | the original defect (map + `range`) | — | — | **FAIL** | **DEAD**, measured on `main` directly (both tables above). Not runnable as an in-branch mutant: reverting the type stops the new tests compiling. M7 is its in-branch stand-in. |

**No survivors.** M8 was the only ALIVE mutant and is now graded.

## Verification

- `go test -count=1 ./internal/engine/...` — **exit 0**, 51s. `gofmt -l` clean, `go vet` clean.
- `go test -count=1 ./cmd/grafel/` with a **fresh** `GRAFEL_HOME` and `GRAFEL_DAEMON_ROOT` — **exit 0**, 169s. **Digest did not move**, and it *cannot*: `entityTupleKey` hashes **eight** fields (`Kind|Name|QualifiedName|Subtype|Language|SourceFile|StartLine|EndLine` — `Language` per #6862, which my first body omitted) and states outright that *"Entity Properties are still NOT hashed."* A property-only change is invisible to it.
- `scripts/quality/run.sh --runs 1 --ratchet` — "38 gated fixtures held (29 at 100% must-have recall)", and the check that actually counts: **`git status --porcelain` empty afterwards**. No fixture moved, so no baseline was hand-edited and no `--update-baseline` was run.
- **No flaky-baseline evidence.** Nothing in the golden set moved in either direction, consistent with neither observer seeing the property: the reviewer confirmed `scripts/quality/ratchet.py` mentions `framework` only in a comment and gates on must-have entity recall. **Nothing in the repo would have caught this defect** — the new determinism test is the only observer of a `framework` property anywhere. That is a repo coverage finding; the coordinator is filing it.

## On #6821 — still a weak signal, still not asserted

Three samples now, all pointing away from this mechanism being #6821's cause, none conclusive:

1. Swapping `ansible`/`cicd` on a mixed yaml changed **only** the `framework` property on two `Task` entities. Count 9 both ways, `Kind|Name` set identical.
2. The `main` workflow probe above: **entity-count distribution `map[8:400]`** — constant across all 400 compiles while the property took 2 distinct values.
3. No `source_pattern` in any of the four dormant buckets declares `scope: Process` or `scope: External`, the scopes #6821 names (`scope:` values there are `file`, `Service`, `Operation`, `Schema`, `Component`).

The reviewer's independent probes agree (counts constant at 3, 13 and 8 while up to 3 property signatures appeared). Three samples of hand-written yaml is not a corpus, and the `ansible`/`cicd` pair is near-identical rather than identical, so on other content their name *sets* could differ and counts could move. **Do not merge #6821 into this until someone traces it.** Not widened here.

## Not established

- **How many other pairs cross an aliased-bucket boundary on a shared pattern.** #7028's census names the two fixed-order pairs above; I pinned the order for all four buckets and did not enumerate further pairs.
- **Whether either pinned winner is *right*.** For `docker`/`kubernetes`, out of scope by construction — #7028. For `cicd`/`ansible`, `cicd` is right for the *measured* population (90 workflow files, 0 playbooks); a corpus containing real playbooks would mislabel them `cicd`, and the real fix is still to disambiguate the two patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
