### PR TITLE
fix(#6916): Tier C — 9 name_group:0 rules mint a marker, not an entity: delete them (79 corpus entities, 0 edges), and correct the "already dropped downstream" claim

### DIFF
--- a/internal/engine/langchain_detect_test.go
+++ b/internal/engine/langchain_detect_test.go
@@ -73,34 +73,38 @@ func TestDetect_LangChain_PromptsChainsTools(t *testing.T) {
 		t.Errorf("expected >=2 Schema (prompt) entities, got %d", c)
 	}
 
-	// chain_composition: .pipe() stages (captures upstream runnable name) +
-	// RunnableSequence.from.
+	// chain_composition: .pipe() stages (captures upstream runnable name).
 	if !names["prompt"] {
 		t.Errorf("expected .pipe() chain stage named 'prompt'; got %v", keys(names))
 	}
-	if !names["RunnableSequence.from("] {
-		t.Errorf("expected RunnableSequence.from composition entity; got %v", keys(names))
-	}
 
-	// tool_use_detection: the three tool declaration idioms + bindTools.
+	// tool_use_detection: the two `new`-constructor tool declaration idioms.
 	if !names["DynamicTool"] {
 		t.Errorf("expected DynamicTool entity; got %v", keys(names))
 	}
 	if !names["DynamicStructuredTool"] {
 		t.Errorf("expected DynamicStructuredTool entity; got %v", keys(names))
 	}
-	if !names[".bindTools("] {
-		t.Errorf("expected bindTools entity; got %v", keys(names))
-	}
-	// tool(async (...) factory.
-	var sawToolFactory bool
-	for n := range names {
-		if n == "tool(async (" || n == "tool((" {
-			sawToolFactory = true
+
+	// #6916 Tier C. Three `name_group: 0` rules in this file were DELETED, and
+	// this test used to require the entities they minted:
+	//
+	//	Operation "RunnableSequence.from("   RunnableSequence.from([...])
+	//	Operation "tool(async ("             the tool() factory
+	//	Operation ".bindTools("              model.bindTools([...])
+	//
+	// Each Name was the whole regex match — a call-site fragment, trailing paren
+	// included — so nothing could ever reference it. The assertions are inverted
+	// here rather than deleted: an absence with no assertion behind it is how a
+	// deleted rule comes back unnoticed, and this test drives the same source as
+	// the surviving assertions above, so it is the cheapest place to grade it.
+	// The full site table and the per-site controls live in
+	// tier_c_marker_deletion_6916_test.go.
+	for _, gone := range []string{"RunnableSequence.from(", ".bindTools(", "tool(async (", "tool(("} {
+		if names[gone] {
+			t.Errorf("#6916 Tier C: the deleted marker rule is back — Operation %q "+
+				"is in the graph again; got %v", gone, keys(names))
 		}
-	}
-	if !sawToolFactory {
-		t.Errorf("expected tool() factory entity; got %v", keys(names))
 	}
 }
 

--- a/internal/engine/precision_dedup.go
+++ b/internal/engine/precision_dedup.go
@@ -279,9 +279,18 @@ func symbolicID(kind, name string) string {
 //
 // This classifier is deliberately NARROW. The codebase legitimately uses
 // non-identifier Operation names for call-idiom detection — e.g.
-// "RunnableSequence.from(", ".bindTools(", "tool(async (", "createTRPCClient<".
-// Those must be KEPT. So we drop ONLY three concrete statement shapes that carry
-// no architectural signal:
+// "createTRPCClient<" (javascript_typescript/frameworks/trpc.yaml). Those must
+// be KEPT. So we drop ONLY three concrete statement shapes that carry no
+// architectural signal:
+//
+// #6916 Tier C note: three of the four examples this comment used to list —
+// "RunnableSequence.from(", ".bindTools(", "tool(async (" — no longer exist.
+// They were `name_group: 0` marker rules in
+// javascript_typescript/frameworks/langchain.yaml and were DELETED at the rule
+// level rather than filtered here. Their presence in this list was also the
+// evidence that #6916's "already dropped downstream as Operation noise" claim
+// about them was wrong: this pass never dropped them, and the langchain site
+// it WAS written for is the python `@tool` decorator, case (1) below.
 //
 //  1. Bare decorator text — name starts with `@` and the remainder is a plain
 //     identifier with no call/args (e.g. "@tool", "@property"). A decorator

--- a/internal/engine/rules/javascript_typescript/frameworks/langchain.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/langchain.yaml
@@ -38,11 +38,10 @@ source_patterns:
     entity_type: Operation
     name_group: 1
     scope: file
-  # RunnableSequence.from([...]) — the explicit composition constructor.
-  - pattern: "RunnableSequence\\.from\\s*\\("
-    entity_type: Operation
-    name_group: 0
-    scope: file
+  # #6916 Tier C: `RunnableSequence.from(` used to mint an Operation entity
+  # literally NAMED "RunnableSequence.from(" via `name_group: 0`, trailing
+  # paren included. The `.pipe()` rule above is the bindable form of the same
+  # LCEL composition fact (it captures the upstream runnable variable).
   # --- prompt_template_extraction (#2865) ---------------------------------
   # ChatPromptTemplate.fromMessages(...) / .fromTemplate(...) and the bare
   # PromptTemplate.fromTemplate(...) factory. Captures the template-class +
@@ -63,15 +62,15 @@ source_patterns:
     entity_type: Operation
     name_group: 1
     scope: file
-  - pattern: "\\btool\\s*\\(\\s*(?:async\\s*)?\\("
-    entity_type: Operation
-    name_group: 0
-    scope: file
-  # .bindTools([...]) — attaches a tool set to a model (function-calling).
-  - pattern: "\\.bindTools\\s*\\("
-    entity_type: Operation
-    name_group: 0
-    scope: file
+  # #6916 Tier C: the `tool(async (` and `.bindTools(` rules used to mint
+  # Operation entities literally NAMED "tool(async (" and ".bindTools(" via
+  # `name_group: 0` — call-site fragments with no referent. Both survive
+  # dropStatementNoiseOperations (measured: its noise predicate keys on a
+  # leading "@", a bare "=", or a leading statement keyword, none of which a
+  # trailing-paren fragment has), so this IS a deliberate removal of entities
+  # that reach the graph, not the deletion of an already-suppressed rule. The
+  # `new DynamicTool(...)` / `new DynamicStructuredTool(...)` rule above keeps
+  # the named form of the tool-declaration fact.
   # --- agents -------------------------------------------------------------
   # Agent factory (createReactAgent, createToolCallingAgent, …).
   - pattern: "create\\w+Agent\\s*\\("

--- a/internal/engine/rules/kotlin/frameworks/kmp.yaml
+++ b/internal/engine/rules/kotlin/frameworks/kmp.yaml
@@ -79,11 +79,21 @@ source_patterns:
     name_group: 1
     scope: class
 
-  # kotlin { sourceSets { ... } } — source set configuration block
-  - pattern: "\\bsourceSets\\s*\\{"
-    entity_type: Config
-    name_group: 0
-    scope: file
+  # #6916 Tier C: `sourceSets {` used to mint a Config entity literally NAMED
+  # "sourceSets {" via `name_group: 0` — a Gradle DSL block opener, not a thing
+  # in the repo. 10 entities on the 60-repo corpus, the 7th-biggest name_group:0
+  # producer, all unbound (no relationship_rule in the kotlin bucket names
+  # Config as an endpoint). The named, bindable form of the same information is
+  # the `val <name>Main by getting` rule below (5 Module entities on the same
+  # corpus: backendMain, frontendMain, jsMain).
+  #
+  # Measured limit, recorded rather than glossed: all 10 deleted markers came
+  # from ktor/ktor-samples build.gradle.kts files that spell their source sets
+  # `jvmMain.dependencies { … }`, which the Module rule below does NOT capture —
+  # so those six files are left with no source-set node at all. What is lost
+  # there is a per-file boolean that could not name WHICH source sets exist; a
+  # rule for the property-access spelling is the fix if that fact is wanted, and
+  # it belongs with the other Tier-D captures, not here.
 
   # val commonMain by getting / val androidMain by getting — source set variable
   - pattern: "val\\s+(\\w+Main)\\s+by\\s+(?:getting|creating)"

--- a/internal/engine/rules/ruby/frameworks/sinatra.yaml
+++ b/internal/engine/rules/ruby/frameworks/sinatra.yaml
@@ -69,11 +69,19 @@ source_patterns:
     name_group: 1
     scope: class
 
-  # Helper block: helpers do ... end
-  - pattern: "(?m)^\\s*helpers\\s+do"
-    entity_type: Service
-    name_group: 0
-    scope: file
+  # #6916 Tier C: `helpers do` used to mint a Service entity literally NAMED
+  # "helpers do" via `name_group: 0` — the matched line, not a helper. Nothing
+  # could bind to it: the only rule targeting Service (Route CALLS Service,
+  # below) takes its target from `(\\w+_helper|authenticate!|authorize!)`, a
+  # method name, which can never equal "helpers do". The helper METHODS inside
+  # the block are already extracted by the Ruby extractor as SCOPE.Operation
+  # (that is what the Route CALLS edge binds to), and the `helpers <Module>`
+  # include form below keeps its real, bindable name. Ruby also has a properly
+  # named producer for the block itself — internal/custom/ruby/sinatra_deep.go
+  # emits SCOPE.Pattern "sinatra_helpers_block" — so this rule was a parallel
+  # shadow population beside it (whether that extractor runs on a given index is
+  # gated separately by GRAFEL_INPROC_CUSTOM_EXTRACTORS; no claim is made here
+  # about which indexes carry it).
 
   # Helper include: helpers HelperModule
   #
@@ -89,17 +97,21 @@ source_patterns:
     name_group: 1
     scope: file
 
-  # Before filter: before "/path" do or before do
-  - pattern: "(?m)^\\s*before\\s+(?:[\"']([^\"']+)[\"']\\s+)?do"
-    entity_type: Middleware
-    name_group: 0
-    scope: file
-
-  # After filter: after "/path" do or after do
-  - pattern: "(?m)^\\s*after\\s+(?:[\"']([^\"']+)[\"']\\s+)?do"
-    entity_type: Middleware
-    name_group: 0
-    scope: file
+  # #6916 Tier C: the `before`/`after` filter rules used to mint Middleware
+  # entities literally NAMED "before '/admin/*' do" / "after do" via
+  # `name_group: 0` — the whole matched line. Deleted rather than renamed to
+  # the optional path group: `extractGroupFromIndex` returns "" for an
+  # unmatched optional group and the detector then skips the match, so
+  # `name_group: 1` would silently stop extracting bare `before do` / `after
+  # do` altogether — a recall change wearing a rename's clothes. Nothing bound
+  # to either name: the only rule targeting Middleware (Controller
+  # REGISTERED_ON Middleware, below) takes its target from `use
+  # Rack::Session::Cookie`, a module constant. `error <code> do` below is the
+  # one filter-family rule that already carries a real name and it stays. As
+  # with `helpers do` above, Ruby has a properly named producer for the same
+  # construct — internal/custom/ruby/middleware.go emits SCOPE.Pattern
+  # "sinatra_filter:before" / "sinatra_filter:before:/admin/*" — so what is
+  # deleted here is the shadow, not the fact.
 
   # Configure block: configure :production do
   - pattern: "(?m)^\\s*configure\\s*(?::(\\w+))?\\s*do"
@@ -113,11 +125,13 @@ source_patterns:
     name_group: 1
     scope: file
 
-  # Sinatra::Application classic-style app boot
-  - pattern: "Sinatra::Application\\.run!"
-    entity_type: Config
-    name_group: 0
-    scope: file
+  # #6916 Tier C: `Sinatra::Application.run!` used to mint a Config entity
+  # literally NAMED "Sinatra::Application.run!" via `name_group: 0` — a boot
+  # call site, not a configuration object. It made the sinatra `Config
+  # ROUTES_TO Controller` rule dangling BY CONSTRUCTION: that rule sources on
+  # `map "/api" do`, i.e. a mount PATH, so the only Config entity the framework
+  # minted could never be the edge's endpoint. The `configure :<env> do` rule
+  # above is the real, named Config producer and is kept.
 
 # relationship_rules: regex patterns that produce edges between entities.
 relationship_rules:

--- a/internal/engine/rules/rust/frameworks/actix_web.yaml
+++ b/internal/engine/rules/rust/frameworks/actix_web.yaml
@@ -86,11 +86,19 @@ source_patterns:
     name_group: 0
     scope: file
 
-  # #[actix_web::main] entry point
-  - pattern: "#\\[actix_web\\s*::\\s*main\\s*\\]"
-    entity_type: Config
-    name_group: 0
-    scope: file
+  # #6916 Tier C: the `#[actix_web::main]` attribute-macro marker used to mint a
+  # Config entity literally NAMED "#[actix_web::main]" via `name_group: 0` — a
+  # per-file boolean ("this file has the actix main macro") with no referent for
+  # any edge to point at, and no relationship_rule in the rust bucket names
+  # Config as an endpoint, so it carried zero edges. It was also the THIRD
+  # marker on the same concept: `HttpServer::new(` and `App::new()` below fire
+  # on the same main.rs and mean the same thing ("server entry point"). Those
+  # two are kept (Tier D still owes them a real name); this one is deleted
+  # rather than renamed because a bare attribute macro has no name to capture.
+  # The attribute is not lost as a FACT either: internal/substrate/
+  # entry_points_rust.go lists `actix_web::main` in rustLifecycleAttrs and reads
+  # it for entry-point classification, which is the modelled form of exactly
+  # what this marker gestured at.
 
   # App::new() — application builder (middleware config point)
   - pattern: "App\\s*::\\s*new\\s*\\(\\s*\\)"

--- a/internal/engine/sinatra_multiline_anchor_6917_test.go
+++ b/internal/engine/sinatra_multiline_anchor_6917_test.go
@@ -157,8 +157,40 @@ func TestIssue6917_ModularSinatraAppYieldsRoutes(t *testing.T) {
 		t.Errorf("configure :production not extracted as Config; Configs: %v",
 			entity6917Names(res, "Config"))
 	}
-	if len(entity6917Names(res, "Service")) == 0 {
-		t.Errorf("expected the `helpers do` block as a Service, got none")
+	// #6916 Tier C deleted the `helpers do` BLOCK rule (a Service named after the
+	// whole matched line), so the Service entities this fixture yields now come
+	// from the `helpers <Module>` INCLUDE rule alone. Naming that expectation is
+	// what keeps the assertion honest: `len(Service) != 0` would have gone on
+	// passing if the include rule had died and the block rule survived.
+	// This fixture carries only the BLOCK form (`helpers do`), not the include
+	// form (`helpers AuthHelpers`), so after the deletion it yields no Service at
+	// all. Both directions are asserted: the name that must not come back, and
+	// the set that must stay empty. The positive controls for "this file is still
+	// being extracted" are the Route / Controller / Config / Middleware
+	// assertions above; the include form's own recall is graded by
+	// internal/quality/golden/ruby-sinatra-modular-mini (Service AuthHelpers,
+	// must_exist) and by tier_c_marker_deletion_6916_test.go.
+	if got := entity6917Names(res, "Service"); len(got) != 0 {
+		t.Errorf("expected no Service entities from a file whose only helpers construct "+
+			"is the deleted `helpers do` block, got %v", got)
+	}
+	if has6917Entity(res, "Service", "helpers do") {
+		t.Errorf("#6916 Tier C: the deleted `helpers do` block rule is back — Service "+
+			"%q is in the graph again; Services: %v", "helpers do",
+			entity6917Names(res, "Service"))
+	}
+	// The same for the two filter rules. `error 404 do` is the Middleware
+	// producer that REMAINS, and it is what the assertion above this one now
+	// rests on, so the deleted names are named explicitly here.
+	for _, gone := range []string{"before '/admin/*' do", "after do"} {
+		if has6917Entity(res, "Middleware", gone) {
+			t.Errorf("#6916 Tier C: the deleted filter rule is back — Middleware %q is "+
+				"in the graph again; Middleware: %v", gone, entity6917Names(res, "Middleware"))
+		}
+	}
+	if !has6917Entity(res, "Middleware", "404") {
+		t.Errorf("`error 404 do` is the filter-family rule Tier C KEPT and it stopped "+
+			"firing; Middleware: %v", entity6917Names(res, "Middleware"))
 	}
 }
 
@@ -249,6 +281,14 @@ func TestIssue6917_MultilinePatternsDoNotOverFire(t *testing.T) {
 		// would accept `Whatever`, so ONLY the line anchor keeps it out — which
 		// is what makes this row grade the anchor rather than the capture.
 		{"Service", "Whatever"},
+		// #6916 Tier C: this row used to sit in the KNOWN-AND-REACHABLE list
+		// below, pinned in the positive direction with the instruction "whoever
+		// teaches the detector about heredocs is told by a red test to come here
+		// and flip these into the forbidden list". The rule it depended on — the
+		// `helpers do` block rule — is deleted instead, so the heredoc's
+		// `helpers do` line can no longer mint anything and the row moves here,
+		// which is the direction that grades the deletion.
+		{"Service", "helpers do"},
 	}
 	for _, f := range forbidden {
 		if has6917Entity(res, f.kind, f.name) {
@@ -271,10 +311,6 @@ func TestIssue6917_MultilinePatternsDoNotOverFire(t *testing.T) {
 	for _, known := range []struct{ kind, name string }{
 		{"Route", "/from-a-heredoc"},
 		{"Config", "from_a_heredoc"},
-		// The heredoc's `helpers do` line mints a Service too. It was the one
-		// YAML-minted heredoc entity the pin did not cover, because the sweeps
-		// below covered Route and Middleware but not Service.
-		{"Service", "helpers do"},
 	} {
 		if !has6917Entity(res, known.kind, known.name) {
 			t.Errorf("heredoc over-firing is no longer happening for %s %q — good news; "+

--- a/internal/engine/tier_c_marker_deletion_6916_test.go
+++ b/internal/engine/tier_c_marker_deletion_6916_test.go
@@ -1,0 +1,422 @@
+package engine
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// #6916 Tier C — the nine `name_group: 0` source_patterns that should not have
+// been entity rules at all, deleted rather than renamed:
+//
+//	rust/frameworks/actix_web.yaml:90    Config    "#[actix_web::main]"
+//	kotlin/frameworks/kmp.yaml:83        Config    "sourceSets {"
+//	ruby/frameworks/sinatra.yaml:73      Service   "helpers do"
+//	ruby/frameworks/sinatra.yaml:93      Middleware "before '/admin/*' do"
+//	ruby/frameworks/sinatra.yaml:99      Middleware "after do"
+//	ruby/frameworks/sinatra.yaml:117     Config    "Sinatra::Application.run!"
+//	javascript_typescript/frameworks/langchain.yaml:42  Operation "RunnableSequence.from("
+//	javascript_typescript/frameworks/langchain.yaml:66  Operation "tool(async ("
+//	javascript_typescript/frameworks/langchain.yaml:71  Operation ".bindTools("
+//
+// (Line numbers are the pre-deletion ones, from the measurement arm's table.)
+//
+// A DELETION IS UNGRADEABLE BY A RECALL TEST. Nothing in the suite fails when a
+// rule that mints an entity nobody asked for comes back — only a forbidden
+// assertion can see it. Every site below therefore carries:
+//
+//   - an input that PROVABLY produced the marker before the deletion (each was
+//     driven through the real detector on the parent commit and printed), and
+//   - a positive control from the SAME file: an entity the surviving patterns
+//     still mint. Without it these absence assertions would pass on a fixture
+//     that silently stopped producing anything at all — for instance if the
+//     whole rule file failed to load.
+//
+// The sibling axis is named explicitly, because enumerating one axis is what
+// makes its neighbour look covered. Each of the four touched rule files KEEPS
+// patterns that were not part of Tier C, and TestIssue6916_TierCSurvivingSiblings
+// pins those by name:
+//
+//	actix_web.yaml  keeps Config "HttpServer::new(" and Config "App::new()"
+//	                (Tier D still owes them a real name) and Middleware from .wrap()
+//	kmp.yaml        keeps Module <name>Main from `val commonMain by getting`
+//	sinatra.yaml    keeps Route, Controller, Config from `configure :<env> do`,
+//	                Middleware from `error <code> do`, Service from `helpers <Module>`
+//	langchain.yaml  keeps Operation from `.pipe(`, Operation from `new DynamicTool(`,
+//	                Schema from the prompt-template factories, and the Tier D
+//	                Service from `create\w+Agent(`
+//
+// Held constant everywhere: the surviving patterns' spellings, `name_group` on
+// every rule that was not deleted, and the four rule files' `frameworks:`
+// detection blocks.
+
+// tierC6916Site is one deleted rule site.
+type tierC6916Site struct {
+	rule string // rule file:line as it stood before the deletion
+	lang string
+	path string
+
+	// src is an input that minted `marker` before the deletion.
+	src string
+
+	// marker is the "<Kind>:<Name>" the deleted `name_group: 0` rule produced.
+	// It must never come back.
+	marker string
+
+	// control is a "<Kind>:<Name>" the SAME src still mints from a rule that
+	// was NOT deleted. It is what makes the absence above evidence.
+	control string
+}
+
+const tierC6916ActixMain = `use actix_web::{web, App, HttpServer, middleware::Logger};
+
+async fn health() -> &'static str { "ok" }
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| App::new().wrap(Logger::default()).route("/health", web::get().to(health)))
+        .bind(("127.0.0.1", 8080))?
+        .run()
+        .await
+}
+`
+
+const tierC6916KmpSourceSets = `plugins {
+    kotlin("multiplatform")
+}
+
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("io.ktor:ktor-client-core:2.3.0")
+            }
+        }
+    }
+}
+`
+
+// The sinatra fixtures mirror internal/quality/golden/ruby-sinatra-modular-mini:
+// every construct is INDENTED inside the class body and none is the first line
+// of the file, which is the shape #6917 restored.
+const tierC6916SinatraHelpersBlock = `require 'sinatra/base'
+
+class MyApp < Sinatra::Base
+  configure :production do
+    set :show_exceptions, false
+  end
+
+  helpers AuthHelpers
+
+  helpers do
+    def json_helper(payload)
+      payload.to_json
+    end
+  end
+end
+`
+
+const tierC6916SinatraBeforeWithPath = `require 'sinatra/base'
+
+class MyApp < Sinatra::Base
+  before '/admin/*' do
+    halt 401 unless authenticate!
+  end
+
+  error 404 do
+    'not found'
+  end
+end
+`
+
+// The BARE spellings are the shape the measurement arm flagged as the Tier C
+// trap: `before`/`after` already carry an OPTIONAL group 1 (the path), and
+// extractGroupFromIndex returns "" for an unmatched optional group, after which
+// the detector skips the match. So `name_group: 1` would have silently stopped
+// extracting these two files while leaving the path-carrying spelling above
+// alive — a recall change wearing a rename's clothes. Both spellings are graded
+// here so the deletion is pinned on the shape a rename would NOT have changed
+// and on the shape it would.
+const tierC6916SinatraBeforeBare = `require 'sinatra/base'
+
+class MyApp < Sinatra::Base
+  before do
+    @started = Time.now
+  end
+
+  error 404 do
+    'not found'
+  end
+end
+`
+
+const tierC6916SinatraAfterWithPath = `require 'sinatra/base'
+
+class MyApp < Sinatra::Base
+  after '/admin/*' do
+    response.headers['X-Admin'] = '1'
+  end
+
+  error 500 do
+    'boom'
+  end
+end
+`
+
+const tierC6916SinatraAfterBare = `require 'sinatra/base'
+
+class MyApp < Sinatra::Base
+  after do
+    response.headers['X-App'] = 'MyApp'
+  end
+
+  error 500 do
+    'boom'
+  end
+end
+`
+
+const tierC6916SinatraClassicBoot = `require 'sinatra'
+
+configure :production do
+  set :show_exceptions, false
+end
+
+get '/invoices' do
+  'ok'
+end
+
+Sinatra::Application.run!
+`
+
+const tierC6916LangchainSequence = `import { RunnableSequence } from "@langchain/core/runnables";
+
+const chain = RunnableSequence.from([prompt, model]);
+const piped = prompt.pipe(model);
+`
+
+const tierC6916LangchainToolFactory = `import { tool } from "@langchain/core/tools";
+
+const lookup = tool(async (input) => input, { name: "lookup" });
+const declared = new DynamicTool({ name: "declared", func: async () => "x" });
+`
+
+const tierC6916LangchainBindTools = `import { ChatOpenAI } from "@langchain/openai";
+
+const model = new ChatOpenAI({});
+const bound = model.bindTools([lookup]);
+const declared = new DynamicTool({ name: "declared", func: async () => "x" });
+`
+
+var tierC6916Sites = []tierC6916Site{
+	{
+		rule: "rust/frameworks/actix_web.yaml:90", lang: "rust", path: "src/main.rs",
+		src:    tierC6916ActixMain,
+		marker: `Config:#[actix_web::main]`,
+		// The .wrap(Logger) Middleware, NOT one of the two surviving Config
+		// markers: using a Config as the control would make "the deleted Config
+		// is gone" and "Config extraction still works" the same assertion.
+		control: "Middleware:Logger",
+	},
+	{
+		rule: "kotlin/frameworks/kmp.yaml:83", lang: "kotlin", path: "build.gradle.kts",
+		src:    tierC6916KmpSourceSets,
+		marker: "Config:sourceSets {",
+		// The named form of the very information the deleted marker gestured at.
+		control: "Module:commonMain",
+	},
+	{
+		rule: "ruby/frameworks/sinatra.yaml:73", lang: "ruby", path: "app.rb",
+		src:    tierC6916SinatraHelpersBlock,
+		marker: "Service:helpers do",
+		// The `helpers <Module>` include form — a DIFFERENT rule in the same
+		// file, kept, and the one that carries a real bindable name.
+		control: "Service:AuthHelpers",
+	},
+	{
+		rule: "ruby/frameworks/sinatra.yaml:93", lang: "ruby", path: "app.rb",
+		src:     tierC6916SinatraBeforeWithPath,
+		marker:  "Middleware:before '/admin/*' do",
+		control: "Middleware:404",
+	},
+	{
+		rule: "ruby/frameworks/sinatra.yaml:93 (bare)", lang: "ruby", path: "app.rb",
+		src:     tierC6916SinatraBeforeBare,
+		marker:  "Middleware:before do",
+		control: "Middleware:404",
+	},
+	{
+		rule: "ruby/frameworks/sinatra.yaml:99", lang: "ruby", path: "app.rb",
+		src:     tierC6916SinatraAfterWithPath,
+		marker:  "Middleware:after '/admin/*' do",
+		control: "Middleware:500",
+	},
+	{
+		rule: "ruby/frameworks/sinatra.yaml:99 (bare)", lang: "ruby", path: "app.rb",
+		src:     tierC6916SinatraAfterBare,
+		marker:  "Middleware:after do",
+		control: "Middleware:500",
+	},
+	{
+		rule: "ruby/frameworks/sinatra.yaml:117", lang: "ruby", path: "boot.rb",
+		src:    tierC6916SinatraClassicBoot,
+		marker: "Config:Sinatra::Application.run!",
+		// `configure :production do` — the file's OTHER Config rule, kept, and
+		// the reason "no Config at all" is not the assertion here.
+		control: "Config:production",
+	},
+	{
+		rule: "javascript_typescript/frameworks/langchain.yaml:42", lang: "typescript", path: "src/chain.ts",
+		src:    tierC6916LangchainSequence,
+		marker: "Operation:RunnableSequence.from(",
+		// `.pipe()` names the upstream runnable — the bindable form of the same
+		// LCEL composition fact.
+		control: "Operation:prompt",
+	},
+	{
+		rule: "javascript_typescript/frameworks/langchain.yaml:66", lang: "typescript", path: "src/tools.ts",
+		src:     tierC6916LangchainToolFactory,
+		marker:  "Operation:tool(async (",
+		control: "Operation:DynamicTool",
+	},
+	{
+		rule: "javascript_typescript/frameworks/langchain.yaml:71", lang: "typescript", path: "src/model.ts",
+		src:     tierC6916LangchainBindTools,
+		marker:  "Operation:.bindTools(",
+		control: "Operation:DynamicTool",
+	},
+}
+
+// TestIssue6916_TierCMarkerIsNoLongerMinted is the change itself, in the only
+// direction a deletion can be graded: the marker entity is absent from an input
+// that produced it before, and the same input still produces something.
+func TestIssue6916_TierCMarkerIsNoLongerMinted(t *testing.T) {
+	for _, s := range tierC6916Sites {
+		t.Run(s.rule, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, s.path, s.lang, s.src))
+
+			if slices.Contains(ids, s.marker) {
+				t.Errorf("%s: the deleted #6916 Tier C rule is back — %q is in the graph again. "+
+					"It is a per-file boolean marker named after the whole regex match, with no "+
+					"referent for any edge to point at. Entities:\n  %s",
+					s.rule, s.marker, strings.Join(ids, "\n  "))
+			}
+			if !slices.Contains(ids, s.control) {
+				t.Errorf("%s: positive control missing — this input no longer mints %q, so the "+
+					"absence of %q above proves nothing (an unloadable rule file would pass it). "+
+					"Entities:\n  %s",
+					s.rule, s.control, s.marker, strings.Join(ids, "\n  "))
+			}
+		})
+	}
+}
+
+// TestIssue6916_TierCSurvivingSiblings pins the NEIGHBOUR axis. Three of the
+// four touched rule files keep patterns of exactly the same shape as the deleted
+// ones — actix_web keeps two other `name_group: 0` Config markers on purpose,
+// because they are Tier D (they name a thing that could be captured) rather than
+// Tier C. A deletion that took a sibling with it would be invisible to the test
+// above, whose only positive control per site is one entity.
+func TestIssue6916_TierCSurvivingSiblings(t *testing.T) {
+	for _, tc := range []struct {
+		name, path, lang, src string
+		want                  []string
+	}{
+		{
+			// The two Config markers actix_web KEEPS. They are still
+			// `name_group: 0` and still ugly; Tier C deleted only the third,
+			// the attribute macro, which has no name to capture at all.
+			name: "actix_web keeps HttpServer::new( and App::new(", path: "src/main.rs", lang: "rust",
+			src:  tierC6916ActixMain,
+			want: []string{"Config:HttpServer::new(", "Config:App::new()", "Middleware:Logger", "Route:/health"},
+		},
+		{
+			name: "kmp keeps the sourceSets MEMBERS", path: "build.gradle.kts", lang: "kotlin",
+			src:  tierC6916KmpSourceSets,
+			want: []string{"Module:commonMain"},
+		},
+		{
+			name: "sinatra keeps routes, the class, configure, error and helpers <Module>",
+			path: "app.rb", lang: "ruby",
+			src: `require 'sinatra/base'
+
+class MyApp < Sinatra::Base
+  configure :production do
+    set :show_exceptions, false
+  end
+
+  helpers AuthHelpers
+
+  get '/invoices' do
+    'ok'
+  end
+
+  error 404 do
+    'not found'
+  end
+end
+`,
+			want: []string{"Route:/invoices", "Controller:MyApp", "Config:production",
+				"Middleware:404", "Service:AuthHelpers"},
+		},
+		{
+			name: "langchain keeps pipe, DynamicTool, the prompt templates and the agent factory",
+			path: "src/chain.ts", lang: "typescript",
+			src: `import { ChatPromptTemplate } from "@langchain/core/prompts";
+import { createReactAgent } from "langchain/agents";
+
+const prompt2 = ChatPromptTemplate.fromMessages([]);
+const piped = prompt.pipe(model);
+const declared = new DynamicTool({ name: "declared", func: async () => "x" });
+const agent = createReactAgent({ llm: model, tools: [declared] });
+`,
+			want: []string{"Operation:prompt", "Operation:DynamicTool",
+				"Schema:ChatPromptTemplate", "Service:createReactAgent("},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ids := entityIDs6916(detect6916(t, tc.path, tc.lang, tc.src))
+			for _, w := range tc.want {
+				if !slices.Contains(ids, w) {
+					t.Errorf("a pattern NOT part of Tier C stopped firing: %q is missing. "+
+						"Entities:\n  %s", w, strings.Join(ids, "\n  "))
+				}
+			}
+		})
+	}
+}
+
+// TestIssue6916_TierCLangchainMarkersWereNotSuppressedDownstream grades the
+// claim this tier's langchain entry rested on — that the three JS `Operation`
+// markers were "already dropped downstream as Operation noise, so the rules are
+// dead weight". They were NOT.
+//
+// dropStatementNoiseOperations (precision_dedup.go) drops an `Operation` whose
+// Name starts with `@`, contains a bare `=`, or opens with a statement keyword.
+// A trailing-paren call fragment has none of those, so all three names sailed
+// through the pass and reached the graph — which makes the deletion above a
+// deliberate REMOVAL of entities that existed, not the tidying of an inert rule.
+// The python `@tool` site (python/frameworks/langchain.yaml, untouched here) is
+// the one the pass's own doc comment names, and it IS dropped: case (1).
+//
+// If the noise predicate is ever widened to cover call fragments, this test
+// fails and should be revisited rather than deleted — the point it pins is that
+// "already suppressed" cannot be assumed from the doc comment.
+func TestIssue6916_TierCLangchainMarkersWereNotSuppressedDownstream(t *testing.T) {
+	for _, name := range []string{
+		"RunnableSequence.from(",
+		"tool(async (",
+		".bindTools(",
+	} {
+		if isStatementNoiseOperationName(name) {
+			t.Errorf("%q is dropped by dropStatementNoiseOperations after all — the Tier C "+
+				"justification recorded in the rule comments (that the deletion removes "+
+				"entities that DID reach the graph) needs re-reading.", name)
+		}
+	}
+	// The control: the shape the pass was written for, still dropped.
+	if !isStatementNoiseOperationName("@tool") {
+		t.Error(`positive control: "@tool" is no longer treated as statement noise, so the ` +
+			`comparison above says nothing about the predicate`)
+	}
+}

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -246,12 +246,12 @@
       "relationship_extracted_total": 35
     },
     "ruby-sinatra-modular-mini": {
-      "entity_found": 13,
-      "entity_expected": 13,
+      "entity_found": 10,
+      "entity_expected": 10,
       "relationship_found": 3,
       "relationship_expected": 3,
-      "entity_extracted_total": 61,
-      "relationship_extracted_total": 118
+      "entity_extracted_total": 58,
+      "relationship_extracted_total": 115
     },
     "rust-tokio-mini": {
       "entity_found": 16,

--- a/internal/quality/golden/ruby-sinatra-modular-mini/expected.json
+++ b/internal/quality/golden/ruby-sinatra-modular-mini/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_name": "ruby-sinatra-modular-mini",
   "language": "ruby",
-  "description": "Modular-style Sinatra app (#6917): routes, filters, error handlers and a configure block all live INDENTED inside `class MyApp < Sinatra::Base`, and every file opens with `require` lines rather than a DSL call. That shape is the whole point — sinatra.yaml's `^\\s*`-anchored patterns were compiled without `(?m)`, so `^` meant start-of-TEXT and every one of them could only fire on a file's opening construct. Against this fixture the pre-fix binary extracted ZERO Route, Middleware, Config and Service entities from the YAML rules; the four http_endpoint_definition entities came from the separate Ruby extractor and are unaffected, which is exactly why the defect could hide. The fixture varies ONE axis — the vertical position of each Sinatra construct (never line 1) — and holds the constructs themselves at their idiomatic spellings.",
+  "description": "Modular-style Sinatra app (#6917): routes, filters, error handlers and a configure block all live INDENTED inside `class MyApp < Sinatra::Base`, and every file opens with `require` lines rather than a DSL call. That shape is the whole point — sinatra.yaml's `^\\s*`-anchored patterns were compiled without `(?m)`, so `^` meant start-of-TEXT and every one of them could only fire on a file's opening construct. Against this fixture the pre-fix binary extracted ZERO Route, Middleware, Config and Service entities from the YAML rules; the four http_endpoint_definition entities came from the separate Ruby extractor and are unaffected, which is exactly why the defect could hide. The fixture varies ONE axis — the vertical position of each Sinatra construct (never line 1) — and holds the constructs themselves at their idiomatic spellings. #6916 Tier C re-baseline: three `name_group: 0` marker rules (`helpers do`, `before ... do`, `after ... do`) were deleted, so their three rows moved from expected_entities to forbidden_entities and must-have recall fell 13 -> 10 by design. The source tree is UNCHANGED — every construct those rules matched is still in src/app.rb, which is what makes the forbidden rows reachable.",
   "expected_entities": [
     { "name": "/invoices", "kind": "Route", "source_file": "app.rb", "must_exist": true,
       "note": "#6917 recall arm. `get '/invoices' do` and `post '/invoices' do` sit indented inside the class body. Extracted ZERO Routes before the fix." },
@@ -15,12 +15,6 @@
       "note": "`configure :production do`, indented." },
     { "name": "404", "kind": "Middleware", "source_file": "app.rb", "must_exist": true,
       "note": "`error 404 do`, indented and near the END of the file — the furthest possible position from start-of-text." },
-    { "name": "before '/admin/*' do", "kind": "Middleware", "source_file": "app.rb", "must_exist": true,
-      "note": "FINDING: the name is the whole matched line because the rule uses `name_group: 0`. Ugly, pre-existing, and pinned so a later cleanup is a deliberate change rather than an accident." },
-    { "name": "after do", "kind": "Middleware", "source_file": "app.rb", "must_exist": true },
-
-    { "name": "helpers do", "kind": "Service", "source_file": "app.rb", "must_exist": true,
-      "note": "The `helpers do ... end` block form." },
     { "name": "AuthHelpers", "kind": "Service", "source_file": "app.rb", "must_exist": true,
       "note": "The `helpers AuthHelpers` include form — a DIFFERENT rule from the block above, and the one whose capture was tightened from `\\w+` to `[A-Z]\\w*`. Present so that tightening is graded rather than assumed." },
 
@@ -31,6 +25,12 @@
     { "name": "http:DELETE:/invoices/{id}", "kind": "http_endpoint_definition", "source_file": "app.rb", "must_exist": true }
   ],
   "forbidden_entities": [
+    { "name": "before '/admin/*' do", "kind": "Middleware", "must_exist": false,
+      "note": "#6916 Tier C. These three rows were `must_exist` until Tier C, with the note \"the name is the whole matched line because the rule uses `name_group: 0`. Ugly, pre-existing, and pinned so a later cleanup is a deliberate change rather than an accident.\" This is that deliberate change: the `before`/`after` filter rules and the `helpers do` block rule are DELETED, because a Middleware named after the matched line has no referent an edge can point at (the only rule targeting Middleware sources on `use <Constant>`; the only rule targeting Service sources on a `<name>_helper` method), and naming them from their optional path group instead would have silently stopped extracting the BARE `before do` / `after do` spellings altogether. Recall falls 13 -> 10 must-haves here, deliberately. The rows are kept in the forbidden direction because a recall gate cannot see a rule coming back — only a forbidden row can." },
+    { "name": "after do", "kind": "Middleware", "must_exist": false,
+      "note": "#6916 Tier C, as above. src/app.rb still contains the bare `after do` filter, so this row is reachable: restoring the deleted rule turns the fixture red." },
+    { "name": "helpers do", "kind": "Service", "must_exist": false,
+      "note": "#6916 Tier C, as above. src/app.rb still contains the `helpers do ... end` block, and `helpers AuthHelpers` above it is the held-constant control: the include form keeps its real name and stays a must-have, so this row grades the deletion of the BLOCK rule specifically rather than the disappearance of sinatra Service extraction." },
     { "name": "do", "kind": "Service", "must_exist": false,
       "note": "#6917 forbidden arm. The `helpers <Module>` include rule used to capture `(\\w+)`, which matched the `do` of `helpers do` and minted a Service entity literally named \"do\" next to the real block entity. It could not fire while the anchor defect kept both patterns dead; restoring `(?m)` made it reachable, so the capture was narrowed to a Ruby constant `([A-Z]\\w*(?:::\\w+)*)`. Reverting that narrowing puts this row back and turns the fixture red." },
     { "name": "Whatever", "kind": "Service", "must_exist": false,


### PR DESCRIPTION
## Tier C of #6916 — 9 sites deleted, per-site measurement first

Nine `name_group: 0` source_patterns are **deleted**, not renamed. Each minted an
entity whose `Name` was the whole regex match: a per-file boolean marker naming a
call site, with no referent for any edge to point at. `name_group: 0` sites in
`internal/engine/rules/`: **29 → 20** (`grep -cE '^ +name_group: 0$'`, so the count
is of rule lines, not of comment mentions).

Instrument: the real `engine.Detector` (`LoadAllRules` + `Detect`, i.e. *post*
`applyPrecisionDedup`) over **12,605 files** of `archigraph-corpora` (60 repos,
read-only, 3-way concurrency), run twice — once from a detached worktree at the
parent `1b115b73b` and once at this branch — with the two binaries' shasums
differing, so the rule change is provably in the embedded FS of the second.

### Per-site: what it mints, and whether anything binds

| site | kind | marker Name | entities on corpus | edges incident | disposition |
|---|---|---|---:|---:|---|
| `rust/.../actix_web.yaml:90` | Config | `#[actix_web::main]` | **69** | **0** | deleted |
| `kotlin/.../kmp.yaml:83` | Config | `sourceSets {` | **10** | **0** | deleted |
| `ruby/.../sinatra.yaml:73` | Service | `helpers do` | 0\* | 0 | deleted |
| `ruby/.../sinatra.yaml:93` | Middleware | `before '/admin/*' do` | 0\* | 0 | deleted |
| `ruby/.../sinatra.yaml:99` | Middleware | `after do` | 0\* | 0 | deleted |
| `ruby/.../sinatra.yaml:117` | Config | `Sinatra::Application.run!` | 0\* | 0 | deleted |
| `js_ts/.../langchain.yaml:42` | Operation | `RunnableSequence.from(` | 0\* | 0 | deleted |
| `js_ts/.../langchain.yaml:66` | Operation | `tool(async (` | 0\* | 0 | deleted |
| `js_ts/.../langchain.yaml:71` | Operation | `.bindTools(` | 0\* | 0 | deleted |

**\* A zero here is CORPUS-RELATIVE, never a capability claim.** The corpus holds no
Sinatra app and no LangChain-JS repo. All seven zero-rows are **proven live** on a
fixture driven through the real detector at the parent commit — that is what the
new test's parent-run failure (below) demonstrates.

**Whole-corpus delta, parent → HEAD:** total entities **13,725 → 13,646 (−79)**;
`Config` **1,655 → 1,576**; entity-name deltas **exactly two** (`#[actix_web::main]`
69→0, `sourceSets {` 10→0); **relationship-endpoint deltas: zero**. Nothing else
moved. Bind status is therefore **unbound for all nine** — every one is dead weight
in the edge sense, and two of them are dead weight at volume.

Bind status was also settled statically, since a bind requires exact Name equality:
only three rule files in these four language buckets name any of these kinds as a
relationship endpoint, and each sources on something the marker Name can never
equal — sinatra `Config ROUTES_TO Controller` on a mount **path**, `Controller
REGISTERED_ON Middleware` on a **module constant**, `Route CALLS Service` on a
`<name>_helper` **method**, express `Operation ROUTES_TO Controller` on a **path**.
`javascript_typescript/frameworks/langchain.yaml` has `relationship_rules: []`.

### Correction to the issue: "already dropped downstream" is FALSE

Tier C's stated reason for the four langchain sites was that they are already
suppressed as Operation noise, so the rules are dead weight. **Verified rather than
relayed, and it does not hold for the three JS sites.**
`dropStatementNoiseOperations` keys on a leading `@`, a bare `=`, or a leading
statement keyword — a trailing-paren call fragment has none of those. All three
names sail through `Detect` and reach the graph. `precision_dedup.go`'s own doc
comment in fact listed them as names that **"must be KEPT"**. So deleting these
three is a **deliberate recall reduction**, labelled as such in the rule comments
and graded here; the site the pass was actually written for is the **python**
`@tool` decorator, which *is* dropped (case 1).

`internal/engine/precision_dedup.go` is updated for that: three of the four
examples its comment cited no longer exist. Doc-only; the predicate is unchanged
and `precision_dedup_test.go`'s rows still pass untouched — `{"RunnableSequence.from(",
false}` and `{".bindTools(", false}` still pin the filter's **narrowness** even though
no rule mints those names now, so the comment edit un-grades nothing.

**How the review adjudicated "must be KEPT", which is better than how this PR put it:**
that sentence is a **blast-radius instruction for the filter**, not an endorsement of the
entities. `dropStatementNoiseOperations` classifies by name shape alone with no idea
which rule minted a name, so widening it to catch trailing-paren fragments would also
have killed trpc's `createTRPCClient<` and every other legitimate call-idiom Operation.
"Must be KEPT" constrains the *filter*; deleting the rule is the surgical alternative the
filter could not perform. Keeping a rule alive because a filter was told not to catch it
inverts the dependency.

### The python langchain site was NOT touched — it is out of my lane

`python/frameworks/langchain.yaml:43` (`@tool`) is the tenth line the Tier C list
names, and `internal/engine/rules/python/frameworks/**` is off-limits to this arm
(unmerged PR). It is also the one site where "already dropped downstream" is TRUE,
so deleting it is free whenever the file is available. **1 site remains in Tier C.**

### What was deleted, and what was deliberately kept (varied vs held constant)

**Varied** (one axis: the nine marker rules, deleted). **Held constant**: every
other pattern in the four files, every `name_group` on a surviving rule, all four
`frameworks:` detection blocks, and all fixture *sources* — the golden fixture's
`src/` tree is untouched, which is what keeps the new forbidden rows reachable.

Each file keeps siblings, pinned by name in `TestIssue6916_TierCSurvivingSiblings`:

- `actix_web.yaml` — **keeps** `Config "HttpServer::new("` and `Config "App::new()"`.
  Both are still `name_group: 0` and still ugly: they are **Tier D** (a thing could
  be captured), not Tier C. Only the attribute macro, which has no name to capture
  at all, is deleted. The fact is not lost either: `internal/substrate/
  entry_points_rust.go` lists `actix_web::main` in `rustLifecycleAttrs`.
- `kmp.yaml` — keeps `Module <name>Main` from `val commonMain by getting`.
  **Measured limit, recorded not glossed:** all 10 deleted markers came from
  ktor/ktor-samples `build.gradle.kts` files spelling their source sets
  `jvmMain.dependencies { … }`, which the Module rule does not capture, so those six
  files lose their only source-set node. What is lost is a boolean that could not
  say *which* source sets exist; a rule for the property-access spelling is Tier D
  work, not a reason to keep a marker.
- `sinatra.yaml` — keeps Route, Controller, `configure :<env>` Config, `error <code>`
  Middleware, and the `helpers <Module>` include form. Ruby also has properly named
  producers for the deleted constructs, **on the gated lane only** — see the next
  section, which states that plainly rather than disclaiming it.
- `langchain.yaml` — keeps `.pipe(` Operation, `new DynamicTool(`/`new
  DynamicStructuredTool(` Operation, the prompt-template Schemas, and the Tier D
  `create\w+Agent(` Service.

### Stated plainly: the replacement producers are OFF by default

Every "there is a properly named producer instead" argument in this PR and in the new
rule comments points at the **custom-extractor lane, and `InProcCustomExtractorsEnabled`
(`internal/extractors/custom_gate.go`) says "The default stays OFF"**. So in a default
index none of these run:

- `internal/custom/ruby/middleware.go` — `SCOPE.Pattern "sinatra_filter:before[:/admin/*]"`
- `internal/custom/ruby/sinatra_deep.go` — `SCOPE.Pattern "sinatra_helpers_block"`
- `internal/custom/javascript/langchain.go:89` — `SCOPE.Operation "RunnableSequence"`
  with `chain_type`/`provenance` properties, for the exact `RunnableSequence.from([`
  construct site 42 deleted (found by the review; site 42 is the easiest of the nine
  to justify and this PR originally cited only `.pipe(`)

**In a default index these facts have no substitute at all — the entities are simply
gone, not produced better elsewhere.** The shadow-population framing is true only with
the gate ON, and the earlier wording read as "deleted here, produced properly over
there", which for a default index is false.

That does **not** change the decision, and the justification never depended on the
replacements: what is deleted is a marker named after the matched line carrying **zero
edges** (measured: zero relationship-endpoint deltas across 12,605 files). A default
index loses **noise, not information** — which is #6916's entire purpose — and that
holds whether or not any replacement producer runs. `internal/substrate/
entry_points_rust.go`'s `rustLifecycleAttrs` reading of `actix_web::main` is the one
cited mechanism that is *not* on the gated lane.

### One recall gap this PR creates, named rather than left to be rediscovered

After this change **`tool(...)` and `.bindTools(` have no producer anywhere** — not in
the YAML, not on the gated lane (`internal/custom/javascript/langchain.go`'s tool regex
requires `new`). And the spelling that survives, `new DynamicTool(`, is the
**deprecated** one, while `tool(...)` is the current `@langchain/core` idiom. So the
file now recognises the old spelling of a tool declaration and not the new one.

The fix is a real pattern capturing the tool's `name:` from the options object — Tier D
work, not a name group — so it is **filed against #6916's Tier D list** rather than
folded in here or left in a rule comment. Recorded here because it is obvious today and
invisible in three months.

### The sinatra golden fixture, re-baselined by hand

`internal/quality/golden/ruby-sinatra-modular-mini/expected.json` pinned three of
these markers as `must_exist` with the note *"pinned so a later cleanup is a
deliberate change rather than an accident."* This is that change:

- the three rows move from `expected_entities` to **`forbidden_entities`** — the only
  direction that can catch a deleted rule coming back — with the reasoning recorded
  in each row's note;
- must-have recall falls **13 → 10 by design**, `helpers AuthHelpers` staying a
  must-have as the held-constant control;
- `baseline.json` is edited **by hand, one fixture, four numbers**:
  `entity_found`/`entity_expected` 13 → 10, `entity_extracted_total` 61 → 58,
  `relationship_extracted_total` 118 → 115 (the three markers plus the three
  containment edges that carried them).

**Two-run diff evidence** (`--runs 1 --update-baseline` at HEAD *and* at the untouched
parent in a second worktree, both with a fresh isolation triple, then the two
generated baselines diffed against each other):

```
249,250c249,250      < entity_found: 13            > entity_found: 10
                     < entity_expected: 13         > entity_expected: 10
253,254c253,254      < entity_extracted_total: 61  > entity_extracted_total: 58
                     < relationship_extracted_total: 118  > ...: 115
```

One fixture, four numbers — that is what MY change did. The control matters: the
**parent-generated** baseline already differs from the committed one on **8 unrelated
fixtures** (extracted totals only, e.g. `entity_extracted_total` 57→49, 36→30, 23→19,
relationship 255→251 …). A blanket `--update-baseline` would have committed those
lowered ceilings as if they were this PR's. They are not, and they are not here.

`scripts/quality/run.sh --runs 1 --ratchet` at HEAD: **`quality ratchet OK — 38 gated
fixtures held their baseline (29 at 100% must-have recall)`**, with `git status
--porcelain` showing only this PR's own edits — no generated churn. The fixture's own
report reads `entity_found 10 / entity_expected 10 / entity_recall 1.0 /
forbidden_entity_hits 0`.

### Grading — deletions are ungradeable by a recall test

New `internal/engine/tier_c_marker_deletion_6916_test.go`: a table of **11 legs over
the 9 sites** (sinatra `before`/`after` get both the path-carrying and the **bare**
spelling), each asserting the marker's `<Kind>:<Name>` is absent from an input that
**provably produced it**, each with a positive control from the same file so an
unloadable rule file cannot pass it. Plus `TestIssue6916_TierCSurvivingSiblings` (the
neighbour axis) and `TestIssue6916_TierCLangchainMarkersWereNotSuppressedDownstream`
(the corrected claim, with `@tool` as its control).

The bare-spelling legs are there because of the trap recorded on the issue: `before`/
`after` already carry an optional group 1, `extractGroupFromIndex` returns `""` for an
unmatched optional group and the detector then skips the match — so `name_group: 1`
would have silently stopped extracting bare `before do` / `after do` while leaving the
path-carrying spelling alive. Deletion is the honest version of that, and both shapes
are now pinned.

**Mutant scores — 13 mutants, 13 DEAD.** Every edit was proven to land (exact
occurrence count asserted before running; a wrong count = SKIP, never a silent
ALIVE), and every mutant was reverted from a shasum-verified copy with byte equality
re-asserted.

| mutant | verdict |
|---|---|
| M1 restore `helpers do` | **DEAD twice** — `internal/engine` (only its own leg fails), **and the always-on quality gate**: `1 forbidden entity row(s) fired — always fatal`, naming `Service "helpers do" app.rb`, plus both extracted ceilings 58→59 / 115→116. Exit 2. |
| M2 restore sinatra `before` | DEAD — fails `:93` **and** `:93 (bare)` |
| M3 restore sinatra `after` | DEAD — fails `:99` **and** `:99 (bare)` |
| M4 restore `Sinatra::Application.run!` | DEAD — fails `:117` |
| M5 restore `#[actix_web::main]` | DEAD — fails `actix_web.yaml:90` |
| M6 restore `sourceSets {` | DEAD — fails `kmp.yaml:83` |
| M7 restore `RunnableSequence.from(` | DEAD — fails `langchain.yaml:42` |
| M8 restore `tool(async (` | DEAD — fails `langchain.yaml:66` |
| M9 restore `.bindTools(` | DEAD — fails `langchain.yaml:71` |
| M10 delete the KEPT `configure` rule | DEAD — sibling test fails (sinatra leg) |
| M11 delete the KEPT `App::new()` Tier D marker | DEAD — sibling test fails (actix leg) |
| M12 delete the KEPT kmp `Module` rule | DEAD — sibling test fails (kmp leg) |
| M13 delete the KEPT langchain `.pipe(` rule | DEAD — sibling test fails (langchain leg) |

Two independent confirmations landed after this table, both at the **gate** rather than
the package: restoring only the `after ... do` rule (coordinator) and restoring only the
`before ... do` rule (reviewer, single-fixture run with an unmutated positive control)
each fired `1 forbidden entity row(s) fired — always fatal`. So all three new forbidden
rows are proven reachable by an actual gate run rather than by inspection. Both also
recorded that **`go test ./internal/quality/...` stays GREEN under those mutants** — only
`scripts/quality/run.sh --ratchet` catches them, which is worth knowing for anyone
verifying a Tier C/D deletion by the package suite alone.

M2–M9 are single-site mutants, each failing **only its own leg**, so per-site
attribution is not inferred from a compound run. Independently, the whole test file
run at the untouched parent worktree (`1b115b73b`, all nine rules present) fails
**all 11 legs**, each naming its own marker — the deletion is pinned, not assumed.

### Verification

- `go test -count=1 ./internal/engine/` — ok (47.9s)
- `go test -count=1 ./internal/quality/...` — ok (all four packages)
- `go test -count=1 ./cmd/grafel/` with a **fresh** `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`
  — **ok (153s), the semantic digest did NOT move.** Predicted and then confirmed: the
  #6118 fixture contains no actix/KMP/sinatra/langchain construct, so no fixture member
  produces a delta. Nothing was bumped.
- `gofmt -l internal/ cmd/` — clean
- Three pre-existing tests asserted the deleted behaviour and were **inverted, not
  deleted**: `TestDetect_LangChain_PromptsChainsTools`, and in
  `sinatra_multiline_anchor_6917_test.go` both the `helpers do` recall assertion (now
  a named absence plus an explicit `error 404` control, replacing a `len(Service) != 0`
  that would have passed with the wrong rule alive) and the heredoc over-fire row,
  which its own comment asked the next person to "move into the forbidden list" — done.

Refs #6916
