### PR TITLE
fix(#6912): java fields carried their declared type at no anchor at all — emit the field→type REFERENCES edge, same-file targets only

### DIFF
--- a/internal/extractors/java/field_type_refs.go
+++ b/internal/extractors/java/field_type_refs.go
@@ -1,0 +1,453 @@
+package java
+
+import (
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// field_type_refs.go — the field→declared-type edge for Java (issue #6912, arm
+// E). Arm A is internal/extractors/csharp/field_type_refs.go (#6984), arm B is
+// internal/extractors/proto/field_type_refs.go (#6991), arm C is
+// internal/extractors/rust/field_type_refs.go (#7000), arm D is
+// internal/extractors/golang/field_type_refs.go (#7036).
+//
+// THE GAP. Java emits a SCOPE.Schema/field entity from two places — record
+// header components (walk's record_declaration arm) and class field
+// declarations (buildField) — and BOTH leave it a leaf on its outbound side.
+// The declared type was never lost: it is a live local at each emit site
+// (`typeName := nodeText(typeNode, …)` for a record component; buildField holds
+// the field_declaration node and already reads its `type` child through
+// buildFieldSignature). The issue body long claimed Java "does not even retain
+// the type string" and that a capture step was needed first; that claim was
+// FALSE, and the grounding pass at 663f6c50a corrected it. Java is structurally
+// the same arm as its predecessors: the datum was in hand and simply never
+// became a relationship.
+//
+// Java is one of the four languages in contributor #6726's corpus (csharp,
+// fsharp, java, protobuf), which measures SCOPE.Schema at 99.3% orphan across
+// 35,353 entities. Arms A and B closed csharp and protobuf; this closes java.
+//
+// WHERE THE ANCHOR IS. Nothing in this package emitted a declared-type edge at
+// ANY anchor before this pass — that is arm B's question, asked here rather than
+// inherited, and the answer differs from Go's. Go already shipped a
+// struct-anchored DEPENDS_ON that this arm had to sit beside; Java has no such
+// edge. What Java does have is three NEIGHBOURING populations that are easy to
+// mistake for one, and none of them is a field→type relation:
+//
+//   - javaInjectFieldTypes (java.go:390-395) emits class → REFERENCES for
+//     @Inject/@Autowired field types. The anchor is the CLASS, the target is
+//     an `ext:`/bare name rather than a structural ref, and it fires only under
+//     a DI annotation. It is untouched.
+//   - emitReferences (references.go) emits operation → REFERENCES → field for
+//     field USAGE inside a method body. Opposite direction, different fact.
+//   - internal/custom/java/hibernate.go and orm_helpers.go emit a
+//     `field_target_type` ref_kind already — but off a PARALLEL
+//     SCOPE.Component population, and internal/custom/** defaults OFF
+//     (internal/extractors/custom_gate.go). #6986 measured that lane's
+//     `Class:<Name>` address at 91.6% dangling. It is not a core producer and
+//     it does not reduce this arm's scope.
+//
+// THE ALLOW-LIST, WRITTEN ON JAVA'S OWN buildComponent RATHER THAN INHERITED.
+// Arm C's guard is `Kind != "SCOPE.Component"`, and arm D measured that exact
+// guard dropping 19% of Go's edges because a Go type_alias is a SCOPE.Schema.
+// Java's shape is the opposite: EVERY declared type this package emits as a
+// nameable target is a SCOPE.Component, because walk's single
+// class/interface/enum/record arm routes all four through buildComponent with
+// only the Subtype varying (java.go:324-355, :1374-1396). So the allow-list is
+// a SUBTYPE list, and it admits all four:
+//
+//	SCOPE.Component + class      → admitted (class Order {…})
+//	SCOPE.Component + interface  → admitted (interface Shipper {…})
+//	SCOPE.Component + enum       → admitted (enum Status {…}) — see below
+//	SCOPE.Component + record     → admitted (record Money(…) {…})
+//
+// Refused, and each for a reason that is stated at the strength it has:
+//
+//   - SCOPE.Component + "file" (#577, extractor.FileEntity) — its Name is the
+//     FILE PATH. At repo root that is a bare-looking `Order.java`, but it
+//     always carries the `.java` extension and a `type_identifier` cannot
+//     contain a dot, so this one is ALSO unreachable by name shape. Refused
+//     anyway; claimed as nothing more.
+//   - SCOPE.Component with an EMPTY subtype — synthComp (lombok.go:332) and the
+//     Panache DSL interfaces (panache.go:866-896) always set one, but a future
+//     synthesizer that does not would otherwise be admitted silently. This is
+//     the java analogue of Go's import placeholder: an unsubtyped Component is
+//     not a declared type.
+//   - SCOPE.Operation, SCOPE.Schema (field entities AND nosql_model.go:187's
+//     `schema` model node, which is named after the CLASS and so genuinely
+//     shares a name with an admitted target), SCOPE.Enum value-sets,
+//     SCOPE.ExceptionType, SCOPE.Template, config keys.
+//
+// The allow-list is a LIVE FILTER, not belt-and-braces: nosql_model.go emits
+// `SCOPE.Schema`/`schema` named `Order` in the SAME FILE as `class Order`, and
+// SCOPE.Schema/`field` records carry `Order.buyer`-shaped names. Neither is a
+// legal target. Graded by TestJavaFieldTypeRefs_NoSqlModelSchemaIsNeverATarget
+// and TestJavaFieldTypeRefs_FieldIsNeverATarget.
+//
+// THE AMBIGUITY RULE, AND WHY JAVA'S IS NOT ARM D'S. Arm D counts distinct
+// KINDS across EVERY same-file record and drops any name denoting more than
+// one graph node. Copying that verbatim here would have been WRONG IN THE
+// EXPENSIVE DIRECTION, and the reason is specific to Java:
+//
+// buildJavaEnumValueSet (enum_valueset.go:25) emits a SCOPE.Enum value-set for
+// every non-empty `enum` declaration, named IDENTICALLY to the
+// SCOPE.Component/enum that walk emits from the same node in the same file. So
+// under arm D's rule EVERY Java enum is two kinds, and EVERY enum target would
+// be refused — and a field typed by a same-file enum is one of the most
+// valuable edges this arm can produce. That is exactly the over-strictness
+// filed as #7038 against arm C, reached by a different route.
+//
+// It would also have been WRONG ON THE RESOLVER'S OWN TERMS, which is what
+// decides it. A component-space structural ref is resolved by
+// Index.lookupStructural (internal/resolve/refs.go:2982) through
+// lookupLocationKind FIRST, filtered to componentKindFamily (refs.go:2341:
+// Component/Class/View/Model and their SCOPE.* spellings). ambigLocation — the
+// kind-AGNOSTIC index arm D's rule mirrors — is only consulted AFTER that
+// lookup misses (refs.go:3004). A SCOPE.Enum sibling is not a member of
+// componentKindFamily, so it never enters the tier that decides this address,
+// and the enum's SCOPE.Component record binds uniquely. Go's type_alias
+// targets were SCOPE.Schema, outside that family, which is why arm D fell
+// through to ambigLocation and had to mirror it; Java's targets never do.
+//
+// So javaInFileTypeTargets counts distinct kinds RESTRICTED TO THE COMPONENT
+// ADDRESS FAMILY — the set lookupLocationKind will actually weigh — and drops a
+// name only when two DISTINCT family kinds carry it. Within one file two records
+// sharing a Kind are ONE graph node (graph.EntityID hashes (repo, Kind, Name,
+// SourceFile) with Subtype EXCLUDED, mirroring refs.go:1308's `existing != e.ID`
+// test), so `class Order` beside Lombok's synthesized `SCOPE.Component`
+// `Order` — or beside a second `SCOPE.Component`/`record` of the same name — is
+// one node and one ToID, and counting RECORDS instead would delete an edge that
+// binds perfectly well. That is #7038's defect and it is graded in BOTH
+// directions here:
+//
+//   - TestJavaFieldTypeRefs_SameFileEnumTypeBinds drives the REAL RESOLVER over
+//     an extracted `enum Status` + `Status status;` file and asserts the edge is
+//     rewritten to the Component's ID — a mutant restoring arm D's all-kinds
+//     count fails it. It carries a POSITIVE CONTROL in the same fixture (a
+//     class-typed field in the same file) so it cannot pass by the edge simply
+//     never being emitted.
+//   - TestJavaFieldTypeRefs_DuplicateComponentRecordsAreOneNode gives a name two
+//     admitted records of the same Kind; a mutant counting records drops it.
+//   - TestJavaFieldTypeRefs_TwoDistinctFamilyKindsAreRefused constructs the
+//     SCOPE.Component + SCOPE.Model collision the rule exists for.
+//   - TestJavaFieldTypeRefs_Unit_AnotherFilesCollisionDoesNotShadowThisFile
+//     grades the pass-1 SCOPE of the count, which fails in the same direction:
+//     the resolver's index is keyed by (file, name), so a collision in a
+//     DIFFERENT file must not refuse a target here.
+//
+// MEASURED, not argued: across the 645 .java files in the read-only corpus at
+// archigraph-corpora, this pass emits 147 edges, of which 147 bind and 0 dangle.
+// Arm D's all-kinds rule, applied unchanged, emits 129 — it drops 18 edges,
+// 12.2%, AND EVERY ONE OF THEM IS AN ENUM TARGET. The bound targets break down
+// as 125 SCOPE.Component/class, 18 /enum, 4 /interface. Arm C's
+// `Kind != "SCOPE.Component"` guard, by contrast, would have cost nothing here:
+// every Java target is a Component, which is the whole reason this arm's
+// departure is on the ambiguity rule rather than on the kind check.
+//
+// A NON-BINDING EDGE IS WORSE THAN NO EDGE. An unresolved stub is kept verbatim,
+// dangles, and is classified `bug-extractor`, so every miss is a full hit. That
+// is why this pass emits ONLY for a type DECLARED IN THIS FILE and refuses
+// everything else outright — see javaFieldTypeCandidates for how java.lang,
+// primitives, generic wrappers and imported types are all refused by the same
+// single check.
+//
+// WHAT THIS PASS IS NOT
+//
+//   - SAME FILE ONLY. Java's one-public-type-per-file convention makes this a
+//     far better fit than it was for Go — but a package-private helper type in a
+//     sibling file, and every imported type, still gets nothing. Binding a bare
+//     type name across files is the exact hazard #6976/#6369 are about, and it
+//     needs the resolver rather than the extractor. Separate arm.
+//   - QUALIFIED NAMES ARE SKIPPED WHOLE, NEVER REDUCED. See
+//     javaFieldTypeCandidates.
+//   - IT DOES NOT UNDERSTAND TYPE PARAMETERS. `class Holder<T> { T item; }`
+//     yields candidate `T`, dropped only because nothing in the file happens to
+//     be DECLARED `T`. A file that also declares `class T {}` gets a wrong edge.
+//     Known-wrong and pinned as such by
+//     TestJavaFieldTypeRefs_KnownOverFire_TypeParameterShadowedByASameFileType,
+//     a case a real fix is expected to break. Java's grammar gives no help here:
+//     a type parameter and a class reference are the same `type_identifier`
+//     node, and separating them needs the enclosing declaration's
+//     `type_parameters` list threaded to the field — the same shape Go's arm
+//     deferred.
+//   - IT DOES NOT INFLATE PAST ONE EDGE PER (field, target). A field written
+//     `Map<Order, Order>` yields the candidate `Order` twice and emits ONE edge.
+
+// javaFieldTypeRefsMetaKey is the per-field stash written at the two emit sites
+// (walk's record_declaration arm and buildField) and consumed — and deleted — by
+// attachJavaFieldTypeRefs.
+//
+// The candidates cannot become edges at the emit site. Two independent reasons,
+// either sufficient: `class Order { Customer buyer; }` may be declared BEFORE
+// `class Customer` in the same file, so the in-file declaration set is complete
+// only once walk has finished; and the target index must see records the
+// synthesizers append AFTER walk returns (Lombok builders, Panache interfaces,
+// the nosql model node), which is what makes the allow-list's nosql case
+// decidable at all.
+const javaFieldTypeRefsMetaKey = "field_type_refs"
+
+// javaFieldTypeRefsOwnerKey stashes the field's declaring type name alongside
+// the candidates. It is NOT re-derived by splitting the field entity's Name on
+// '.', because a field's leaf name and its owner are both free-form: a nested
+// type's members are emitted bare (walk's parentType does not propagate through
+// unrelated nodes), so `A.b` cannot be assumed to mean owner `A`. The emit site
+// knows the owner exactly; carrying it is cheaper than guessing it.
+const javaFieldTypeRefsOwnerKey = "field_type_refs_owner"
+
+// javaFieldTargetRefKind is the value of the `ref_kind` edge property. It
+// matches arm A's csFieldTargetRefKind, arm B's protoFieldTargetRefKind, arm C's
+// rustFieldTargetRefKind and arm D's goFieldTargetRefKind verbatim — the
+// discriminator is what makes the edge queryable as a field→declared-type edge
+// across languages, so it must be one string. There is deliberately no shared
+// constant: arm D scored that as a mutant (CZ-2) and found four independent
+// literals grade the agreement transitively, where one shared constant would be
+// a single grader.
+const javaFieldTargetRefKind = "field_target_type"
+
+// javaFieldTypeCandidates returns every bare type name written in a field's
+// declared type expression, in source order and without deduplication.
+//
+// It descends the type node and collects `type_identifier` leaves, which unwraps
+// array (`Order[]`), generic (`List<Order>` → BOTH `List` and `Order`), nested
+// generic (`Map<String, Order>` → `Map`, `String`, `Order`) and wildcard
+// (`List<? extends Order>` → `List`, `Order`) syntax for free, with no wrapper
+// list to keep in sync.
+//
+// A JAVA PRIMITIVE NEEDS NO BLOCKLIST, AND — UNLIKE GO — CANNOT NEED ONE. Go's
+// `int` is a shadowable universe-scope identifier that tree-sitter-go emits as a
+// plain `type_identifier`, so arm D had to reach the primitive through its
+// in-file declaration check and pin the shadowing case. Java's primitives are
+// KEYWORDS: the grammar gives `int`/`long`/`short`/`byte`/`char` the node type
+// `integral_type`, `float`/`double` `floating_point_type`, and `boolean`
+// `boolean_type`. None is a `type_identifier`, none can be redeclared, and
+// `long[]` descends to `integral_type` + `dimensions` and yields nothing at all.
+// So a primitive is not merely refused, it is never a candidate — verified
+// against the grammar rather than assumed, and pinned by
+// TestJavaFieldTypeRefs_PrimitiveFieldsProduceNoEdge, which enumerates all eight
+// against an independent literal list.
+//
+// THE BOXED TYPES, java.lang AND EVERY IMPORTED TYPE are ordinary
+// `type_identifier`s and ARE collected — then refused by the single in-file
+// declaration check in javaInFileTypeTargets, which is the only gate this pass
+// has and the only one it needs. `String`, `Integer`, `List`, `HttpClient` and
+// `com.acme.Widget` are none of them declared in the file, so none produces an
+// edge. Writing a name blocklist instead would be actively wrong: a file that
+// declares its own `class String` means THAT type in field position, and Java
+// permits it (the unqualified name resolves to the local declaration, shadowing
+// java.lang). Pinned in both directions by that primitive test and by
+// TestJavaFieldTypeRefs_BoxedAndJavaLangTypesProduceNoEdge.
+//
+// ONE node kind is skipped WHOLE, without descending:
+//
+//   - `scoped_type_identifier` — `com.example.Order`, `java.util.List`,
+//     `Outer.Inner`. The trailing segment is NEVER taken. Arm D found that Go's
+//     resolveTypeReferences stripped `other.Order` to `Order` and bound it to a
+//     same-file `Order` — a silently wrong binding, since a bound edge never
+//     reaches bug-extractor. Java's shape is identical and its `Outer.Inner`
+//     form is worse still: BOTH segments are plausible same-file names, so any
+//     reduction is a guess between two wrong answers. Skipping it whole is
+//     narrower than a resolver would be and is the only honest option at
+//     extractor scope. Pinned by
+//     TestJavaFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName and
+//     TestJavaFieldTypeRefs_NestedQualifiedTypeTakesNeitherSegment.
+//
+//     It is skipped WITHOUT losing the type argument beside it: in
+//     `java.util.List<Order>` the `type_arguments` node is a SIBLING of the
+//     `scoped_type_identifier` under `generic_type`, so `Order` is still
+//     collected while `java`, `util` and `List` are not. That is the correct
+//     answer and it falls out of the traversal rather than being special-cased;
+//     pinned by TestJavaFieldTypeRefs_QualifiedGenericStillBindsItsArgument.
+func javaFieldTypeCandidates(typ ts.Node, src []byte) []string {
+	var out []string
+	var walkType func(n ts.Node)
+	walkType = func(n ts.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "scoped_type_identifier":
+			return
+		case "type_identifier":
+			out = append(out, nodeText(n, src))
+			return
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			walkType(n.NamedChild(i))
+		}
+	}
+	walkType(typ)
+	return out
+}
+
+// javaFieldTypeTarget is one in-file type declaration a field can point at: the
+// structural ToID that binds to it, and the bare name for the `target_type`
+// property.
+type javaFieldTypeTarget struct {
+	toID string
+	name string
+}
+
+// javaComponentAddressFamily is the set of entity Kinds that
+// internal/resolve's lookupLocationKind weighs when resolving a
+// `scope:component:…` structural ref — componentKindFamily at
+// internal/resolve/refs.go:2341, both the bare and SCOPE.-prefixed spellings,
+// since BuildIndex writes each entity under its raw Kind AND its SCOPE-trimmed
+// alias (refs.go:1289-1296).
+//
+// It is duplicated here rather than exported from internal/resolve because the
+// dependency must not run extractor → resolver, and because arm D established
+// that an independently-written literal is a stronger grader than a shared
+// constant. The invariant this pass depends on is narrow and stated so the next
+// edit can check it: a Kind ABSENT from this set cannot make a component-space
+// ref ambiguous, so admitting one here can only cost edges, and adding a Kind to
+// componentKindFamily upstream without adding it here would let this pass emit
+// a stub that dangles.
+var javaComponentAddressFamily = map[string]bool{
+	"Component": true, "Class": true, "View": true, "Model": true,
+	"SCOPE.Component": true, "SCOPE.View": true, "SCOPE.Model": true,
+}
+
+// javaInFileTypeTargets indexes every TYPE DECLARED in this file that a
+// field-type edge may address, keyed by bare name.
+//
+// Two rules, both argued in the header block:
+//
+//  1. The record must be a Component this package emits for a real type
+//     declaration — subtype class, interface, enum or record. This is a check on
+//     the EMITTED RECORD rather than on the AST, so a declaration the extractor
+//     chose not to emit can never be addressed, and so the nosql `schema` node
+//     and the field entities are visible to the check and refused by it.
+//
+//  2. A name carried by MORE THAN ONE DISTINCT KIND IN THE COMPONENT ADDRESS
+//     FAMILY is dropped. Restricted to that family — not every same-file kind —
+//     because a non-family kind never enters the tier that resolves this
+//     address; see the header block for why arm D's wider rule would refuse
+//     every Java enum. The unit is the KIND, not the record, mirroring
+//     refs.go:1308 exactly: within one file two records sharing a Kind are one
+//     graph node.
+//
+// The record set is the one that exists AT THE HOOK POINT in Extract — after
+// walk, the synthesizers, emitReferences and the config/exception/template
+// passes — not every record the indexer eventually holds. The passes that run
+// after it emit PREFIXED names (`error_handling:…`, `exception:…`, `config:…`)
+// that no bare type_identifier can equal, so a collision invisible here cannot
+// arise today; a future producer emitting a BARE-named entity for a java file
+// would reintroduce dangling, and that is the invariant to preserve rather than
+// an accident to rely on.
+func javaInFileTypeTargets(records []types.EntityRecord, filePath string) map[string]javaFieldTypeTarget {
+	// Pass 1 — how many DISTINCT COMPONENT-FAMILY KINDS each same-file name
+	// carries, target-eligible or not.
+	nameKinds := make(map[string]map[string]bool)
+	for i := range records {
+		r := &records[i]
+		if r.SourceFile != filePath || r.Name == "" || !javaComponentAddressFamily[r.Kind] {
+			continue
+		}
+		if nameKinds[r.Name] == nil {
+			nameKinds[r.Name] = make(map[string]bool)
+		}
+		nameKinds[r.Name][r.Kind] = true
+	}
+
+	// Pass 2 — admit the type declarations whose name is unambiguous.
+	targets := make(map[string]javaFieldTypeTarget)
+	for i := range records {
+		r := &records[i]
+		if r.SourceFile != filePath || r.Name == "" || r.Kind != "SCOPE.Component" {
+			continue
+		}
+		switch r.Subtype {
+		case "class", "interface", "enum", "record":
+		default:
+			continue
+		}
+		if len(nameKinds[r.Name]) > 1 {
+			continue
+		}
+		targets[r.Name] = javaFieldTypeTarget{
+			toID: extractor.BuildComponentStructuralRef("java", filePath, r.Name),
+			name: r.Name,
+		}
+	}
+	return targets
+}
+
+// stashJavaFieldTypeRefs records a field entity's declared-type candidates and
+// owning type on the record, for attachJavaFieldTypeRefs to turn into edges once
+// the file's full record set exists. typ is the field's `type` AST node; owner
+// is the declaring type's bare name, or "" for a field with no stable enclosing
+// type.
+//
+// A no-op when the type expression names nothing addressable (a bare primitive),
+// so a field that can never produce an edge carries no metadata at all.
+func stashJavaFieldTypeRefs(rec *types.EntityRecord, typ ts.Node, src []byte, owner string) {
+	cands := javaFieldTypeCandidates(typ, src)
+	if len(cands) == 0 {
+		return
+	}
+	if rec.Metadata == nil {
+		rec.Metadata = make(map[string]interface{})
+	}
+	rec.Metadata[javaFieldTypeRefsMetaKey] = cands
+	rec.Metadata[javaFieldTypeRefsOwnerKey] = owner
+}
+
+// attachJavaFieldTypeRefs appends one REFERENCES edge per (field, in-file
+// declared type) pair and clears the stash it consumed.
+//
+// FromID is left empty so graph assembly anchors the edge on the field record
+// that carries it — the Django precedent at
+// internal/extractors/python/django_relational.go:246-252, and arms A-D.
+// (internal/custom/java/hibernate.go sets an explicit structural FromID because
+// it hangs its edge off its own parallel SCOPE.Component node; that is a
+// different shape and not the one to copy — #6912's own body was corrected on
+// this point.)
+//
+// Relationships is APPENDED to, never assigned: a Java field record carries no
+// outbound edge today, but assigning would silently clobber one added later.
+func attachJavaFieldTypeRefs(records []types.EntityRecord, filePath string) {
+	targets := javaInFileTypeTargets(records, filePath)
+	for i := range records {
+		r := &records[i]
+		if r.Metadata == nil {
+			continue
+		}
+		cands, _ := r.Metadata[javaFieldTypeRefsMetaKey].([]string)
+		owner, _ := r.Metadata[javaFieldTypeRefsOwnerKey].(string)
+		delete(r.Metadata, javaFieldTypeRefsMetaKey)
+		delete(r.Metadata, javaFieldTypeRefsOwnerKey)
+		if len(cands) == 0 || r.Kind != "SCOPE.Schema" || r.Subtype != "field" {
+			continue
+		}
+		fieldName := r.Name
+		if owner != "" {
+			fieldName = strings.TrimPrefix(r.Name, owner+".")
+		}
+		emitted := make(map[string]bool)
+		for _, cand := range cands {
+			t, ok := targets[cand]
+			if !ok || emitted[t.toID] {
+				continue
+			}
+			// A field never targets its own declaring type: `class Node {
+			// Node next; }` is a self-reference the CONTAINS edge already
+			// relates, and arms C and D decline it identically.
+			if owner != "" && t.name == owner {
+				continue
+			}
+			emitted[t.toID] = true
+			r.Relationships = append(r.Relationships, types.RelationshipRecord{
+				ToID: t.toID,
+				Kind: string(types.RelationshipKindReferences),
+				Properties: types.Props{
+					{K: "field_name", V: fieldName},
+					{K: "ref_kind", V: javaFieldTargetRefKind},
+					{K: "target_type", V: t.name},
+				},
+			})
+		}
+	}
+}

--- a/internal/extractors/java/field_type_refs.go
+++ b/internal/extractors/java/field_type_refs.go
@@ -85,7 +85,7 @@ import (
 // `SCOPE.Schema`/`schema` named `Order` in the SAME FILE as `class Order`, and
 // SCOPE.Schema/`field` records carry `Order.buyer`-shaped names. Neither is a
 // legal target. Graded by TestJavaFieldTypeRefs_NoSqlModelSchemaIsNeverATarget
-// and TestJavaFieldTypeRefs_FieldIsNeverATarget.
+// and TestJavaFieldTypeRefs_Unit_FieldIsNeverATarget.
 //
 // THE AMBIGUITY RULE, AND WHY JAVA'S IS NOT ARM D'S. Arm D counts distinct
 // KINDS across EVERY same-file record and drops any name denoting more than
@@ -117,21 +117,30 @@ import (
 // name only when two DISTINCT family kinds carry it. Within one file two records
 // sharing a Kind are ONE graph node (graph.EntityID hashes (repo, Kind, Name,
 // SourceFile) with Subtype EXCLUDED, mirroring refs.go:1308's `existing != e.ID`
-// test), so `class Order` beside Lombok's synthesized `SCOPE.Component`
-// `Order` — or beside a second `SCOPE.Component`/`record` of the same name — is
-// one node and one ToID, and counting RECORDS instead would delete an edge that
-// binds perfectly well. That is #7038's defect and it is graded in BOTH
-// directions here:
+// test), so two same-file records sharing a Kind are one node and one ToID, and
+// counting RECORDS instead would delete an edge that binds perfectly well. That
+// is #7038's defect.
 //
-//   - TestJavaFieldTypeRefs_SameFileEnumTypeBinds drives the REAL RESOLVER over
-//     an extracted `enum Status` + `Status status;` file and asserts the edge is
-//     rewritten to the Component's ID — a mutant restoring arm D's all-kinds
-//     count fails it. It carries a POSITIVE CONTROL in the same fixture (a
-//     class-typed field in the same file) so it cannot pass by the edge simply
-//     never being emitted.
-//   - TestJavaFieldTypeRefs_DuplicateComponentRecordsAreOneNode gives a name two
-//     admitted records of the same Kind; a mutant counting records drops it.
-//   - TestJavaFieldTypeRefs_TwoDistinctFamilyKindsAreRefused constructs the
+// It is NOT hypothetical, and the production shape is Lombok's: `@Builder class
+// Order` makes synthesizeLombokEntities emit a SCOPE.Component/class named
+// `OrderBuilder` (lombok.go:438 — always `<Class>Builder`, NEVER the annotated
+// class's own name), so a file that ALSO declares `class OrderBuilder` carries
+// TWO SCOPE.Component/class records of that name. One graph node; a field typed
+// `OrderBuilder` binds; a record count deletes the edge. Graded from java SOURCE
+// by TestJavaFieldTypeRefs_LombokBuilderDuplicateComponentIsOneNode, not only
+// from a hand-built record set. Both directions:
+//
+//   - TestJavaFieldTypeRefs_ResolvesToEntityIDs drives the REAL RESOLVER over an
+//     extracted file carrying `enum Status` beside `Status state;` and asserts
+//     the edge is rewritten to the Component's ID — a mutant restoring arm D's
+//     all-kinds count fails it. It carries POSITIVE CONTROLS in the same fixture
+//     (class-, interface- and record-typed fields) so it cannot pass by the edge
+//     simply never being emitted.
+//   - TestJavaFieldTypeRefs_LombokBuilderDuplicateComponentIsOneNode gives a name
+//     two same-Kind records FROM JAVA SOURCE, and
+//     TestJavaFieldTypeRefs_Unit_DuplicateComponentRecordsAreOneNode does the
+//     same at record level; a mutant counting records drops both.
+//   - TestJavaFieldTypeRefs_Unit_TwoDistinctFamilyKindsAreRefused constructs the
 //     SCOPE.Component + SCOPE.Model collision the rule exists for.
 //   - TestJavaFieldTypeRefs_Unit_AnotherFilesCollisionDoesNotShadowThisFile
 //     grades the pass-1 SCOPE of the count, which fails in the same direction:
@@ -290,24 +299,40 @@ type javaFieldTypeTarget struct {
 	name string
 }
 
-// javaComponentAddressFamily is the set of entity Kinds that
-// internal/resolve's lookupLocationKind weighs when resolving a
-// `scope:component:…` structural ref — componentKindFamily at
-// internal/resolve/refs.go:2341, both the bare and SCOPE.-prefixed spellings,
-// since BuildIndex writes each entity under its raw Kind AND its SCOPE-trimmed
-// alias (refs.go:1289-1296).
+// javaComponentAddressFamily is the set of entity Kinds that can make a
+// `scope:component:…` structural ref ambiguous — i.e. every Kind that
+// internal/resolve's lookupLocationKind weighs when resolving one.
+//
+// It is NOT a copy of componentKindFamily (internal/resolve/refs.go:2341,
+// {Component, Class, View, Model, SCOPE.Component, SCOPE.View, SCOPE.Model}).
+// It is that slice CLOSED UNDER THE INDEX'S TRIM ALIAS, and the distinction is
+// load-bearing rather than pedantic. BuildIndex writes each entity under its raw
+// Kind AND its SCOPE-trimmed alias (refs.go:1208-1211), so an entity whose Kind
+// is `SCOPE.Class` is keyed under BOTH "SCOPE.Class" and "Class" — and "Class"
+// IS in the family, even though "SCOPE.Class" itself is not. Such an entity
+// therefore participates in uniqueMatchInFamily, blanks the match against a
+// same-(file, name) Component, and drops the ref through to ambigLocation, where
+// it dangles.
+//
+// So the membership test is `K ∈ family || strings.TrimPrefix(K, "SCOPE.") ∈
+// family`, and the eight entries below are exactly that set. An earlier revision
+// omitted "SCOPE.Class" while its own comment claimed to carry "both spellings":
+// a real mirror hole, found by a reviewer's mutant, unreachable from java source
+// today (no java producer emits a bare- or SCOPE.Class-kinded entity) but wrong
+// in the direction that emits a stub the resolver refuses. Graded by
+// TestJavaFieldTypeRefs_Unit_ScopeClassParticipatesViaTheTrimAlias.
 //
 // It is duplicated here rather than exported from internal/resolve because the
 // dependency must not run extractor → resolver, and because arm D established
 // that an independently-written literal is a stronger grader than a shared
-// constant. The invariant this pass depends on is narrow and stated so the next
-// edit can check it: a Kind ABSENT from this set cannot make a component-space
-// ref ambiguous, so admitting one here can only cost edges, and adding a Kind to
-// componentKindFamily upstream without adding it here would let this pass emit
-// a stub that dangles.
+// constant. The invariant to preserve: a Kind ABSENT from this set cannot make a
+// component-space ref ambiguous, so adding a Kind to componentKindFamily
+// upstream — or adding a Kind whose trimmed alias lands in it — without adding
+// it here would let this pass emit a stub that dangles.
 var javaComponentAddressFamily = map[string]bool{
 	"Component": true, "Class": true, "View": true, "Model": true,
-	"SCOPE.Component": true, "SCOPE.View": true, "SCOPE.Model": true,
+	"SCOPE.Component": true, "SCOPE.Class": true,
+	"SCOPE.View": true, "SCOPE.Model": true,
 }
 
 // javaInFileTypeTargets indexes every TYPE DECLARED in this file that a

--- a/internal/extractors/java/field_type_refs_6912_test.go
+++ b/internal/extractors/java/field_type_refs_6912_test.go
@@ -1,0 +1,574 @@
+package java_test
+
+// #6912 arm E — the field→declared-type edge for Java. See field_type_refs.go
+// for the kind / address / same-file / allow-list / ambiguity decisions; this
+// file grades them.
+//
+// Every assertion below names FIELDS AND TARGETS. A count table cannot see a
+// substitution (#6973) and recall cannot see over-firing at all (#6926), so the
+// forbidden set is asserted BY NAME beside the expected set: named primitive
+// fields, a named java.lang field, a named boxed field, a named
+// package-qualified field, a named nested-qualified field, the self-reference,
+// the cross-file target, and the unbound type parameter.
+//
+// AXES. The main fixture VARIES the wrapper form (bare, array, generic
+// argument, qualified-generic argument, map key AND value, wildcard,
+// user-generic argument) and the TARGET'S DECLARATION FORM (class, interface,
+// enum, record) and the ANCHOR (class field_declaration vs record header
+// component). It HOLDS CONSTANT the file path, the declaring type (`Order`
+// wherever a class field is wanted) and the target name (`Customer` wherever a
+// class target is wanted), so a wrapper regression shows up as a missing row
+// rather than as a changed target.
+//
+// The axes that cannot vary inside that fixture without also varying something
+// else get their own: cross-file targets need a second FILE; the type-parameter
+// over-fire needs a file that DECLARES the parameter's name; the nosql `schema`
+// collision needs an @Document annotation; the Lombok duplicate-Component case
+// needs a @Builder. Each is below with its own comment.
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const javaFTPath = "com/example/Order.java"
+
+const javaFTSrc = `package com.example;
+
+import java.util.List;
+import java.util.Map;
+
+class Customer { String name; }
+
+interface Shipper { void ship(); }
+
+enum Status { NEW, DONE }
+
+record Money(String currency, long amount) {}
+
+record Invoice(Customer buyer, List<Customer> cc, long total) {}
+
+class Holder<T> { T item; }
+
+class Outer {}
+
+class Inner {}
+
+class Order {
+  int quantity;
+  boolean flagged;
+  double weight;
+  String label;
+  Integer boxed;
+  Customer buyer;
+  Customer[] history;
+  List<Customer> watchers;
+  java.util.List<Customer> qualifiedWatchers;
+  Map<Status, Customer> byStatus;
+  List<? extends Customer> wild;
+  Holder<Customer> wrapped;
+  Map<Customer, Customer> both;
+  Shipper ship;
+  Status state;
+  Money price;
+  Order next;
+  com.other.Customer foreign;
+  Outer.Inner nested;
+  Warehouse depot;
+}
+`
+
+// javaFTRivalPath declares a SECOND `Customer` in a different file so the bare
+// name `Customer` is ambiguous across the graph. Without it the structural
+// address would be ungraded by the resolver test: a bare-name ToID would bind
+// too, and the test could not tell the two dialects apart. It also supplies the
+// cross-file target `Warehouse`, which must produce NO edge.
+const javaFTRivalPath = "com/other/Customer.java"
+
+const javaFTRivalSrc = `package com.other;
+
+class Customer { String note; }
+
+class Warehouse { String code; }
+`
+
+func extractJavaFT(t *testing.T, files map[string]string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("java")
+	if !ok {
+		t.Fatal("java extractor not registered")
+	}
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	var all []types.EntityRecord
+	for _, p := range paths {
+		src := files[p]
+		got, err := ext.Extract(context.Background(), extractor.FileInput{
+			Path: p, Content: []byte(src), Language: "java", TSTree: parseForTest(t, src),
+		})
+		if err != nil {
+			t.Fatalf("extract %s: %v", p, err)
+		}
+		all = append(all, got...)
+	}
+	return all
+}
+
+// javaFTEdges returns "<file>:<fieldEntityName> => <target_type>" for every
+// field→declared-type edge in recs, across ALL records — so an edge that
+// escaped onto a non-field record shows up here rather than being filtered
+// away by a field-shaped query.
+func javaFTEdges(recs []types.EntityRecord) []string {
+	var out []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || r.Properties.Get("ref_kind") != "field_target_type" {
+				continue
+			}
+			out = append(out, recs[i].SourceFile+":"+recs[i].Name+" => "+r.Properties.Get("target_type"))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func javaFTWantEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	sort.Strings(want)
+	if strings.Join(got, "\n") == strings.Join(want, "\n") {
+		return
+	}
+	t.Fatalf("field→type edge set mismatch\n got (%d):\n  %s\nwant (%d):\n  %s",
+		len(got), strings.Join(got, "\n  "), len(want), strings.Join(want, "\n  "))
+}
+
+// TestJavaFieldTypeRefs_EdgeSet is the whole-set assertion: it pins every edge
+// the main fixture produces AND, by being an equality rather than a
+// containment, every edge it must not. Each forbidden row is called out by name
+// in the comments below so a future reader can see which decision each field
+// grades rather than reading an unexplained absence.
+//
+//	quantity/flagged/weight  — PRIMITIVES. Not a type_identifier in the
+//	                           grammar at all, so never even a candidate.
+//	label / boxed            — java.lang and a boxed type: ordinary
+//	                           type_identifiers, refused solely by the
+//	                           in-file declaration check.
+//	watchers / byStatus      — the generic WRAPPERS List and Map are refused
+//	                           by that same check while their ARGUMENTS bind.
+//	qualifiedWatchers        — the scoped `java.util.List` is skipped whole,
+//	                           yet its sibling type argument still binds.
+//	both                     — Map<Customer, Customer> is ONE edge, not two.
+//	next                     — the self-reference is declined.
+//	foreign                  — `com.other.Customer` is NOT reduced to
+//	                           `Customer`, which IS declared in this file.
+//	nested                   — `Outer.Inner` takes NEITHER segment, though
+//	                           both are declared in this file.
+//	depot                    — `Warehouse` is declared in the OTHER file.
+//	Holder.item              — the type parameter `T` binds to nothing.
+//	Money.currency/amount    — a record component with no in-file target.
+func TestJavaFieldTypeRefs_EdgeSet(t *testing.T) {
+	recs := extractJavaFT(t, map[string]string{
+		javaFTPath:      javaFTSrc,
+		javaFTRivalPath: javaFTRivalSrc,
+	})
+	const f = "com/example/Order.java:"
+	javaFTWantEqual(t, javaFTEdges(recs), []string{
+		f + "Order.buyer => Customer",
+		f + "Order.history => Customer",
+		f + "Order.watchers => Customer",
+		f + "Order.qualifiedWatchers => Customer",
+		f + "Order.byStatus => Status",
+		f + "Order.byStatus => Customer",
+		f + "Order.wild => Customer",
+		f + "Order.wrapped => Holder",
+		f + "Order.wrapped => Customer",
+		f + "Order.both => Customer",
+		f + "Order.ship => Shipper",
+		f + "Order.state => Status",
+		f + "Order.price => Money",
+		f + "Invoice.buyer => Customer",
+		f + "Invoice.cc => Customer",
+	})
+}
+
+// TestJavaFieldTypeRefs_EdgeProperties pins the three properties on one edge
+// against INDEPENDENT LITERALS rather than against the constants under test, so
+// a near-miss in the ref_kind spelling (`field_target_types`) fails here.
+// field_name is the field's LEAF name, not the `<Owner>.<field>` entity Name.
+func TestJavaFieldTypeRefs_EdgeProperties(t *testing.T) {
+	recs := extractJavaFT(t, map[string]string{javaFTPath: javaFTSrc})
+	var found int
+	for i := range recs {
+		if recs[i].Name != "Order.buyer" {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" {
+				continue
+			}
+			found++
+			if got := r.Properties.Get("ref_kind"); got != "field_target_type" {
+				t.Errorf("ref_kind = %q, want field_target_type", got)
+			}
+			if got := r.Properties.Get("field_name"); got != "buyer" {
+				t.Errorf("field_name = %q, want buyer (leaf, not Order.buyer)", got)
+			}
+			if got := r.Properties.Get("target_type"); got != "Customer" {
+				t.Errorf("target_type = %q, want Customer", got)
+			}
+			if got := r.ToID; got != "scope:component:class:java:com/example/Order.java:Customer" {
+				t.Errorf("ToID = %q, want the file-scoped component structural ref", got)
+			}
+			if r.FromID != "" {
+				t.Errorf("FromID = %q, want empty so assembly anchors on the field record", r.FromID)
+			}
+		}
+	}
+	if found != 1 {
+		t.Fatalf("Order.buyer carries %d REFERENCES edges, want exactly 1", found)
+	}
+}
+
+// TestJavaFieldTypeRefs_PrimitiveFieldsProduceNoEdge enumerates Java's eight
+// primitives against an INDEPENDENT literal list rather than trusting the main
+// fixture's three, and pairs each with a same-named DECLARED CLASS so the test
+// cannot pass merely because the name is undeclared.
+//
+// This is the conjunct where Java differs from Go most sharply. Go's `int` is a
+// shadowable identifier and arm D had to pin the shadowing case; Java's
+// primitives are keywords with their own node types, so `class int {}` does not
+// even parse and the primitive can never be a candidate. Declaring `class Int`
+// (capitalised) alongside is the closest constructible neighbour and it MUST get
+// its edge — the positive control that separates "primitives are refused" from
+// "this fixture emits nothing".
+func TestJavaFieldTypeRefs_PrimitiveFieldsProduceNoEdge(t *testing.T) {
+	const path = "Prim.java"
+	src := `class Int {}
+class Prim {
+  byte a; short b; int c; long d; float e; double f; boolean g; char h;
+  Int ok;
+}
+`
+	recs := extractJavaFT(t, map[string]string{path: src})
+	javaFTWantEqual(t, javaFTEdges(recs), []string{path + ":Prim.ok => Int"})
+
+	// Independent restatement: no edge anywhere carries a primitive target.
+	for _, p := range []string{"byte", "short", "int", "long", "float", "double", "boolean", "char"} {
+		for _, e := range javaFTEdges(recs) {
+			if strings.HasSuffix(e, " => "+p) {
+				t.Errorf("primitive %q became a target: %s", p, e)
+			}
+		}
+	}
+}
+
+// TestJavaFieldTypeRefs_BoxedAndJavaLangTypesProduceNoEdge grades the OTHER
+// half of the primitive story: the boxed types and java.lang names ARE
+// candidates and are refused only by the in-file declaration check. The second
+// file declares `class Integer` locally, which Java permits and which then
+// genuinely means THAT type in field position — so the same source text yields
+// no edge in one file and an edge in the other. That pair is what proves the
+// refusal is the declaration check and not a name blocklist.
+func TestJavaFieldTypeRefs_BoxedAndJavaLangTypesProduceNoEdge(t *testing.T) {
+	recs := extractJavaFT(t, map[string]string{"A.java": `class A {
+  Integer n; String s; Object o; Boolean b;
+}
+`})
+	javaFTWantEqual(t, javaFTEdges(recs), nil)
+
+	shadowed := extractJavaFT(t, map[string]string{"B.java": `class Integer { int v; }
+class B {
+  Integer n; String s;
+}
+`})
+	javaFTWantEqual(t, javaFTEdges(shadowed), []string{"B.java:B.n => Integer"})
+}
+
+// TestJavaFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName is the
+// correctness fix arm D found in Go and this arm inherits deliberately. The
+// field is declared `com.other.Customer` and the SAME FILE declares `Customer`;
+// reducing the qualified name to its trailing segment binds the field to the
+// WRONG entity, silently, because a bound edge never reaches bug-extractor.
+//
+// The same-file `Customer` is exercised by a POSITIVE CONTROL field in the same
+// class, so the test distinguishes "the qualified form is skipped" from
+// "`Customer` is not a target here at all".
+func TestJavaFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName(t *testing.T) {
+	recs := extractJavaFT(t, map[string]string{"Q.java": `class Customer {}
+class Q {
+  com.other.Customer foreign;
+  Customer local;
+}
+`})
+	javaFTWantEqual(t, javaFTEdges(recs), []string{"Q.java:Q.local => Customer"})
+}
+
+// TestJavaFieldTypeRefs_NestedQualifiedTypeTakesNeitherSegment is the Java-only
+// half of that ruling, and the reason a "take the last segment" heuristic is
+// worse here than in Go. `Outer.Inner` is a nested-type reference whose BOTH
+// segments name a type declared in this file, so a reduction is a guess between
+// two wrong answers rather than one. Both are exercised as positive controls by
+// bare-named fields, so the absence is specific to the qualified form.
+func TestJavaFieldTypeRefs_NestedQualifiedTypeTakesNeitherSegment(t *testing.T) {
+	recs := extractJavaFT(t, map[string]string{"N.java": `class Outer {}
+class Inner {}
+class N {
+  Outer.Inner nested;
+  Outer o;
+  Inner i;
+}
+`})
+	javaFTWantEqual(t, javaFTEdges(recs), []string{
+		"N.java:N.o => Outer",
+		"N.java:N.i => Inner",
+	})
+}
+
+// TestJavaFieldTypeRefs_QualifiedGenericStillBindsItsArgument pins the
+// interaction the two rules have, which is the one place skipping a node whole
+// could have cost a real edge. In `java.util.List<Order>` the type_arguments
+// node is a SIBLING of the scoped_type_identifier under generic_type, not a
+// child of it, so skipping the qualified wrapper leaves the argument reachable.
+// Asserted with the unqualified form beside it: both must yield exactly the
+// argument, and the qualified form must NOT additionally yield `List`.
+func TestJavaFieldTypeRefs_QualifiedGenericStillBindsItsArgument(t *testing.T) {
+	recs := extractJavaFT(t, map[string]string{"G.java": `import java.util.List;
+class Order {}
+class List {}
+class G {
+  java.util.List<Order> qualified;
+  List<Order> bare;
+}
+`})
+	javaFTWantEqual(t, javaFTEdges(recs), []string{
+		"G.java:G.qualified => Order",
+		"G.java:G.bare => Order",
+		"G.java:G.bare => List",
+	})
+}
+
+// TestJavaFieldTypeRefs_SelfReferenceProducesNoEdge — a field whose declared
+// type is its own declaring type. The CONTAINS edge already relates the two
+// records; arms C and D decline it identically. The sibling field proves the
+// target is otherwise reachable.
+func TestJavaFieldTypeRefs_SelfReferenceProducesNoEdge(t *testing.T) {
+	recs := extractJavaFT(t, map[string]string{"S.java": `class Node {
+  Node next;
+  Node[] children;
+  Leaf leaf;
+}
+class Leaf {}
+`})
+	javaFTWantEqual(t, javaFTEdges(recs), []string{"S.java:Node.leaf => Leaf"})
+}
+
+// TestJavaFieldTypeRefs_ForwardDeclaredTargetBinds is why the candidates are
+// stashed during the walk instead of becoming edges at the emit site: the target
+// is declared BELOW the field that references it, so the in-file declaration set
+// is complete only after walk returns. A mutant that emitted at the emit site
+// would produce nothing here.
+func TestJavaFieldTypeRefs_ForwardDeclaredTargetBinds(t *testing.T) {
+	recs := extractJavaFT(t, map[string]string{"F.java": `class Order {
+  Customer buyer;
+}
+class Customer {}
+`})
+	javaFTWantEqual(t, javaFTEdges(recs), []string{"F.java:Order.buyer => Customer"})
+}
+
+// TestJavaFieldTypeRefs_AllFourComponentSubtypesAreTargets grades the
+// allow-list's ADMIT direction one subtype at a time. Java routes class,
+// interface, enum and record through the SAME buildComponent call with only the
+// Subtype varying, so a guard written on Kind alone would look correct and a
+// guard that dropped one subtype would be invisible without this row-per-subtype
+// assertion.
+func TestJavaFieldTypeRefs_AllFourComponentSubtypesAreTargets(t *testing.T) {
+	recs := extractJavaFT(t, map[string]string{"T.java": `class C {}
+interface I { void x(); }
+enum E { A, B }
+record R(int v) {}
+class Host {
+  C c; I i; E e; R r;
+}
+`})
+	javaFTWantEqual(t, javaFTEdges(recs), []string{
+		"T.java:Host.c => C",
+		"T.java:Host.i => I",
+		"T.java:Host.e => E",
+		"T.java:Host.r => R",
+	})
+}
+
+// TestJavaFieldTypeRefs_RecordComponentIsAnAnchor grades the SECOND emit site.
+// A record header component is emitted by a completely separate code path from
+// buildField (walk's record_declaration arm), so an arm that wired only
+// buildField would still pass every class-field test above.
+func TestJavaFieldTypeRefs_RecordComponentIsAnAnchor(t *testing.T) {
+	recs := extractJavaFT(t, map[string]string{"R.java": `class Customer {}
+record Invoice(Customer buyer, String note, int total) {}
+`})
+	javaFTWantEqual(t, javaFTEdges(recs), []string{"R.java:Invoice.buyer => Customer"})
+}
+
+// TestJavaFieldTypeRefs_KnownOverFire_TypeParameterShadowedByASameFileType pins
+// a case this pass gets WRONG, so the wrongness is a graded fact rather than a
+// silent one. `class Holder<T>` uses `T` in field position; a file that also
+// declares `class T {}` gets an edge that asserts something false. A real fix —
+// threading the enclosing declaration's type_parameters list to the field — is
+// EXPECTED to break this test, and breaking it is the signal that the fix
+// landed.
+//
+// The control is the same source WITHOUT `class T {}`, which must produce
+// nothing: that separates "the type parameter is mistaken for a type" from
+// "type parameters produce edges unconditionally".
+func TestJavaFieldTypeRefs_KnownOverFire_TypeParameterShadowedByASameFileType(t *testing.T) {
+	overfire := extractJavaFT(t, map[string]string{"H.java": `class T {}
+class Holder<T> { T item; }
+`})
+	javaFTWantEqual(t, javaFTEdges(overfire), []string{"H.java:Holder.item => T"})
+
+	clean := extractJavaFT(t, map[string]string{"H2.java": `class Holder<T> { T item; }`})
+	javaFTWantEqual(t, javaFTEdges(clean), nil)
+}
+
+// TestJavaFieldTypeRefs_NoSqlModelSchemaIsNeverATarget grades the allow-list
+// against a REAL same-file competitor rather than a synthetic one.
+// nosql_model.go emits a `SCOPE.Schema`/`schema` entity named after the ANNOTATED
+// CLASS, in the same file, so `@Document class Customer` yields two records
+// named `Customer`: the admitted SCOPE.Component and a SCOPE.Schema that is not
+// a legal target.
+//
+// Two things must hold together and are asserted separately: the field still
+// binds (the SCOPE.Schema must not make the name ambiguous — it is outside the
+// component address family), and the edge's ToID addresses the component space.
+func TestJavaFieldTypeRefs_NoSqlModelSchemaIsNeverATarget(t *testing.T) {
+	const path = "Doc.java"
+	src := `import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+class Customer { String name; }
+
+class Order { Customer buyer; }
+`
+	recs := extractJavaFT(t, map[string]string{path: src})
+	// Premise: the competitor record actually exists in this fixture.
+	var schemaNamed int
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "schema" && recs[i].Name == "Customer" {
+			schemaNamed++
+		}
+	}
+	if schemaNamed == 0 {
+		t.Skip("nosql model pass did not fire on this fixture; the collision it grades is absent")
+	}
+	javaFTWantEqual(t, javaFTEdges(recs), []string{path + ":Order.buyer => Customer"})
+}
+
+// TestJavaFieldTypeRefs_ResolvesToEntityIDs is the assertion that makes "a
+// non-binding edge is worse than no edge" a graded property rather than a stated
+// intention. It drives the REAL resolver and requires every emitted edge to bind
+// to an entity ID; a dangling stub is kept verbatim and classified
+// bug-extractor, so a mis-addressed edge would be a full hit.
+//
+// THE ENUM ROW IS THE POINT. `Order.state => Status` binds even though the file
+// carries BOTH a SCOPE.Component/enum and a SCOPE.Enum value-set named `Status`.
+// Arm D's rule — count kinds across EVERY same-file record — would have refused
+// that edge and every other same-file enum target in Java, which is the
+// over-strictness filed as #7038. This test is what says the narrower Java rule
+// is correct on the resolver's own terms rather than merely cheaper: it does not
+// assert the emit-site decision, it asserts the BINDING.
+//
+// The class rows beside it are the positive control: without them a rule that
+// emitted nothing at all would also pass "no edge dangled".
+func TestJavaFieldTypeRefs_ResolvesToEntityIDs(t *testing.T) {
+	recs := extractJavaFT(t, map[string]string{
+		javaFTPath:      javaFTSrc,
+		javaFTRivalPath: javaFTRivalSrc,
+	})
+	for i := range recs {
+		if recs[i].ID == "" {
+			recs[i].ID = graph.EntityID("issue6912", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+		}
+	}
+	idx := resolve.BuildIndex(recs)
+
+	before := len(javaFTEdges(recs))
+	if before == 0 {
+		t.Fatal("no field-type edges to drive through the resolver")
+	}
+
+	// Positive control on the address dialect: the BARE name must be ambiguous
+	// here, otherwise this test does not distinguish the structural address from
+	// a bare-name ToID, which would pass too.
+	if _, st := idx.LookupStatusHint("Customer", "REFERENCES"); st == 1 {
+		t.Fatalf("the bare name %q binds in this fixture, so the ambiguity this "+
+			"test controls for is absent and the structural address is ungraded",
+			"Customer")
+	}
+
+	idToName := map[string]string{}
+	idToSubs := map[string]map[string]bool{}
+	for i := range recs {
+		id := recs[i].ID
+		idToName[id] = recs[i].SourceFile + ":" + recs[i].Kind + ":" + recs[i].Name
+		if idToSubs[id] == nil {
+			idToSubs[id] = map[string]bool{}
+		}
+		idToSubs[id][recs[i].Subtype] = true
+	}
+	describe := func(id string) string {
+		subs := make([]string, 0, len(idToSubs[id]))
+		for s := range idToSubs[id] {
+			subs = append(subs, s)
+		}
+		sort.Strings(subs)
+		return idToName[id] + " [" + strings.Join(subs, "+") + "]"
+	}
+
+	resolve.ReferencesEmbedded(recs, idx)
+
+	var bound []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || r.Properties.Get("ref_kind") != "field_target_type" {
+				continue
+			}
+			if _, ok := idToName[r.ToID]; !ok {
+				t.Errorf("%s:%s -[REFERENCES]-> %q did NOT bind to an entity id "+
+					"(dangling stub → bug-extractor)",
+					recs[i].SourceFile, recs[i].Name, r.ToID)
+				continue
+			}
+			bound = append(bound, recs[i].SourceFile+":"+recs[i].Name+" => "+describe(r.ToID))
+		}
+	}
+	sort.Strings(bound)
+	const f = "com/example/Order.java:"
+	javaFTWantEqual(t, bound, []string{
+		f + "Order.buyer => " + f + "SCOPE.Component:Customer [class]",
+		f + "Order.history => " + f + "SCOPE.Component:Customer [class]",
+		f + "Order.watchers => " + f + "SCOPE.Component:Customer [class]",
+		f + "Order.qualifiedWatchers => " + f + "SCOPE.Component:Customer [class]",
+		f + "Order.byStatus => " + f + "SCOPE.Component:Status [enum]",
+		f + "Order.byStatus => " + f + "SCOPE.Component:Customer [class]",
+		f + "Order.wild => " + f + "SCOPE.Component:Customer [class]",
+		f + "Order.wrapped => " + f + "SCOPE.Component:Holder [class]",
+		f + "Order.wrapped => " + f + "SCOPE.Component:Customer [class]",
+		f + "Order.both => " + f + "SCOPE.Component:Customer [class]",
+		f + "Order.ship => " + f + "SCOPE.Component:Shipper [interface]",
+		f + "Order.state => " + f + "SCOPE.Component:Status [enum]",
+		f + "Order.price => " + f + "SCOPE.Component:Money [record]",
+		f + "Invoice.buyer => " + f + "SCOPE.Component:Customer [class]",
+		f + "Invoice.cc => " + f + "SCOPE.Component:Customer [class]",
+	})
+}

--- a/internal/extractors/java/field_type_refs_6912_test.go
+++ b/internal/extractors/java/field_type_refs_6912_test.go
@@ -24,7 +24,23 @@ package java_test
 // else get their own: cross-file targets need a second FILE; the type-parameter
 // over-fire needs a file that DECLARES the parameter's name; the nosql `schema`
 // collision needs an @Document annotation; the Lombok duplicate-Component case
-// needs a @Builder. Each is below with its own comment.
+// needs a @Builder beside a hand-declared `<Class>Builder`. Each is below with
+// its own comment.
+//
+// RECALL CEILING — what 147 corpus edges is bounded BY, so the number is not
+// read as completeness. This arm can only ever emit for a field that has a
+// field ENTITY, and java's field-entity population has two pre-existing holes
+// (neither introduced here, neither this arm's to fix):
+//
+//   - A MULTI-DECLARATOR field emits only its FIRST name. `class M { Customer
+//     a, b; }` yields `SCOPE.Schema/field M.a` and nothing for `b`, so `b` can
+//     never carry an edge.
+//   - AN INTERFACE CONSTANT emits NO field entity at all. `interface Consts {
+//     Customer DEFAULT = null; }` yields no field record and no edge.
+//
+// A third, smaller ceiling is on the TARGET side: an `@interface` annotation
+// type gets no SCOPE.Component, so an in-file annotation type can never be a
+// target. All three were observed by probe, not inferred.
 
 import (
 	"context"
@@ -570,5 +586,67 @@ func TestJavaFieldTypeRefs_ResolvesToEntityIDs(t *testing.T) {
 		f + "Order.price => " + f + "SCOPE.Component:Money [record]",
 		f + "Invoice.buyer => " + f + "SCOPE.Component:Customer [class]",
 		f + "Invoice.cc => " + f + "SCOPE.Component:Customer [class]",
+	})
+}
+
+// TestJavaFieldTypeRefs_LombokBuilderDuplicateComponentIsOneNode is the
+// PRODUCTION-REACHABLE grader for the count-kinds-not-records rule, and it
+// exists because an earlier revision of this arm described the shape wrongly.
+//
+// synthesizeLombokEntities emits a synthesized SCOPE.Component/class for
+// `@Builder` named `<Class>Builder` (lombok.go:438) — never the annotated
+// class's own name, which is what the earlier description claimed. So the
+// collision is constructible only like this: `@Builder class Order` synthesizes
+// `OrderBuilder` into this file, and the file ALSO declares `class OrderBuilder`
+// by hand. Two SCOPE.Component/class records, one Name, one file — and
+// therefore ONE graph node, since graph.EntityID excludes Subtype and both
+// records carry the same Kind.
+//
+// A field typed `OrderBuilder` must still get its edge. A rule counting RECORDS
+// deletes it, which is #7038's defect reached from java source rather than from
+// a hand-built record set. The fixture asserts the premise (two records, one
+// name) before asserting the edge, so it cannot pass vacuously if Lombok stops
+// synthesizing.
+func TestJavaFieldTypeRefs_LombokBuilderDuplicateComponentIsOneNode(t *testing.T) {
+	const path = "Order.java"
+	recs := extractJavaFT(t, map[string]string{path: `import lombok.Builder;
+
+@Builder
+class Order {
+  String id;
+}
+
+class OrderBuilder {
+  String stage;
+}
+
+class Host {
+  OrderBuilder ob;
+  Order order;
+}
+`})
+	// Premise: TWO SCOPE.Component records named OrderBuilder in this file,
+	// one synthesized and one declared. Without both, the rule this test
+	// grades is not exercised and the assertion below would be vacuous.
+	var synthesized, declared int
+	for i := range recs {
+		if recs[i].Kind != "SCOPE.Component" || recs[i].Name != "OrderBuilder" ||
+			recs[i].SourceFile != path {
+			continue
+		}
+		if recs[i].Properties["synthesized_from"] != "" {
+			synthesized++
+		} else {
+			declared++
+		}
+	}
+	if synthesized != 1 || declared != 1 {
+		t.Fatalf("premise absent: %d synthesized + %d declared OrderBuilder "+
+			"components, want 1 + 1 — the duplicate-record rule is not exercised",
+			synthesized, declared)
+	}
+	javaFTWantEqual(t, javaFTEdges(recs), []string{
+		path + ":Host.ob => OrderBuilder",
+		path + ":Host.order => Order",
 	})
 }

--- a/internal/extractors/java/field_type_refs_units_6912_test.go
+++ b/internal/extractors/java/field_type_refs_units_6912_test.go
@@ -1,0 +1,283 @@
+package java
+
+// #6912 arm E — in-package grading for javaInFileTypeTargets.
+//
+// These conjuncts cannot be reached from Java SOURCE. The allow-list refuses
+// four record shapes and the ambiguity rule refuses one, and for three of them
+// no .java file makes the extractor emit a competitor with the right Name: a
+// file entity is always named after the file path, a Component with an empty
+// Subtype is emitted by no producer today, and Java emits no SCOPE.Model at all.
+//
+// Testing them only through source would leave each one either UNGRADED or
+// graded vacuously by an absence that some OTHER rule already caused — the
+// mutually-masking-guards failure. So the target index is driven directly with
+// synthetic records, one conjunct per test, each carrying a POSITIVE CONTROL in
+// the same record set (an admitted Component of a different name) so a mutant
+// that broke the index entirely fails every one of them rather than passing by
+// returning nothing.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const javaFTUnitFile = "Model.java"
+
+// javaFTComp is an admitted target: a SCOPE.Component the extractor emits for a
+// real type declaration.
+func javaFTComp(name, subtype string) types.EntityRecord {
+	return types.EntityRecord{
+		Name: name, Kind: "SCOPE.Component", Subtype: subtype,
+		SourceFile: javaFTUnitFile, Language: "java",
+	}
+}
+
+// javaFTAssertTargets asserts the EXACT admitted name set, so a rule that
+// admits too much fails as loudly as one that admits too little.
+func javaFTAssertTargets(t *testing.T, recs []types.EntityRecord, want ...string) {
+	t.Helper()
+	got := javaInFileTypeTargets(recs, javaFTUnitFile)
+	if len(got) != len(want) {
+		t.Fatalf("admitted %d targets %v, want %d %v", len(got), javaFTNames(got), len(want), want)
+	}
+	for _, w := range want {
+		tgt, ok := got[w]
+		if !ok {
+			t.Fatalf("target %q missing; admitted %v", w, javaFTNames(got))
+		}
+		if exp := "scope:component:class:java:" + javaFTUnitFile + ":" + w; tgt.toID != exp {
+			t.Errorf("toID for %q = %q, want %q", w, tgt.toID, exp)
+		}
+		if tgt.name != w {
+			t.Errorf("name for %q = %q", w, tgt.name)
+		}
+	}
+}
+
+func javaFTNames(m map[string]javaFieldTypeTarget) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// A SCOPE.Schema/field record sharing a type's name is not a target. Reachable
+// in principle — a field emitted at module scope keeps a BARE name — and refused
+// on the Kind check rather than on name shape, unlike Go's equivalent.
+func TestJavaFieldTypeRefs_Unit_FieldIsNeverATarget(t *testing.T) {
+	javaFTAssertTargets(t, []types.EntityRecord{
+		javaFTComp("Order", "class"),
+		{Name: "Customer", Kind: "SCOPE.Schema", Subtype: "field", SourceFile: javaFTUnitFile},
+	}, "Order")
+}
+
+// The #577 file entity is a SCOPE.Component and would sail through a Kind-only
+// guard. Its Name is normally a file path, so this constructs the name it could
+// never have — which is precisely what makes the SUBTYPE half of the allow-list
+// gradeable at all.
+func TestJavaFieldTypeRefs_Unit_FileEntityIsNeverATarget(t *testing.T) {
+	javaFTAssertTargets(t, []types.EntityRecord{
+		javaFTComp("Order", "class"),
+		javaFTComp("Customer", "file"),
+	}, "Order")
+}
+
+// A SCOPE.Component with an EMPTY Subtype is not a declared type. No producer
+// emits one for Java today (synthComp and the Panache interfaces always set
+// one), so this grades the default arm of the subtype switch against the
+// producer that has not been written yet — the Java analogue of Go's import
+// placeholder.
+func TestJavaFieldTypeRefs_Unit_UnsubtypedComponentIsNeverATarget(t *testing.T) {
+	javaFTAssertTargets(t, []types.EntityRecord{
+		javaFTComp("Order", "class"),
+		javaFTComp("Customer", ""),
+	}, "Order")
+}
+
+// The ambiguity rule's REFUSE direction. Two DISTINCT kinds inside the component
+// address family denote two graph nodes at one (file, name), so
+// lookupLocationKind's uniqueMatchInFamily finds two IDs, returns no match, and
+// the ref falls through to ambigLocation and dangles. Declining to emit is
+// strictly better than emitting a stub that cannot bind.
+func TestJavaFieldTypeRefs_Unit_TwoDistinctFamilyKindsAreRefused(t *testing.T) {
+	javaFTAssertTargets(t, []types.EntityRecord{
+		javaFTComp("Order", "class"),
+		javaFTComp("Customer", "class"),
+		{Name: "Customer", Kind: "SCOPE.Model", Subtype: "model", SourceFile: javaFTUnitFile},
+	}, "Order")
+}
+
+// The ambiguity rule's ADMIT direction, and the half that #7038 says arm C got
+// wrong. Two RECORDS sharing Kind and Name in one file are ONE graph node —
+// graph.EntityID hashes (repo, Kind, Name, SourceFile) with Subtype EXCLUDED —
+// so a rule counting records would delete an edge that binds perfectly well.
+// The two subtypes differ deliberately: it is the KIND that decides identity.
+func TestJavaFieldTypeRefs_Unit_DuplicateComponentRecordsAreOneNode(t *testing.T) {
+	javaFTAssertTargets(t, []types.EntityRecord{
+		javaFTComp("Order", "class"),
+		javaFTComp("Customer", "class"),
+		javaFTComp("Customer", "record"),
+	}, "Order", "Customer")
+}
+
+// A SCOPE.Enum value-set sharing an enum's name does NOT make it ambiguous:
+// SCOPE.Enum is outside the component address family, so it never enters the
+// tier that resolves a scope:component ref. This is the unit-level statement of
+// what TestJavaFieldTypeRefs_ResolvesToEntityIDs proves against the real
+// resolver, and it is where arm D's wider rule would have refused every Java
+// enum target.
+func TestJavaFieldTypeRefs_Unit_EnumValueSetDoesNotShadowItsComponent(t *testing.T) {
+	javaFTAssertTargets(t, []types.EntityRecord{
+		javaFTComp("Order", "class"),
+		javaFTComp("Status", "enum"),
+		{Name: "Status", Kind: "SCOPE.Enum", Subtype: "enum", SourceFile: javaFTUnitFile},
+	}, "Order", "Status")
+}
+
+// A record in ANOTHER file is not a target however admissible its shape.
+func TestJavaFieldTypeRefs_Unit_OtherFileRecordsAreNeverTargets(t *testing.T) {
+	other := javaFTComp("Customer", "class")
+	other.SourceFile = "Other.java"
+	javaFTAssertTargets(t, []types.EntityRecord{javaFTComp("Order", "class"), other}, "Order")
+}
+
+// An unnamed record cannot be a target and must not create an empty-string key
+// that a candidate could never match but a mutant might.
+func TestJavaFieldTypeRefs_Unit_UnnamedRecordIsSkipped(t *testing.T) {
+	javaFTAssertTargets(t, []types.EntityRecord{
+		javaFTComp("Order", "class"),
+		javaFTComp("", "class"),
+	}, "Order")
+}
+
+// The Kind half of the allow-list, graded APART from the Subtype half so the
+// two do not mask each other. Java's own producers happen to make this one
+// unreachable from source — every same-file record carrying one of the four
+// admitted subtypes is either a SCOPE.Component or a SCOPE.Enum value-set that
+// SHARES ITS NAME with one (buildJavaEnumValueSet and the `java_const_group`
+// arm of buildJavaConstCollections both name the value-set after the enclosing
+// type), so admitting it would compute the identical component-space toID and
+// change no output.
+//
+// That is an accident of today's producers, not a property of the rule, and the
+// distinguishing input is one line away: a non-Component record with an admitted
+// subtype, a BARE name, and NO same-file Component of that name. Addressing it
+// through BuildComponentStructuralRef would mint a ToID pointing at a component
+// that does not exist — a dangling stub, classified bug-extractor. Constructed
+// here rather than left as a reasoned-about equivalence.
+func TestJavaFieldTypeRefs_Unit_NonComponentKindWithAnAdmittedSubtypeIsRefused(t *testing.T) {
+	javaFTAssertTargets(t, []types.EntityRecord{
+		javaFTComp("Order", "class"),
+		{Name: "Rates", Kind: "SCOPE.Enum", Subtype: "enum", SourceFile: javaFTUnitFile},
+		{Name: "Draft", Kind: "SCOPE.Schema", Subtype: "record", SourceFile: javaFTUnitFile},
+	}, "Order")
+}
+
+// javaFTStashed builds a record carrying the field-type stash, so
+// attachJavaFieldTypeRefs's own guard can be graded independently of the two
+// emit sites (which only ever stash onto SCOPE.Schema/field records today).
+func javaFTStashed(name, kind, subtype string, cands ...string) types.EntityRecord {
+	return types.EntityRecord{
+		Name: name, Kind: kind, Subtype: subtype, SourceFile: javaFTUnitFile, Language: "java",
+		Metadata: map[string]interface{}{
+			javaFieldTypeRefsMetaKey:  cands,
+			javaFieldTypeRefsOwnerKey: "Host",
+		},
+	}
+}
+
+func javaFTEdgeCount(recs []types.EntityRecord) int {
+	n := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "REFERENCES" && r.Properties.Get("ref_kind") == javaFieldTargetRefKind {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// attachJavaFieldTypeRefs emits ONLY onto a SCOPE.Schema/field record, and the
+// two conjuncts of that guard are graded SEPARATELY — a single test carrying a
+// record that violates both would leave either conjunct free to be deleted.
+// Both are unreachable from Java source today because the only two stash sites
+// are on field records; the guard is what keeps that true if a third site is
+// added. Each case carries a real field record as a positive control, so a
+// mutant that stopped emitting altogether fails here too.
+func TestJavaFieldTypeRefs_Unit_OnlyAFieldRecordCarriesTheEdge(t *testing.T) {
+	target := javaFTComp("Customer", "class")
+
+	for _, tc := range []struct {
+		label         string
+		kind, subtype string
+	}{
+		{"wrong kind, field subtype", "SCOPE.Component", "field"},
+		{"schema kind, wrong subtype", "SCOPE.Schema", "schema"},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			recs := []types.EntityRecord{
+				target,
+				javaFTStashed("Host.impostor", tc.kind, tc.subtype, "Customer"),
+				javaFTStashed("Host.real", "SCOPE.Schema", "field", "Customer"),
+			}
+			attachJavaFieldTypeRefs(recs, javaFTUnitFile)
+			if got := javaFTEdgeCount(recs); got != 1 {
+				t.Fatalf("emitted %d edges, want exactly 1 (the field record only)", got)
+			}
+			if len(recs[1].Relationships) != 0 {
+				t.Errorf("%s/%s record carries %d edges, want 0",
+					tc.kind, tc.subtype, len(recs[1].Relationships))
+			}
+			if len(recs[2].Relationships) != 1 {
+				t.Errorf("the SCOPE.Schema/field control carries %d edges, want 1",
+					len(recs[2].Relationships))
+			}
+		})
+	}
+}
+
+// The stash is DELETED after it is consumed, on every record it appears on —
+// including the ones the guard refuses to emit for. A leaked key would ride into
+// the graph as entity metadata.
+func TestJavaFieldTypeRefs_Unit_StashIsAlwaysCleared(t *testing.T) {
+	recs := []types.EntityRecord{
+		javaFTComp("Customer", "class"),
+		javaFTStashed("Host.impostor", "SCOPE.Operation", "method", "Customer"),
+		javaFTStashed("Host.real", "SCOPE.Schema", "field", "Customer"),
+	}
+	attachJavaFieldTypeRefs(recs, javaFTUnitFile)
+	for i := range recs {
+		for _, k := range []string{javaFieldTypeRefsMetaKey, javaFieldTypeRefsOwnerKey} {
+			if _, ok := recs[i].Metadata[k]; ok {
+				t.Errorf("%s still carries metadata key %q", recs[i].Name, k)
+			}
+		}
+	}
+}
+
+// The ambiguity count is scoped to THIS FILE on both of its passes, and the two
+// scopings are graded separately because they fail differently. Pass 2's
+// same-file filter decides which records may be TARGETS
+// (TestJavaFieldTypeRefs_Unit_OtherFileRecordsAreNeverTargets); pass 1's decides
+// which records may make a name AMBIGUOUS, and dropping it is the permissive
+// mutation's opposite — it would REFUSE a perfectly bindable same-file target
+// because some unrelated file happens to carry the name under another
+// component-family kind.
+//
+// The resolver's index is keyed by (file, name), so a record in another file
+// cannot make this file's name ambiguous; a rule that let it would silently
+// delete edges as the graph grew, which is #7038's failure mode reached from the
+// other direction.
+func TestJavaFieldTypeRefs_Unit_AnotherFilesCollisionDoesNotShadowThisFile(t *testing.T) {
+	rival := types.EntityRecord{
+		Name: "Customer", Kind: "SCOPE.Model", Subtype: "model", SourceFile: "Other.java",
+	}
+	javaFTAssertTargets(t, []types.EntityRecord{
+		javaFTComp("Order", "class"),
+		javaFTComp("Customer", "class"),
+		rival,
+	}, "Order", "Customer")
+}

--- a/internal/extractors/java/field_type_refs_units_6912_test.go
+++ b/internal/extractors/java/field_type_refs_units_6912_test.go
@@ -281,3 +281,30 @@ func TestJavaFieldTypeRefs_Unit_AnotherFilesCollisionDoesNotShadowThisFile(t *te
 		rival,
 	}, "Order", "Customer")
 }
+
+// SCOPE.Class participates in the component address family through the INDEX'S
+// TRIM ALIAS, not through componentKindFamily directly, and that indirection is
+// what an earlier revision of javaComponentAddressFamily missed.
+//
+// BuildIndex keys every entity under its raw Kind AND its SCOPE-trimmed alias
+// (refs.go:1208-1211), so a `SCOPE.Class` entity is reachable under "Class" —
+// which IS a componentKindFamily member even though "SCOPE.Class" is not. Such
+// an entity therefore blanks uniqueMatchInFamily against a same-(file, name)
+// Component and drops the ref through to ambigLocation, where it dangles.
+//
+// Not reachable from java source today: no java producer emits a Class- or
+// SCOPE.Class-kinded entity. It is graded anyway because the map's whole job is
+// to mirror the resolver, and a mirror with a hole in it is worse than no mirror
+// — it emits a stub the resolver has already decided to refuse. The bare "Class"
+// spelling is graded beside it so neither entry can be deleted unnoticed.
+func TestJavaFieldTypeRefs_Unit_ScopeClassParticipatesViaTheTrimAlias(t *testing.T) {
+	for _, kind := range []string{"SCOPE.Class", "Class"} {
+		t.Run(kind, func(t *testing.T) {
+			javaFTAssertTargets(t, []types.EntityRecord{
+				javaFTComp("Order", "class"),
+				javaFTComp("Customer", "class"),
+				{Name: "Customer", Kind: kind, Subtype: "class", SourceFile: javaFTUnitFile},
+			}, "Order")
+		})
+	}
+}

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -249,15 +249,31 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// builders and the nosql `schema` model node all reach `entities` from
 	// inside it, and the allow-list and the ambiguity rule have to weigh all
 	// of them. The position is LATER than that but the extra distance is NOT
-	// load-bearing today, and saying so is more useful than implying it is:
-	// of the passes between walk and here, synthesizePanacheDSLEntities is
-	// the only one that appends entities at all and it stamps a SYNTHETIC
-	// source path, while emitReferences / emitConfigConsumerEdges /
-	// emitExceptionFlowEdges / emitTemplateRenderEdges attach relationships
-	// only. Moving this call up to walk's return changes no output, and a
-	// mutant that does so is alive under the suite for exactly that reason.
-	// It sits here so a future pass that DOES append a same-file entity is
-	// seen by default rather than by luck.
+	// load-bearing today, and saying so is more useful than implying it is.
+	//
+	// An equivalence argument is only as good as its enumeration, so here is
+	// the complete list of the SEVEN passes between walk's return and this
+	// call, and what each does to `entities`:
+	//
+	//	stampClassLevelTransactional  takes &entities, but only mutates
+	//	                              op.Properties via findJavaOp
+	//	attachImportRelationships     handed &entities[0]; cannot append
+	//	synthesizePanacheDSLEntities  the ONLY appender — and it stamps
+	//	                              panacheDSLSyntheticSourceFile, so its
+	//	                              records never share this file's path
+	//	emitReferences                relationships only
+	//	emitConfigConsumerEdges       relationships only
+	//	emitExceptionFlowEdges        relationships only
+	//	emitTemplateRenderEdges       relationships only
+	//
+	// The first two were missing from an earlier revision of this comment,
+	// and stampClassLevelTransactional is the only other pass that takes the
+	// slice BY POINTER — exactly the one an incomplete enumeration should not
+	// have dropped. So no record for this file exists here that did not exist
+	// at walk's return: moving this call up changes no output, a mutant that
+	// does so is alive under the suite AND produces a byte-identical 147/147
+	// corpus result, and it sits here only so a future pass that DOES append a
+	// same-file entity is seen by default rather than by luck.
 	attachJavaFieldTypeRefs(entities, file.Path)
 
 	// Track B (analog of #642/#650 for Java) — IMPORTS ToID rewrite.

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -241,6 +241,25 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		emitTemplateRenderEdges(root, file, &entities)
 	}()
 
+	// Issue #6912 arm E — field -> declared-type REFERENCES edges, same-file
+	// targets only. See field_type_refs.go for the full ruling.
+	//
+	// It must run after walk, which is where every record for THIS file is
+	// produced: the classes, the enum value-sets, Lombok's synthesized
+	// builders and the nosql `schema` model node all reach `entities` from
+	// inside it, and the allow-list and the ambiguity rule have to weigh all
+	// of them. The position is LATER than that but the extra distance is NOT
+	// load-bearing today, and saying so is more useful than implying it is:
+	// of the passes between walk and here, synthesizePanacheDSLEntities is
+	// the only one that appends entities at all and it stamps a SYNTHETIC
+	// source path, while emitReferences / emitConfigConsumerEdges /
+	// emitExceptionFlowEdges / emitTemplateRenderEdges attach relationships
+	// only. Moving this call up to walk's return changes no output, and a
+	// mutant that does so is alive under the suite for exactly that reason.
+	// It sits here so a future pass that DOES append a same-file entity is
+	// seen by default rather than by luck.
+	attachJavaFieldTypeRefs(entities, file.Path)
+
 	// Track B (analog of #642/#650 for Java) — IMPORTS ToID rewrite.
 	// Rewrites IMPORTS edges whose source_module's longest dotted
 	// prefix matches a known external JVM package to an
@@ -446,6 +465,15 @@ func walk(
 						EndLine:    int(p.EndPoint().Row) + 1,
 						Signature:  sig,
 					}
+					// Issue #6912 arm E — stash the record component's
+					// declared type so attachJavaFieldTypeRefs can emit the
+					// field -> type REFERENCES edge once the file's full
+					// record set exists. typeNode is the same node typeName
+					// was read from; the AST is passed rather than the string
+					// because a flat type string cannot be unwrapped safely
+					// (arm C's ruling, and swift's lossy field_type property
+					// is the live counter-example).
+					stashJavaFieldTypeRefs(&fieldRec, typeNode, file.Content, rec.Name)
 					*out = append(*out, fieldRec)
 					(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 						types.RelationshipRecord{
@@ -1464,7 +1492,7 @@ func buildField(node ts.Node, file extractor.FileInput, parentType string) (type
 	// Build field signature: "Type name" (strip visibility).
 	fieldSig := buildFieldSignature(node, file.Content, name)
 
-	return types.EntityRecord{
+	rec := types.EntityRecord{
 		Name:       emittedName,
 		Kind:       "SCOPE.Schema",
 		Subtype:    "field",
@@ -1473,7 +1501,15 @@ func buildField(node ts.Node, file extractor.FileInput, parentType string) (type
 		StartLine:  int(node.StartPoint().Row) + 1,
 		EndLine:    int(node.EndPoint().Row) + 1,
 		Signature:  fieldSig,
-	}, true
+	}
+	// Issue #6912 arm E — stash the declared type's AST node so
+	// attachJavaFieldTypeRefs can emit the field -> type REFERENCES edge once
+	// the file's full record set exists. The `type` child is the node
+	// buildFieldSignature already spans as text; leafTypeName is deliberately
+	// NOT reused here (it reduces a type expression to one leaf, which is the
+	// lossy shape arm C refused).
+	stashJavaFieldTypeRefs(&rec, node.ChildByFieldName("type"), file.Content, parentType)
+	return rec, true
 }
 
 // buildFieldSignature produces "Type name" for a Java field, stripping visibility.


### PR DESCRIPTION
Arm E of #6912 (A=C#/#6984, B=proto/#6991, C=rust/#7000, D=go/#7036), and the remaining language of contributor **#6726**'s corpus (csharp/fsharp/java/protobuf) that this issue covers.

Java field entities — from **both** emit sites, class `field_declaration` and record header component — were leaves on their outbound side. This adds one field-anchored `REFERENCES` edge with `ref_kind=field_target_type`, same-file targets only, matching the shipped vocabulary and address.

**The issue's long-standing claim that java "retains NO type string at all" is false**, as the grounding pass at `663f6c50a` found and as this arm re-verified: `typeName := nodeText(typeNode, …)` is a live local at the record-component site, and `buildFieldEntity` holds the `field_declaration` node whose `type` child `buildFieldSignature` already spans. No capture step was needed.

**Arm B's question, asked rather than inherited: is the FIELD the anchor, or is something else?** Unlike Go, java shipped **no declared-type edge at any anchor**. Three neighbouring populations look like one and are each left untouched — `javaInjectFieldTypes` (class-anchored, DI-annotation-gated, bare/`ext:` target), `emitReferences` (operation → field *usage*, opposite direction), and `internal/custom/java/{hibernate,orm_helpers}.go` (already spells `field_target_type`, but off a parallel `SCOPE.Component` population, and `internal/custom/**` defaults OFF; #6986 measured that lane's address at 91.6% dangling).

> **Second commit (`3609dfc`) is review follow-up.** It corrects **two claims that were invented rather than observed** and two reasons that were stated wrongly, and closes one mirror hole. Each is called out inline below with what was wrong. Corpus output is byte-identical across the two commits (147/147/0, same 125/18/4 breakdown).

---

## The allow-list, and why

Written on java's own `buildComponent` rather than inherited. Java routes `class_declaration`, `interface_declaration`, `enum_declaration` and `record_declaration` through **one** `buildComponent` call with only the Subtype varying (`java.go:324-355`, `:1374-1396`) — the grounding pass could not confirm the class subtype string because it is set through a variable; it is the literal `"class"` at `java.go:326`. So the allow-list is a **subtype** list:

| record | verdict |
|---|---|
| `SCOPE.Component` + `class` | admitted |
| `SCOPE.Component` + `interface` | admitted |
| `SCOPE.Component` + `enum` | admitted |
| `SCOPE.Component` + `record` | admitted |
| `SCOPE.Component` + `file` (#577) | refused — Name is the file path; **also** unreachable by name shape (always carries `.java`, and a `type_identifier` cannot contain a dot). Claimed as nothing more. |
| `SCOPE.Component` + empty subtype | refused — no producer emits one today; this grades the default arm against the producer not yet written |
| `SCOPE.Schema` + `schema` (`nosql_model.go:187`) | refused — **a live competitor**: `@Document class Customer` emits this named after the *class*, in the same file |
| `SCOPE.Schema` + `field` | refused — reachable in principle (a module-scope field keeps a **bare** name), so refused on Kind, not on name shape |
| `SCOPE.Enum` value-sets, `SCOPE.Operation`, `SCOPE.ExceptionType`, `SCOPE.Template`, config keys | refused |

The subtype universe reaching a java file's records is `{class, interface, enum, record, file}` — walk's four, `extractor.FileEntity`, `synthComp` (`"class"`), panache (`"interface"`, synthetic path). The four admitted are exhaustive and the two refusals are complete.

**Arm C's `Kind != "SCOPE.Component"` guard would have cost nothing here** — every java target is a Component. Arm D measured that same guard dropping 19% of Go's edges; the shape simply does not recur. That is exactly why this arm's real departure is on the *other* rule.

## The ambiguity rule — counting kinds, and the java-specific scope

Kinds, never records: `graph.EntityID` hashes `(repo, Kind, Name, SourceFile)` with **Subtype excluded**, mirroring `resolve/refs.go:1308`'s `existing != e.ID`, so two same-file records sharing a Kind are **one node**. Counting records refuses edges that would have bound — the defect filed as **#7038** against arm C.

> ⚠️ **Corrected in `3609dfc` — the original write-up's example was fabricated.** It claimed `class Order` could sit beside "Lombok's synthesized `SCOPE.Component` `Order`". It cannot: `synthComp`'s only call site (`lombok.go:438`) passes `className + "Builder"`, **never the class's own name** — and the test file then promised an `@Builder` fixture that was never written. Rather than delete the example, the actual reachable shape was found and pinned: **`@Builder class Order` synthesizes `OrderBuilder` into this file**, so a file that *also* declares `class OrderBuilder` by hand carries two `SCOPE.Component/class` records of one name — one graph node. `TestJavaFieldTypeRefs_LombokBuilderDuplicateComponentIsOneNode` now grades this **from java source**, asserts the two-record premise before the edge so it cannot pass vacuously, and kills M4 alongside the unit test. #7038's defect is now graded on a production-reachable shape rather than only a hand-built record set.

**The count is restricted to the component address family, not to every same-file record, and that is a deliberate departure from arm D.**

`buildJavaEnumValueSet` (`enum_valueset.go:25`) emits a `SCOPE.Enum` value-set named **identically** to the `SCOPE.Component/enum` walk emits from the same node in the same file. Under arm D's all-kinds rule *every* java enum is two kinds and **every enum target is refused**.

It would also be wrong on the resolver's own terms. `lookupStructural` (`refs.go:2982`) resolves a `scope:component:…` ref through `lookupLocationKind` filtered to `componentKindFamily` (`refs.go:2341`) **first**; `ambigLocation` — the kind-agnostic index arm D's rule mirrors — is only consulted **after that misses** (`refs.go:3004`). `SCOPE.Enum` is not in that family, so it never enters the tier that decides this address. Go's `type_alias` targets were `SCOPE.Schema`, *outside* the family, which is precisely why arm D fell through to `ambigLocation` and had to mirror it.

**Measured, not argued:** arm D's rule applied unchanged emits **129** edges here instead of 147 — it drops **18, 12.24%, and every one of them is an enum target**.

**Proved, not read:** `TestJavaFieldTypeRefs_ResolvesToEntityIDs` drives the **real resolver** over an extracted file carrying both records and asserts `Order.state` binds to the Component's ID. It carries class-, interface- and record-typed rows as positive controls, so a rule that emitted nothing could not pass it, and a bare-name-ambiguity precondition, so the structural address is not ungraded.

> ⚠️ **Corrected in `3609dfc`.** The original header cited `TestJavaFieldTypeRefs_SameFileEnumTypeBinds` — in detail, as the grader for this arm's headline departure — and **no such test was ever written**. The substance *was* graded (`ResolvesToEntityIDs` + `EdgeSet` + `Unit_EnumValueSetDoesNotShadowItsComponent`), so there was no coverage gap, but a named grader that does not exist is worse than none: the next reader greps for it, fails, and distrusts the rest. Fixed, along with three citations that dropped the `_Unit_` infix.

Both directions of the record-vs-kind question are graded: `LombokBuilderDuplicateComponentIsOneNode` (source) and `Unit_DuplicateComponentRecordsAreOneNode` (record level) kill a record-counting mutant; `Unit_TwoDistinctFamilyKindsAreRefused` kills a no-ambiguity mutant; `Unit_AnotherFilesCollisionDoesNotShadowThisFile` kills the pass-1 scope in the *permissive-in-reverse* direction.

### The one behaviour change in the follow-up commit: `SCOPE.Class`

The reviewer's mutant **MZ-1** — deleting `"Class"` from `javaComponentAddressFamily` — was **ALIVE**, and it exposed a genuine asymmetry. The comment claimed the map carried "both the bare and SCOPE.-prefixed spellings", yet **`SCOPE.Class` was absent**. `BuildIndex` dual-keys a `SCOPE.Class` entity under *both* `"SCOPE.Class"` and the trimmed `"Class"` (`refs.go:1208-1211`), and `"Class"` **is** in `componentKindFamily` — so such an entity blanks `uniqueMatchInFamily`, falls through to `ambigLocation`, and **dangles**, while this pass would happily emit for it.

The map is **not** a copy of `componentKindFamily`. It is that slice **closed under the index's trim alias** — `K ∈ family || TrimPrefix(K, "SCOPE.") ∈ family` — and the eight entries are now exactly that set. Unreachable from java source today (no java producer emits a `Class`- or `SCOPE.Class`-kinded entity); fixed anyway, because a mirror with a hole in it is worse than no mirror. Both spellings graded by `Unit_ScopeClassParticipatesViaTheTrimAlias`; **deleting either entry is now DEAD.**

## Qualified names — skipped whole, never reduced

`scoped_type_identifier` is skipped without descending. Arm D found Go's `resolveTypeReferences` stripping `other.Order` → `Order` and binding it to a same-file `Order` — silently wrong, since a bound edge never reaches `bug-extractor`. **Java's `Outer.Inner` form is worse**: *both* segments plausibly name a same-file type, so any reduction is a guess between two wrong answers.

This costs no argument recall: in `java.util.List<Order>` the `type_arguments` node is a **sibling** of the `scoped_type_identifier` under `generic_type`, so `Order` is still collected while `java`/`util`/`List` are not.

## Generics

The constructor **and** the arguments are collected and judged independently — arm A's and arm C's rule. `List<Order>` yields `[List, Order]`; `List` is refused by the in-file declaration check unless the file genuinely declares `class List`, in which case the edge is correct. `Map<String, Order>` yields both halves; `List<? extends Order>` unwraps the wildcard; `Order[]` unwraps the array; `Map<Customer, Customer>` emits **one** edge. No wrapper blocklist to keep in sync. A type **parameter** (`class Holder<T> { T item; }`) is a known over-fire, pinned as such with a control.

## Primitives, boxed types, java.lang

**Java primitives can never be candidates** — `int`/`long`/`short`/`byte`/`char` parse as `integral_type`, `float`/`double` as `floating_point_type`, `boolean` as `boolean_type`; none is a `type_identifier`, and `long[]` yields nothing at all. This is the inverse of Go, where `int` is a shadowable identifier and arm D had to pin the shadowing case. Enumerated against an independent literal list of all eight, each paired with a declared `class Int` positive control.

**Boxed and `java.lang` names ARE candidates** and are refused solely by the in-file declaration check — no name blocklist, which would be actively wrong: a file declaring its own `class Integer` genuinely means *that* type in field position. The same source text yields no edge in one file and an edge in the other; that pair is what proves the refusal is the declaration check.

## Corpus yield (read-only, capped at 3 cores)

| | |
|---|---|
| `.java` files | **645** — `kafka` 471, `kafka-streams-examples` 115, `spring-petclinic` 47, `awesome-compose` 11, `ratpack-example-books` 1 |
| repos contributing **edges** | 2 (`kafka` 137, `kafka-streams-examples` 10) |
| edges emitted | **147** |
| **bound** | **147** |
| **dangling** | **0** |
| bound targets | 125 `SCOPE.Component/class`, **18 `/enum`**, 4 `/interface` |

Independently reproduced by the reviewer with a separate in-process harness over the same 645 files, including the 18-dropped/129-remaining counterfactual.

### What 147/147 does *not* establish

- **There is no recall denominator.** Nothing here counts fields whose declared type *is* same-file-declared and got nothing, so the under-firing direction is unaudited **on the corpus**; over-firing is graded only by fixtures.
- **Zero `/record` targets** is corpus-relative, not a capability claim — `RecordComponentIsAnAnchor` and `AllFourComponentSubtypesAreTargets` both produce them.
- **The corpus is java-thin** and nothing here transfers to #6726's. The mechanism transfers; the number does not.
- **Recall ceiling** (added in `3609dfc`, observed by probe, all pre-existing and none introduced here): a **multi-declarator field emits only its first name** (`class M { Customer a, b; }` → `M.a` only, so `b` can never carry an edge); an **interface constant emits no field entity at all** (`interface Consts { Customer DEFAULT = null; }` → no record, no edge); and an **`@interface` type gets no Component**, so an in-file annotation type can never be a target. These cap the arm's ceiling and are worth a follow-up.

## Gate movement

- **`scripts/quality/run.sh --runs 1 --ratchet`** — green, and **`git status --porcelain` shows no baseline drift**, which is the real check.

  > ⚠️ **Enumeration corrected in `3609dfc`.** The original body said "all **6** `java-spring-mini` files declare exactly one type each". The golden set has **8** java files across **two** fixtures, and the omitted one holds **the only multi-type java file in the entire golden set** — `java-quartz-mini/src/jobs/SendEmailJob.java` — i.e. exactly the shape the claim turns on. The conclusion survives: **both quartz files declare no fields at all**, so there is still nowhere an edge could appear. Same defect class as arm D's "go-chi-mini is the only golden fixture with `.go` files"; the fix is to enumerate the *set*, not one repo in it.

- **`go test ./internal/quality/...`** — green, separately from the above; they are not the same gate.
- **`go test -count=1 ./cmd/grafel/`** — green in an isolated `GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT` (140s, then 157s after the follow-up), digest tests run not skipped. **No digest movement is claimed as coverage.**

  > ⚠️ **Reason corrected in `3609dfc`, and it was wrong in the flattering direction.** The original said the digest "could not have moved for this change". `semanticDigest6118` keys relationships as `(fromTuple, Kind, toTuple)` with properties discarded, so it is blind to **`ref_kind`** — but it is **not** blind to a *new* `REFERENCES` edge appearing, which is what this arm adds. It could not move because its java fixture (`java/OrdersController.java` in `custom_extractor_spans_6118_test.go`) declares one class and **no fields**, so there is no field entity to carry an edge. **"Nothing to move", not "the instrument is blind."** Declining to cite it as coverage was right; the reason was not.

- `go test -count=1` green on `./internal/extractors/java/...`, `./internal/resolve/...`, `./internal/extractor/...`, `./internal/quality/{,analytics,audit,fitness}`, `./internal/graph/...`.

**`ReferencesPerFunction` will inflate** and is *not* fixed here — it spans arms A–E and is filed as **#7037**.

## Axes — varied vs held constant

The main fixture **varies**: wrapper form (bare, array, generic argument, qualified-generic argument, map key *and* value, wildcard, user-generic argument), the target's **declaration form** (class / interface / enum / record), and the **anchor** (class `field_declaration` vs record header component).
It **holds constant**: the file path, the declaring type (`Order`), and the target name (`Customer`), so a wrapper regression surfaces as a *missing row* rather than a *changed target*.

Axes that cannot vary inside it without also varying something else get their own fixture, each stated: cross-file targets need a second **file**; the type-parameter over-fire needs a file that **declares** the parameter's name; the nosql collision needs an `@Document` annotation; the boxed-type shadowing needs a second file with the local declaration; **the Lombok duplicate-Component case needs a `@Builder` beside a hand-declared `<Class>Builder`** — and that fixture now exists, which it did not when the sentence was first written.

The whole-set assertion is an **equality**, so it grades over-firing as loudly as under-firing, and every forbidden row is named in a comment against the decision it grades.

## Mutants — per conjunct

**22 of 22 DEAD**, re-scored in full after the follow-up commit. Every edit's landing proved by an exact occurrence count before the run and re-derived after (`EDIT-DID-NOT-LAND` / `EDIT-VERIFY-FAILED` are distinct harness outcomes). Private `GOCACHE` throughout — the shared cache was purged mid-run and produced phantom `build failed` / `package net/http is not in std` errors; three runs were discarded and re-run rather than scored.

| # | mutation (permissive direction unless noted) | verdict |
|---|---|---|
| M1 | allow-list **subtype** switch deleted | **DEAD** — 2 |
| M2 | allow-list **Kind** check deleted | **DEAD** — `Unit_NonComponentKindWithAnAdmittedSubtypeIsRefused`. Alive at first pass; *not* deferred as equivalent. Unreachable from java **source** (every same-file record with an admitted subtype is a Component, or a `SCOPE.Enum` value-set that **shares its name with one** and so computes the identical toID), but the distinguishing input is one line and was constructed. |
| M3 | ambiguity rule deleted | **DEAD** — 2 |
| M4 | ambiguity counts **records** not kinds (#7038's defect) | **DEAD** — now **2**: `LombokBuilderDuplicateComponentIsOneNode` (source) + `Unit_DuplicateComponentRecordsAreOneNode` |
| M5 | ambiguity spans **all** kinds (arm D's rule verbatim) | **DEAD** — 5, incl. `ResolvesToEntityIDs` |
| M6 | `scoped_type_identifier` descended | **DEAD** — 5 |
| M7 | self-reference skip deleted | **DEAD** — 3 |
| M8 | per-field target dedupe deleted | **DEAD** — 2 |
| M9 | `ref_kind` near-miss → `field_target_types` | **DEAD** — **15**, all against independent literals |
| M10 | address dialect → bare name | **DEAD** — 13, incl. `ResolvesToEntityIDs` |
| M11 | record-component stash removed | **DEAD** — 3. Grades the **second** emit site. |
| M12 | `buildField` stash removed | **DEAD** — 14 |
| M13 | emit guard deleted | **DEAD** — also alive at first pass, also constructed rather than deferred |
| M14 | owner prefix not stripped from `field_name` | **DEAD** — `EdgeProperties` |
| M15 | …guard's **Kind** conjunct alone | **DEAD** — fails *only* subtest `wrong_kind, field_subtype` |
| M16 | …guard's **Subtype** conjunct alone | **DEAD** — fails *only* subtest `schema_kind, wrong_subtype`. Complementary with M15, so neither conjunct masks the other. |
| M17 | stash not cleared | **DEAD** |
| M18 | pass-2 same-file filter dropped | **DEAD** |
| M19 | pass-1 same-file filter dropped (**restrictive** direction) | **DEAD** |
| M20 | hook call removed | **DEAD** — 15 |
| **MZ-1** | `"Class"` deleted from the address family | **DEAD** — was ALIVE at review; closed by adding `"SCOPE.Class"` and the grader |
| **MZ-3** | `"SCOPE.Class"` deleted from the address family | **DEAD** — the new entry is itself graded, so it cannot be removed unnoticed |
| M21 | hook **moved** to immediately after `walk` | **ALIVE — equivalent, with a complete enumeration.** ⚠️ The original enumeration named five passes and **omitted two**, including `stampClassLevelTransactional` — the only other pass that takes `&entities` **by pointer**, i.e. precisely the one an incomplete enumeration should not have dropped. All **seven** are now listed with what each does to the slice: `stampClassLevelTransactional` mutates `op.Properties` only, `attachImportRelationships` is handed `&entities[0]` and cannot append, `synthesizePanacheDSLEntities` is the only appender and stamps a **synthetic** source path, and the remaining four attach relationships only. Conclusion unchanged, and the reviewer confirmed it beyond the suite: moving the hook produces a byte-identical 147/147/0 on all 645 corpus files. |

No compound mutant was used as evidence anywhere. M15/M16 split M13's two conjuncts precisely because a single record violating both would leave either free to be deleted.

## Still not established

- **Cross-file targets are out of scope.** Java's one-public-type-per-file convention makes same-file a better fit than it was for Go, but a package-private sibling type and every imported type still get nothing. Binding a bare type name across files is the hazard #6976/#6369 are about.
- The **type-parameter over-fire** is known-wrong and pinned, not fixed. A real fix must thread the enclosing declaration's `type_parameters` list to the field and is *expected* to break `KnownOverFire_TypeParameterShadowedByASameFileType`.
- The **pass-1 record-set invariant is stated, not enforced**: it holds because every producer running after the hook emits a **prefixed** name no bare `type_identifier` can equal. A future producer emitting a bare-named java entity would reintroduce dangling.
- **Convention, not taken:** every other post-`walk` pass in `Extract` is wrapped in a `recover()`; `attachJavaFieldTypeRefs` is called bare. No panic path was found (nil type node and nil `Metadata` are both handled), and the coordinator scoped this follow-up to non-behavioural changes, so it is reported rather than changed.

Refs #6912

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
