### PR TITLE
feat(#6912): F# record fields carried their declared type only as a string property — emit the field→type REFERENCES edge, same-file targets only

### DIFF
--- a/internal/extractors/fsharp/extractor.go
+++ b/internal/extractors/fsharp/extractor.go
@@ -534,7 +534,32 @@ func extractFSharp(src, filePath string) []types.EntityRecord {
 	// `Core.fs` declaring `module Core.fs` already emits a record named
 	// exactly the path, and graph.EntityID does not hash Subtype, so a second
 	// SCOPE.Component would land under the module record's id (#6369/#6480).
-	return extractor.PrependFileCarrier(filePath, "fsharp", entities)
+	// #6912 arm E: the field→declared-type REFERENCES edge. Placement is
+	// load-bearing in BOTH directions and the call therefore wraps the carrier
+	// rather than preceding it:
+	//
+	//   - It runs AFTER applyElmishFeliz, which RE-KINDS the `Model` record to
+	//     SCOPE.Model and the `Msg` DU to SCOPE.Event. This is NOT because the
+	//     earlier placement would lose those edges — measured, it would not:
+	//     before the re-kind both records are already-admitted
+	//     SCOPE.Component subtypes, and moving the call produces identical
+	//     output. The reason is that reading at the END means the allow-list
+	//     and the ambiguity rule see every record's FINAL Kind and Subtype, so
+	//     a future pass that re-kinds something cannot silently invalidate
+	//     either. See the fsharpTypeDeclKinds comment for the three-row
+	//     experiment behind that claim.
+	//   - It must run after EVERY producer that can add a same-file record,
+	//     because its ambiguity rule counts the graph nodes a name denotes in
+	//     this file and a collision it cannot see reaches the resolver as a
+	//     dangling edge. Passing the post-PrependFileCarrier slice makes that
+	//     unconditional rather than resting on the carrier's Name always being
+	//     a path. That half is defence-in-depth and is scored as such: moving
+	//     the call to BEFORE PrependFileCarrier is an EQUIVALENT mutant (ALIVE,
+	//     and unkillable) because FileEntity names the carrier file.Path
+	//     (extractor/extractor.go:344) and every F# path contains a `.`, which
+	//     no bare candidate token ever does.
+	return attachFSharpFieldTypeRefs(
+		extractor.PrependFileCarrier(filePath, "fsharp", entities), filePath)
 }
 
 // classifyTypeSubtype determines the F# type subtype from the declaration context.

--- a/internal/extractors/fsharp/extractor.go
+++ b/internal/extractors/fsharp/extractor.go
@@ -539,15 +539,18 @@ func extractFSharp(src, filePath string) []types.EntityRecord {
 	// rather than preceding it:
 	//
 	//   - It runs AFTER applyElmishFeliz, which RE-KINDS the `Model` record to
-	//     SCOPE.Model and the `Msg` DU to SCOPE.Event. This is NOT because the
-	//     earlier placement would lose those edges — measured, it would not:
-	//     before the re-kind both records are already-admitted
-	//     SCOPE.Component subtypes, and moving the call produces identical
-	//     output. The reason is that reading at the END means the allow-list
-	//     and the ambiguity rule see every record's FINAL Kind and Subtype, so
-	//     a future pass that re-kinds something cannot silently invalidate
-	//     either. See the fsharpTypeDeclKinds comment for the three-row
-	//     experiment behind that claim.
+	//     SCOPE.Model and the `Msg` DU to SCOPE.Event — and this ordering is
+	//     LOAD-BEARING, via the AMBIGUITY RULE rather than the allow-list.
+	//     `open Foo.Model` beside an Elmish `type Model` is the distinguishing
+	//     input: read after the re-kind the name denotes two kinds and the pass
+	//     declines (0 edges); read before, both records are SCOPE.Component,
+	//     one kind, and the pass emits a stub that DANGLES because Component
+	//     and Model share a kind family. It is not, as an earlier draft of this
+	//     comment claimed, that the allow-list would lose the re-kinded rows —
+	//     before the re-kind those records are already admitted. See the
+	//     fsharpTypeDeclKinds block for the full experiment, and
+	//     TestFSharpFieldTypeRefs_PlacementAfterTheElmishRekindIsLoadBearing
+	//     for the grader.
 	//   - It must run after EVERY producer that can add a same-file record,
 	//     because its ambiguity rule counts the graph nodes a name denotes in
 	//     this file and a collision it cannot see reaches the resolver as a

--- a/internal/extractors/fsharp/field_type_refs.go
+++ b/internal/extractors/fsharp/field_type_refs.go
@@ -36,16 +36,25 @@ import (
 //     (extractor.go's moduleRE/typeRE/memberRE + extractIndentBody). There is
 //     no tree-sitter grammar for F# in this tree, so "stash from the AST" is
 //     not an available option, not a choice declined.
-//  2. `member_type` IS THE VERBATIM SOURCE TEXT, NOT A LOSSY PROJECTION.
+//  2. `member_type` IS THE VERBATIM SEGMENT TEXT, NOT A LOSSY PROJECTION.
 //     parseRecordFields takes everything after the first `:` in the field
 //     segment and only TrimSpace's it (du_record_members.go:140). Probed
 //     against `Order`, `Customer option`, `Customer list`,
 //     `Map<string, Customer>`, `Customer[]`, `int * Customer`,
-//     `int -> Customer`, `Domain.Customer` and `'T`, the property is character
-//     for character the declared type as written. It is the one shipped
-//     field-type property on this issue that loses nothing, which is why this
-//     arm needs no stash and why the fixture in
-//     field_type_refs_6912_test.go pins all nine shapes against literals.
+//     `int -> Customer`, `Domain.Customer` and `'T`, it is character for
+//     character what was written. It is the one shipped field-type property on
+//     this issue that loses nothing — swift's is the first pre-order
+//     type_identifier and yields `Dictionary` for `Dictionary<String, Order>` —
+//     which is why this arm needs no stash.
+//
+//     THE PRECISE CLAIM IS "THE SEGMENT AFTER THE COLON", NOT "THE TYPE".
+//     Nothing strips a trailing comment, so `Anno: Customer // why` arrives as
+//     `"Customer // why"` and scans to candidates [Customer why]. It is
+//     harmless — `why` is refused by the declaration gate and the right edge
+//     still emits — but it is a real edge of the verbatim claim rather than a
+//     rounding of it, and a file that happened to declare `type why` would get
+//     a spurious edge. Pinned by the trailing-comment row in
+//     TestFSharpFieldTypeRefs_MemberTypeIsVerbatimSourceText.
 //
 // F#'s POSTFIX GENERICS ARE NOT A SPECIAL CASE — THEY ARE WHY TOKENISING WORKS
 //
@@ -230,29 +239,51 @@ type fsharpFieldTypeTarget struct {
 // dropped there. Graded by TestFSharpFieldTypeRefs_ElmishModelAndMsgAreTargets,
 // which fails when those two rows alone are deleted.
 //
-// THESE TWO ROWS AND THE CALL PLACEMENT ARE ONE DECISION, NOT TWO GUARDS, AND
-// SCORING THEM SEPARATELY IS MISLEADING. Measured rather than argued:
+// THE CALL PLACEMENT IS LOAD-BEARING TOO — BUT THROUGH RULE 2, NOT THIS
+// ALLOW-LIST. This paragraph has been wrong twice in opposite directions and
+// the sequence is worth keeping, because the second error is the rarer one.
+//
+// The first draft said the after-applyElmishFeliz placement was load-bearing
+// BECAUSE the allow-list needs the re-kinded rows. A three-row experiment
+// refuted that justification:
 //
 //	drop the two rows, keep the placement          -> DEAD (1 test)
 //	move the call before applyElmishFeliz,
-//	  keep the two rows                            -> ALIVE
-//	move the call AND drop the two rows            -> ALIVE
+//	  keep the two rows                            -> ALIVE  <- fixture-bound
+//	move the call AND drop the two rows            -> ALIVE  <- fixture-bound
 //
-// Before the re-kind, `Model` is still SCOPE.Component/record and `Msg` still
-// SCOPE.Component/discriminated_union — both already admitted — so the earlier
-// placement needs no extra rows and produces identical output. The two
-// arrangements are equivalent, which means the middle row above is the honest
-// verdict for the placement: it is NOT independently graded, and the two rows'
-// kill holds only while the placement is held constant. Recorded because a pair
-// of mutually-masking guards grades neither, and the failure mode is claiming
-// both are load-bearing when one arrangement of the pair is what matters.
+// Before the re-kind, `Model` is SCOPE.Component/record and `Msg` is
+// SCOPE.Component/discriminated_union — both already admitted — so on THAT
+// input the two arrangements agree, and the allow-list explanation is indeed
+// wrong. The second draft then RETRACTED THE CLAIM ALONG WITH ITS REASON. That
+// over-corrected: the claim survives on a different mechanism, and withdrawing
+// it left a reachable dangling-edge mutant ungraded.
 //
-// The after-placement is nonetheless the one kept, on an argument that does not
-// depend on the Elmish rows at all: read at the END, the pass sees the FINAL
-// Kind and Subtype of every record, so a future producer that re-kinds or adds
-// a same-file record cannot silently invalidate either the allow-list or the
-// ambiguity rule. Reading earlier would rest on the invariant "no later pass
-// changes a Kind" — an invariant applyElmishFeliz already breaks.
+// The distinguishing input is the commonest module name in an Elmish app:
+//
+//	module App
+//	open Elmish
+//	open Foo.Model      // import placeholder, SCOPE.Component, named "Model"
+//	type Model = { Count: int }
+//	type Env = { State: Model }
+//
+//	as shipped (read AFTER the re-kind)  -> 0 edges
+//	call moved BEFORE the re-kind        -> 1 edge, DANGLING through
+//	                                        BuildIndex -> ReferencesEmbedded
+//
+// The separator is RULE 2. Read after the re-kind, `Model` denotes two kinds
+// (SCOPE.Model/elmish_model + SCOPE.Component/import), so rule 2 refuses. Read
+// before, both records are SCOPE.Component — one kind — so rule 2 is silent,
+// the allow-list admits, and the emitted stub cannot resolve: Component and
+// Model are BOTH in componentKindFamily, so lookupLocationKind finds no unique
+// answer and ambigLocation blanks it. Graded by
+// TestFSharpFieldTypeRefs_PlacementAfterTheElmishRekindIsLoadBearing.
+//
+// So: the two allow-list rows are graded (each individually — deleting either
+// one alone kills), AND the placement is graded, and they are graded by
+// DIFFERENT rules. Recorded at length because "the justification failed, so the
+// claim falls" is the wrong inference — re-derive whether the claim still holds
+// before retracting it.
 //
 //	REFUSED, and each of the three refusals is a distinct hazard:
 //
@@ -308,14 +339,35 @@ var fsharpTypeDeclKinds = map[string]bool{
 //
 //  2. A name that denotes MORE THAN ONE DISTINCT GRAPH NODE in this file is
 //     dropped, and the count spans EVERY record in the file rather than only
-//     the admitted ones. This is the resolver's own ambiguity rule mirrored at
-//     the emit site: buildSymbolIndex marks (file, name) ambiguous on meeting a
-//     second distinct entity ID (`existing != e.ID`, internal/resolve/refs.go:1308),
-//     and the byLocation fallback this address depends on consults
-//     ambigLocation first — so a name shared with a NON-target node cannot bind
-//     either, and emitting would guarantee a dangling stub. Arm C's rule (count
-//     only within the admitted set) would not see such a collision; #7038 is
-//     filed against it for that.
+//     the admitted ones. Arm C's rule (count only within the admitted set)
+//     would not see such a collision; #7038 is filed against it for that.
+//
+//     IT IS A CONSERVATIVE APPROXIMATION OF THE RESOLVER'S RULE, NOT A MIRROR
+//     OF IT, and the earlier draft of this comment claimed otherwise: it said
+//     that a second kind means statusAmbiguous so "emitting would GUARANTEE a
+//     dangling stub". That premise is false in the direction the rule is
+//     graded. Measured by hand-emitting the refused edge on this arm's own
+//     shadow fixture and driving it through BuildIndex -> ReferencesEmbedded:
+//
+//     rival SCOPE.Operation/let beside SCOPE.Component/record  -> BINDS, correctly
+//     rival SCOPE.Component/import beside SCOPE.Model          -> DANGLES
+//
+//     The separator is the KIND FAMILY. refs.go:2982 tries
+//     lookupLocationKind(file, name, structuralKindFamilies("component"))
+//     BEFORE the kind-agnostic byLocation tier that ambigLocation guards, so a
+//     rival OUTSIDE componentKindFamily is simply not weighed and the edge
+//     resolves. The rule is therefore genuinely load-bearing only when the
+//     rival kind is INSIDE that family — Component/View/Model, the case rule 2
+//     shares with the call-placement experiment above — and it silently costs
+//     recall for every out-of-family rival (SCOPE.Operation, SCOPE.Pattern, the
+//     SCOPE.Schema sub-populations).
+//
+//     The over-strictness is KEPT here rather than narrowed: mirroring the
+//     family table at the emit site is real coupling to the resolver's internal
+//     tiering and deserves its own decision across arms C/D/E, not a rider on
+//     this one. What is fixed is the stated reason. The general form — count
+//     the kinds the resolver TIER THAT RESOLVES YOUR ADDRESS actually weighs —
+//     is recorded on #6912.
 //
 //     THE UNIT IS THE KIND, NOT THE RECORD, and that too is the resolver's own
 //     rule rather than a convenience: graph.EntityID hashes

--- a/internal/extractors/fsharp/field_type_refs.go
+++ b/internal/extractors/fsharp/field_type_refs.go
@@ -1,0 +1,434 @@
+package fsharp
+
+import (
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// field_type_refs.go — the field→declared-type edge for F# (issue #6912, arm E).
+// Arm A is internal/extractors/csharp/field_type_refs.go (#6984), arm B is
+// internal/extractors/proto/field_type_refs.go (#6991), arm C is
+// internal/extractors/rust/field_type_refs.go (#7000), arm D is
+// internal/extractors/golang/field_type_refs.go (#7036).
+//
+// THE GAP. du_record_members.go emits one SCOPE.Schema/field entity per record
+// field, with the declared type recorded only as Properties["member_type"] and
+// Signature. The single edge it attaches is the owner→member CONTAINS, which
+// the orphan definition excludes by design, so every record field is a LEAF on
+// its outbound side. F# is one of the four languages in contributor #6726's
+// corpus — csharp / fsharp / java / protobuf — whose headline number is
+// SCOPE.Schema at 99.3% orphan of 35,353 entities, and F# record members are
+// minted as SCOPE.Schema by du_record_members.go:77. They are part of the
+// exact population reported.
+//
+// WHY THIS ARM READS A PROPERTY WHEN NO PREVIOUS ARM DID
+//
+// Arm C stashed AST candidates during the walk rather than reading rust's
+// `field_type` property, because a flat type STRING cannot generally be
+// unwrapped safely; swift's equivalent property is actively wrong (it is the
+// first pre-order type_identifier, so `Dictionary<String, Order>` yields
+// `Dictionary`). Neither objection applies here, for two reasons that were
+// established by probe rather than assumed:
+//
+//  1. THERE IS NO AST. The F# extractor is regex- and text-driven end to end
+//     (extractor.go's moduleRE/typeRE/memberRE + extractIndentBody). There is
+//     no tree-sitter grammar for F# in this tree, so "stash from the AST" is
+//     not an available option, not a choice declined.
+//  2. `member_type` IS THE VERBATIM SOURCE TEXT, NOT A LOSSY PROJECTION.
+//     parseRecordFields takes everything after the first `:` in the field
+//     segment and only TrimSpace's it (du_record_members.go:140). Probed
+//     against `Order`, `Customer option`, `Customer list`,
+//     `Map<string, Customer>`, `Customer[]`, `int * Customer`,
+//     `int -> Customer`, `Domain.Customer` and `'T`, the property is character
+//     for character the declared type as written. It is the one shipped
+//     field-type property on this issue that loses nothing, which is why this
+//     arm needs no stash and why the fixture in
+//     field_type_refs_6912_test.go pins all nine shapes against literals.
+//
+// F#'s POSTFIX GENERICS ARE NOT A SPECIAL CASE — THEY ARE WHY TOKENISING WORKS
+//
+// `Customer list` and `Customer option` are a shape no shipped arm has faced:
+// the type constructor trails its argument. A wrapper-list unwrapper ("strip a
+// known `option`/`list` suffix") would have to enumerate FSharp.Core and would
+// still be wrong for a user-defined postfix constructor. So this pass does not
+// unwrap at all. It TOKENISES the type expression into bare identifiers and
+// judges each one independently against the same-file declaration set — arm
+// D's rule, reached by a different route.
+//
+// That works because every named type in an F# type expression appears as a
+// bare identifier, whatever the syntax composing them: prefix generics
+// (`Map<string, Customer>`), postfix generics (`Customer list`), arrays
+// (`Customer[]`), tuples (`int * Customer`), functions (`int -> Customer`),
+// units of measure (`float<kg>`). Each token is then admitted only if the file
+// DECLARES a type of that name, so `option`, `list`, `seq` and `Map` — all of
+// them FSharp.Core, none of them declared here — fall out with no blocklist to
+// maintain.
+//
+// The order of operations is load-bearing and is arm D's argument transplanted:
+// a PRIMITIVE is collected as a candidate and refused by the declaration gate,
+// never by a blocklist. `int`, `string` and `float` are type ABBREVIATIONS in
+// F#, not keywords, and are legally shadowable by a same-file
+// `type string = ...`. A blocklist would refuse the one edge that should exist
+// there. Both directions are graded:
+// TestFSharpFieldTypeRefs_PrimitiveFieldsProduceNoEdge and
+// TestFSharpFieldTypeRefs_ShadowedPrimitiveAbbreviationIsATarget.
+//
+// A QUALIFIED NAME IS SKIPPED WHOLE, NEVER REDUCED TO ITS LAST SEGMENT
+//
+// `Domain.Customer` is tokenised as ONE token containing a dot and dropped.
+// Taking the trailing segment is the failure arm D found in go's
+// resolveTypeReferences: `other.Order` reduced to `Order` binds to a same-file
+// `Order`, a WRONG binding, and a wrong binding never reaches `bug-extractor`
+// because it binds. F# has the identical hazard — `Domain.Customer` where the
+// file also declares its own `Customer` — and declines it the same way. Pinned
+// by TestFSharpFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName.
+//
+// A GENERIC TYPE PARAMETER IS SKIPPED WHOLE for the same reason: `'T` is
+// consumed leading-quote-first so it can never re-enter the scanner as the
+// bare token `T` and bind to a same-file `type T`. Arm D shipped that exact
+// over-fire as a known-wrong case because Go's `T` is indistinguishable from a
+// type name; F#'s leading apostrophe makes it distinguishable, so this arm
+// closes it instead of pinning it.
+//
+// RECORDS ONLY — THE DU CASE IS A DIFFERENT PROPOSITION, DELIBERATELY DECLINED
+//
+// du_record_members.go emits DU cases through the same function, as
+// SCOPE.Schema/du_case, and `| Placed of Order` does put a type name in
+// `member_type`. This pass still refuses them, on Subtype, for two separate
+// reasons either of which is sufficient:
+//
+//   - IT IS NOT THE SAME RELATION. A record field IS a member with a declared
+//     type: `Order.Buyer : Customer` means every Order has a Customer. A DU
+//     case is a CONSTRUCTOR — `Status.Placed of Customer` means a Status may be
+//     built FROM a Customer, and only in that one alternative. Emitting it
+//     under `ref_kind=field_target_type` would make one query return two
+//     different facts, which is #6902's defect family. If the DU-case relation
+//     is worth having it wants its own ref_kind and its own arm.
+//   - THE DATUM IS LOSSIER. splitDUCase takes everything after ` of `
+//     verbatim, so a named-field case `| Named of who: Customer * qty: int`
+//     arrives with the FIELD LABELS still in it (probed). Tokenising that
+//     yields `who` and `qty` as candidates alongside the real types — harmless
+//     under the declaration gate today, but it is inference on a parse that was
+//     never built to carry types.
+//
+// Graded rather than asserted: TestFSharpFieldTypeRefs_DUCasePayloadGetsNoEdge
+// uses a payload type that IS declared in the file and IS admitted by the
+// allow-list, so the case fails if the Subtype guard is removed, rather than
+// passing because nothing would have bound anyway.
+//
+// A NON-BINDING EDGE IS WORSE THAN NO EDGE. An unresolved stub is kept verbatim
+// and dangling and classified `bug-extractor`, so the two rules below are both
+// about declining to emit rather than about recall.
+
+// fsharpFieldTargetRefKind is the value of the `ref_kind` edge property. It
+// matches arm A's csFieldTargetRefKind, arm B's protoFieldTargetRefKind, arm
+// C's rustFieldTargetRefKind, arm D's goFieldTargetRefKind and the custom
+// lane's referencesClassEdge verbatim — the discriminator is what makes the
+// edge queryable as a field→declared-type edge across languages, so it must be
+// one string. Arm D established there is no shared constant and no cross-arm
+// agreement test, and that this is deliberate: five independent literals
+// asserted in five packages enforce agreement transitively, where a shared
+// constant would be one grader instead of five.
+const fsharpFieldTargetRefKind = "field_target_type"
+
+// fsharpFieldTypeCandidates returns every bare identifier written in an F# type
+// expression, in source order and without deduplication.
+//
+// It is a scanner, not a parser, and that is the point: it does not model
+// `option`, `list`, `<>`, `*`, `->` or `[]` at all, so there is no wrapper list
+// to keep in sync with F#'s type syntax and no postfix/prefix asymmetry to get
+// wrong. Every named type in the expression is a bare identifier; every bare
+// identifier becomes a candidate; the declaration gate in
+// fsharpInFileTypeTargets decides which are real.
+//
+// TWO token shapes are consumed WHOLE and discarded, and consuming them WHOLE
+// is what makes them safe — a scanner that merely skipped the leading
+// character would re-enter mid-token and produce exactly the bare name the
+// skip exists to prevent:
+//
+//   - A DOTTED token (`Domain.Customer`, `System.Collections.Generic.List`).
+//     `.` is scanned as an identifier continuation character precisely so the
+//     whole qualified name arrives as one token and can be rejected as one.
+//   - A token opening with `'` (`'T`, `'TKey`) — an F# generic type parameter.
+//
+// A field type is at most a few dozen characters, so the scan is linear in the
+// property length with no allocation beyond the result slice.
+func fsharpFieldTypeCandidates(typ string) []string {
+	var out []string
+	r := []rune(typ)
+	i := 0
+	for i < len(r) {
+		switch {
+		case r[i] == '\'':
+			// Generic type parameter — consume the apostrophe AND the name.
+			i++
+			for i < len(r) && isFSharpIdentRune(r[i]) {
+				i++
+			}
+		case isLetter(r[i]) || r[i] == '_':
+			j := i
+			for j < len(r) && (isFSharpIdentRune(r[j]) || r[j] == '.') {
+				j++
+			}
+			if tok := string(r[i:j]); !strings.ContainsRune(tok, '.') {
+				out = append(out, tok)
+			}
+			i = j
+		default:
+			i++
+		}
+	}
+	return out
+}
+
+// isFSharpIdentRune reports whether r may appear in the interior of an F#
+// identifier. The apostrophe is included (`x'` is a legal F# name), which is
+// also why a LEADING apostrophe must be consumed by the generic-parameter
+// branch above rather than merely skipped.
+func isFSharpIdentRune(r rune) bool {
+	return r == '_' || r == '\'' || isLetter(r) || (r >= '0' && r <= '9')
+}
+
+// fsharpFieldTypeTarget is one in-file type declaration a field-type edge may
+// address: the structural ToID that binds to it, and the bare name for the
+// `target_type` property.
+type fsharpFieldTypeTarget struct {
+	toID string
+	name string
+}
+
+// fsharpTypeDeclKinds is the target ALLOW-LIST, keyed "<Kind>/<Subtype>".
+//
+// It is an allow-list and not a denylist because F# emits several BARE-NAMED
+// records that are not type declarations, and a future producer adding another
+// one must be refused by default. Enumerated from this package's own emit
+// sites rather than inherited:
+//
+//	ADMITTED — every subtype classifyTypeSubtype can return for a `type`
+//	declaration (extractor.go:503, :540-570), plus detectCEBuilder's
+//	re-subtyping and applyElmishFeliz's two re-KINDINGS:
+//
+//	  SCOPE.Component/record               type T = { ... }
+//	  SCOPE.Component/discriminated_union  type T = A | B
+//	  SCOPE.Component/interface            type T = interface ... / IFoo
+//	  SCOPE.Component/class                type T() = class ...
+//	  SCOPE.Component/struct               [<Struct>] type T = ...
+//	  SCOPE.Component/alias                type Id = int          (#4942)
+//	  SCOPE.Component/type                 classifyTypeSubtype catch-all
+//	  SCOPE.Component/computation_builder  detectCEBuilder (#5048)
+//	  SCOPE.Model/elmish_model             the `Model` RECORD, re-kinded
+//	  SCOPE.Event/elmish_msg               the `Msg` DU, re-kinded
+//
+// The last two are why this map is keyed on Kind AND Subtype rather than
+// testing `Kind == "SCOPE.Component"`. applyElmishFeliz (elmish_feliz.go:104,
+// :109) re-kinds the Model record and the Msg DU in any file that opens
+// Elmish/Feliz/Fable, and `State: Model` is then the single most common
+// declared-type relation in an Elmish app. Arm C's `Kind != "SCOPE.Component"`
+// guard would drop both — the same shape as the 19% of Go edges it would have
+// dropped there. Graded by TestFSharpFieldTypeRefs_ElmishModelAndMsgAreTargets,
+// which fails when those two rows alone are deleted.
+//
+// THESE TWO ROWS AND THE CALL PLACEMENT ARE ONE DECISION, NOT TWO GUARDS, AND
+// SCORING THEM SEPARATELY IS MISLEADING. Measured rather than argued:
+//
+//	drop the two rows, keep the placement          -> DEAD (1 test)
+//	move the call before applyElmishFeliz,
+//	  keep the two rows                            -> ALIVE
+//	move the call AND drop the two rows            -> ALIVE
+//
+// Before the re-kind, `Model` is still SCOPE.Component/record and `Msg` still
+// SCOPE.Component/discriminated_union — both already admitted — so the earlier
+// placement needs no extra rows and produces identical output. The two
+// arrangements are equivalent, which means the middle row above is the honest
+// verdict for the placement: it is NOT independently graded, and the two rows'
+// kill holds only while the placement is held constant. Recorded because a pair
+// of mutually-masking guards grades neither, and the failure mode is claiming
+// both are load-bearing when one arrangement of the pair is what matters.
+//
+// The after-placement is nonetheless the one kept, on an argument that does not
+// depend on the Elmish rows at all: read at the END, the pass sees the FINAL
+// Kind and Subtype of every record, so a future producer that re-kinds or adds
+// a same-file record cannot silently invalidate either the allow-list or the
+// ambiguity rule. Reading earlier would rest on the invariant "no later pass
+// changes a Kind" — an invariant applyElmishFeliz already breaks.
+//
+//	REFUSED, and each of the three refusals is a distinct hazard:
+//
+//	  SCOPE.Component/import    — THE LIVE KILL. buildImportEntities
+//	    (extractor.go:678) mints one Component per `open`, named
+//	    importDisplayName(mod), which is the LAST SEGMENT of the module path.
+//	    So `open Acme.Customer` puts a Component literally named `Customer` in
+//	    this file. resolve/refs.go filters import placeholders out of
+//	    indexByName (refs.go:1611) but NOT out of byLocation/byLocationKind
+//	    (refs.go:1271-1317, no such test), and byLocation is precisely the
+//	    fallback a component-space structural ref lands in. So without this
+//	    refusal a field typed `Customer` in a file that opens `Acme.Customer`
+//	    and declares no `Customer` BINDS TO THE IMPORT PLACEHOLDER. It is a
+//	    wrong binding, not a dangle, so nothing downstream would report it.
+//	    F# is more exposed than Go here, where the import record's Name is the
+//	    whole path: truncation to a segment is what makes the collision
+//	    ordinary rather than contrived. Graded by
+//	    TestFSharpFieldTypeRefs_ImportPlaceholderIsNeverATarget, whose file
+//	    declares NO type of that name so rule 2 cannot mask the allow-list.
+//	  SCOPE.Component/module and /namespace — also bare-named
+//	    (extractor.go:267, :293), and `module Order` beside `type Order` is the
+//	    F# companion-module idiom, so the collision is the norm rather than an
+//	    edge case. It costs nothing today because the two records share Kind
+//	    AND Name AND file, hence ONE graph node under graph.EntityID, so the
+//	    admitted record supplies the same ToID either way — but a module with
+//	    NO companion type is a bare name with nothing behind it, and that is
+//	    the case the refusal is for.
+//	  SCOPE.Operation, SCOPE.Pattern, SCOPE.UIComponent, SCOPE.Component/file,
+//	    SCOPE.Schema/{field,du_case,active_pattern_case} — a value, a pattern,
+//	    a UI function, the file carrier, and the sub-entity populations. None
+//	    is a type. The three SCOPE.Schema subtypes are additionally unreachable
+//	    by name shape (their Names are dotted and a candidate token never
+//	    contains a dot), and that is claimed as nothing more than belt.
+var fsharpTypeDeclKinds = map[string]bool{
+	"SCOPE.Component/record":              true,
+	"SCOPE.Component/discriminated_union": true,
+	"SCOPE.Component/interface":           true,
+	"SCOPE.Component/class":               true,
+	"SCOPE.Component/struct":              true,
+	"SCOPE.Component/alias":               true,
+	"SCOPE.Component/type":                true,
+	"SCOPE.Component/computation_builder": true,
+	"SCOPE.Model/elmish_model":            true,
+	"SCOPE.Event/elmish_msg":              true,
+}
+
+// fsharpInFileTypeTargets indexes every TYPE DECLARED in this file that a
+// field-type edge may address, keyed by bare name.
+//
+// Two rules:
+//
+//  1. The record must be an admitted type declaration per fsharpTypeDeclKinds.
+//
+//  2. A name that denotes MORE THAN ONE DISTINCT GRAPH NODE in this file is
+//     dropped, and the count spans EVERY record in the file rather than only
+//     the admitted ones. This is the resolver's own ambiguity rule mirrored at
+//     the emit site: buildSymbolIndex marks (file, name) ambiguous on meeting a
+//     second distinct entity ID (`existing != e.ID`, internal/resolve/refs.go:1308),
+//     and the byLocation fallback this address depends on consults
+//     ambigLocation first — so a name shared with a NON-target node cannot bind
+//     either, and emitting would guarantee a dangling stub. Arm C's rule (count
+//     only within the admitted set) would not see such a collision; #7038 is
+//     filed against it for that.
+//
+//     THE UNIT IS THE KIND, NOT THE RECORD, and that too is the resolver's own
+//     rule rather than a convenience: graph.EntityID hashes
+//     (repo, Kind, Name, SourceFile) with SUBTYPE EXCLUDED, so within one file
+//     two records collide into ONE node exactly when they share a Kind.
+//     Counting RECORDS would refuse edges that bind perfectly well — the F#
+//     companion-module idiom `type Order = {...}` beside `module Order` is two
+//     records, both SCOPE.Component/Order in this file, and ONE node. Counting
+//     KINDS keeps that edge and still drops the genuinely-two-node cases (a
+//     type sharing a name with a SCOPE.Pattern or a SCOPE.Operation). BOTH
+//     directions are graded:
+//     TestFSharpFieldTypeRefs_CompanionModuleSharingATypeNameBinds is the
+//     record-count mutant's kill, and
+//     TestFSharpFieldTypeRefs_TypeShadowedByAnotherKindGetsNoEdge is the
+//     no-rule mutant's, with a positive control in the SAME fixture so it
+//     cannot pass by the target never working at all.
+func fsharpInFileTypeTargets(records []types.EntityRecord, filePath string) map[string]fsharpFieldTypeTarget {
+	// Pass 1 — how many DISTINCT GRAPH NODES each same-file name denotes,
+	// target or not.
+	nameKinds := make(map[string]map[string]bool)
+	for i := range records {
+		r := &records[i]
+		if r.SourceFile != filePath || r.Name == "" {
+			continue
+		}
+		if nameKinds[r.Name] == nil {
+			nameKinds[r.Name] = make(map[string]bool)
+		}
+		nameKinds[r.Name][r.Kind] = true
+	}
+
+	// Pass 2 — admit the type declarations whose name is unambiguous.
+	targets := make(map[string]fsharpFieldTypeTarget)
+	for i := range records {
+		r := &records[i]
+		if r.SourceFile != filePath || r.Name == "" {
+			continue
+		}
+		if !fsharpTypeDeclKinds[r.Kind+"/"+r.Subtype] {
+			continue
+		}
+		if len(nameKinds[r.Name]) > 1 {
+			continue
+		}
+		targets[r.Name] = fsharpFieldTypeTarget{
+			toID: extractor.BuildComponentStructuralRef("fsharp", filePath, r.Name),
+			name: r.Name,
+		}
+	}
+	return targets
+}
+
+// attachFSharpFieldTypeRefs appends one REFERENCES edge per (record field,
+// in-file declared type) pair.
+//
+// SAME FILE ONLY. A field whose type is declared in another .fs file gets
+// nothing. Closing that needs the cross-file view pass 1 has none of, and
+// binding a bare type name across files is the exact hazard #6976/#6369 are
+// about — #6369 was an F# defect, so this package has already paid for that
+// lesson once. Separate arm, not a widening of this one.
+//
+// FromID is left empty so graph assembly anchors the edge on the field record
+// that carries it — the Django precedent at
+// internal/extractors/python/django_relational.go:246-252, and arms B, C and D.
+//
+// Relationships is APPENDED to, never assigned: the field record already
+// carries none, but a later producer's edge must not be clobbered. (The
+// owner→member CONTAINS lives on the OWNER's record, not here.)
+//
+// It must run after every producer that can create or re-kind a same-file
+// record, which is why extractFSharp calls it on the fully assembled slice
+// INCLUDING the file carrier — see the placement comment at the call site.
+func attachFSharpFieldTypeRefs(records []types.EntityRecord, filePath string) []types.EntityRecord {
+	targets := fsharpInFileTypeTargets(records, filePath)
+	if len(targets) == 0 {
+		return records
+	}
+	for i := range records {
+		r := &records[i]
+		// Subtype "field" ONLY — never du_case, never active_pattern_case; see
+		// the "RECORDS ONLY" section of the header block.
+		if r.Kind != "SCOPE.Schema" || r.Subtype != "field" || r.SourceFile != filePath {
+			continue
+		}
+		declared := r.Properties["member_type"]
+		if declared == "" {
+			continue
+		}
+		owner := r.Properties["parent_class"]
+		fieldName := r.Properties["member_name"]
+		emitted := make(map[string]bool)
+		for _, cand := range fsharpFieldTypeCandidates(declared) {
+			t, ok := targets[cand]
+			if !ok || emitted[t.toID] {
+				continue
+			}
+			// A field never targets its own owning type: `type Node = { Next:
+			// Node option }` is a self-reference the CONTAINS edge already
+			// relates, and the recursive-type edge asserts nothing new.
+			if owner != "" && t.name == owner {
+				continue
+			}
+			emitted[t.toID] = true
+			r.Relationships = append(r.Relationships, types.RelationshipRecord{
+				ToID: t.toID,
+				Kind: string(types.RelationshipKindReferences),
+				Properties: types.Props{
+					{K: "field_name", V: fieldName},
+					{K: "ref_kind", V: fsharpFieldTargetRefKind},
+					{K: "target_type", V: t.name},
+				},
+			})
+		}
+	}
+	return records
+}

--- a/internal/extractors/fsharp/field_type_refs_6912_test.go
+++ b/internal/extractors/fsharp/field_type_refs_6912_test.go
@@ -117,7 +117,8 @@ type Order =
       Fn: int -> Customer
       Qual: Domain.Customer
       Gen: 'T
-      Mut: mutable Customer }
+      Anno: Customer // why this field exists
+      mutable Bal: Customer }
 `
 	got := map[string]string{}
 	for _, e := range extractFSharp(src, "D.fs") {
@@ -136,7 +137,17 @@ type Order =
 		"Order.Fn":    "int -> Customer",
 		"Order.Qual":  "Domain.Customer",
 		"Order.Gen":   "'T",
-		"Order.Mut":   "mutable Customer",
+		// `mutable` is a prefix on the FIELD, not on the type — the earlier
+		// spelling of this row (`Mut: mutable Customer`) is not legal F# and
+		// graded a shape that cannot occur. parseRecordFields TrimPrefix'es
+		// "mutable " off the segment, so the real construct lands here.
+		"Order.Bal": "Customer",
+		// THE EDGE OF THE VERBATIM CLAIM. Nothing strips a trailing comment,
+		// so the property is the SEGMENT after the colon, not the type. It is
+		// harmless under the declaration gate (`why`/`this`/... are not
+		// declared here) but it is a real limitation rather than a rounding,
+		// and a file declaring `type why` would get a spurious edge.
+		"Order.Anno": "Customer // why this field exists",
 	}
 	for name, w := range want {
 		if got[name] != w {
@@ -404,6 +415,75 @@ type Env =
 		"App.fs:Env.Cfg -> "+p+"Config",
 		"App.fs:Env.Last -> "+p+"Msg",
 		"App.fs:Env.State -> "+p+"Model",
+	)
+}
+
+// TestFSharpFieldTypeRefs_PlacementAfterTheElmishRekindIsLoadBearing grades
+// WHERE attachFSharpFieldTypeRefs is called from, which no other row does.
+//
+// The header's first draft claimed the placement mattered because the
+// allow-list needs the re-kinded SCOPE.Model/SCOPE.Event rows. A three-row
+// experiment refuted that reason — before the re-kind those records are
+// already-admitted SCOPE.Component subtypes — and the second draft then
+// retracted the CLAIM along with its reason. That over-corrected. The claim
+// holds on a different mechanism: RULE 2.
+//
+// `open Foo.Model` is not exotic; `Model` is the commonest module name in an
+// Elmish app, and importDisplayName truncates the path to its last segment.
+//
+//	read AFTER the re-kind (as shipped): `Model` denotes SCOPE.Model AND
+//	  SCOPE.Component/import -> two kinds -> rule 2 refuses -> 0 edges.
+//	read BEFORE: both records are SCOPE.Component -> ONE kind -> rule 2 is
+//	  silent, the allow-list admits, and the emitted stub DANGLES, because
+//	  Component and Model are both in componentKindFamily so
+//	  lookupLocationKind finds no unique answer and ambigLocation blanks it.
+//
+// Measured: as shipped 0 edges; with the call moved before applyElmishFeliz,
+// 1 edge that fails to resolve through BuildIndex -> ReferencesEmbedded. So
+// this is a reachable dangling-edge mutant, and it was ALIVE until this test.
+//
+// Two premise guards below, because the fixture only grades what it says if
+// BOTH records really exist with the kinds claimed.
+func TestFSharpFieldTypeRefs_PlacementAfterTheElmishRekindIsLoadBearing(t *testing.T) {
+	src := `module App
+
+open Elmish
+open Foo.Model
+
+type Config = { Debug: bool }
+
+type Model = { Count: int }
+
+type Env =
+    { State: Model
+      Cfg: Config }
+`
+	recs := fsExtract(t, map[string]string{"App.fs": src})
+
+	var sawRekind, sawPlaceholder bool
+	for _, e := range recs {
+		if e.Name == "Model" && e.Kind == "SCOPE.Model" && e.Subtype == "elmish_model" {
+			sawRekind = true
+		}
+		if e.Name == "Model" && e.Kind == "SCOPE.Component" && e.Subtype == "import" {
+			sawPlaceholder = true
+		}
+	}
+	if !sawRekind {
+		t.Fatal("applyElmishFeliz did not re-kind Model to SCOPE.Model — this " +
+			"fixture is not exercising the ordering it was written for")
+	}
+	if !sawPlaceholder {
+		t.Fatal("no SCOPE.Component/import named Model — importDisplayName no " +
+			"longer truncates `open Foo.Model` to its last segment, so the " +
+			"in-family rival this row depends on is absent")
+	}
+
+	// `Cfg: Config` is the POSITIVE CONTROL: the same file, the same pass, an
+	// ordinary record target with no rival. Without it, "no Model edge" is
+	// indistinguishable from "this file produces nothing".
+	fsWantEdges(t, recs,
+		"App.fs:Env.Cfg -> scope:component:class:fsharp:App.fs:Config",
 	)
 }
 

--- a/internal/extractors/fsharp/field_type_refs_6912_test.go
+++ b/internal/extractors/fsharp/field_type_refs_6912_test.go
@@ -1,0 +1,871 @@
+package fsharp
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6912 arm E — the field→declared-type edge for F#.
+//
+// VARIED vs HELD CONSTANT, stated up front because #6912's neighbours kept
+// pinning one axis and leaving the adjacent one open:
+//
+//	VARIED across the fixtures below
+//	  - the TYPE-EXPRESSION SHAPE: bare, postfix `option`/`list`, prefix
+//	    `Map<,>`, array `[]`, tuple `*`, function `->`, qualified `A.B`,
+//	    generic parameter `'T`, nested `Customer list option`
+//	  - the TARGET's Kind/Subtype: record, DU, class, interface, alias,
+//	    computation_builder, and the two Elmish re-kinds
+//	  - the NON-target record that shares a name: import placeholder, module,
+//	    SCOPE.Operation, active pattern
+//	  - WHERE the target is declared: same file vs sibling file
+//	  - the MEMBER's Subtype: field vs du_case
+//
+//	HELD CONSTANT
+//	  - one repo, one language, the `.fs` extension (`.fsi` differs only in
+//	    hierarchy emission, which this pass does not touch)
+//	  - the edge Kind (REFERENCES) and the anchor (the field record)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func fsExtract(t *testing.T, files map[string]string) []types.EntityRecord {
+	t.Helper()
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	var out []types.EntityRecord
+	for _, p := range paths {
+		out = append(out, extractFSharp(files[p], p)...)
+	}
+	return out
+}
+
+func fsPropOf(ps types.Props, k string) string {
+	for _, p := range ps {
+		if p.K == k {
+			return p.V
+		}
+	}
+	return ""
+}
+
+// fsFieldTypeRefEdges renders every field→declared-type edge as
+// "<file>:<Field> -> <ToID>", sorted. It filters on the `ref_kind` property
+// with an INDEPENDENT literal rather than on fsharpFieldTargetRefKind, so a
+// mutant that respells the constant is not silently followed by the grader.
+func fsFieldTypeRefEdges(t *testing.T, recs []types.EntityRecord) []string {
+	t.Helper()
+	var out []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || fsPropOf(r.Properties, "ref_kind") != "field_target_type" {
+				continue
+			}
+			out = append(out, recs[i].SourceFile+":"+recs[i].Name+" -> "+r.ToID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func fsWantEdges(t *testing.T, recs []types.EntityRecord, want ...string) {
+	t.Helper()
+	got := fsFieldTypeRefEdges(t, recs)
+	sort.Strings(want)
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("field-type edges mismatch\n got:\n  %s\nwant:\n  %s",
+			strings.Join(got, "\n  "), strings.Join(want, "\n  "))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 1. What Properties["member_type"] actually contains
+// ---------------------------------------------------------------------------
+
+// TestFSharpFieldTypeRefs_MemberTypeIsVerbatimSourceText is the EVIDENCE this
+// whole arm rests on, and it is asserted rather than assumed because #6912's
+// body was wrong about the analogous java datum in one direction and about
+// swift's in the other.
+//
+// The claim being pinned is exact: `member_type` is the declared type as
+// WRITTEN, character for character after TrimSpace — not a leaf, not a first
+// pre-order identifier (swift's failure), not absent (java's alleged one). If
+// parseRecordFields ever starts normalising, unwrapping or truncating, this
+// test fails BEFORE the candidate scanner silently starts seeing a different
+// string, which is the ordering that matters: the scanner's correctness is
+// entirely a function of this property's shape.
+func TestFSharpFieldTypeRefs_MemberTypeIsVerbatimSourceText(t *testing.T) {
+	src := `namespace D
+
+type Order =
+    { Plain: Customer
+      Opt: Customer option
+      Lst: Customer list
+      Deep: Customer list option
+      Mp: Map<string, Customer>
+      Arr: Customer[]
+      Tup: int * Customer
+      Fn: int -> Customer
+      Qual: Domain.Customer
+      Gen: 'T
+      Mut: mutable Customer }
+`
+	got := map[string]string{}
+	for _, e := range extractFSharp(src, "D.fs") {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" {
+			got[e.Name] = e.Properties["member_type"]
+		}
+	}
+	want := map[string]string{
+		"Order.Plain": "Customer",
+		"Order.Opt":   "Customer option",
+		"Order.Lst":   "Customer list",
+		"Order.Deep":  "Customer list option",
+		"Order.Mp":    "Map<string, Customer>",
+		"Order.Arr":   "Customer[]",
+		"Order.Tup":   "int * Customer",
+		"Order.Fn":    "int -> Customer",
+		"Order.Qual":  "Domain.Customer",
+		"Order.Gen":   "'T",
+		"Order.Mut":   "mutable Customer",
+	}
+	for name, w := range want {
+		if got[name] != w {
+			t.Errorf("member_type[%s] = %q, want %q", name, got[name], w)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("field count = %d, want %d (%v)", len(got), len(want), got)
+	}
+}
+
+// TestFSharpFieldTypeRefs_CandidateScannerEnumeratesTheShapeSpace drives the
+// scanner directly over an ENUMERATED shape space rather than over three
+// hand-picked strings. Every row is a type expression F# can write; the
+// expected output is the set of bare identifiers in it, with dotted tokens and
+// generic parameters absent WHOLE.
+func TestFSharpFieldTypeRefs_CandidateScannerEnumeratesTheShapeSpace(t *testing.T) {
+	cases := []struct {
+		typ  string
+		want []string
+	}{
+		{"Customer", []string{"Customer"}},
+		{"int", []string{"int"}},
+		{"Customer option", []string{"Customer", "option"}},
+		{"Customer list", []string{"Customer", "list"}},
+		{"Customer list option", []string{"Customer", "list", "option"}},
+		{"Map<string, Customer>", []string{"Map", "string", "Customer"}},
+		{"Customer[]", []string{"Customer"}},
+		{"Customer [] []", []string{"Customer"}},
+		{"int * Customer", []string{"int", "Customer"}},
+		{"int -> Customer", []string{"int", "Customer"}},
+		{"(int -> Customer) option", []string{"int", "Customer", "option"}},
+		{"float<kg>", []string{"float", "kg"}},
+		{"Result<Customer, string>", []string{"Result", "Customer", "string"}},
+		{"x'", []string{"x'"}},
+		{"Customer' option", []string{"Customer'", "option"}},
+		{"_private", []string{"_private"}},
+		{"T2", []string{"T2"}},
+		// Qualified — the WHOLE token is dropped, never its tail. Three
+		// depths, because a one-dot case cannot tell "dropped whole" from
+		// "the scanner stopped at the first dot".
+		{"Domain.Customer", nil},
+		{"A.B.Customer", nil},
+		{"System.Collections.Generic.List<Customer>", []string{"Customer"}},
+		{"Domain.Customer option", []string{"option"}},
+		// Generic parameters — consumed leading-quote-first, so the bare name
+		// can never re-enter the scanner.
+		{"'T", nil},
+		{"'TKey", nil},
+		{"Map<'TKey, Customer>", []string{"Map", "Customer"}},
+		{"'T -> 'U", nil},
+		{"", nil},
+		{"  ", nil},
+		{"<>", nil},
+	}
+	for _, c := range cases {
+		got := fsharpFieldTypeCandidates(c.typ)
+		if strings.Join(got, "|") != strings.Join(c.want, "|") {
+			t.Errorf("candidates(%q) = %v, want %v", c.typ, got, c.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Recall — the shapes that must produce an edge
+// ---------------------------------------------------------------------------
+
+const fsRecallSrc = `namespace Domain
+
+type Customer =
+    { Id: int
+      Name: string }
+
+type Money =
+    { Amount: decimal }
+
+type Order =
+    { Buyer: Customer
+      MaybeBuyer: Customer option
+      History: Customer list
+      Nested: Customer list option
+      ByName: Map<string, Customer>
+      Batch: Customer[]
+      Pair: int * Customer
+      Lookup: int -> Customer
+      Total: Money
+      Both: Map<Customer, Customer>
+      Count: int
+      Label: string }
+`
+
+// TestFSharpFieldTypeRefs_EveryWrapperShapeBinds is the recall row. Ten of the
+// twelve fields must produce an edge, one per DISTINCT target, and the two
+// primitive fields must produce none.
+//
+// `Both: Map<Customer, Customer>` names one target twice and grades the
+// per-field ToID dedup — it matters because the audit pass does not dedup
+// edges, so a duplicate would be counted twice by every metric that reads them.
+func TestFSharpFieldTypeRefs_EveryWrapperShapeBinds(t *testing.T) {
+	recs := fsExtract(t, map[string]string{"Domain.fs": fsRecallSrc})
+	c := "scope:component:class:fsharp:Domain.fs:Customer"
+	m := "scope:component:class:fsharp:Domain.fs:Money"
+	fsWantEdges(t, recs,
+		"Domain.fs:Order.Batch -> "+c,
+		"Domain.fs:Order.Both -> "+c,
+		"Domain.fs:Order.Buyer -> "+c,
+		"Domain.fs:Order.ByName -> "+c,
+		"Domain.fs:Order.History -> "+c,
+		"Domain.fs:Order.Lookup -> "+c,
+		"Domain.fs:Order.MaybeBuyer -> "+c,
+		"Domain.fs:Order.Nested -> "+c,
+		"Domain.fs:Order.Pair -> "+c,
+		"Domain.fs:Order.Total -> "+m,
+	)
+}
+
+// TestFSharpFieldTypeRefs_EdgePropertiesAreComplete pins the three properties
+// and the anchor. FromID must stay EMPTY so graph assembly anchors the edge on
+// the field record — an explicit FromID is Hibernate's shape, which hangs its
+// edge off a parallel node, and #6912's own body was corrected on that point.
+func TestFSharpFieldTypeRefs_EdgePropertiesAreComplete(t *testing.T) {
+	recs := fsExtract(t, map[string]string{"Domain.fs": fsRecallSrc})
+	var found int
+	for i := range recs {
+		if recs[i].Name != "Order.MaybeBuyer" {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" {
+				continue
+			}
+			found++
+			if r.FromID != "" {
+				t.Errorf("FromID = %q, want empty so the edge anchors on the field record", r.FromID)
+			}
+			for k, want := range map[string]string{
+				"field_name":  "MaybeBuyer",
+				"ref_kind":    "field_target_type",
+				"target_type": "Customer",
+			} {
+				if got := fsPropOf(r.Properties, k); got != want {
+					t.Errorf("property %s = %q, want %q", k, got, want)
+				}
+			}
+		}
+		// The owner→member CONTAINS lives on the OWNER's record, so the field
+		// record must carry exactly the one new edge.
+		if n := len(recs[i].Relationships); n != 1 {
+			t.Errorf("field record carries %d relationships, want exactly 1", n)
+		}
+	}
+	if found != 1 {
+		t.Fatalf("found %d REFERENCES edges on Order.MaybeBuyer, want 1", found)
+	}
+}
+
+// TestFSharpFieldTypeRefs_RefKindSpellingIsExact near-misses the constant. The
+// spelling is the cross-language discriminator: five arms hardcode the same
+// literal with no shared constant, so each arm's own literal is the only thing
+// enforcing agreement.
+func TestFSharpFieldTypeRefs_RefKindSpellingIsExact(t *testing.T) {
+	if fsharpFieldTargetRefKind != "field_target_type" {
+		t.Fatalf("ref_kind = %q, want %q — arms A-D spell it this way and the "+
+			"edge is only queryable across languages if all five agree",
+			fsharpFieldTargetRefKind, "field_target_type")
+	}
+}
+
+// TestFSharpFieldTypeRefs_EveryAdmittedTargetKindBinds enumerates the
+// allow-list's admitted rows against a real source construct for each, so a
+// row that is admitted but unreachable in practice shows up as a missing edge
+// rather than as silent dead weight.
+func TestFSharpFieldTypeRefs_EveryAdmittedTargetKindBinds(t *testing.T) {
+	src := `namespace Domain
+
+type Rec = { A: int }
+
+type Du =
+    | X
+    | Y
+
+type Alias = int
+
+type IShipper =
+    interface
+        abstract Ship: unit -> unit
+    end
+
+type Klass(x: int) =
+    class
+        member _.X = x
+    end
+
+type OptionBuilder() =
+    member _.Bind(m, f) = f m
+    member _.Return(x) = x
+    member _.Zero() = None
+
+type Holder =
+    { R: Rec
+      D: Du
+      A: Alias
+      I: IShipper
+      K: Klass
+      B: OptionBuilder }
+`
+	recs := fsExtract(t, map[string]string{"Domain.fs": src})
+	p := "scope:component:class:fsharp:Domain.fs:"
+	fsWantEdges(t, recs,
+		"Domain.fs:Holder.A -> "+p+"Alias",
+		"Domain.fs:Holder.B -> "+p+"OptionBuilder",
+		"Domain.fs:Holder.D -> "+p+"Du",
+		"Domain.fs:Holder.I -> "+p+"IShipper",
+		"Domain.fs:Holder.K -> "+p+"Klass",
+		"Domain.fs:Holder.R -> "+p+"Rec",
+	)
+}
+
+// TestFSharpFieldTypeRefs_ElmishModelAndMsgAreTargets grades the two rows arm
+// C's `Kind != "SCOPE.Component"` guard would have dropped. applyElmishFeliz
+// re-kinds the `Model` record to SCOPE.Model and the `Msg` DU to SCOPE.Event,
+// and `State: Model` is the commonest declared-type relation in an Elmish app.
+//
+// The fixture carries a POSITIVE CONTROL — an ordinary record `Config` in the
+// same file — so a failure distinguishes "the re-kinded targets are dropped"
+// from "this file produces no edges at all", which is what makes the row a
+// grader rather than a recall assertion.
+func TestFSharpFieldTypeRefs_ElmishModelAndMsgAreTargets(t *testing.T) {
+	src := `module App
+
+open Elmish
+
+type Config = { Debug: bool }
+
+type Model = { Count: int }
+
+type Msg =
+    | Inc
+    | Dec
+
+type Env =
+    { State: Model
+      Last: Msg
+      Cfg: Config }
+`
+	recs := fsExtract(t, map[string]string{"App.fs": src})
+	// Guard the premise: if the re-kind did not happen this test would be
+	// grading the plain Component path and prove nothing.
+	var sawModel, sawMsg bool
+	for _, e := range recs {
+		if e.Name == "Model" && e.Kind == "SCOPE.Model" {
+			sawModel = true
+		}
+		if e.Name == "Msg" && e.Kind == "SCOPE.Event" {
+			sawMsg = true
+		}
+	}
+	if !sawModel || !sawMsg {
+		t.Fatalf("applyElmishFeliz did not re-kind Model/Msg (model=%v msg=%v) — "+
+			"this fixture is not exercising the SCOPE.Model/SCOPE.Event allow-list rows",
+			sawModel, sawMsg)
+	}
+	p := "scope:component:class:fsharp:App.fs:"
+	fsWantEdges(t, recs,
+		"App.fs:Env.Cfg -> "+p+"Config",
+		"App.fs:Env.Last -> "+p+"Msg",
+		"App.fs:Env.State -> "+p+"Model",
+	)
+}
+
+// ---------------------------------------------------------------------------
+// 3. Forbidden rows — the permissive direction
+// ---------------------------------------------------------------------------
+
+// TestFSharpFieldTypeRefs_PrimitiveFieldsProduceNoEdge enumerates F#'s common
+// primitive type abbreviations against an INDEPENDENT literal list. There is
+// no primitive blocklist in the implementation — these are refused by the
+// in-file declaration gate — so this row grades that gate in the direction a
+// recall assertion cannot see.
+func TestFSharpFieldTypeRefs_PrimitiveFieldsProduceNoEdge(t *testing.T) {
+	prims := []string{
+		"int", "int64", "float", "float32", "decimal", "string", "bool",
+		"char", "byte", "unit", "obj", "bigint", "single", "sbyte", "uint32",
+	}
+	var b strings.Builder
+	b.WriteString("namespace Domain\n\ntype Prims =\n    { ")
+	for i, p := range prims {
+		if i > 0 {
+			b.WriteString("\n      ")
+		}
+		b.WriteString("F" + strings.ToUpper(p[:1]) + p[1:] + ": " + p)
+	}
+	b.WriteString(" }\n")
+	recs := fsExtract(t, map[string]string{"Domain.fs": b.String()})
+	fsWantEdges(t, recs)
+	// The fixture must actually have produced the fields, or the emptiness
+	// above is vacuous.
+	n := 0
+	for _, e := range recs {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" {
+			n++
+		}
+	}
+	if n != len(prims) {
+		t.Fatalf("fixture produced %d field entities, want %d — the empty edge "+
+			"set above proves nothing if the fields were never emitted", n, len(prims))
+	}
+}
+
+// TestFSharpFieldTypeRefs_NoPrimitiveBlocklistIsNeeded_AndTheReasonIsNotTheObviousOne
+// is the mirror of the row above, and the reason it is written as one test with
+// two halves is that the obvious justification for having no blocklist turned
+// out to be WRONG for F# and had to be replaced by a measured one.
+//
+// The obvious argument — arm D's, for Go — is that a primitive is a legally
+// shadowable identifier, so a blocklist would refuse the one edge that SHOULD
+// exist when a file declares its own `type string`. HALF of that does not hold
+// here: typeRE (extractor.go:73) requires `[A-Z]` as the first character, so a
+// LOWERCASE F# type declaration emits no entity at all. `type string = {...}`
+// is legal F# and this extractor is blind to it, which means no lowercase
+// primitive abbreviation — int, string, float, bool, char, unit, obj — can ever
+// be an in-file target however the gate is written. Recorded as a pre-existing
+// limitation of typeRE, NOT introduced or relied on here.
+//
+// What survives is the UPPERCASE half, and it is live: `String`, `Object`,
+// `Decimal` and friends are real .NET type names an F# module may legally
+// declare its own version of, and there the blocklist a naive port would have
+// written (arm B's protoScalars, transliterated) WOULD refuse a correct edge.
+// So the design stands — refuse by the declaration gate, never by a name list —
+// but on the second argument rather than the first.
+func TestFSharpFieldTypeRefs_NoPrimitiveBlocklistIsNeeded_AndTheReasonIsNotTheObviousOne(t *testing.T) {
+	src := `namespace Domain
+
+type string = { LowerCaseIsInvisibleToTypeRE: char }
+
+type String = { Chars: char }
+
+type Holder =
+    { Lower: string
+      Upper: String }
+`
+	recs := fsExtract(t, map[string]string{"Domain.fs": src})
+
+	// Half 1 — the pre-existing typeRE limitation, pinned so a future widening
+	// of typeRE shows up here rather than silently changing this arm's output.
+	for _, e := range recs {
+		if e.Name == "string" && e.Kind == "SCOPE.Component" {
+			t.Fatal("typeRE now emits lowercase type declarations — this arm's " +
+				"lowercase-primitive reasoning is stale; re-derive it and check " +
+				"whether a blocklist is now needed for `int`/`string`/`float`")
+		}
+	}
+
+	// Half 2 — the live one. `String` is an uppercase .NET type name a
+	// blocklist would plausibly have carried, and the edge to the file's own
+	// declaration of it is correct.
+	fsWantEdges(t, recs,
+		"Domain.fs:Holder.Upper -> scope:component:class:fsharp:Domain.fs:String",
+	)
+}
+
+// TestFSharpFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName is the
+// correctness row arm D found the hard way in Go: reducing `other.Order` to
+// `Order` binds to a same-file `Order`, a WRONG binding that never reaches
+// `bug-extractor` because it binds.
+//
+// The fixture is built so the two possible behaviours give DIFFERENT output —
+// `Domain.Customer` is written in a file that also declares its own
+// `Customer`, with a positive control (`Direct: Customer`) proving the target
+// is otherwise reachable. A scanner that took the trailing segment would emit
+// two edges here, not one.
+func TestFSharpFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName(t *testing.T) {
+	src := `namespace Local
+
+type Customer = { Id: int }
+
+type Order =
+    { Direct: Customer
+      Foreign: Domain.Customer
+      Deep: A.B.Customer
+      Wrapped: Domain.Customer option }
+`
+	recs := fsExtract(t, map[string]string{"Local.fs": src})
+	fsWantEdges(t, recs,
+		"Local.fs:Order.Direct -> scope:component:class:fsharp:Local.fs:Customer",
+	)
+}
+
+// TestFSharpFieldTypeRefs_GenericParameterIsNotStrippedToASameFileType is the
+// same failure mode one token over. Arm D SHIPPED this as a known over-fire
+// because Go's `T` is indistinguishable from a type name; F#'s leading
+// apostrophe makes it distinguishable, so this arm closes it.
+//
+// The distinguishing input is a file that declares `type T` — without it, `'T`
+// would produce no edge for the wrong reason (nothing named `T` exists) and
+// the test would pass against a scanner that merely skipped the apostrophe.
+func TestFSharpFieldTypeRefs_GenericParameterIsNotStrippedToASameFileType(t *testing.T) {
+	src := `namespace Domain
+
+type T = { Marker: int }
+
+type Holder<'T> =
+    { Item: 'T
+      Real: T
+      Keyed: Map<'T, int> }
+`
+	recs := fsExtract(t, map[string]string{"Domain.fs": src})
+	fsWantEdges(t, recs,
+		"Domain.fs:Holder.Real -> scope:component:class:fsharp:Domain.fs:T",
+	)
+}
+
+// TestFSharpFieldTypeRefs_ImportPlaceholderIsNeverATarget is THE allow-list's
+// kill, and F# is more exposed to it than Go: buildImportEntities names the
+// placeholder importDisplayName(mod) — the LAST SEGMENT of the module path —
+// so `open Acme.Customer` puts a SCOPE.Component literally named `Customer` in
+// this file.
+//
+// The file declares NO type of that name, which is what makes the row grade
+// the ALLOW-LIST specifically: with one record of that name there is one graph
+// node, so the ambiguity rule stays silent and cannot mask the result. Without
+// the allow-list the field binds TO THE IMPORT PLACEHOLDER — resolve/refs.go
+// filters placeholders out of indexByName (:1611) but not out of byLocation
+// (:1271-1317), and byLocation is the fallback this address lands in — so the
+// failure is a wrong binding, not a dangle.
+//
+// The positive control (`Ok: Money`) proves the file emits edges at all.
+func TestFSharpFieldTypeRefs_ImportPlaceholderIsNeverATarget(t *testing.T) {
+	src := `namespace App
+
+open Acme.Customer
+
+type Money = { Amount: decimal }
+
+type Order =
+    { Buyer: Customer
+      Ok: Money }
+`
+	recs := fsExtract(t, map[string]string{"App.fs": src})
+	// Premise guard: the placeholder must really be present and really be
+	// named `Customer`, or the row grades nothing.
+	var placeholder bool
+	for _, e := range recs {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "import" && e.Name == "Customer" {
+			placeholder = true
+		}
+	}
+	if !placeholder {
+		t.Fatal("no SCOPE.Component/import named Customer in this file — " +
+			"importDisplayName no longer truncates to the last segment, so this " +
+			"test is not exercising the hazard it was written for")
+	}
+	fsWantEdges(t, recs,
+		"App.fs:Order.Ok -> scope:component:class:fsharp:App.fs:Money",
+	)
+}
+
+// TestFSharpFieldTypeRefs_OperationSharingATypeNameGetsNoEdge grades rule 2 in
+// its no-rule direction: `let Customer = ...` emits a SCOPE.Operation named
+// `Customer` beside the type of the same name. Two KINDS, hence two graph
+// nodes, hence resolve's ambigLocation returns statusAmbiguous and any edge
+// would DANGLE.
+//
+// The POSITIVE CONTROL is in the SAME fixture — `Ok: Money`, an identical
+// record field whose target has no rival — so the assertion cannot pass by the
+// pass being dead. Without the pair, "the shadowed name is respected" is
+// indistinguishable from "a record target never works".
+func TestFSharpFieldTypeRefs_TypeShadowedByAnotherKindGetsNoEdge(t *testing.T) {
+	src := `namespace Domain
+
+type Customer = { Id: int }
+
+type Money = { Amount: decimal }
+
+let Customer = 42
+
+type Order =
+    { Buyer: Customer
+      Ok: Money }
+`
+	recs := fsExtract(t, map[string]string{"Domain.fs": src})
+	// Premise guard: two DISTINCT kinds must really share the name.
+	kinds := map[string]bool{}
+	for _, e := range recs {
+		if e.Name == "Customer" && e.SourceFile == "Domain.fs" {
+			kinds[e.Kind] = true
+		}
+	}
+	if len(kinds) < 2 {
+		t.Fatalf("Customer denotes %d kind(s) %v in this file, want 2 — the "+
+			"ambiguity this row grades is not present", len(kinds), kinds)
+	}
+	fsWantEdges(t, recs,
+		"Domain.fs:Order.Ok -> scope:component:class:fsharp:Domain.fs:Money",
+	)
+}
+
+// TestFSharpFieldTypeRefs_CompanionModuleSharingATypeNameBinds is rule 2's
+// OTHER direction, and it is the mutant that separates counting KINDS from
+// counting RECORDS.
+//
+// `module Customer` heading a `Customer.fs` that also declares `type Customer`
+// is the ordinary F# file shape, not a contrivance. Both records are
+// SCOPE.Component with the same Name in the same file, so graph.EntityID
+// (which excludes Subtype) hashes them to ONE node and the resolver binds the
+// name perfectly well. A rule that counted RECORDS would refuse this edge; the
+// resolver's own rule, mirrored here, keeps it. #7038 is filed against arm C
+// for the same over-strictness.
+//
+// The fixture uses the TOP-LEVEL module form deliberately. The nested
+// companion-module form (`module Customer =`, indented under a namespace) does
+// NOT produce a second record at all: moduleRE (extractor.go:51) anchors on
+// `\s*$` and so never matches a module header ending in `=`. That is a
+// pre-existing gap in this extractor, noted here because it is the reason the
+// more famous spelling of this idiom could not be used — not because this arm
+// depends on it either way.
+func TestFSharpFieldTypeRefs_CompanionModuleSharingATypeNameBinds(t *testing.T) {
+	src := `module Customer
+
+type Customer = { Id: int }
+
+type Order =
+    { Buyer: Customer }
+`
+	recs := fsExtract(t, map[string]string{"Domain.fs": src})
+	// Premise guard: there really must be TWO records and ONE kind.
+	recCount, kinds := 0, map[string]bool{}
+	for _, e := range recs {
+		if e.Name == "Customer" && e.SourceFile == "Domain.fs" {
+			recCount++
+			kinds[e.Kind] = true
+		}
+	}
+	if recCount < 2 || len(kinds) != 1 {
+		t.Fatalf("Customer has %d records across %d kind(s) %v, want >=2 records "+
+			"in exactly 1 kind — a record-count rule and a kind-count rule are "+
+			"indistinguishable on this fixture otherwise", recCount, len(kinds), kinds)
+	}
+	fsWantEdges(t, recs,
+		"Domain.fs:Order.Buyer -> scope:component:class:fsharp:Domain.fs:Customer",
+	)
+}
+
+// TestFSharpFieldTypeRefs_DUCasePayloadGetsNoEdge grades the RECORDS-ONLY
+// decision. `| Placed of Customer` puts a real, admitted, same-file,
+// unambiguous type name in the du_case record's `member_type` — so with the
+// Subtype guard removed this fixture WOULD emit, and the row fails. It is a
+// grader, not an assertion that nothing would have bound anyway.
+//
+// The positive control is the record field `Latest: Customer` in the same
+// file, naming the same target.
+func TestFSharpFieldTypeRefs_DUCasePayloadGetsNoEdge(t *testing.T) {
+	src := `namespace Domain
+
+type Customer = { Id: int }
+
+type Status =
+    | Placed of Customer
+    | Named of who: Customer * qty: int
+    | Empty
+
+type Order =
+    { Latest: Customer }
+`
+	recs := fsExtract(t, map[string]string{"Domain.fs": src})
+	// Premise guard: the du_case records must really carry the type.
+	var payload string
+	for _, e := range recs {
+		if e.Name == "Status.Placed" {
+			payload = e.Properties["member_type"]
+		}
+	}
+	if payload != "Customer" {
+		t.Fatalf("Status.Placed member_type = %q, want %q — the Subtype guard "+
+			"is ungraded if the du_case carries no admissible candidate", payload, "Customer")
+	}
+	fsWantEdges(t, recs,
+		"Domain.fs:Order.Latest -> scope:component:class:fsharp:Domain.fs:Customer",
+	)
+}
+
+// TestFSharpFieldTypeRefs_SelfReferenceGetsNoEdge — `type Node = { Next: Node
+// option }`. The CONTAINS edge already relates the field to its owner and the
+// self-edge asserts nothing new. Arm D declines it for the same reason.
+func TestFSharpFieldTypeRefs_SelfReferenceGetsNoEdge(t *testing.T) {
+	src := `namespace Domain
+
+type Leaf = { V: int }
+
+type Node =
+    { Next: Node option
+      Self: Node
+      Down: Leaf }
+`
+	recs := fsExtract(t, map[string]string{"Domain.fs": src})
+	fsWantEdges(t, recs,
+		"Domain.fs:Node.Down -> scope:component:class:fsharp:Domain.fs:Leaf",
+	)
+}
+
+// TestFSharpFieldTypeRefs_CrossFileTypeGetsNoEdge — the same-file promise.
+// `Customer` is declared in Customer.fs and used in Order.fs; no edge. The
+// positive control (`Money`, declared in Order.fs) proves the pass is live in
+// that file, so the emptiness is a refusal rather than a no-op.
+func TestFSharpFieldTypeRefs_CrossFileTypeGetsNoEdge(t *testing.T) {
+	recs := fsExtract(t, map[string]string{
+		"Customer.fs": "namespace Domain\n\ntype Customer = { Id: int }\n",
+		"Order.fs": `namespace Domain
+
+type Money = { Amount: decimal }
+
+type Order =
+    { Buyer: Customer
+      Total: Money }
+`,
+	})
+	fsWantEdges(t, recs,
+		"Order.fs:Order.Total -> scope:component:class:fsharp:Order.fs:Money",
+	)
+}
+
+// TestFSharpFieldTypeRefs_ActivePatternCasesAreNotFields — the third
+// SCOPE.Schema subtype in this package. An active-pattern case carries no
+// `member_type` at all, so this row also grades the empty-property guard.
+func TestFSharpFieldTypeRefs_ActivePatternCasesAreNotFields(t *testing.T) {
+	src := `namespace Domain
+
+type Customer = { Id: int }
+
+let (|Even|Odd|) n = if n % 2 = 0 then Even else Odd
+
+type Order = { Buyer: Customer }
+`
+	recs := fsExtract(t, map[string]string{"Domain.fs": src})
+	fsWantEdges(t, recs,
+		"Domain.fs:Order.Buyer -> scope:component:class:fsharp:Domain.fs:Customer",
+	)
+}
+
+// ---------------------------------------------------------------------------
+// 4. The binding gate
+// ---------------------------------------------------------------------------
+
+// TestFSharpFieldTypeRefs_ResolverBindsEveryEdge is the gate this whole issue
+// class turns on: #6906 exists because a comment described a binding nobody
+// built, and #6912's standing instruction is that a NON-BINDING edge is worse
+// than no edge.
+//
+// It matters more here than in any previous arm, because the corpus at
+// /Users/jorgecajas/Projects/archigraph-corpora contains ZERO .fs/.fsi/.fsx
+// files — arms A-D could each cite a corpus bind-rate and this one cannot. So
+// every emitted edge is driven through the PRODUCTION resolver
+// (BuildIndex -> ReferencesEmbedded, exactly as graph assembly does) and must
+// come back rewritten to a real entity ID. Zero dangling is the assertion, not
+// a ratio.
+func TestFSharpFieldTypeRefs_ResolverBindsEveryEdge(t *testing.T) {
+	recs := fsExtract(t, map[string]string{
+		"Domain.fs": fsRecallSrc,
+		// A rival file declaring the SAME names, so the address dialect is
+		// under test rather than merely being unique by accident.
+		"Rival.fs": `namespace Other
+
+type Customer = { Other: int }
+
+type Money = { Other: int }
+`,
+	})
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6912fs", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+	idx := resolve.BuildIndex(recs)
+
+	// Positive control on the dialect: the BARE name is AMBIGUOUS in this
+	// two-file set, which is exactly why a bare-name ToID is not what we emit
+	// (#6986 measured that form at 91.6% dangling).
+	if _, st := idx.LookupStatusHint("Customer", "REFERENCES"); st == 1 {
+		t.Fatal("the bare name Customer binds unambiguously in this fixture, so " +
+			"the ambiguity the structural address controls for is absent and the " +
+			"dialect is ungraded")
+	}
+
+	idToName := map[string]string{}
+	for i := range recs {
+		idToName[recs[i].ID] = recs[i].SourceFile + ":" + recs[i].Kind + ":" + recs[i].Name
+	}
+
+	before := len(fsFieldTypeRefEdges(t, recs))
+	if before == 0 {
+		t.Fatal("no field-type edges to drive through the resolver")
+	}
+
+	resolve.ReferencesEmbedded(recs, idx)
+
+	var bound []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || fsPropOf(r.Properties, "ref_kind") != "field_target_type" {
+				continue
+			}
+			target, ok := idToName[r.ToID]
+			if !ok {
+				t.Errorf("%s -[REFERENCES]-> %q did NOT bind to an entity ID (dangling stub)",
+					recs[i].Name, r.ToID)
+				continue
+			}
+			bound = append(bound, recs[i].Name+" => "+target)
+		}
+	}
+	sort.Strings(bound)
+	want := []string{
+		"Order.Batch => Domain.fs:SCOPE.Component:Customer",
+		"Order.Both => Domain.fs:SCOPE.Component:Customer",
+		"Order.Buyer => Domain.fs:SCOPE.Component:Customer",
+		"Order.ByName => Domain.fs:SCOPE.Component:Customer",
+		"Order.History => Domain.fs:SCOPE.Component:Customer",
+		"Order.Lookup => Domain.fs:SCOPE.Component:Customer",
+		"Order.MaybeBuyer => Domain.fs:SCOPE.Component:Customer",
+		"Order.Nested => Domain.fs:SCOPE.Component:Customer",
+		"Order.Pair => Domain.fs:SCOPE.Component:Customer",
+		"Order.Total => Domain.fs:SCOPE.Component:Money",
+	}
+	if strings.Join(bound, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("resolved edges mismatch\n got:\n  %s\nwant:\n  %s",
+			strings.Join(bound, "\n  "), strings.Join(want, "\n  "))
+	}
+	if len(bound) != before {
+		t.Fatalf("%d edges emitted but %d resolved to an entity", before, len(bound))
+	}
+}

--- a/internal/extractors/fsharp/field_type_refs_scope_6912_test.go
+++ b/internal/extractors/fsharp/field_type_refs_scope_6912_test.go
@@ -106,6 +106,54 @@ func TestFSharpFieldTypeRefs_TargetsAreScopedToTheRequestedFile(t *testing.T) {
 	}
 }
 
+// TestFSharpFieldTypeRefs_OnlySchemaKindedFieldsAreAnchors grades the
+// `r.Kind != "SCOPE.Schema"` conjunct of the field loop, which the external
+// suite cannot reach.
+//
+// It IS equivalent for anything extractFSharp can produce: du_record_members.go:46
+// is the only site in the package that mints Subtype "field", and it always sets
+// Kind SCOPE.Schema, so through Extract the two conjuncts fire together and
+// deleting either changes nothing. That makes it exactly the shape M13/M14/M15
+// are — reachable only through the direct-call path this arm already relies on —
+// and this arm's own standard is that "unreachable from outside" is a reason to
+// call the function directly, not a reason to leave a conjunct ungraded.
+//
+// The distinguishing input is a hand-built SCOPE.Component record carrying
+// Subtype "field": without the Kind conjunct it becomes an edge ANCHOR, and the
+// pass would start hanging field-type edges off a record that is not a field
+// entity at all.
+func TestFSharpFieldTypeRefs_OnlySchemaKindedFieldsAreAnchors(t *testing.T) {
+	records := []types.EntityRecord{
+		{Name: "Money", Kind: "SCOPE.Component", Subtype: "record", SourceFile: "A.fs"},
+		// Subtype says "field"; Kind does not. Only the Kind conjunct refuses it.
+		{Name: "Impostor.Amount", Kind: "SCOPE.Component", Subtype: "field", SourceFile: "A.fs",
+			Properties: map[string]string{
+				"member_name": "Amount", "member_type": "Money", "parent_class": "Impostor",
+			}},
+		// POSITIVE CONTROL — a real field record, same file, same target, so a
+		// failure separates "the Kind conjunct held" from "nothing emits here".
+		{Name: "Real.Amount", Kind: "SCOPE.Schema", Subtype: "field", SourceFile: "A.fs",
+			Properties: map[string]string{
+				"member_name": "Amount", "member_type": "Money", "parent_class": "Real",
+			}},
+	}
+
+	out := attachFSharpFieldTypeRefs(records, "A.fs")
+	got := map[string]int{}
+	for i := range out {
+		got[out[i].Name] = len(out[i].Relationships)
+	}
+	if got["Impostor.Amount"] != 0 {
+		t.Errorf("a SCOPE.Component record with Subtype \"field\" received %d edge(s) — "+
+			"the field loop's Kind conjunct is not holding, so a non-field record "+
+			"can become a field-type edge anchor", got["Impostor.Amount"])
+	}
+	if got["Real.Amount"] != 1 {
+		t.Fatalf("the positive control received %d edge(s), want 1 — the assertion "+
+			"above proves nothing if this input emits nothing at all", got["Real.Amount"])
+	}
+}
+
 func fsKeysOf(m map[string]fsharpFieldTypeTarget) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/internal/extractors/fsharp/field_type_refs_scope_6912_test.go
+++ b/internal/extractors/fsharp/field_type_refs_scope_6912_test.go
@@ -1,0 +1,115 @@
+package fsharp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6912 arm E — an INTERNAL test, and it exists for one reason: the
+// `r.SourceFile != filePath` conjunct appears THREE times in this arm (both
+// loops of fsharpInFileTypeTargets and the field loop in
+// attachFSharpFieldTypeRefs) and none of the three can be reached through
+// Extract.
+//
+// extractFSharp is called once per file and every record it builds carries that
+// file's path, so from the outside the conjunct never fires and a mutant
+// deleting it survives the entire external suite — the "alive but unreachable"
+// verdict. Calling the function directly with the input the guard exists for is
+// the cheap answer; the whole cost is this file.
+//
+// The guard is what keeps the pass correct if it is ever handed a multi-file
+// slice, which is not hypothetical: attachFSharpFieldTypeRefs is called on the
+// post-PrependFileCarrier slice precisely so it sees EVERY record, and a future
+// caller that batches files would silently start binding a field in one file to
+// a same-named type in another. That is the cross-file hazard #6976/#6369 are
+// about, and #6369 was an F# defect.
+func TestFSharpFieldTypeRefs_TargetsAreScopedToTheRequestedFile(t *testing.T) {
+	records := []types.EntityRecord{
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "record", SourceFile: "A.fs"},
+		{Name: "Money", Kind: "SCOPE.Component", Subtype: "record", SourceFile: "A.fs"},
+		// Same shape, different file. Neither may appear in A.fs's target set,
+		// and — the direction that matters — `Shipper` must NOT become a target
+		// for A.fs merely because some other file declares it.
+		{Name: "Shipper", Kind: "SCOPE.Component", Subtype: "interface", SourceFile: "B.fs"},
+		{Name: "Meters", Kind: "SCOPE.Component", Subtype: "alias", SourceFile: "B.fs"},
+		// A DIFFERENT-KINDED record in B.fs sharing a name with an A.fs type.
+		// This row grades the SourceFile conjunct in the FIRST loop — the one
+		// that builds nameKinds — which the rows above cannot: they share no
+		// name with A.fs, so a cross-file leak there changes nothing. With that
+		// conjunct removed, nameKinds["Customer"] gains a second kind from B.fs
+		// and the ambiguity rule wrongly suppresses A.fs's unambiguous Customer.
+		// Both loops carry the conjunct, so both are graded rather than one
+		// being paid for and its twin left open.
+		{Name: "Customer", Kind: "SCOPE.Operation", Subtype: "let", SourceFile: "B.fs"},
+	}
+
+	got := fsharpInFileTypeTargets(records, "A.fs")
+	want := map[string]string{
+		"Customer": "scope:component:class:fsharp:A.fs:Customer",
+		"Money":    "scope:component:class:fsharp:A.fs:Money",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("target set has %d entries %v, want %d %v", len(got), fsKeysOf(got), len(want), want)
+	}
+	for name, toID := range want {
+		tgt, ok := got[name]
+		if !ok {
+			t.Fatalf("%q missing from A.fs's target set %v", name, fsKeysOf(got))
+		}
+		if tgt.toID != toID {
+			t.Errorf("%q toID = %q, want %q", name, tgt.toID, toID)
+		}
+	}
+	for _, foreign := range []string{"Shipper", "Meters"} {
+		if _, ok := got[foreign]; ok {
+			t.Errorf("%q is declared in B.fs and must NOT be a target for A.fs — "+
+				"the same-file rule is this arm's central promise", foreign)
+		}
+	}
+
+	// The mirror direction, so the assertion above is not merely "B.fs's
+	// records were ignored entirely": asking for B.fs returns B.fs's
+	// declarations and none of A.fs's.
+	gotB := fsharpInFileTypeTargets(records, "B.fs")
+	if _, ok := gotB["Shipper"]; !ok {
+		t.Fatalf("B.fs's own target set %v is missing Shipper — the assertions "+
+			"above would pass even if the function returned nothing", fsKeysOf(gotB))
+	}
+	if _, ok := gotB["Customer"]; ok {
+		// TWO independent reasons this name must be absent from B.fs's set, and
+		// the row above means they are no longer the same reason: A.fs's
+		// Customer is cross-file, and B.fs's OWN Customer is a SCOPE.Operation,
+		// which the allow-list refuses. Either alone suffices; the absence
+		// covers both.
+		t.Errorf("Customer must not be a target for B.fs: A.fs's is cross-file " +
+			"and B.fs's own is a SCOPE.Operation, which is not a type declaration")
+	}
+
+	// The THIRD site: attachFSharpFieldTypeRefs' own SourceFile conjunct on the
+	// field record. A field in B.fs must not pick up A.fs's targets even when
+	// the target set was built for A.fs.
+	withField := append([]types.EntityRecord{}, records...)
+	withField = append(withField, types.EntityRecord{
+		Name: "Foreign.Buyer", Kind: "SCOPE.Schema", Subtype: "field", SourceFile: "B.fs",
+		Properties: map[string]string{
+			"member_name": "Buyer", "member_type": "Money", "parent_class": "Foreign",
+		},
+	})
+	out := attachFSharpFieldTypeRefs(withField, "A.fs")
+	for i := range out {
+		if out[i].Name == "Foreign.Buyer" && len(out[i].Relationships) != 0 {
+			t.Errorf("a B.fs field received %d edge(s) from A.fs's target set — "+
+				"the field loop's SourceFile conjunct is not holding",
+				len(out[i].Relationships))
+		}
+	}
+}
+
+func fsKeysOf(m map[string]fsharpFieldTypeTarget) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Arm E of #6912 — the field→declared-type `REFERENCES` edge for F#, `ref_kind=field_target_type`, field-anchored, **same-file targets only**. Arms A (C#/#6984), B (proto/#6991), C (rust/#7000), D (go/#7036) precede it.

F# is one of the four languages in contributor **#6726**'s corpus (csharp / fsharp / java / protobuf) and `du_record_members.go:77` mints F# record members as `Kind: "SCOPE.Schema"` — so they are part of the exact 99.3%-orphan population that issue reports. F# was never assessed by #6912's grounding pass, which covered php/cpp/swift/java/kotlin/scala/go/ruby.

---

## 1. What `member_type` actually contains — probed, and it changes the design

`parseRecordFields` (`du_record_members.go:140`) takes everything after the first `:` in the field segment and only `TrimSpace`s it. Probed output, pinned against literals in `TestFSharpFieldTypeRefs_MemberTypeIsVerbatimSourceText`:

| written | `member_type` |
|---|---|
| `Plain: Acct` | `Acct` |
| `Opt: Acct option` | `Acct option` |
| `Lst: Acct list` | `Acct list` |
| `Deep: Acct list option` | `Acct list option` |
| `Mp: Map<string, Acct>` | `Map<string, Acct>` |
| `Arr: Acct[]` | `Acct[]` |
| `Tup: int * Acct` | `int * Acct` |
| `Fn: int -> Acct` | `int -> Acct` |
| `Qual: Domain.Acct` | `Domain.Acct` |
| `Gen: 'T` | `'T` |
| `Mut: mutable Acct` | `mutable Acct` |

So it is the declared type **as written, character for character** — not swift's lossy first-pre-order-identifier, and not absent. **It is the one shipped field-type property on this issue that loses nothing**, which is why this arm reads the property where arm C stashed AST candidates.

**Arm C's alternative is not available here anyway:** the F# extractor is regex- and text-driven end to end (`moduleRE`/`typeRE`/`memberRE` + `extractIndentBody`); there is no tree-sitter grammar for F# in this tree. "Stash from the AST" is not a choice declined, it is a thing that does not exist.

## 2. Postfix generics — why the pass tokenises instead of unwrapping

`Acct list` / `Acct option` put the type constructor **after** its argument. No shipped arm has faced that, and a wrapper-list unwrapper would have to enumerate FSharp.Core and would still miss a user-defined postfix constructor.

So the pass **does not unwrap at all.** It scans the type expression into bare identifiers and judges each independently against the same-file declaration set — arm D's rule, reached by a different route. It works because every named type in an F# type expression is a bare identifier, whatever composes them: `<>`, postfix juxtaposition, `[]`, `*`, `->`, units of measure. `option`, `list`, `seq`, `Map` fall out because the file does not declare them — **no blocklist**.

`TestFSharpFieldTypeRefs_CandidateScannerEnumeratesTheShapeSpace` enumerates 28 rows rather than hand-picking three.

### Qualified names: skipped **whole**, never reduced

`Domain.Acct` is scanned as **one token** (`.` is an identifier-continuation char precisely so the whole qualified name arrives together) and dropped. Taking the trailing segment is the wrong binding arm D found in go's `resolveTypeReferences`. The fixture writes `Domain.Acct` in a file that **also declares its own `Acct`**, with a positive control, so the two behaviours give different output. Three depths tested (`A.B`, `A.B.C`, `System.Collections.Generic.List<Acct>`), because one dot cannot distinguish "dropped whole" from "the scanner stopped at the first dot".

### Generic parameters: closed, not pinned as a known over-fire

`'T` is consumed apostrophe-first so it can never re-enter the scanner as bare `T`. Arm D **shipped** this as a known over-fire because Go's `T` is indistinguishable from a type name; F#'s leading apostrophe makes it distinguishable. The fixture declares `type T` so the row grades the consumption rather than the absence of a target.

## 3. The target allow-list, and its live kill

Enumerated from this package's own emit sites, keyed `Kind/Subtype`:

**Admitted** — every subtype `classifyTypeSubtype` can return, plus `detectCEBuilder`'s and `applyElmishFeliz`'s re-labels:
`SCOPE.Component/{record, discriminated_union, interface, class, struct, alias, type, computation_builder}`, `SCOPE.Model/elmish_model`, `SCOPE.Event/elmish_msg`.

**Refused, three distinct hazards:**

- **`SCOPE.Component/import` — THE LIVE KILL, and sharper than Go's.** `buildImportEntities` (`extractor.go:678`) names each `open` placeholder `importDisplayName(mod)` — the **LAST SEGMENT** — so `open Acme.Acct` puts a `SCOPE.Component` literally named `Acct` in the file. `resolve/refs.go` filters import placeholders out of `indexByName` (`:1611`) but **not** out of `byLocation`/`byLocationKind` (`:1271-1317`), and `byLocation` is exactly the fallback a component-space structural ref lands in. Without the refusal a field typed `Acct` **binds to the import placeholder** — a *wrong binding*, not a dangle, so nothing downstream reports it. Graded by a fixture that declares **no** type of that name, so the ambiguity rule cannot mask the allow-list.
- **`SCOPE.Component/module` and `/namespace`** — also bare-named. Costs nothing today (same Kind + Name + file ⇒ one node), but a module with no companion type is a bare name with nothing behind it.
- **`SCOPE.Operation` / `SCOPE.Pattern` / `SCOPE.UIComponent` / `Component/file` / `Schema/{field,du_case,active_pattern_case}`** — not types. The three `SCOPE.Schema` subtypes are additionally unreachable by name shape (dotted names; a candidate never contains a dot), claimed as nothing more than belt.

Arm C's `Kind != "SCOPE.Component"` guard would drop `SCOPE.Model` and `SCOPE.Event` — i.e. `State: Model`, the commonest declared-type relation in an Elmish app. On the realistic probe below, 3 of 19 edges (15.8%) target a re-kinded record.

### An honest correction: the allow-list rows and the call placement are **mutually masking**

The first draft of the header claimed the after-`applyElmishFeliz` placement was load-bearing. Measured, it is not:

| mutant | verdict |
|---|---|
| drop the two Elmish rows, keep the placement | **DEAD** (1 test) |
| move the call before `applyElmishFeliz`, keep the rows | **ALIVE** |
| both | **ALIVE** |

Before the re-kind, `Model` is `SCOPE.Component/record` and `Msg` is `SCOPE.Component/discriminated_union` — both already admitted — so the two arrangements produce identical output. **The rows' kill holds only while the placement is held constant, and the placement is not independently graded.** Recorded in the header, because a pair of mutually-masking guards grades neither and the failure mode is claiming both are load-bearing.

The after-placement is kept on an argument that does **not** depend on the Elmish rows: read at the end, the pass sees every record's **final** Kind and Subtype, so a future re-kind cannot silently invalidate the allow-list or the ambiguity rule — an invariant `applyElmishFeliz` already breaks for the earlier placement.

## 4. Ambiguity counts KINDS, not records — both directions graded

`graph.EntityID` hashes `(repo, Kind, Name, SourceFile)` with **Subtype excluded**, and `resolve/refs.go:1308` flips `(file, name)` ambiguous on `existing != e.ID`. So within a file, two records collide into **one node** exactly when they share a Kind.

- **No-rule mutant** → `let Acct = 42` beside `type Acct` is two Kinds, two nodes, `statusAmbiguous`, a guaranteed dangle. DEAD, with a positive control (`Ok: Money`) in the *same* fixture so it cannot pass by the pass being dead.
- **Record-count mutant** → `module Acct` heading an `Acct.fs` that also declares `type Acct` is two records, **one node**, an edge that binds. DEAD.

(The nested companion-module form `module Acct =` produces no second record at all: `moduleRE` anchors on `\s*$` and never matches a header ending in `=`. Pre-existing gap, noted because it is why the fixture uses the top-level form.)

**#7038** is the same over-strictness in the already-shipped rust arm.

## 5. DU decision: **records only**, deliberately

`du_record_members.go` emits DU cases through the same function, and `| Placed of Acct` does put a type name in `member_type`. Refused on `Subtype`, for two independently sufficient reasons:

- **Different relation.** A record field *is* a member with a declared type. A DU case is a **constructor** — `Status.Placed of Acct` means a `Status` may be *built from* an `Acct`, in one alternative only. Emitting it under `ref_kind=field_target_type` would make one query return two different facts (#6902's family). If it is worth having it wants its own `ref_kind` and its own arm.
- **Lossier datum.** `splitDUCase` takes everything after ` of ` verbatim, so `| Named of who: Acct * qty: int` arrives **with the field labels still in it** (probed). Harmless under the declaration gate, but it is inference on a parse never built to carry types.

Graded, not asserted: the fixture's payload type **is** declared in the file and **is** admitted, so removing the `Subtype` guard emits and the row fails.

## 6. Varied vs held-constant axes

**Varied:** type-expression shape (bare / postfix `option`,`list` / prefix `Map<,>` / array / tuple / function / qualified / generic param / nested `list option`); target Kind+Subtype (record, DU, class, interface, alias, computation_builder, `SCOPE.Model`, `SCOPE.Event`); the *rival* record sharing the name (import placeholder, module, `SCOPE.Operation`, active pattern); where the target is declared (same file vs sibling file); member Subtype (field vs du_case vs active_pattern_case); uppercase vs lowercase type names.

**Held constant:** one repo, one language, the `.fs` extension (`.fsi` differs only in hierarchy emission, untouched here); the edge Kind (`REFERENCES`) and the anchor (the field record).

## 7. Mutants — 18 scored, per conjunct, permissive direction first

| # | mutation | verdict |
|---|---|---|
| M1 | allow-list removed entirely | **DEAD** (2) |
| M2 | arm C's `Kind != "SCOPE.Component"` verbatim | **DEAD** (2) |
| M2b | only the two Elmish rows removed | **DEAD** (1) |
| M3 | ambiguity rule removed | **DEAD** (1) |
| M4 | ambiguity counts records, not kinds | **DEAD** (1) |
| M5 | qualified name reduced to its trailing segment | **DEAD** (2) |
| M6 | `'T` skips only the apostrophe (re-enters as `T`) | **DEAD** (2) |
| M7 | records-only `Subtype` guard removed | **DEAD** (1) |
| M8 | self-reference guard neutered | **DEAD** (1) |
| M9 | per-field ToID dedup removed | **DEAD** (2) |
| M10 | `ref_kind` → `field_target_types` (near-miss) | **DEAD** (16) |
| M12 | explicit `FromID` (Hibernate's shape) | **DEAD** (1) |
| M13 | `SourceFile` conjunct removed from pass 1 (`nameKinds`) | **DEAD** (1) |
| M14 | `SourceFile` conjunct removed from pass 2 (admission) | **DEAD** (1) |
| M15 | `SourceFile` conjunct removed from the field loop | **DEAD** (1) |
| M11 | call moved before `PrependFileCarrier` | **ALIVE — equivalent** |
| M11b | call moved before `applyElmishFeliz` | **ALIVE — equivalent** |
| M16 | `declared == ""` early continue removed | **ALIVE — equivalent** |
| M17 | `len(targets) == 0` early return removed | **ALIVE — equivalent** |

Each conjunct was scored **separately**: the three `SourceFile` sites are three mutants (M13/M14/M15), not one; the allow-list and the ambiguity rule are M1/M2/M2b and M3/M4. No compound was offered as evidence for a half — and the one pair that looked compound (M2b/M11b) is reported above as *mutually masking* rather than as two kills.

**Why the four ALIVE ones are equivalent, with reasons rather than "too expensive":**
- **M11** — `FileEntity` names the carrier `file.Path` (`extractor/extractor.go:344`) and every F# path contains a `.`, which no bare candidate token ever does. Unkillable; the placement is defence-in-depth that removes the need for the invariant.
- **M11b** — measured above; the two arrangements produce identical output.
- **M16 / M17** — pure short-circuits. An empty `member_type` yields zero candidates; an empty target map misses every lookup.

M13/M14/M15 are unreachable through `Extract` (one file per call), so `field_type_refs_scope_6912_test.go` calls the functions directly with the multi-file input the guards exist for — the whole cost of grading them is one file.

**Every mutant edit was proved to land** with an exact occurrence count before the run, and the tree was restored by `cp` from a shasum-verified backup taken from *this* tree, with `git diff HEAD` empty afterwards.

## 8. Measurement — and the corpus has no F# at all

**`/Users/jorgecajas/Projects/archigraph-corpora` contains ZERO `.fs`/`.fsi`/`.fsx`/`.fsproj` files.** So this arm **produced nothing there** — a fact about the corpus, not about the producer. Stating it plainly rather than reporting a zero as success, and it is why the binding gate is a test rather than a corpus bind-rate.

**The probe is sufficient to ship the arm and NOT sufficient to claim yield or orphan clearance for #6726.** It establishes that the address dialect binds for the shapes its author imagined; it says nothing about yield on real F# or about clearing #6726's `Schema` orphan population. Review found two defects living in shapes it omits (an import placeholder colliding with a re-kinded `Model`; a `let` shadowing a type). Since #6726 is expressed in orphan rates and four of its six headline numbers were already defects in our own measurement, "19/19 bound" must not be read as a yield figure for it.

Substitute measurement, labelled as synthetic: a **4-file realistic probe** (Elmish client with `Model`/`Msg`/`Filter`, a shared domain module with records + a DU + an alias, a server wiring module with a class, plus the repo's own `testdata/elmish_counter.fs`) — 92 entities, **39 record-field entities** — driven through the **production resolver** (`BuildIndex` → `ReferencesEmbedded`):

**19 edges, 19 BOUND, 0 dangling.**

Also refused, correctly, on that probe: `Map<string, string>` (no in-file target), `Map<string, Shared.Order>` (qualified skipped), `Shared.Customer` (qualified + cross-file). `TestFSharpFieldTypeRefs_ResolverBindsEveryEdge` carries the same gate in-suite over a two-file fixture, with a **positive control on the address dialect** — the bare name is ambiguous there, which is why a bare-name ToID (`#6986`: 91.6% dangling) is not what we emit.

## 9. Gates

- `go test -count=1` green on `./internal/extractors/fsharp/...`, `./internal/resolve/...`, `./internal/quality/...` (incl. `analytics`, `audit`, `fitness`), `./internal/extractor/...`, `./internal/graph/...`.
- **`go test -count=1 ./cmd/grafel/`** green (148s) in a **fresh** `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`, with the parity tests verified **run, not skipped** (`-run Parity`, 15 PASS; the 3 Django skips are pre-existing and unrelated). Not cited as coverage of this change — that digest is a same-binary parity set keyed `(from,to,kind)` with **properties discarded**, so it cannot see `ref_kind`.
- `scripts/quality/run.sh --runs 1 --ratchet` — 38 fixtures held, and the real check passes: **`git status --porcelain` shows only this arm's own files.** `baseline.json` is untouched, and that is enumerable rather than lucky: `find internal/quality/golden -name '*.fs*'` returns **0** — there is no F# golden fixture, so no baseline could move. No `--update-baseline`, no hand-edit needed.
- `gofmt -l` clean, `go vet` clean.
- **`ReferencesPerFunction` will inflate** (these edges are `REFERENCES` and a `SCOPE.Schema/field` is not function-like). Left alone per **#7037**, deliberately, so this arm's numbers stay comparable with arms A–D.

## 10. Environment finding worth recording

Mid-run a build failed with `no space left on device`; the data volume was genuinely at **1.6 GiB free** (the shared scratchpad is ~67 GB). I ran `go clean -cache`, which reclaimed ~190 GB — but it ran for many minutes **concurrently with other agents' builds**, and that is what produced the phantom `build failed` / missing-cache-object errors a parallel agent reported. Not disk pressure at the time they saw it: **my `go clean`**. Every `go` invocation from that point on, including **every mutant in the table above**, ran under a **private `GOCACHE`** in this lane's scratchpad, and every suite in §9 was re-run under it. No verdict in this PR rests on a shared-cache build.

Refs #6912
