### PR TITLE
fix(#6916): Tier C's 10th and last site — delete the python `@tool` marker rule, the one site where "already dropped downstream" is TRUE

### DIFF
--- a/internal/engine/precision_dedup.go
+++ b/internal/engine/precision_dedup.go
@@ -15,9 +15,11 @@ package engine
 //     dropped kind so no relationship is lost.
 //
 //  2. Statement-level noise — `Operation` entities whose Name is not a valid
-//     identifier (e.g. the langchain `@tool` source_pattern emits an Operation
-//     literally named "@tool" via name_group: 0). These are statement /
-//     decorator fragments, not operations, and are dropped.
+//     identifier (historically the langchain `@tool` source_pattern, which
+//     emitted an Operation literally named "@tool" via name_group: 0; that rule
+//     was deleted at the rule level in #6916 Tier C, but the filter stays — any
+//     rule can still produce this shape). These are statement / decorator
+//     fragments, not operations, and are dropped.
 //
 // CONSERVATIVE BY DESIGN:
 //   - Multi-kind collapse only fires when a group genuinely contains >1 distinct
@@ -283,14 +285,18 @@ func symbolicID(kind, name string) string {
 // be KEPT. So we drop ONLY three concrete statement shapes that carry no
 // architectural signal:
 //
-// #6916 Tier C note: three of the four examples this comment used to list —
-// "RunnableSequence.from(", ".bindTools(", "tool(async (" — no longer exist.
-// They were `name_group: 0` marker rules in
-// javascript_typescript/frameworks/langchain.yaml and were DELETED at the rule
-// level rather than filtered here. Their presence in this list was also the
-// evidence that #6916's "already dropped downstream as Operation noise" claim
-// about them was wrong: this pass never dropped them, and the langchain site
-// it WAS written for is the python `@tool` decorator, case (1) below.
+// #6916 Tier C note: all four of the examples this comment used to list —
+// "RunnableSequence.from(", ".bindTools(", "tool(async (" and the python
+// "@tool" — were `name_group: 0` marker rules in the two langchain.yaml files,
+// and all four have now been DELETED at the rule level rather than filtered
+// here. The first three were the evidence that #6916's "already dropped
+// downstream as Operation noise" claim was wrong: this pass never dropped them.
+// The python `@tool` decorator is the one site where the claim held — it is
+// case (1) below and WAS always dropped, which is why deleting its rule (this
+// tier's 10th and last site) changed no graph.
+//
+// The predicate below is deliberately NOT narrowed to match: it guards the
+// SHAPE, not those particular rules, and any future rule can reintroduce it.
 //
 //  1. Bare decorator text — name starts with `@` and the remainder is a plain
 //     identifier with no call/args (e.g. "@tool", "@property"). A decorator

--- a/internal/engine/rules/python/frameworks/langchain.yaml
+++ b/internal/engine/rules/python/frameworks/langchain.yaml
@@ -39,11 +39,24 @@ source_patterns:
     entity_type: Operation
     name_group: 1
     scope: file
-  # @tool decorator
-  - pattern: "@tool\\b"
-    entity_type: Operation
-    name_group: 0
-    scope: function
+  # #6916 Tier C (10th and last site): the `@tool` decorator used to mint an
+  # Operation entity literally NAMED "@tool" via `name_group: 0` — the decorator
+  # text itself, identical for every decorated function in the repo, so a whole
+  # file's tools collapsed to ONE per-file boolean marker with no referent for
+  # any edge to point at (`relationship_rules: []` here, so it never had one).
+  #
+  # Unlike the three JS langchain markers deleted alongside it, this one really
+  # was already dead weight: dropStatementNoiseOperations
+  # (internal/engine/precision_dedup.go) drops an Operation whose Name is "@" +
+  # a bare identifier, and "@tool" is exactly that — case (1), the shape the
+  # pass's own doc comment was written for. `@tool("named")` matches only
+  # "@tool" too (the pattern ends at `\b`), so the Name was ALWAYS "@tool" and
+  # ALWAYS dropped. Measured through the real detector, not read off the
+  # comment: the entity reached the rule layer and never reached the graph.
+  #
+  # So this deletion is a zero-recall-change cleanup, and the ONLY input that
+  # distinguishes it is a detector run with PrecisionDedupEnabled=false — see
+  # TestIssue6916_TierCPythonToolMarkerIsNoLongerMintedAtTheRuleLayer.
   # Agent factory
   - pattern: "create_\\w+_agent\\s*\\("
     entity_type: Service

--- a/internal/engine/tier_c_python_tool_6916_test.go
+++ b/internal/engine/tier_c_python_tool_6916_test.go
@@ -1,0 +1,159 @@
+package engine
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// #6916 Tier C, 10th and LAST site — python/frameworks/langchain.yaml:43,
+// the `@tool` decorator, deleted.
+//
+//	pattern: "@tool\b"   entity_type: Operation   name_group: 0   scope: function
+//
+// Name group 0 is the whole match, and the match is the decorator text itself,
+// so EVERY decorated function in a file produced the same Name "@tool" — one
+// per-file boolean marker, not one entity per tool. `@tool("named")` matched
+// only "@tool" as well (the pattern ends at `\b`), so the Name was invariant.
+//
+// WHY THIS SITE NEEDS ITS OWN TEST INSTEAD OF A ROW IN tierC6916Sites:
+//
+// It is the ONLY one of the ten where "already dropped downstream" is TRUE, and
+// that makes the ordinary Tier C assertion VACUOUS here. dropStatementNoiseOperations
+// (precision_dedup.go, always on — PrecisionDedupEnabled has no production
+// toggle) drops an Operation whose Name is "@" + a bare identifier, which
+// "@tool" is exactly. So `Operation:@tool` was absent from Detect's output
+// BEFORE this deletion too: a post-dedup absence assertion passes at the parent
+// commit and grades nothing.
+//
+// The only input that distinguishes the deletion is a detector run with the
+// precision pass OFF, which is what TestIssue6916_TierCPythonToolMarkerIsNoLongerMintedAtTheRuleLayer
+// does. Its companion below then pins the OTHER half of the claim — that with
+// the pass ON nothing observable changed, i.e. this was a zero-recall-change
+// cleanup rather than a recall reduction.
+//
+// VARIED across the two decorator spellings: bare `@tool` and `@tool("named")`
+// (the second is why "capture the argument instead" was not an option — the
+// bare form has no argument, and the pattern never reached the parenthesis).
+// HELD CONSTANT: the file's two surviving source_patterns (the LCEL pipe-chain
+// Operation at name_group 1 and the `create_\w+_agent(` Service at name_group 0,
+// which is Tier D, not Tier C), the `frameworks:` detection block, and
+// isStatementNoiseOperationName's predicate — the filter is deliberately NOT
+// narrowed to match the rule deletion, because it guards a shape, not a rule.
+
+// tierC6916PyTool is one python source file that fired the deleted rule. Both
+// decorated functions are indented inside no class and are not the first line
+// of the file, and the file also exercises both surviving patterns so every
+// absence assertion below has a positive control from the SAME input.
+const tierC6916PyTool = `from langchain_core.tools import tool
+from langchain.agents import create_react_agent
+from langchain_core.prompts import ChatPromptTemplate
+
+
+@tool
+def search(query: str) -> str:
+    """Search the web."""
+    return "results"
+
+
+@tool("weather-lookup")
+def weather(city: str) -> str:
+    """Look up the weather."""
+    return "sunny"
+
+
+prompt = ChatPromptTemplate.from_messages([])
+chain = prompt | model | parser
+agent = create_react_agent(llm, tools=[search, weather])
+`
+
+const (
+	// tierC6916PyToolMarker is the "<Kind>:<Name>" the deleted rule produced.
+	// Measured at the parent commit with the precision pass off; it must never
+	// come back.
+	tierC6916PyToolMarker = "Operation:@tool"
+
+	// The two positive controls, from the file's two SURVIVING patterns. Without
+	// them the absence assertion would also pass on a rule file that failed to
+	// load — the loader silently SKIPS an unparseable rule file, so "no entities
+	// at all" is a real and silent failure mode here.
+	tierC6916PyChainControl = "Operation:chain"
+	tierC6916PyAgentControl = "Service:create_react_agent("
+)
+
+// TestIssue6916_TierCPythonToolMarkerIsNoLongerMintedAtTheRuleLayer is the
+// change itself, graded on the only input that can see it: the precision pass
+// disabled, so what is asserted is the RULE's output rather than the filtered
+// graph's.
+func TestIssue6916_TierCPythonToolMarkerIsNoLongerMintedAtTheRuleLayer(t *testing.T) {
+	old := PrecisionDedupEnabled
+	PrecisionDedupEnabled = false
+	t.Cleanup(func() { PrecisionDedupEnabled = old })
+
+	ids := entityIDs6916(detect6916(t, "app/agent.py", "python", tierC6916PyTool))
+
+	if slices.Contains(ids, tierC6916PyToolMarker) {
+		t.Errorf("python/frameworks/langchain.yaml: the deleted #6916 Tier C `@tool` rule is "+
+			"back — %q is minted again. It is the decorator text itself, identical for every "+
+			"decorated function in the file, so it is one per-file boolean marker with no "+
+			"referent for any edge. Entities:\n  %s",
+			tierC6916PyToolMarker, strings.Join(ids, "\n  "))
+	}
+	for _, control := range []string{tierC6916PyChainControl, tierC6916PyAgentControl} {
+		if !slices.Contains(ids, control) {
+			t.Errorf("positive control missing — this input no longer mints %q, so the absence "+
+				"of %q above proves nothing (an unloadable langchain.yaml would pass it). "+
+				"Entities:\n  %s", control, tierC6916PyToolMarker, strings.Join(ids, "\n  "))
+		}
+	}
+}
+
+// TestIssue6916_TierCPythonToolDeletionChangedNoGraph pins the second half of
+// the justification: with the precision pass ON — its only production state —
+// the marker was ALREADY absent, so this deletion removed a rule whose output
+// never reached a graph. If this test ever fails, the deletion above stopped
+// being a no-op and became a recall reduction that needs re-arguing.
+func TestIssue6916_TierCPythonToolDeletionChangedNoGraph(t *testing.T) {
+	if !PrecisionDedupEnabled {
+		t.Fatal("precondition: PrecisionDedupEnabled must be true here — that is the " +
+			"production state this test is about")
+	}
+	ids := entityIDs6916(detect6916(t, "app/agent.py", "python", tierC6916PyTool))
+
+	if slices.Contains(ids, tierC6916PyToolMarker) {
+		t.Errorf("%q reached the post-dedup graph, which contradicts the premise this "+
+			"deletion rested on (that dropStatementNoiseOperations always removed it). "+
+			"Entities:\n  %s", tierC6916PyToolMarker, strings.Join(ids, "\n  "))
+	}
+	// Same controls: the surviving patterns must still reach the real graph, not
+	// merely the rule layer.
+	for _, control := range []string{tierC6916PyChainControl, tierC6916PyAgentControl} {
+		if !slices.Contains(ids, control) {
+			t.Errorf("a python langchain pattern NOT part of Tier C stopped reaching the "+
+				"graph: %q is missing. Entities:\n  %s", control, strings.Join(ids, "\n  "))
+		}
+	}
+}
+
+// TestIssue6916_TierCPythonToolPredicateStillGuardsTheShape pins that the
+// filter was NOT narrowed alongside the rule deletion. The rule is gone; the
+// shape it produced is still noise, and any other rule that produces it must
+// still be dropped. Deleting the rule and relaxing the filter in the same change
+// would leave the shape ungated with nothing failing.
+func TestIssue6916_TierCPythonToolPredicateStillGuardsTheShape(t *testing.T) {
+	for _, name := range []string{"@tool", "@property", "@app.route"} {
+		if !isStatementNoiseOperationName(name) {
+			t.Errorf("isStatementNoiseOperationName(%q) = false — the bare-decorator case (1) "+
+				"was relaxed. #6916 Tier C deleted the RULE that produced this shape, not the "+
+				"guard against it.", name)
+		}
+	}
+	// The negative direction, so the assertion above is not satisfied by a
+	// predicate that returns true for everything: a real call idiom is kept.
+	for _, name := range []string{"createTRPCClient<", "DynamicTool", "prompt"} {
+		if isStatementNoiseOperationName(name) {
+			t.Errorf("isStatementNoiseOperationName(%q) = true — the predicate widened and is "+
+				"now eating real operations.", name)
+		}
+	}
+}


### PR DESCRIPTION
Closes the 10th and last **Tier C** site of #6916. Refs #6916.

`internal/engine/rules/python/frameworks/langchain.yaml:43` (line number re-verified on `main`, not taken from the board) matched `@tool\b` with `name_group: 0`, so the entity Name was the **decorator text itself** — identical for every decorated function in a file, one per-file boolean marker with no referent for any edge. `relationship_rules: []` in that file, so it never had one.

## 1. The downstream-filter claim, verified rather than relayed

Tier C's premise for this site — "already dropped downstream" — is the **only** one of the ten where it is TRUE, and #7034 proved the premise false for the other three. So I measured it instead of citing it.

Driving a python langchain file through the **real detector** (`LoadAllRules` → `Detect`), printing both sides of the precision pass:

```
RAW (PrecisionDedupEnabled=false):   Operation:@tool   Operation:chain   Service:create_react_agent(
AFTER (production, pass ON):                           Operation:chain   Service:create_react_agent(
```

The rule minted it; the graph never saw it. Mechanism, checked statically as well as by measurement:

- `dropStatementNoiseOperations` case (1) drops an Operation whose Name is `@` + a bare identifier. `"@tool"` is exactly that — it is the shape the pass's own doc comment was written for.
- The Name was **invariant**: the pattern ends at `\b`, so `@tool("named-tool")` also matches only `@tool`. There is no spelling that escapes the filter.
- `PrecisionDedupEnabled` has **no production toggle** — `grep` over all non-test Go shows only the declaration, the default `true`, and the one guard. There is no config path that turns the filter off.

**So this deletion is a zero-recall-change cleanup, not a recall reduction.** Had it come out the other way I would have reported that instead.

## 2. Grading a deletion that was ALREADY inert

This is the wrinkle that makes this site different from the nine in #7034, and it is a trap: **a post-dedup absence assertion is vacuous here** — `Operation:@tool` is absent from `Detect`'s output at the parent commit too, so such a test passes with the rule fully alive and grades nothing. Demonstrated, not assumed: under M1 (rule restored verbatim) `TestIssue6916_TierCPythonToolDeletionChangedNoGraph` **PASSED** while the rule-layer test failed.

The only input that distinguishes the change is a detector run with `PrecisionDedupEnabled=false`. Three tests:

| test | what it grades |
|---|---|
| `…MarkerIsNoLongerMintedAtTheRuleLayer` | the change itself — marker absent at the **rule layer** (pass OFF) |
| `…DeletionChangedNoGraph` | the other half of the justification — with the pass ON the marker was already absent, i.e. no graph moved |
| `…PredicateStillGuardsTheShape` | the filter was **not** narrowed alongside the rule, in both directions |

Both absence tests carry **two** positive controls from the same input (`Operation:chain` from the LCEL pipe-chain rule, `Service:create_react_agent(` from the agent factory), so a silently-skipped rule file cannot pass them — the loader skips an unparseable rule file without erroring, which is a real and silent failure mode.

## 3. Varied vs held constant

**Varied:** the two decorator spellings — bare `@tool` and `@tool("weather-lookup")`. The second is also *why* "capture the argument instead" was never an option: the bare form has no argument and the pattern never reached the parenthesis. Also varied: the precision pass ON vs OFF, which is the axis the whole test design turns on.

**Held constant:** the file's two surviving `source_patterns` (the LCEL pipe-chain `Operation` at `name_group: 1`, and the `create_\w+_agent(` `Service` at `name_group: 0` — that one is **Tier D**, not Tier C, and is deliberately untouched); the `frameworks:` detection block; and `isStatementNoiseOperationName`'s predicate. The predicate is deliberately **not** narrowed to match the rule deletion — it guards a *shape*, not a rule, and any future rule can reintroduce that shape.

## 4. Measurement

**Corpus** (`archigraph-corpora`, read-only): **0 mints, 0 edges** — and this one is not merely corpus-relative, it is doubly zero. The corpus contains **zero** files mentioning `langchain` and **zero** `@tool` occurrences in any `.py` file, so the rule never fired there; and even where it fires, the marker is filtered before the graph. **"Produced nothing here" is not "cannot produce"** — liveness is proven on a fixture instead (the RAW row above mints it).

**Extraction-quality gate:** `scripts/quality/run.sh --ratchet` → *38 gated fixtures held (29 at 100% must-have recall)*, and — the check that actually means something — **`git status --porcelain` empty afterwards** apart from this PR's own three files. No baseline hand-edit was needed and none was made: the golden set contains **no langchain fixture** (`grep -rl 'langchain\|@tool\|bindTools' internal/quality/golden/` → nothing), so no name this PR affects is pinned anywhere. No blanket `--update-baseline` was run.

**`cmd/grafel` digest:** green under a **fresh `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`**. Stating what the null means rather than citing it as coverage: its fixtures hold 40 `.py` files and **zero** contain `@tool` or `langchain`, so it had no affected construct — the same shape as #7034. Here the null is *doubly* determined, and that part is stronger than #7034's: even a fixture containing `@tool` could not have moved the digest, because the entity was filtered out before reaching the graph the digest hashes.

## 5. Item 2 — the `tool()` / `.bindTools(` gap: **priced and left**, with the measurement

After #7034, `tool()` and `.bindTools(` have no producer while the surviving `new DynamicTool(` is the deprecated spelling. I established the cost before deciding, and **the recorded suggestion does not survive contact**.

The suggestion was to capture `name:` from the options object. Source patterns are matched against whole file content, so multiline is possible in principle — but the options literal sits behind an **arbitrary async-arrow body containing nested parens and braces**, and Go's RE2 has no recursion or backtracking to bound it. Measured on an adversarial input — a `tool(...)` call with **no** `name:` in its options, followed later by unrelated object literals:

```
tool\s*\([\s\S]*?name:\s*["']([\w.-]+)   ->  2 matches
        group1="NOT_A_TOOL"        (an unrelated router config object)
        group1="ALSO_NOT_A_TOOL"   (reached via builder.tool( — any library's .tool( method)
```

It mints entities **named after unrelated object literals elsewhere in the file**. That is a worse defect than the one #6916 exists to remove, so it is not shippable.

The cheap substitute — assigned-variable capture, the template Tier A/B used eight times — reopens the exact TypeScript trap #7023 needed three entries per site to close:

```
(\w+)\s*=\s*tool\s*\(  ->  group1="getWeather"        (correct)
                           group1="StructuredTool"    (the TYPE, from `const typed: StructuredTool = tool(...)`)
```

**Price:** the `tool()` site needs the multi-entry type-annotation treatment from #7023 plus its own fixtures and over-fire grading — a real rewrite, not a pattern change. `.bindTools(` alone *is* one line (`(\w+)\.bindTools\s*\(`, `name_group: 1` — an exact clone of the `.pipe(` sibling in the same file, correct on both shapes tested). I left it out deliberately: shipping it alone closes the model side while the half that names the actual *tool* stays open, and it would add a new framework-ungated orphan `Operation` population that **nothing grades** (0 langchain files in the corpus, 0 langchain golden fixtures, `relationship_rules: []`) inside a PR whose subject is deleting that exact shape. Per the brief, leaving it priced beats a half-done capture.

## 6. Mutant scores

Every edit was proven to land by an exact occurrence count before scoring, and each mutated YAML was confirmed to still parse (an unloadable rule file is silently *skipped*, which yields green for the wrong reason).

| # | mutant | verdict |
|---|---|---|
| **M1** | restore the deleted `@tool` rule verbatim (occurrence count 1; loader test green ⇒ YAML parsed) | **DEAD** — rule-layer test fails with `Operation:@tool` back. Also the evidence for §2: the post-dedup test **passed** under it. |
| **M2** | disable case (1) of `isStatementNoiseOperationName` (`if false && name[0] == '@'`) | **DEAD** — 5 tests, incl. 3 pre-existing (`TestPrecision_IsStatementNoiseOperationName`, `…StatementNoiseDropped_RealOperationKept`, `…RouteShapedOperationSurvivesNoiseFilter`) and `TestIssue6916_TierCLangchainMarkersWereNotSuppressedDownstream` |
| **M3** | widen the predicate to return `true` for everything | **DEAD** — the *negative* loop of the predicate test fires, so the positive loop is not satisfied by an always-true predicate |
| **M4** | delete the surviving LCEL pipe-chain sibling (occurrences 1→0) | **DEAD** — both absence tests fail on the `Operation:chain` control |
| **M5** | delete the surviving `create_\w+_agent(` sibling (occurrences 1→0) | **DEAD** — both fail on the agent control, **while `Operation:chain` is still listed** — so the two controls are independently graded and this is distinguishable from a load failure |
| **M6** | append invalid YAML, making the rule file unparseable (confirmed: `ScannerError`) | **DEAD** — the silent-skip failure mode the brief warns about is caught by the controls |

No mutant was equivalent, alive, or ungraded.

## 7. Verification

- `go test -count=1 ./internal/engine/` — **ok**
- `go test -count=1 ./internal/quality/... ./internal/extractors/` — **ok** (5 packages)
- `go test -count=1 ./cmd/grafel/` — **ok**, fresh isolated `GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT`
- `scripts/quality/run.sh --ratchet` — 38 fixtures held, **`git status --porcelain` clean**
- `gofmt -l internal/` clean; `go vet ./internal/engine/` clean

Reporting both gate signals per the standing finding: the Go package suite and `--ratchet` are **not** the same check. Here they agree, and M2's kill by three pre-existing `internal/engine` tests is what the package suite contributed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
