### PR TITLE
feat(#6912): go fields carried their declared type only at the struct anchor — emit the field→type REFERENCES edge, same-file targets only

### DIFF
--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -191,6 +191,17 @@ func (g *GoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]
 	records = attachClassContains(records, file.Path)
 
 	// ----------------------------------------------------------------
+	// 4b-bis. Issue #6912 — field→declared-type REFERENCES. Runs after
+	//     every primary-pass record for the file is in place, because the
+	//     pass refuses any target name carried by more than one same-file
+	//     record and the SCOPE.Enum value-sets (step 2) and import
+	//     placeholders (step 3) are part of that count. See
+	//     field_type_refs.go. The struct-anchored DEPENDS_ON emitted by
+	//     extractStructFieldDependencies is deliberately left untouched.
+	// ----------------------------------------------------------------
+	records = attachGoFieldTypeRefs(records, file.Path)
+
+	// ----------------------------------------------------------------
 	// 4c. Track A (analog of #641/#650/#670 for Go) — REFERENCES-edge
 	//     emission. Runs after every primary-pass entity is in place so
 	//     the file-scope symbol table covers functions, methods,

--- a/internal/extractors/golang/field_type_refs.go
+++ b/internal/extractors/golang/field_type_refs.go
@@ -1,0 +1,418 @@
+package golang
+
+import (
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// field_type_refs.go — the field→declared-type edge for Go (issue #6912, arm D).
+// Arm A is internal/extractors/csharp/field_type_refs.go (#6984), arm B is
+// internal/extractors/proto/field_type_refs.go (#6991), arm C is
+// internal/extractors/rust/field_type_refs.go (#7000).
+//
+// THE GAP, AND WHY GO IS ARM B'S SHAPE RATHER THAN ARM C'S. Go is the ONLY
+// language on this issue that already ships a same-file-gated declared-type
+// edge: extractStructFieldDependencies emits DEPENDS_ON per struct field type,
+// gated on collectDeclaredTypeNames. But it anchors that edge on the STRUCT
+// (`FromID: ownerName`), so the struct is wired and the FIELD is not. Every
+// SCOPE.Schema/field entity extractStructFieldEntities emits (#4850) is a leaf
+// on its outbound side, which is the #6912 population: #6726 measures
+// SCOPE.Schema at 99.3% orphan across their corpus, and Go is one of their
+// languages.
+//
+// So this pass adds a SECOND edge, anchored on the field, and leaves the
+// struct-anchored DEPENDS_ON exactly as it was. That is arm B's ruling: the
+// duplicated thing is the ANCHOR, not the information. "Which FIELDS point at
+// Order?" is what the new anchor answers and the old one cannot — DEPENDS_ON
+// names no field at all, not even in a property, so after this pass the two
+// edges carry different facts rather than the same fact twice.
+//
+// DOES THE SECOND ANCHOR DOUBLE-COUNT IN internal/quality? This was arm B's
+// open question and it lands here because Go is the only language shipping both
+// edges. MEASURED, by reading the arithmetic rather than reasoning about it —
+// answer: no metric counts the same fact twice, because no metric counts
+// ENDPOINTS; but two rates move, both in the flattering direction, and neither
+// dedups.
+//
+//   - internal/quality/audit/audit.go:424 OrphanRate is DEFLATED. `touched`
+//     (audit.go:363-368) admits any non-CONTAINS/DECLARES edge in EITHER
+//     direction, so a field that was previously reachable only by its CONTAINS
+//     edge flips to non-orphan the moment it is the FromID here. That is the
+//     #6912 gap closing and is the intended effect — but it is worth naming that
+//     the connectivity is derived from a fact the graph already recorded at the
+//     struct anchor. Note internal/quality/fitness/rule.go:511-526 computes a
+//     SECOND, inbound-only orphan rate that will NOT move for the field, so the
+//     two published orphan numbers diverge further after this arm.
+//   - audit.go:433 ReferencesPerFunction is INFLATED, and this one is a genuine
+//     distortion rather than a gain. Its numerator counts REFERENCES EDGES
+//     (audit.go:382-384) while its denominator counts FUNCTION ENTITIES, and a
+//     SCOPE.Schema/field is not function-like (audit.go:480-493) — so every edge
+//     added here raises the ratio with no denominator movement. DEPENDS_ON is
+//     counted by nothing, so the old anchor contributed zero and the new one
+//     contributes one. It feeds refHealth/RiskScore (audit.go:584) and the
+//     "REFERENCES emission missing" gate at audit.go:680, which it can therefore
+//     mask. The honest fix is for that metric to exclude ref_kind=field_target_type
+//     — nothing in internal/quality reads `ref_kind` today — but that is a
+//     quality-metric change touching every arm A–D at once, not a Go-only one,
+//     so it is reported rather than smuggled in here.
+//
+// THREE PLACES THIS ARM DELIBERATELY DOES NOT COPY ITS NEIGHBOUR
+//
+//  1. THE ADDRESS IS STRUCTURAL, NOT A BARE NAME. The adjacent DEPENDS_ON uses
+//     `ToID: t` — the bare type name. That is not the address arms A–C settled
+//     on, and adjacency is not a reason to inherit it: a bare name is resolved
+//     by name-family lookup across the whole graph and is what #6986 measured at
+//     91.6% dangling for the custom lane's `Class:<Name>` form. This pass uses
+//     BuildComponentStructuralRef — `scope:component:class:go:<file>:<Name>` —
+//     which is FILE-SCOPED, so a second .go file declaring a same-named type
+//     cannot make it ambiguous. Post-resolution the ToID is the target entity's
+//     ID, so no query sees the dialect. The existing DEPENDS_ON keeps its bare
+//     name; re-spelling it is a graph-wide change with no bearing on #6912.
+//
+//  2. THE ALLOW-LIST ADMITS SCOPE.Schema, BECAUSE IN GO A TYPE ALIAS IS ONE.
+//     Arm C's guard is `Kind != "SCOPE.Component"`, which is correct for Rust
+//     (buildRustTypeAlias emits a Component) and WRONG here: extractTypes emits
+//     `type Celsius float64`, `type Handler func()`, `type UserID string` and
+//     the Go-1.9 `type T = U` form as Kind SCOPE.Schema, Subtype type_alias
+//     (extractor.go:11-13, and the two type_alias branches). Inheriting arm C's
+//     kind check verbatim would have silently dropped every alias target — the
+//     single largest non-struct declared-type population in idiomatic Go. So the
+//     allow-list is written on Go's own buildComponent behaviour:
+//
+//     SCOPE.Component + struct     → admitted (type T struct{…})
+//     SCOPE.Component + interface  → admitted (type T interface{…})
+//     SCOPE.Schema    + type_alias → admitted (type T U / type T = U)
+//
+//     Everything else is refused. Being HONEST about what that refusal is worth:
+//     the excluded records are refused by NAME SHAPE before the subtype check
+//     ever sees them, so the subtype conjunct is a belt-and-braces guard rather
+//     than a live filter, and the PR body reports it as such rather than
+//     claiming a kill it does not have.
+//
+//     - IMPORT ENTITIES are SCOPE.Component with an EMPTY Subtype and Name set
+//     to the whole import path (extractImportEntities), never truncated to a
+//     segment. A single-segment path IS a bare name sharing this file's
+//     namespace, and it is reachable — `import _ "embed"` does not bind the
+//     identifier, so a file may legally BLANK-import "embed" and also declare
+//     `type embed struct{…}`. But both records are SCOPE.Component/embed in this
+//     file, hence ONE graph node under rule 2, so admitting the import record
+//     would address the same node by the same ToID and change no output. The
+//     case is still pinned — TestGoFieldTypeRefs_BlankImportSharingATypeNameBinds
+//     — because it is the case that proves rule 2 must count KINDS and not
+//     records: under a record count this edge disappears.
+//     - SCOPE.Schema + field is refused so a field never targets a field. Also
+//     unreachable by name shape: a field entity's Name is dotted
+//     (`Order.Buyer`) and a candidate is a single type_identifier, which cannot
+//     contain a dot.
+//     - SCOPE.Component + file (#577) is refused; its Name is the file path.
+//
+//  3. THE CANDIDATE COLLECTOR IS NOT resolveTypeReferences, and this is the one
+//     correctness fix in the arm. resolveTypeReferences collects EVERY
+//     descendant type_identifier, which for Go's `qualified_type` node
+//     (`other.Order`) is the TRAILING SEGMENT — so it strips `other.Order` to
+//     `Order`. In a file that also declares its own `Order`, the struct-anchored
+//     DEPENDS_ON therefore binds to the WRONG entity today, silently, because a
+//     bound edge never reaches `bug-extractor`. Arms B and C both carry a
+//     forbidden row for exactly that mutation. goFieldTypeCandidates skips
+//     `qualified_type` WHOLE rather than taking its tail, so the new edge is
+//     deliberately narrower than its neighbour on qualified names. Pinned in
+//     both directions by TestGoFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName,
+//     which also pins that DEPENDS_ON's behaviour is UNCHANGED by this arm —
+//     narrowing resolveTypeReferences is a separate fix with its own blast
+//     radius, not a rider on this one.
+//
+// A NON-BINDING EDGE IS WORSE THAN NO EDGE, AND GO HAS A PARALLEL POPULATION
+// THAT MAKES THIS SHARPER THAN IT WAS FOR RUST. An unresolved stub is kept
+// verbatim and dangling and classified `bug-extractor`, so every miss is a full
+// hit. The Go-specific hazard is extractGoEnums: a `type Status int` beside a
+// const block typed by it produces a SCOPE.Enum value-set named `Status`
+// (extractor.EnumEntity) IN ADDITION to the SCOPE.Schema/type_alias of the same
+// name in the same file. The resolver's byLocation fallback is what binds a
+// component-space ref to a Schema entity, and that fallback consults
+// ambigLocation FIRST — so a name carried by two same-file entities returns
+// statusAmbiguous and the edge dangles.
+//
+// Arm C's collision check only looked for duplicates WITHIN its own admitted
+// set and would not have seen this: the alias is admitted and the enum
+// value-set is not. So goInFileTypeTargets counts across EVERY same-file record
+// and drops any name denoting more than one graph node, whether or not the
+// second node is a legal target. That is strictly the resolver's own ambiguity
+// rule, mirrored at the emit site so the pass declines to emit rather than
+// emitting a stub that cannot bind.
+//
+// The rule is graded by a POSITIVE CONTROL IN THE SAME FIXTURE rather than by
+// the shadowed case alone: `type Status int` carries a typed const block and
+// gets no edge, while `type Tier int` — the same declaration form with no const
+// block, hence no value-set and one node — DOES get one. Without that pair the
+// test cannot tell "the enum shadow is respected" from "a type_alias target
+// never works at all", which is the failure mode a recall-only assertion has.
+// See TestGoFieldTypeRefs_TypeShadowedByAnEnumValueSetGetsNoEdge.
+//
+// WHAT THIS PASS IS NOT
+//
+//   - SAME FILE ONLY. A field whose type is declared in another file of the
+//     same package gets nothing, and for Go — where a package is a directory of
+//     files and one-type-per-file is not the convention — that is the dominant
+//     miss, larger than it was for C# or Rust. Closing it needs the cross-file
+//     package type view that pass 1 has none of; binding a bare type name
+//     across files is the exact hazard #6976/#6369 are about. Separate arm, not
+//     a widening of this one.
+//   - IT DOES NOT UNDERSTAND TYPE PARAMETERS. `type Holder[T any] struct { Item
+//     T }` yields candidate `T`, which is dropped only because nothing in the
+//     file happens to be DECLARED `T`. A file that also declares `type T
+//     struct{}` gets a wrong edge. Known-wrong and pinned as such by
+//     TestGoFieldTypeRefs_KnownOverFire_TypeParameterShadowedByASameFileType, a
+//     case a real fix is expected to break.
+//   - AN ANONYMOUS NESTED STRUCT OR INTERFACE IS NOT A TARGET AND CONTRIBUTES
+//     NONE. `Inner struct { A Order }` yields nothing: `Order` is the declared
+//     type of `Inner.A`, not of `Inner`, and emitting `Inner → Order` with
+//     target_type=Order would assert something false. struct_type and
+//     interface_type are therefore skipped whole. This costs no reachable
+//     recall — `topLevelFieldDeclarations` already refuses to treat nested
+//     struct members as the outer struct's fields (#4850), so the nested field
+//     has no entity of its own to carry the edge either.
+
+// goFieldTypeRefsMetaKey is the per-field stash written by
+// extractStructFieldEntities and consumed — and deleted — by
+// attachGoFieldTypeRefs.
+//
+// The candidates cannot become edges during the walk. Two independent reasons,
+// either sufficient: `type Order struct { Buyer Customer }` may be declared
+// BEFORE `type Customer struct{}` in the same file, so the in-file declaration
+// set is complete only once the walk has finished; and the collision rule above
+// must see the enum value-sets and import records, which are appended to
+// `records` after extractTypes returns.
+const goFieldTypeRefsMetaKey = "field_type_refs"
+
+// goFieldTargetRefKind is the value of the `ref_kind` edge property. It matches
+// arm A's csFieldTargetRefKind, arm B's protoFieldTargetRefKind, arm C's
+// rustFieldTargetRefKind and the custom lane's referencesClassEdge verbatim —
+// the discriminator is what makes the edge queryable as a field→declared-type
+// edge across languages, so it must be one string.
+//
+// It is NOT the spelling the pre-existing struct-anchored DEPENDS_ON uses (that
+// edge carries no properties at all). That is a different relation with a
+// different anchor and is left exactly as it was.
+const goFieldTargetRefKind = "field_target_type"
+
+// goFieldTypeCandidates returns every bare type name written in a field's
+// declared type expression, in source order and without deduplication.
+//
+// It descends the type node and collects `type_identifier` leaves, which unwraps
+// pointer (`*Order`), slice (`[]Order`), array (`[3]Order`), map
+// (`map[Key]Order` — BOTH halves, each judged independently), channel (`chan
+// Order`), variadic, function (`func(Order) error`) and generic (`Holder[Order]`)
+// syntax for free, with no wrapper list to keep in sync.
+//
+// A Go PRIMITIVE needs no blocklist here and, unlike arm B's protoScalars, a
+// blocklist would be actively wrong rather than merely redundant. `int`,
+// `string` and `bool` are not keywords in Go's grammar — tree-sitter-go emits
+// them as `type_identifier`, exactly like a user type, because Go's predeclared
+// identifiers live in the universe scope and are legally shadowable. So the
+// primitive is collected as a candidate and then refused by the in-file
+// declaration check, which is the correct order of operations: a file that
+// writes `type string struct { v int }` (legal Go — the predeclared identifier
+// is shadowed at package scope) genuinely does mean THAT type in field position,
+// and a blocklist would refuse the one edge that should exist. This is the exact
+// inverse of arm B's case, where protoc's grammar binds `string` to the scalar
+// before it ever considers a same-named message, and is why that guard is not
+// portable. Both directions graded:
+// TestGoFieldTypeRefs_PrimitiveFieldsProduceNoEdge enumerates the predeclared
+// set against an independent literal, and
+// TestGoFieldTypeRefs_ShadowedPredeclaredIdentifierIsATarget constructs the
+// shadowing declaration.
+//
+// TWO node kinds are skipped WHOLE, without descending:
+//
+//   - `qualified_type` — `other.Order`, `time.Time`. The trailing segment is
+//     never taken; see point 3 of the header block. This is the one place the
+//     field edge is narrower than the struct-anchored DEPENDS_ON.
+//   - `struct_type` and `interface_type` — an anonymous nested struct or
+//     interface written in field position. Not a named target, and its members
+//     are not this field's declared type; see the header block.
+func goFieldTypeCandidates(typ ts.Node, src []byte) []string {
+	var out []string
+	var walkType func(n ts.Node)
+	walkType = func(n ts.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "qualified_type", "struct_type", "interface_type":
+			return
+		case "type_identifier":
+			out = append(out, nodeText(n, src))
+			return
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			walkType(n.NamedChild(i))
+		}
+	}
+	walkType(typ)
+	return out
+}
+
+// goFieldTypeTarget is one in-file type declaration a field can point at: the
+// structural ToID that binds to it, and the bare name for the `target_type`
+// property.
+type goFieldTypeTarget struct {
+	toID string
+	name string
+}
+
+// goInFileTypeTargets indexes every TYPE DECLARED in this file that a field-type
+// edge may address, keyed by bare name.
+//
+// Two rules, and the second is the Go-specific one:
+//
+//  1. The record must be a type declaration this package emits as an entity, per
+//     the three-line allow-list in the header block. This is a check on the
+//     EMITTED RECORD, not on collectDeclaredTypeNames, and the reason is NOT the
+//     one it would be natural to give.
+//
+//     The natural argument is that knownTypeNames is a superset: it takes the
+//     name of every type_spec node, while extractTypes `continue`s without
+//     emitting anything when it recognises none of the body node kinds, so
+//     gating on it could address an entity that does not exist. THAT ARGUMENT IS
+//     UNSUPPORTED — the body-kind list is wide enough that no Go type_spec form
+//     tried here escapes it. `Stack[int]`, `pkg.Stack[int]`, `[...]int`,
+//     `func(...int)`, `[][]map[string]*J`, `(int)`, `interface{}`,
+//     `interface{ int | string }` and `struct{}` ALL produce an entity. The
+//     superset is real in the code and empty in fact, and it is recorded as an
+//     unconstructed case rather than a demonstrated one.
+//
+//     The load-bearing reason is the other one: a NAME SET CANNOT EXPRESS EITHER
+//     RULE THIS PASS NEEDS. knownTypeNames is a map[string]bool and carries no
+//     Kind and no Subtype, so it cannot separate an admitted type declaration
+//     from a value-set that merely shares its name (rule 2), and it cannot
+//     express the allow-list at all. Reading the records is what makes the
+//     enum-shadow rule possible; using knownTypeNames would have forced the
+//     dangling edge described in the header block.
+//
+//  2. A name that denotes MORE THAN ONE DISTINCT GRAPH NODE in this file is
+//     dropped, and the count spans every record in the file rather than only the
+//     admitted ones. The resolver's ambigLocation check runs before the
+//     byLocation fallback this address depends on, so a name shared with a
+//     NON-target node — a SCOPE.Enum value-set over a `type Status int`, the
+//     overwhelmingly common Go enum idiom — cannot bind either. Counting only
+//     admitted records (arm C's rule) would emit a stub guaranteed to dangle.
+//     The unit is the KIND rather than the record, mirroring the resolver
+//     exactly; see the comment on nameKinds below for why, and why counting
+//     records instead would refuse edges that bind.
+func goInFileTypeTargets(records []types.EntityRecord, filePath string) map[string]goFieldTypeTarget {
+	// Pass 1 — how many DISTINCT GRAPH NODES each same-file name denotes,
+	// target or not.
+	//
+	// The unit is the KIND, not the record, and that is the resolver's own rule
+	// rather than a convenience. buildSymbolIndex marks (file, name) ambiguous
+	// only when it meets a SECOND DISTINCT ENTITY ID there (`existing != e.ID`,
+	// internal/resolve/refs.go:1308), and graph.EntityID hashes
+	// (repo, Kind, Name, SourceFile) — so within one file two records collide
+	// into ONE node exactly when they share a Kind. Counting RECORDS instead
+	// would refuse names the resolver binds perfectly well: `import _ "embed"`
+	// beside `type embed struct{…}` is two records and ONE node, both
+	// SCOPE.Component/embed in this file. Counting kinds keeps that edge and
+	// still drops the type_alias-plus-enum case, which is two kinds and
+	// genuinely two nodes.
+	nameKinds := make(map[string]map[string]bool)
+	for i := range records {
+		r := &records[i]
+		if r.SourceFile != filePath || r.Name == "" {
+			continue
+		}
+		if nameKinds[r.Name] == nil {
+			nameKinds[r.Name] = make(map[string]bool)
+		}
+		nameKinds[r.Name][r.Kind] = true
+	}
+
+	// Pass 2 — admit the type declarations whose name is unambiguous.
+	targets := make(map[string]goFieldTypeTarget)
+	for i := range records {
+		r := &records[i]
+		if r.SourceFile != filePath || r.Name == "" {
+			continue
+		}
+		switch {
+		case r.Kind == "SCOPE.Component" && (r.Subtype == "struct" || r.Subtype == "interface"):
+		case r.Kind == "SCOPE.Schema" && r.Subtype == "type_alias":
+		default:
+			continue
+		}
+		if len(nameKinds[r.Name]) > 1 {
+			continue
+		}
+		targets[r.Name] = goFieldTypeTarget{
+			toID: extractor.BuildComponentStructuralRef("go", filePath, r.Name),
+			name: r.Name,
+		}
+	}
+	return targets
+}
+
+// attachGoFieldTypeRefs appends one REFERENCES edge per (field, in-file declared
+// type) pair and clears the stash it consumed.
+//
+// FromID is left empty so graph assembly anchors the edge on the field record
+// that carries it — the Django precedent at
+// internal/extractors/python/django_relational.go:246-252, and arms B and C.
+// (Hibernate sets an explicit structural FromID because it hangs its edge off
+// its own parallel SCOPE.Component node; that is a different shape and not the
+// one to copy — #6912's own body was corrected on this point.)
+//
+// Relationships is APPENDED to, never assigned: a Go field record carries no
+// outbound edge today, but assigning would silently clobber one added later.
+//
+// The `field_name` property is the field entity's own leaf name, recovered by
+// stripping the `<owner>.` prefix extractStructFieldEntities built the Name
+// from. That leaf is the JSON WIRE NAME when a `json:"…"` tag renamed the field
+// — the same value the Name and the CONTAINS structural-ref already carry, so
+// the property agrees with the endpoints rather than introducing a third
+// spelling of the same field.
+func attachGoFieldTypeRefs(records []types.EntityRecord, filePath string) []types.EntityRecord {
+	targets := goInFileTypeTargets(records, filePath)
+	for i := range records {
+		r := &records[i]
+		if r.Metadata == nil {
+			continue
+		}
+		cands, _ := r.Metadata[goFieldTypeRefsMetaKey].([]string)
+		delete(r.Metadata, goFieldTypeRefsMetaKey)
+		if len(cands) == 0 || r.Kind != "SCOPE.Schema" || r.Subtype != "field" {
+			continue
+		}
+		owner, _ := r.Metadata["owner"].(string)
+		fieldName := r.Name
+		if owner != "" {
+			fieldName = strings.TrimPrefix(r.Name, owner+".")
+		}
+		emitted := make(map[string]bool)
+		for _, cand := range cands {
+			t, ok := targets[cand]
+			if !ok || emitted[t.toID] {
+				continue
+			}
+			// A field never targets its own owning struct: `type Node struct {
+			// Next *Node }` is a self-reference the struct-anchored DEPENDS_ON
+			// also declines (`t == ownerName`), and the CONTAINS edge already
+			// relates the two records.
+			if owner != "" && t.name == owner {
+				continue
+			}
+			emitted[t.toID] = true
+			r.Relationships = append(r.Relationships, types.RelationshipRecord{
+				ToID: t.toID,
+				Kind: string(types.RelationshipKindReferences),
+				Properties: types.Props{
+					{K: "field_name", V: fieldName},
+					{K: "ref_kind", V: goFieldTargetRefKind},
+					{K: "target_type", V: t.name},
+				},
+			})
+		}
+	}
+	return records
+}

--- a/internal/extractors/golang/field_type_refs.go
+++ b/internal/extractors/golang/field_type_refs.go
@@ -86,27 +86,50 @@ import (
 //     SCOPE.Component + interface  → admitted (type T interface{…})
 //     SCOPE.Schema    + type_alias → admitted (type T U / type T = U)
 //
-//     Everything else is refused. Being HONEST about what that refusal is worth:
-//     the excluded records are refused by NAME SHAPE before the subtype check
-//     ever sees them, so the subtype conjunct is a belt-and-braces guard rather
-//     than a live filter, and the PR body reports it as such rather than
-//     claiming a kill it does not have.
+//     Everything else is refused, and THE ALLOW-LIST IS A LIVE FILTER WITH A
+//     REAL KILL. An earlier draft of this comment claimed the opposite — that
+//     the excluded records were refused by name shape before the subtype check
+//     saw them, making it belt-and-braces — and offered a compound mutant
+//     (allow-list removed TOGETHER with rule 2) as evidence. That experiment
+//     established nothing: rule 2's mutant is independently lethal, so the
+//     compound killed exactly the tests rule 2 alone kills and carried no
+//     information about the allow-list. Recorded because the reasoning error is
+//     more portable than the fix: a compound mutant grades its second half only
+//     if its first half is NOT lethal on its own.
+//
+//     The distinguishing input, and the reason the claim was false:
 //
 //     - IMPORT ENTITIES are SCOPE.Component with an EMPTY Subtype and Name set
 //     to the whole import path (extractImportEntities), never truncated to a
 //     segment. A single-segment path IS a bare name sharing this file's
-//     namespace, and it is reachable — `import _ "embed"` does not bind the
-//     identifier, so a file may legally BLANK-import "embed" and also declare
-//     `type embed struct{…}`. But both records are SCOPE.Component/embed in this
-//     file, hence ONE graph node under rule 2, so admitting the import record
-//     would address the same node by the same ToID and change no output. The
-//     case is still pinned — TestGoFieldTypeRefs_BlankImportSharingATypeNameBinds
-//     — because it is the case that proves rule 2 must count KINDS and not
-//     records: under a record count this edge disappears.
-//     - SCOPE.Schema + field is refused so a field never targets a field. Also
-//     unreachable by name shape: a field entity's Name is dotted
+//     namespace, and it is reachable twice over, because `import _ "embed"`
+//     does not bind the identifier:
+//
+//     SAME-FILE (`type embed struct{…}` here too): two records, both
+//     SCOPE.Component/embed, hence ONE graph node under rule 2 — so admitting
+//     the import would address the same node by the same ToID and change no
+//     output. Pinned by TestGoFieldTypeRefs_BlankImportSharingATypeNameBinds,
+//     which is really rule 2's test: it proves the count must be over KINDS,
+//     since under a record count this edge disappears.
+//
+//     SIBLING-FILE (`type embed struct{…}` in another file of the package —
+//     the ORDINARY case, since a Go package is a directory): the import
+//     placeholder is then the ONLY record named `embed` in this file. One node,
+//     so rule 2 is silent; a bare name, so "refused by name shape" does not
+//     apply. Without the allow-list the field binds TO THE IMPORT PLACEHOLDER —
+//     a wrong binding, and wrong bindings never reach bug-extractor precisely
+//     because they bind. This is the case the allow-list exists for, and it is
+//     graded by TestGoFieldTypeRefs_ImportPlaceholderIsNeverATarget.
+//
+//     Enumerated rather than hand-picked: of the records emitted before this
+//     pass runs that carry a bare (non-dotted, non-path) Name, package-level
+//     funcs are excluded by Go's own package-scope uniqueness, enum value-sets
+//     always present a second kind (they require a same-file named type), and
+//     the import placeholder is the only one that can stand alone.
+//     - SCOPE.Schema + field is refused so a field never targets a field. This
+//     one IS unreachable by name shape: a field entity's Name is dotted
 //     (`Order.Buyer`) and a candidate is a single type_identifier, which cannot
-//     contain a dot.
+//     contain a dot. Refused anyway, but claimed as nothing more.
 //     - SCOPE.Component + file (#577) is refused; its Name is the file path.
 //
 //  3. THE CANDIDATE COLLECTOR IS NOT resolveTypeReferences, and this is the one
@@ -299,6 +322,20 @@ type goFieldTypeTarget struct {
 //     NON-target node — a SCOPE.Enum value-set over a `type Status int`, the
 //     overwhelmingly common Go enum idiom — cannot bind either. Counting only
 //     admitted records (arm C's rule) would emit a stub guaranteed to dangle.
+//
+//     "EVERY same-file record" means every record that exists AT STEP 4b-bis,
+//     which is where this pass runs — not every record Extract eventually
+//     returns. Steps 4c-6b append more (SCOPE.Pattern, SCOPE.ExceptionType,
+//     config keys, constant sets) and buildSymbolIndex sees those too, so a
+//     collision invisible here would reach the resolver as a dangling edge.
+//     It holds today only because every one of those producers emits a PREFIXED
+//     name (`error_handling:…`, `exception:…`, `config:…`), which no bare
+//     type_identifier candidate can equal; verified empirically at review, with
+//     all 168 corpus edges re-checked against the POST-Extract record set —
+//     0 target names carrying more than one kind, 0 targets without a same-file
+//     declaration. A future producer emitting a BARE-named entity would
+//     silently reintroduce dangling here, so that is the invariant to preserve
+//     rather than an accident to rely on.
 //     The unit is the KIND rather than the record, mirroring the resolver
 //     exactly; see the comment on nameKinds below for why, and why counting
 //     records instead would refuse edges that bind.

--- a/internal/extractors/golang/field_type_refs_6912_test.go
+++ b/internal/extractors/golang/field_type_refs_6912_test.go
@@ -1,0 +1,691 @@
+package golang_test
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6912 arm D — the field→declared-type edge for Go. See field_type_refs.go for
+// the kind / address / same-file / ambiguity decisions; this file grades them.
+//
+// Every assertion below names FIELDS AND TARGETS. A count table cannot see a
+// substitution (#6973) and recall cannot see over-firing at all (#6926), so the
+// forbidden set is asserted BY NAME beside the expected set: a named primitive
+// field, a named package-qualified field, a named anonymous-struct field, a
+// named anonymous-interface field, the self-reference, and the field whose
+// target name is shadowed by an enum value-set.
+//
+// AXES. The main fixture VARIES the wrapper form (bare, pointer, slice, array,
+// map key+value, channel, func parameter, generic argument, embedded), the
+// target's entity kind (SCOPE.Component/struct, SCOPE.Component/interface,
+// SCOPE.Schema/type_alias) and the field's wire-name form (plain vs json-tag
+// renamed). It HOLDS CONSTANT the file path, the owning struct and the target
+// name (`Customer` wherever a struct target is wanted), so a wrapper regression
+// shows up as a missing row rather than as a changed target. The axes that need
+// a different FILE or a different DECLARATION SHAPE — cross-file, enum shadow,
+// blank-import name sharing, shadowed predeclared identifier, type-parameter
+// over-fire — each get their own fixture below precisely because they cannot
+// vary inside this one without also varying something else.
+
+const goFTPath = "models.go"
+
+const goFTSrc = `package models
+
+import (
+	_ "embed"
+	"other"
+)
+
+type Status int
+
+const (
+	StatusNew Status = iota
+	StatusDone
+)
+
+type Tier int
+
+type Customer struct{ Name string }
+
+type Shipper interface{ Ship() }
+
+type Holder[T any] struct{ Item T }
+
+type embed struct{ Blob []byte }
+
+type Order struct {
+	Buyer    Customer
+	Ptr      *Customer
+	Watchers []Customer
+	Hist     [3]Customer
+	ByName   map[Tier]Customer
+	Ch       chan Customer
+	Cb       func(Customer) error
+	Wrapped  Holder[Customer]
+	Ship     Shipper
+	Emb      embed
+	St       Status
+	Foreign  other.Order
+	Nested   struct{ A Customer }
+	Anon     interface{ Do() }
+	Self     *Order
+	Qty      int
+	Label    string
+	Renamed  Customer ` + "`json:\"renamed_wire\"`" + `
+}
+`
+
+// goFTRivalPath declares types of the SAME bare names in a SECOND file. Its only
+// job is to make the bare-name resolver tier ambiguous, which is why the address
+// is structural; the edges from models.go must be identical with and without it.
+const goFTRivalPath = "other.go"
+
+// It also declares an `Order` with a same-named `Buyer` field pointing at a
+// same-named `Customer`, so the two files differ in NOTHING the edge can see
+// except the file. If the address were not file-scoped, these two rows would
+// collapse or cross-bind.
+const goFTRivalSrc = `package models
+
+type Customer struct{ Other string }
+type Shipper interface{ Ship() }
+type Tier int
+
+type Order struct{ Buyer Customer }
+`
+
+func extractGoFiles(t *testing.T, files map[string]string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("go")
+	if !ok {
+		t.Fatal("go extractor not registered")
+	}
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	var recs []types.EntityRecord
+	for _, p := range paths {
+		content := []byte(files[p])
+		got, err := ext.Extract(context.Background(), extractor.FileInput{
+			Path:     p,
+			Content:  content,
+			Language: "go",
+			TSTree:   parseGo(content),
+		})
+		if err != nil {
+			t.Fatalf("Extract %s: %v", p, err)
+		}
+		recs = append(recs, got...)
+	}
+	return recs
+}
+
+func goFTOne(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	return extractGoFiles(t, map[string]string{goFTPath: src})
+}
+
+// goFTEdges returns "<record name> -> <ToID>" for every REFERENCES edge carrying
+// ref_kind=field_target_type, across ALL records, so an edge that escaped onto
+// some other record is still seen. It fails on a non-empty FromID: the Django
+// precedent leaves it empty so assembly anchors the edge on the record that
+// carries it.
+func goFTEdges(t *testing.T, recs []types.EntityRecord) []string {
+	t.Helper()
+	var out []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || r.Properties.Get("ref_kind") != "field_target_type" {
+				continue
+			}
+			if r.FromID != "" {
+				t.Errorf("%s -[REFERENCES]-> %s has FromID=%q, want empty so assembly "+
+					"anchors it on the carrying record", recs[i].Name, r.ToID, r.FromID)
+			}
+			if recs[i].Kind != "SCOPE.Schema" || recs[i].Subtype != "field" {
+				t.Errorf("field-type edge escaped onto %s/%s %q — only a "+
+					"SCOPE.Schema/field record may carry one",
+					recs[i].Kind, recs[i].Subtype, recs[i].Name)
+			}
+			out = append(out, recs[i].Name+" -> "+r.ToID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// goFTTargetsOf returns the sorted target_type property values of the field-type
+// edges carried by the field record named `field`.
+func goFTTargetsOf(recs []types.EntityRecord, field string) []string {
+	var out []string
+	for i := range recs {
+		if recs[i].Name != field {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "REFERENCES" && r.Properties.Get("ref_kind") == "field_target_type" {
+				out = append(out, r.Properties.Get("target_type"))
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func goFTWantEqual(t *testing.T, got, want []string, what string) {
+	t.Helper()
+	sort.Strings(want)
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("%s mismatch\n got:\n  %s\nwant:\n  %s",
+			what, strings.Join(got, "\n  "), strings.Join(want, "\n  "))
+	}
+}
+
+// TestGoFieldTypeRefs_EdgeSetIsExact pins the whole emitted set by name, in both
+// directions at once: every wrapper form that MUST yield an edge, and every
+// forbidden field that must yield none. The two rival files are extracted
+// together so the assertion also proves the address is file-scoped.
+func TestGoFieldTypeRefs_EdgeSetIsExact(t *testing.T) {
+	recs := extractGoFiles(t, map[string]string{
+		goFTPath:      goFTSrc,
+		goFTRivalPath: goFTRivalSrc,
+	})
+	const c = "scope:component:class:go:models.go:"
+	goFTWantEqual(t, goFTEdges(t, recs), []string{
+		// Wrapper forms — target held constant at Customer so a regression
+		// reads as a missing row, not a changed target.
+		"Order.Buyer -> " + c + "Customer",
+		"Order.Ptr -> " + c + "Customer",
+		"Order.Watchers -> " + c + "Customer",
+		"Order.Hist -> " + c + "Customer",
+		"Order.Ch -> " + c + "Customer",
+		"Order.Cb -> " + c + "Customer",
+		"Order.renamed_wire -> " + c + "Customer",
+		// map[Tier]Customer — BOTH halves are judged, and both are declared
+		// here, so this field carries TWO edges. The key is not skipped.
+		"Order.ByName -> " + c + "Tier",
+		"Order.ByName -> " + c + "Customer",
+		// Holder[Customer] — the generic constructor is a legitimate target
+		// (it is declared here) AND so is the argument.
+		"Order.Wrapped -> " + c + "Holder",
+		"Order.Wrapped -> " + c + "Customer",
+		// Non-struct target kinds.
+		"Order.Ship -> " + c + "Shipper", // SCOPE.Component/interface
+		"Order.Emb -> " + c + "embed",    // name shared with a blank import
+		// The rival file's own field resolves against ITS own file.
+		"Order.Buyer -> scope:component:class:go:other.go:Customer",
+	}, "field-type edge set")
+
+	// Forbidden, by name. Each of these is a field that EXISTS in the fixture
+	// and must carry no edge; asserting the set above is not enough on its own,
+	// because a renamed or mis-attributed row would still pass a set compare
+	// while these names silently gained an edge.
+	for _, forbidden := range []string{
+		"Order.Qty",     // predeclared int
+		"Order.Label",   // predeclared string
+		"Order.Foreign", // other.Order — qualified, never stripped to Order
+		"Order.Nested",  // anonymous struct — its member is not this field's type
+		"Order.Anon",    // anonymous interface
+		"Order.Self",    // *Order — the owning struct
+		"Order.St",      // Status — shadowed by a SCOPE.Enum value-set
+	} {
+		if got := goFTTargetsOf(recs, forbidden); len(got) != 0 {
+			t.Errorf("%s must carry NO field-type edge, got targets %v", forbidden, got)
+		}
+	}
+}
+
+// TestGoFieldTypeRefs_TypeShadowedByAnEnumValueSetGetsNoEdge grades the
+// Go-specific ambiguity rule WITH A POSITIVE CONTROL IN THE SAME FIXTURE.
+//
+// `type Status int` carries a typed const block, so extractGoEnums emits a
+// SCOPE.Enum value-set ALSO named Status in this file. Two kinds at one (file,
+// name) is two graph nodes, the resolver returns statusAmbiguous, and an edge
+// would dangle — so none is emitted. `type Tier int` is the IDENTICAL
+// declaration form with no const block, hence one node, and it MUST get an edge.
+//
+// Without the Tier row this test could not tell "the enum shadow is respected"
+// from "a type_alias target never works at all" — the failure mode a
+// recall-only or absence-only assertion has.
+func TestGoFieldTypeRefs_TypeShadowedByAnEnumValueSetGetsNoEdge(t *testing.T) {
+	recs := goFTOne(t, goFTSrc)
+
+	// Premise: both declarations really are SCOPE.Schema/type_alias, and Status
+	// really does have a second, differently-kinded record. If the premise
+	// stops holding, the test is vacuous rather than passing.
+	kinds := map[string]map[string]bool{}
+	for i := range recs {
+		if recs[i].SourceFile != goFTPath || recs[i].Name == "" {
+			continue
+		}
+		if kinds[recs[i].Name] == nil {
+			kinds[recs[i].Name] = map[string]bool{}
+		}
+		kinds[recs[i].Name][recs[i].Kind+"/"+recs[i].Subtype] = true
+	}
+	if !kinds["Status"]["SCOPE.Schema/type_alias"] || !kinds["Status"]["SCOPE.Enum/enum"] {
+		t.Fatalf("premise gone: Status carries %v, want both a type_alias and an "+
+			"enum value-set — the shadow this test grades is not present", kinds["Status"])
+	}
+	if !kinds["Tier"]["SCOPE.Schema/type_alias"] || len(kinds["Tier"]) != 1 {
+		t.Fatalf("premise gone: Tier carries %v, want exactly one type_alias — "+
+			"the positive control is not comparable to Status", kinds["Tier"])
+	}
+
+	if got := goFTTargetsOf(recs, "Order.St"); len(got) != 0 {
+		t.Errorf("Order.St targets %v; Status is shadowed by an enum value-set so "+
+			"the ref cannot bind and must not be emitted", got)
+	}
+	if got := goFTTargetsOf(recs, "Order.ByName"); !contains(got, "Tier") {
+		t.Errorf("Order.ByName targets %v, want Tier among them — the positive "+
+			"control for a type_alias target is missing, so the Status assertion "+
+			"above grades nothing", got)
+	}
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGoFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName is the forbidden
+// row arms B and C both carry, and for Go it also documents a PRE-EXISTING BUG
+// in the neighbouring edge that this arm deliberately does not inherit.
+//
+// `other.Order` in a file that also declares its own `Order` must yield NO field
+// edge — taking the trailing segment would bind to the wrong entity, silently,
+// because a bound edge never reaches bug-extractor. resolveTypeReferences (used
+// by the struct-anchored DEPENDS_ON) DOES strip it, so the same fixture asserts
+// that DEPENDS_ON's behaviour is UNCHANGED by this arm: fixing that is a
+// separate change with its own blast radius, not a rider on this one.
+func TestGoFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName(t *testing.T) {
+	const src = `package models
+
+import "other"
+
+type Order struct{ ID string }
+
+type Holder struct {
+	Foreign other.Order
+	Local   Order
+}
+`
+	recs := goFTOne(t, src)
+
+	if got := goFTTargetsOf(recs, "Holder.Foreign"); len(got) != 0 {
+		t.Errorf("Holder.Foreign targets %v; `other.Order` is package-qualified and "+
+			"must NOT be stripped to the same-file `Order`", got)
+	}
+	// Positive control: the UNqualified field in the same struct does bind, so
+	// the assertion above is about the qualifier and not about Order being
+	// untargetable.
+	if got := goFTTargetsOf(recs, "Holder.Local"); !contains(got, "Order") {
+		t.Fatalf("Holder.Local targets %v, want Order — the control for the "+
+			"qualified-name rule is missing", got)
+	}
+
+	// The struct-anchored DEPENDS_ON is untouched, strip included. This is
+	// asserted so the pre-existing behaviour is pinned as pre-existing: if a
+	// later change narrows resolveTypeReferences, THIS is the line that says
+	// the field edge never depended on it.
+	var dep []string
+	for i := range recs {
+		if recs[i].Name != "Holder" || recs[i].Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "DEPENDS_ON" {
+				dep = append(dep, r.FromID+" -> "+r.ToID)
+			}
+		}
+	}
+	sort.Strings(dep)
+	goFTWantEqual(t, dep, []string{"Holder -> Order"},
+		"struct-anchored DEPENDS_ON (bare-name ToID, qualified type stripped) "+
+			"must be unchanged by this arm")
+}
+
+// TestGoFieldTypeRefs_PrimitiveFieldsProduceNoEdge enumerates Go's predeclared
+// type names against an INDEPENDENT LITERAL rather than against the production
+// set (#6975) — there is no production blocklist to share, which is the point:
+// a predeclared name is refused because nothing DECLARES it in the file, not by
+// a list. The companion test proves the same code path admits the name when the
+// file does declare it, so this test is not merely observing a blocklist.
+func TestGoFieldTypeRefs_PrimitiveFieldsProduceNoEdge(t *testing.T) {
+	predeclared := []string{
+		"bool", "string", "int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
+		"byte", "rune", "float32", "float64", "complex64", "complex128",
+		"error", "any",
+	}
+	var b strings.Builder
+	b.WriteString("package models\n\ntype Holder struct {\n")
+	for i, p := range predeclared {
+		b.WriteString("\tF")
+		b.WriteString(string(rune('A' + i%26)))
+		b.WriteString(string(rune('a' + i/26)))
+		b.WriteString(" ")
+		b.WriteString(p)
+		b.WriteString("\n")
+	}
+	b.WriteString("}\n")
+	recs := goFTOne(t, b.String())
+
+	// Premise: the fields exist. Otherwise "no edges" is vacuous.
+	n := 0
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" {
+			n++
+		}
+	}
+	if n != len(predeclared) {
+		t.Fatalf("fixture emitted %d field entities, want %d — the absence of "+
+			"edges below would be vacuous", n, len(predeclared))
+	}
+	goFTWantEqual(t, goFTEdges(t, recs), nil,
+		"no predeclared-type field may carry a field-type edge")
+}
+
+// TestGoFieldTypeRefs_ShadowedPredeclaredIdentifierIsATarget is the inverse of
+// the test above, and it is why Go must NOT carry arm B's protoScalars-style
+// blocklist. Go's predeclared identifiers live in the universe scope and are
+// legally shadowable at package scope; tree-sitter-go emits them as
+// type_identifier exactly like a user type. So when a file really does declare
+// `type rune struct{…}`, a field written `rune` genuinely means THAT type, and a
+// blocklist would refuse the one edge that should exist.
+//
+// This is the exact inverse of arm B's case, where protoc's grammar binds
+// `string` to the scalar before it ever considers a same-named message — which
+// is why that guard is correct there and would be wrong here.
+func TestGoFieldTypeRefs_ShadowedPredeclaredIdentifierIsATarget(t *testing.T) {
+	const src = `package models
+
+type rune struct{ Cp int32 }
+
+type Holder struct {
+	Shadowed rune
+	Plain    int
+}
+`
+	recs := goFTOne(t, src)
+	if got := goFTTargetsOf(recs, "Holder.Shadowed"); !contains(got, "rune") {
+		t.Errorf("Holder.Shadowed targets %v, want `rune` — the file DECLARES "+
+			"type rune, so the field names that type and a predeclared-name "+
+			"blocklist would wrongly refuse the edge", got)
+	}
+	if got := goFTTargetsOf(recs, "Holder.Plain"); len(got) != 0 {
+		t.Errorf("Holder.Plain targets %v; `int` is not declared here", got)
+	}
+}
+
+// TestGoFieldTypeRefs_BlankImportSharingATypeNameBinds is the case that proves
+// the ambiguity rule must count KINDS and not RECORDS.
+//
+// `import _ "embed"` does not bind the identifier, so a file may legally
+// blank-import "embed" and also declare `type embed struct{…}`. That is TWO
+// records named `embed` in one file — an import placeholder and a struct — but
+// both are SCOPE.Component, so graph.EntityID gives them ONE id and the resolver
+// binds the name without complaint. A record-counting ambiguity rule would see
+// two and delete this edge; a kind-counting one keeps it.
+func TestGoFieldTypeRefs_BlankImportSharingATypeNameBinds(t *testing.T) {
+	recs := goFTOne(t, goFTSrc)
+
+	// Premise: there really are two same-named records, and they really do
+	// share a Kind. Without this the test would pass for the wrong reason.
+	var subs []string
+	for i := range recs {
+		if recs[i].SourceFile == goFTPath && recs[i].Name == "embed" {
+			subs = append(subs, recs[i].Kind+"/"+recs[i].Subtype)
+		}
+	}
+	sort.Strings(subs)
+	goFTWantEqual(t, subs, []string{"SCOPE.Component/", "SCOPE.Component/struct"},
+		"premise: `embed` must be carried by an import placeholder AND a struct, "+
+			"both SCOPE.Component")
+
+	if got := goFTTargetsOf(recs, "Order.Emb"); !contains(got, "embed") {
+		t.Errorf("Order.Emb targets %v, want `embed` — two records of the SAME "+
+			"kind are one graph node, so this name is not ambiguous and the "+
+			"edge must survive", got)
+	}
+}
+
+// TestGoFieldTypeRefs_CrossFileTypeGetsNoEdge — the same-file rule, and for Go
+// this is the dominant miss rather than an edge case: a Go package is a
+// DIRECTORY of files, so a field whose type lives in a sibling file of the same
+// package is ordinary rather than unusual. Stated as the honest floor and
+// asserted by name; closing it needs a cross-file package type view that pass 1
+// does not have.
+func TestGoFieldTypeRefs_CrossFileTypeGetsNoEdge(t *testing.T) {
+	recs := extractGoFiles(t, map[string]string{
+		"a.go": `package models
+
+type Order struct {
+	Buyer Customer
+	Local Local
+}
+
+type Local struct{ X int }
+`,
+		"b.go": `package models
+
+type Customer struct{ Name string }
+`,
+	})
+	if got := goFTTargetsOf(recs, "Order.Buyer"); len(got) != 0 {
+		t.Errorf("Order.Buyer targets %v; Customer is declared in b.go and this "+
+			"pass is same-file only", got)
+	}
+	// Positive control in the same struct: the same-file type DOES bind, so the
+	// absence above is about the file boundary and not about the pass being off.
+	if got := goFTTargetsOf(recs, "Order.Local"); !contains(got, "Local") {
+		t.Fatalf("Order.Local targets %v, want Local — the same-file control is "+
+			"missing so the cross-file assertion grades nothing", got)
+	}
+}
+
+// TestGoFieldTypeRefs_KnownOverFire_TypeParameterShadowedByASameFileType pins a
+// KNOWN-WRONG edge, deliberately, so a fix breaks a test rather than passing
+// silently.
+//
+// The pass does not understand type parameters. `type Box[T any] struct{ Item T
+// }` yields candidate `T`, which is normally dropped only because nothing in the
+// file is DECLARED `T`. In a file that also declares `type T struct{…}` the
+// candidate matches and the edge is emitted — asserting that Box.Item's declared
+// type is that struct, which is false. A real fix (tracking the type-parameter
+// list as a shadowing scope) is EXPECTED to break this test.
+func TestGoFieldTypeRefs_KnownOverFire_TypeParameterShadowedByASameFileType(t *testing.T) {
+	const src = `package models
+
+type T struct{ Unrelated string }
+
+type Box[T any] struct {
+	Item T
+}
+`
+	recs := goFTOne(t, src)
+	got := goFTTargetsOf(recs, "Box.Item")
+	if !contains(got, "T") {
+		t.Skipf("KNOWN-WRONG edge is gone (Box.Item targets %v). If type "+
+			"parameters are now tracked as a shadowing scope, DELETE this test; "+
+			"it exists only to make the over-fire visible.", got)
+	}
+	t.Logf("known over-fire present as expected: Box.Item -> %v (a type parameter "+
+		"shadowed by a same-file declaration)", got)
+}
+
+// TestGoFieldTypeRefs_StashIsClearedFromMetadata — the candidate stash is an
+// internal handoff between the walk and the attach pass. Leaving it on the record
+// would ship extractor scratch state into the graph as entity metadata.
+func TestGoFieldTypeRefs_StashIsClearedFromMetadata(t *testing.T) {
+	recs := goFTOne(t, goFTSrc)
+	saw := false
+	for i := range recs {
+		if recs[i].Metadata == nil {
+			continue
+		}
+		if v, ok := recs[i].Metadata["field_type_refs"]; ok {
+			t.Errorf("%s still carries the field_type_refs stash: %v", recs[i].Name, v)
+		}
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Fatal("no field records in fixture — the absence of a stash is vacuous")
+	}
+}
+
+// TestGoFieldTypeRefs_ResolvesToEntityIDs drives the emitted edges through the
+// real resolver and asserts EVERY ONE BINDS to a real entity id, naming the
+// entity it binds to. This is the assertion that makes "a non-binding edge is
+// worse than no edge" a graded property rather than a stated intention: a
+// dangling stub is kept verbatim and classified bug-extractor, so a mis-addressed
+// edge would be a full hit on the disposition denominator.
+//
+// The two rival files are both indexed, so the bare name `Customer` is ambiguous
+// across the graph — checked explicitly, because if it were NOT ambiguous the
+// structural address would be ungraded here and a bare-name ToID would pass too.
+func TestGoFieldTypeRefs_ResolvesToEntityIDs(t *testing.T) {
+	recs := extractGoFiles(t, map[string]string{
+		goFTPath:      goFTSrc,
+		goFTRivalPath: goFTRivalSrc,
+	})
+	for i := range recs {
+		if recs[i].ID == "" {
+			recs[i].ID = graph.EntityID("issue6912", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+		}
+	}
+	idx := resolve.BuildIndex(recs)
+
+	before := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "REFERENCES" && r.Properties.Get("ref_kind") == "field_target_type" {
+				before++
+			}
+		}
+	}
+	if before == 0 {
+		t.Fatal("no field-type edges to drive through the resolver")
+	}
+
+	// Positive control on the address dialect: the BARE name must be ambiguous
+	// here, otherwise this test does not distinguish the structural address from
+	// the bare-name form the adjacent DEPENDS_ON uses.
+	if _, st := idx.LookupStatusHint("Customer", "REFERENCES"); st == 1 {
+		t.Fatalf("the bare name %q binds in this fixture, so the ambiguity this "+
+			"test controls for is absent and the structural address is ungraded",
+			"Customer")
+	}
+
+	// An import placeholder and a struct of the same name are ONE graph node,
+	// not two: graph.EntityID hashes (repo, Kind, Name, SourceFile) and both are
+	// SCOPE.Component/embed in models.go, so they share an ID by construction.
+	// The description below therefore carries the SORTED SET of subtypes behind
+	// each ID — `embed` must come back as "+struct", the empty subtype first —
+	// because keying a map by ID and writing the subtype into it would silently
+	// report whichever record came last and read as a mis-binding.
+	idToName := map[string]string{}
+	idToSubs := map[string]map[string]bool{}
+	for i := range recs {
+		id := recs[i].ID
+		idToName[id] = recs[i].SourceFile + ":" + recs[i].Kind + ":" + recs[i].Name
+		if idToSubs[id] == nil {
+			idToSubs[id] = map[string]bool{}
+		}
+		idToSubs[id][recs[i].Subtype] = true
+	}
+	describe := func(id string) string {
+		subs := make([]string, 0, len(idToSubs[id]))
+		for s := range idToSubs[id] {
+			subs = append(subs, s)
+		}
+		sort.Strings(subs)
+		return idToName[id] + " [" + strings.Join(subs, "+") + "]"
+	}
+
+	resolve.ReferencesEmbedded(recs, idx)
+
+	var bound []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || r.Properties.Get("ref_kind") != "field_target_type" {
+				continue
+			}
+			_, ok := idToName[r.ToID]
+			if !ok {
+				t.Errorf("%s:%s -[REFERENCES]-> %q did NOT bind to an entity id "+
+					"(dangling stub → bug-extractor)",
+					recs[i].SourceFile, recs[i].Name, r.ToID)
+				continue
+			}
+			bound = append(bound, recs[i].SourceFile+":"+recs[i].Name+" => "+describe(r.ToID))
+		}
+	}
+	sort.Strings(bound)
+	const m = "models.go:"
+	goFTWantEqual(t, bound, []string{
+		m + "Order.Buyer => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.ByName => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.ByName => " + m + "SCOPE.Schema:Tier [type_alias]",
+		m + "Order.Cb => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.Ch => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.Emb => " + m + "SCOPE.Component:embed [+struct]",
+		m + "Order.Hist => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.Ptr => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.Ship => " + m + "SCOPE.Component:Shipper [interface]",
+		m + "Order.Watchers => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.Wrapped => " + m + "SCOPE.Component:Customer [struct]",
+		m + "Order.Wrapped => " + m + "SCOPE.Component:Holder [struct]",
+		m + "Order.renamed_wire => " + m + "SCOPE.Component:Customer [struct]",
+		"other.go:Order.Buyer => other.go:SCOPE.Component:Customer [struct]",
+	}, "resolved field-type endpoints")
+}
+
+// TestGoFieldTypeRefs_PropertiesAgreeWithTheEndpoints — the field_name property
+// must be the field entity's own leaf name, INCLUDING when a json tag renamed it,
+// so the property agrees with the Name and with the CONTAINS structural-ref
+// rather than introducing a third spelling of the same field.
+func TestGoFieldTypeRefs_PropertiesAgreeWithTheEndpoints(t *testing.T) {
+	recs := goFTOne(t, goFTSrc)
+	seen := map[string]string{}
+	for i := range recs {
+		r := &recs[i]
+		if r.Kind != "SCOPE.Schema" || r.Subtype != "field" {
+			continue
+		}
+		owner, _ := r.Metadata["owner"].(string)
+		for _, rel := range r.Relationships {
+			if rel.Kind != "REFERENCES" || rel.Properties.Get("ref_kind") != "field_target_type" {
+				continue
+			}
+			fn := rel.Properties.Get("field_name")
+			if owner+"."+fn != r.Name {
+				t.Errorf("%s carries field_name=%q; owner+field_name must rebuild "+
+					"the entity Name exactly", r.Name, fn)
+			}
+			if rel.Properties.Get("target_type") == "" {
+				t.Errorf("%s -> %s has an empty target_type", r.Name, rel.ToID)
+			}
+			seen[r.Name] = fn
+		}
+	}
+	if seen["Order.renamed_wire"] != "renamed_wire" {
+		t.Errorf("json-renamed field carries field_name=%q, want %q — the "+
+			"json-tag axis is the one that can disagree with the Name, so it "+
+			"must be the one asserted", seen["Order.renamed_wire"], "renamed_wire")
+	}
+}

--- a/internal/extractors/golang/field_type_refs_6912_test.go
+++ b/internal/extractors/golang/field_type_refs_6912_test.go
@@ -66,6 +66,7 @@ type Order struct {
 	Watchers []Customer
 	Hist     [3]Customer
 	ByName   map[Tier]Customer
+	Both     map[Customer]Customer
 	Ch       chan Customer
 	Cb       func(Customer) error
 	Wrapped  Holder[Customer]
@@ -74,7 +75,7 @@ type Order struct {
 	St       Status
 	Foreign  other.Order
 	Nested   struct{ A Customer }
-	Anon     interface{ Do() }
+	Anon     interface{ Get() Customer }
 	Self     *Order
 	Qty      int
 	Label    string
@@ -213,6 +214,12 @@ func TestGoFieldTypeRefs_EdgeSetIsExact(t *testing.T) {
 		// here, so this field carries TWO edges. The key is not skipped.
 		"Order.ByName -> " + c + "Tier",
 		"Order.ByName -> " + c + "Customer",
+		// map[Customer]Customer names the SAME declared type in both halves.
+		// Exactly ONE row: the per-field dedup on ToID is what makes it one,
+		// and a second identical row here would be counted twice by
+		// ReferencesTotal and by relationship_extracted_total, neither of
+		// which dedups edges (audit.go:355-388).
+		"Order.Both -> " + c + "Customer",
 		// Holder[Customer] — the generic constructor is a legitimate target
 		// (it is declared here) AND so is the argument.
 		"Order.Wrapped -> " + c + "Holder",
@@ -641,6 +648,7 @@ func TestGoFieldTypeRefs_ResolvesToEntityIDs(t *testing.T) {
 		m + "Order.Buyer => " + m + "SCOPE.Component:Customer [struct]",
 		m + "Order.ByName => " + m + "SCOPE.Component:Customer [struct]",
 		m + "Order.ByName => " + m + "SCOPE.Schema:Tier [type_alias]",
+		m + "Order.Both => " + m + "SCOPE.Component:Customer [struct]",
 		m + "Order.Cb => " + m + "SCOPE.Component:Customer [struct]",
 		m + "Order.Ch => " + m + "SCOPE.Component:Customer [struct]",
 		m + "Order.Emb => " + m + "SCOPE.Component:embed [+struct]",
@@ -687,5 +695,76 @@ func TestGoFieldTypeRefs_PropertiesAgreeWithTheEndpoints(t *testing.T) {
 		t.Errorf("json-renamed field carries field_name=%q, want %q — the "+
 			"json-tag axis is the one that can disagree with the Name, so it "+
 			"must be the one asserted", seen["Order.renamed_wire"], "renamed_wire")
+	}
+}
+
+// TestGoFieldTypeRefs_ImportPlaceholderIsNeverATarget grades the ALLOW-LIST,
+// and it exists because the first version of this arm claimed the allow-list had
+// no kill and offered a compound mutant as proof. The compound proved nothing —
+// its other half was independently lethal — and the claim was false.
+//
+// This is the input that separates them, and the axis it varies is the ONE that
+// TestGoFieldTypeRefs_BlankImportSharingATypeNameBinds holds constant: WHERE the
+// type is declared.
+//
+// `import _ "embed"` emits a SCOPE.Component with an EMPTY Subtype whose Name is
+// the whole import path — here the bare name `embed`. A blank import does not
+// bind the identifier, and a Go package is a DIRECTORY of files, so declaring
+// `type embed struct{…}` in a sibling file is ordinary, legal Go. In THIS file
+// the only record named `embed` is therefore the import placeholder:
+//
+//   - one node, so the ambiguity rule (rule 2) does not fire;
+//   - a bare name, so the "refused by name shape" argument does not apply;
+//   - and the real type is in another file, so the same-file rule already
+//     refuses the edge for an unrelated reason.
+//
+// The allow-list is the ONLY thing standing between this field and an edge bound
+// to an import placeholder. With it, no edge. Without it, `Order.Blob` binds to
+// the import — a wrong binding, which never reaches bug-extractor precisely
+// because it binds. That is the failure class this whole arm exists to avoid.
+func TestGoFieldTypeRefs_ImportPlaceholderIsNeverATarget(t *testing.T) {
+	recs := extractGoFiles(t, map[string]string{
+		"a.go": `package models
+
+import _ "embed"
+
+type Order struct {
+	Blob  embed
+	Local Local
+}
+
+type Local struct{ X int }
+`,
+		// The real type, in a sibling file of the same package.
+		"b.go": `package models
+
+type embed struct{ Data []byte }
+`,
+	})
+
+	// Premise: a.go really does carry a bare-named import placeholder, and it
+	// is the ONLY record named `embed` there. If either stops holding, the
+	// absence asserted below would be vacuous.
+	var aKinds []string
+	for i := range recs {
+		if recs[i].SourceFile == "a.go" && recs[i].Name == "embed" {
+			aKinds = append(aKinds, recs[i].Kind+"/"+recs[i].Subtype)
+		}
+	}
+	goFTWantEqual(t, aKinds, []string{"SCOPE.Component/"},
+		"premise: a.go must carry exactly one record named `embed`, the "+
+			"import placeholder with an empty Subtype")
+
+	if got := goFTTargetsOf(recs, "Order.Blob"); len(got) != 0 {
+		t.Errorf("Order.Blob targets %v; the only same-file record named `embed` "+
+			"is an IMPORT PLACEHOLDER, and binding a field to one is a wrong "+
+			"binding that never reaches bug-extractor because it binds", got)
+	}
+	// Positive control in the same struct: a legitimate same-file target still
+	// binds, so the absence above is about the allow-list and not about the
+	// pass being inert in this fixture.
+	if got := goFTTargetsOf(recs, "Order.Local"); !contains(got, "Local") {
+		t.Fatalf("Order.Local targets %v, want Local — without this control the "+
+			"assertion above grades nothing", got)
 	}
 }

--- a/internal/extractors/golang/field_type_refs_scope_6912_test.go
+++ b/internal/extractors/golang/field_type_refs_scope_6912_test.go
@@ -33,6 +33,15 @@ func TestGoFieldTypeRefs_TargetsAreScopedToTheRequestedFile(t *testing.T) {
 		// for a.go merely because some other file declares it.
 		{Name: "Shipper", Kind: "SCOPE.Component", Subtype: "interface", SourceFile: "b.go"},
 		{Name: "Meters", Kind: "SCOPE.Schema", Subtype: "type_alias", SourceFile: "b.go"},
+		// A DIFFERENT-KINDED record in b.go sharing a name with an a.go type.
+		// This row grades the SourceFile conjunct in goInFileTypeTargets' FIRST
+		// loop — the one that builds nameKinds — which the rows above cannot:
+		// they share no name with a.go, so a cross-file leak there changes
+		// nothing. With that conjunct removed, nameKinds["Customer"] gains a
+		// second kind from b.go and the ambiguity rule wrongly suppresses a.go's
+		// perfectly unambiguous Customer. Both loops carry the conjunct, so both
+		// are graded rather than one being paid for and its twin left open.
+		{Name: "Customer", Kind: "SCOPE.Enum", Subtype: "enum", SourceFile: "b.go"},
 	}
 
 	got := goInFileTypeTargets(records, "a.go")
@@ -69,7 +78,13 @@ func TestGoFieldTypeRefs_TargetsAreScopedToTheRequestedFile(t *testing.T) {
 			"would pass even if the function returned nothing", keysOf(gotB))
 	}
 	if _, ok := gotB["Customer"]; ok {
-		t.Errorf("Customer is declared in a.go and must not be a target for b.go")
+		// TWO reasons this name must be absent from b.go's set, and the row
+		// added above means they are no longer the same reason: a.go's
+		// Customer is in another file, and b.go's OWN Customer is a
+		// SCOPE.Enum, which the allow-list refuses. Either one alone is
+		// sufficient; asserting the absence covers both.
+		t.Errorf("Customer must not be a target for b.go: a.go's is cross-file " +
+			"and b.go's own is a SCOPE.Enum, which is not a type declaration")
 	}
 }
 

--- a/internal/extractors/golang/field_type_refs_scope_6912_test.go
+++ b/internal/extractors/golang/field_type_refs_scope_6912_test.go
@@ -1,0 +1,82 @@
+package golang
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6912 arm D — an INTERNAL test, and it exists for one reason: the
+// `r.SourceFile != filePath` conjunct in goInFileTypeTargets cannot be reached
+// through Extract.
+//
+// Extract is called once per file and every record it builds carries that file's
+// path, so from the outside the conjunct never fires and a mutant that deletes it
+// survives the entire external suite. That is the "alive but unreachable" verdict
+// — and the cheap answer to it is to call the function directly with the input
+// the guard exists for, rather than to leave a conjunct ungraded and say it was
+// too expensive. The whole cost is this file.
+//
+// The guard is what keeps the pass correct if goInFileTypeTargets is ever handed
+// a multi-file slice — which is not hypothetical: attachClassContains and
+// attachImplementsRelationships next door take the same (records, filePath)
+// shape, and a future caller that batches files would silently start binding a
+// field in one file to a same-named type in another. That is exactly the
+// cross-file hazard #6976/#6369 are about, and the same-file rule is this arm's
+// central promise.
+func TestGoFieldTypeRefs_TargetsAreScopedToTheRequestedFile(t *testing.T) {
+	records := []types.EntityRecord{
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "struct", SourceFile: "a.go"},
+		{Name: "Order", Kind: "SCOPE.Component", Subtype: "struct", SourceFile: "a.go"},
+		// Same shape, different file. Neither may appear in a.go's target set,
+		// and — the direction that matters — `Shipper` must NOT become a target
+		// for a.go merely because some other file declares it.
+		{Name: "Shipper", Kind: "SCOPE.Component", Subtype: "interface", SourceFile: "b.go"},
+		{Name: "Meters", Kind: "SCOPE.Schema", Subtype: "type_alias", SourceFile: "b.go"},
+	}
+
+	got := goInFileTypeTargets(records, "a.go")
+
+	want := map[string]string{
+		"Customer": "scope:component:class:go:a.go:Customer",
+		"Order":    "scope:component:class:go:a.go:Order",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("target set has %d entries %v, want %d %v", len(got), keysOf(got), len(want), want)
+	}
+	for name, toID := range want {
+		tgt, ok := got[name]
+		if !ok {
+			t.Fatalf("%q missing from a.go's target set %v", name, keysOf(got))
+		}
+		if tgt.toID != toID {
+			t.Errorf("%q toID = %q, want %q", name, tgt.toID, toID)
+		}
+	}
+	for _, foreign := range []string{"Shipper", "Meters"} {
+		if _, ok := got[foreign]; ok {
+			t.Errorf("%q is declared in b.go and must NOT be a target for a.go — "+
+				"the same-file rule is this arm's central promise", foreign)
+		}
+	}
+
+	// The mirror direction, so the assertion above is not just "b.go's records
+	// were ignored entirely": asking for b.go returns b.go's declarations and
+	// none of a.go's.
+	gotB := goInFileTypeTargets(records, "b.go")
+	if _, ok := gotB["Shipper"]; !ok {
+		t.Fatalf("b.go's own target set %v is missing Shipper — the test above "+
+			"would pass even if the function returned nothing", keysOf(gotB))
+	}
+	if _, ok := gotB["Customer"]; ok {
+		t.Errorf("Customer is declared in a.go and must not be a target for b.go")
+	}
+}
+
+func keysOf(m map[string]goFieldTypeTarget) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/extractors/golang/struct_fields.go
+++ b/internal/extractors/golang/struct_fields.go
@@ -140,6 +140,22 @@ func extractStructFieldEntities(
 				Metadata:           map[string]interface{}{"subtype": "field", "owner": ownerName},
 				EnrichmentRequired: false,
 			})
+			// Issue #6912 — stash every bare type name written in the declared
+			// type for attachGoFieldTypeRefs, which turns the ones DECLARED IN
+			// THIS FILE into field-anchored REFERENCES edges once every record
+			// for the file exists. Nothing is decided here: a field may be
+			// declared before the type it names, and the collision rule needs
+			// the enum value-sets and import records that are appended after
+			// extractTypes returns (field_type_refs.go).
+			//
+			// The TYPE NODE is read, not the Signature string, so the grammar's
+			// own qualified_type / anonymous-struct classification is what the
+			// candidate rule stands on. Computed per field record rather than
+			// per field_declaration so `A, B Order` gives each of A and B its
+			// own stash.
+			if cands := goFieldTypeCandidates(typeNode, src); len(cands) > 0 {
+				fields[len(fields)-1].Metadata[goFieldTypeRefsMetaKey] = cands
+			}
 		}
 	}
 

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -99,7 +99,7 @@
       "relationship_found": 19,
       "relationship_expected": 19,
       "entity_extracted_total": 71,
-      "relationship_extracted_total": 207
+      "relationship_extracted_total": 208
     },
     "graphql-schema-mini": {
       "entity_found": 8,


### PR DESCRIPTION
Arm D of #6912. Arms A (C#, #6984), B (proto, #6991) and C (rust, #7000) shipped `REFERENCES` with `ref_kind=field_target_type`, same-file targets only. This is the Go arm, and it is the root cause of contributor issue #6726 (`Schema` 99.3% orphan of 35,353 entities).

`Refs #6912` — one arm of several, so not a closure keyword.

## Why Go is arm B's shape, not arm C's

Go is the only language on this issue that **already** shipped a same-file-gated declared-type edge: `extractStructFieldDependencies` emits `DEPENDS_ON` per struct field type, gated on `knownTypeNames`. But it anchors on the **struct**, leaving the field a leaf on its outbound side — and `DEPENDS_ON` names no field at all, not even in a property. So "which fields point at `Customer`?" was unanswerable.

This adds a **second** edge anchored on the field and leaves the existing one untouched. The duplicated thing is the anchor, not the information.

## The two decisions the brief asked me to make deliberately

**1. Address — `BuildComponentStructuralRef`, not the neighbour's bare name.** The adjacent `DEPENDS_ON` uses `ToID: t` (bare). #6986 measured that form at 91.6% dangling for the custom lane. The new edge uses `scope:component:class:go:<file>:<Name>`, which is file-scoped. Adjacency was not treated as a reason to inherit.

**2. Allow-list — I admit `SCOPE.Schema`, and it is load-bearing.** Read from Go's own `extractTypes` rather than inherited:

| Kind | Subtype | Admitted | Why |
|---|---|---|---|
| `SCOPE.Component` | `struct` | yes | `type T struct{…}` |
| `SCOPE.Component` | `interface` | yes | `type T interface{…}` |
| `SCOPE.Schema` | `type_alias` | **yes** | `type Celsius float64`, `type Handler func()`, `type T = U` |
| everything else | | no | |

Arm C's guard is `Kind != "SCOPE.Component"`, which is right for Rust and **wrong here** — in Go a type alias is a `SCOPE.Schema`. Inheriting it would have silently dropped **32 of the 168 corpus edges (19%)**. Measured, not argued: mutant **M4** applies exactly that guard and is DEAD.

## A Go-specific hazard arm C's rule would not have caught

`type Status int` beside a typed const block produces a `SCOPE.Enum` value-set named `Status` **in the same file**, alongside the `SCOPE.Schema/type_alias`. Two kinds at one (file, name) is two graph nodes; the resolver's `ambigLocation` check runs *before* the `byLocation` fallback this address depends on, so the edge would dangle. Arm C's collision check looked only **within its own admitted set** — the alias is admitted, the value-set is not — so it would not have seen this.

The rule here spans **every** same-file record, and counts **kinds, not records**, mirroring `internal/resolve/refs.go:1308` (`existing != e.ID`) exactly. Counting records instead would delete a legitimate edge: `import _ "embed"` beside `type embed struct{…}` is two records but one node. Both directions graded (M5, M6 both DEAD).

## Candidate collector is not `resolveTypeReferences`

The brief pointed at `resolveTypeReferences` as the existing unwrapper. I did **not** reuse it: it collects every descendant `type_identifier`, which for a `qualified_type` means it **strips `other.Order` to `Order`** — binding to a same-file `Order` silently, since a bound edge never reaches `bug-extractor`. Arms B and C both forbid exactly that. `goFieldTypeCandidates` skips `qualified_type` whole, and also skips anonymous `struct_type`/`interface_type` (an anonymous struct's member is not the field's declared type).

The pre-existing `DEPENDS_ON` keeps its strip, **pinned as pre-existing** in `TestGoFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName`. Narrowing it is a separate change with its own blast radius, not a rider.

No primitive blocklist, and that is deliberate: Go's predeclared identifiers are `type_identifier` in the grammar and are legally shadowable, so `type rune struct{…}` means a field written `rune` genuinely names that type. Arm B's `protoScalars` guard is correct there and would be **wrong** here — both directions asserted.

## Corpus yield — `archigraph-corpora`, read-only, sequential

| | |
|---|---|
| Go files scanned | 686 |
| Files emitting edges | 73 |
| `field_target_type` edges | **168** |
| **BOUND** | **168** |
| **Dangling** | **0** (100% bind) |

Target kinds: `Component/struct` 107, **`Schema/type_alias` 32**, `Component/interface` 29. Top repos: etcd 87, grpc-go-examples 44, gin 25, chi 12.

Per-file resolution is faithful here because `byLocation`/`ambigLocation` are keyed by file path and the pass is same-file only.

## The double-count question (arm B's open question — answered)

**Measured by reading the arithmetic, not reasoned.** No metric double-counts, because **no metric in `internal/quality` counts endpoints**, and there is **no edge dedup anywhere** in the counting path. But two rates move, both flattering:

- **`audit.go:424` OrphanRate is DEFLATED** — `touched` (`audit.go:363-368`) admits any non-`CONTAINS`/`DECLARES` edge in either direction, so a field flips to non-orphan on being a `FromID`. That is the #6912 gap closing and is intended. Worth naming: `fitness/rule.go:511-526` computes a *second*, inbound-only orphan rate that will **not** move, so the two published orphan numbers diverge further after this arm.
- **`audit.go:433` ReferencesPerFunction is INFLATED — a genuine distortion.** Numerator counts REFERENCES **edges** (`audit.go:382-384`), denominator counts function **entities**; a `SCOPE.Schema/field` is not function-like (`audit.go:480-493`), so every edge raises the ratio with no denominator movement. `DEPENDS_ON` is counted by nothing, so the old anchor contributed 0 and the new one contributes 1. It feeds `refHealth`/`RiskScore` (`audit.go:584`) and the "REFERENCES emission missing" gate at `audit.go:680`, **which it can therefore mask.**

**Price of the fix:** nothing in `internal/quality` reads `ref_kind` today. Excluding `field_target_type` from that one numerator is a ~5-line change at `audit.go:382-384` plus a test — but it affects **arms A–D at once**, so it belongs in its own issue rather than smuggled into the Go arm. Reported, not absorbed.

## Digest and ratchet movement — enumerated

- **`go test ./cmd/grafel/`**: green, fresh `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`; parity tests confirmed **run, not skipped**.
  **The unmoved digest is NOT evidence for this change and is not cited as such.** That digest is a same-binary **parity** set (`worktree_seed_parity_test.go:161`) keyed `(FromID, ToID, Kind)` with properties discarded — it cannot see `ref_kind`, could not move for this arm by construction, and would not see a duplicate edge either. Running it is still correct; reading it as coverage is not. (My brief described it as a cross-run pin; that was wrong.)
- **`scripts/quality/run.sh --runs 1 --ratchet`**: caught exactly one fixture — `go-chi-mini`, `relationship_extracted_total` 207 → 208.

**Delta enumerated, not bumped blind.** I extracted the real fixture tree and listed the new edges: exactly one, `MemoryStore.users -> User` (`store/store.go`, `users map[string]User`, `User` declared in the same file). That accounts for +1 precisely. Note `UsersHandler.Store store.Store` correctly gets **nothing** — a qualified cross-package type. Hand-edited that **one number**; `git diff` on the baseline is a single line. No blanket `--update-baseline`. Re-run: **38 gated fixtures held**, `git status --porcelain` empty.

## Verification

- `go test -count=1` green: `./internal/extractors/golang/...`, `./internal/resolve/...`, `./internal/quality/...` (incl. `analytics`, `audit`, `fitness`), `./internal/extractor/...`, `./internal/graph/...`, `./cmd/grafel/`.
- `go test ./internal/quality/...` **and** the extraction-quality gate run separately — **both green, both reported.**
- `gofmt -l internal/` clean.

## Axes — varied vs held constant

Main fixture **varies**: wrapper form (bare, pointer, slice, array, map key *and* value, channel, func param, generic argument), target entity kind (`Component/struct`, `Component/interface`, `Schema/type_alias`), wire-name form (plain vs json-tag renamed). **Holds constant**: file path, owning struct, and target name (`Customer`) — so a wrapper regression reads as a missing row, not a changed target.

Axes needing a different file or declaration shape get **their own fixture**, because they cannot vary inside the main one without also varying something else: cross-file, enum shadow, blank-import name sharing, shadowed predeclared identifier, qualified-name strip, type-parameter over-fire.

Every forbidden row is asserted **by name** (`Qty`, `Label`, `Foreign`, `Nested`, `Anon`, `Self`, `St`), not by a count. Each negative assertion carries a **positive control in the same fixture** — `Status` (shadowed, no edge) beside `Tier` (identical form, no const block, edge present); `Holder.Foreign` beside `Holder.Local`; cross-file `Order.Buyer` beside same-file `Order.Local` — so an absence can never pass by the pass simply being off.

## Per-conjunct mutant verdicts — RE-SCORED after review

Every edit proven to land by an **exact occurrence count**; `cp`-restore from a backup taken **from the tree being mutated**, shasum-verified back afterwards.

| Mutant | Verdict |
|---|---|
| M1 — pass 2 `SourceFile != filePath` | **DEAD** |
| N2 — pass 1 `SourceFile != filePath` (M1's twin) | **DEAD** *(new)* |
| M2 — drop `Name == ""` | equivalent-under-the-suite |
| **M3 — allow-list** | **DEAD** *(was mis-scored; see below)* |
| M4 — arm C's `Kind != "SCOPE.Component"` | **DEAD** ×3 |
| M5 — ambiguity guard | **DEAD** ×3 |
| M6 — ambiguity counts records, not kinds | **DEAD** ×3 |
| M7 — collector skip: `qualified_type` | **DEAD** |
| M8a — collector skip: `struct_type` | **DEAD** |
| **M8b — collector skip: `interface_type`** | **DEAD** *(was vacuous)* |
| M9 — self-reference guard | **DEAD** |
| N1 — per-field ToID dedup | **DEAD** *(new)* |
| M10 — field-record guard in attach | equivalent-under-the-suite |
| M11 — stash uses `resolveTypeReferences` | **DEAD** ×3 |

**12 DEAD, 2 equivalent.**

### B1 — I was wrong about the allow-list, and the experiment I offered proved nothing

I claimed the allow-list was belt-and-braces and cited an M3+M5 compound as evidence. **M5 is independently lethal, so the compound killed exactly the tests M5 alone kills** — it carried no information about M3. A compound mutant grades its second half only if its first half is *not* lethal alone. Checking the compound was the right instinct; the conclusion was not available from it.

The claim was also false. Varying the one axis `BlankImportSharingATypeNameBinds` **holds constant** — *where* the type is declared — gives the distinguishing input:

```go
import _ "embed"   // SCOPE.Component, Subtype "", Name "embed"
type Order struct{ Blob embed }   // `type embed struct{…}` is in a SIBLING file
```

`import _` does not bind the identifier, and a Go package is a directory, so this is ordinary legal Go. The import placeholder is then the **only** same-file record named `embed`: one node (rule 2 silent), bare name ("refused by name shape" inapplicable). Without the allow-list, `Order.Blob` binds **to an import placeholder** — a wrong binding, which never reaches `bug-extractor` precisely because it binds.

Graded by `TestGoFieldTypeRefs_ImportPlaceholderIsNeverATarget`. **The allow-list is load-bearing, not belt-and-braces**, and the header now says so — and records the reasoning error, since that part is the more portable lesson.

### B2 — the `interface_type` skip was vacuous

`Anon interface{ Do() }` contains no `type_identifier`, so deleting `interface_type` from the skip list survived the whole package. Now `Get() Customer`. Scored as two mutants: **M8a and M8b both DEAD**, where the earlier "M8 DEAD ×2" was really DEAD once and vacuous once.

### N1 / N2 — the two cheap ungraded conjuncts, taken

- **N1**: added `Both map[Customer]Customer` (one declared type named twice) to grade the ToID dedup. DEAD. Matters because the audit pass has **no edge dedup**, so a duplicate would count twice in `ReferencesTotal` and `relationship_extracted_total`.
- **N2**: `goInFileTypeTargets` carries the `SourceFile` conjunct in **both** loops; I had paid to kill it in pass 2 and left pass 1 open. Added a `b.go` record sharing a name with an `a.go` type under a *different kind* — which is what makes a pass-1 leak observable at all. DEAD.

### The two survivors, stated rather than glossed

- **M2** is a dead store: a candidate is a `type_identifier`'s text, never empty, so `targets[""]` is never consulted.
- **M10** is masked because only field records receive the stash; if that changed, `goFTEdges` asserts no non-field record carries one of these edges.

### N4 — invariant documented

Rule 2 spans every record **at step 4b-bis**, not every record `Extract` returns. Steps 4c–6b append more that `buildSymbolIndex` sees. It holds today only because those producers emit *prefixed* names (`error_handling:`, `exception:`, `config:`) that no bare `type_identifier` can equal — now written down as an invariant to preserve rather than an accident relied on.

## Known-wrong, pinned deliberately

`TestGoFieldTypeRefs_KnownOverFire_TypeParameterShadowedByASameFileType` — the pass does not model type parameters, so `type Box[T any]` beside `type T struct{}` over-fires. Pinned so a real fix breaks a test rather than changing behaviour silently.

## Honest floor

Same-file only. For Go — where a package is a *directory* of files — this is the dominant miss, larger than for C# or Rust. Closing it needs a cross-file package type view pass 1 does not have; binding bare type names across files is the exact hazard #6976/#6369 are about, and I did not open it.

Also recorded honestly: I could **not** construct a Go `type_spec` form that names a type without emitting an entity (all of `Stack[int]`, `[...]int`, `func(...int)`, `(int)`, `interface{ int | string }` etc. emit one). The "knownTypeNames is a superset" argument is therefore recorded as **unconstructed**, and the real reason for reading records instead is stated instead: a `map[string]bool` carries no Kind, so it cannot express either rule this pass needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
