### PR TITLE
fix(#6912): arm H — PHP fields carried their declared type only as a string property; emit the field→type REFERENCES edge (and the corpus yield is ZERO — read §12)

### DIFF
--- a/internal/extractors/php/field_type_refs.go
+++ b/internal/extractors/php/field_type_refs.go
@@ -1,0 +1,484 @@
+package php
+
+import (
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// field_type_refs.go — the field→declared-type edge for PHP (issue #6912, arm H).
+//
+// Shipped predecessors: arm A csharp/field_type_refs.go (#6984), arm B
+// proto/field_type_refs.go (#6991), arm C rust/field_type_refs.go (#7000), arm D
+// golang/field_type_refs.go (#7036), arm F java/field_type_refs.go (#7039), arm E
+// fsharp/field_type_refs.go (#7040).
+//
+// THE GAP. emitPhpFieldMembers (field_members.go:60) mints one SCOPE.Schema/field
+// entity per typed class property and per promoted constructor parameter, and
+// records the declared type ONLY as Properties["field_type"] and inside Signature.
+// The single edge attached to it is the owner→member CONTAINS, which the orphan
+// definition excludes by design, so every PHP field is a LEAF on its outbound
+// side. Contributor #6726 measures SCOPE.Schema at 99.3% orphan of 35,353
+// entities; PHP fields are minted as SCOPE.Schema, so they are part of that
+// population.
+//
+// ============================================================================
+// 1. THE PROPERTY IS LOSSLESS — VERIFIED BY PROBE, NOT BY READING
+// ============================================================================
+//
+// phpDeclaredType (field_members.go:135) returns the VERBATIM source span of the
+// first primitive_type | named_type | optional_type | union_type |
+// intersection_type | type_list child. Probed through the real extractor on 18
+// property shapes, every one arrives character for character as written:
+//
+//	?Customer   Customer|Money   Customer&Shipper   \Other\Order   ?\Money
+//	string|int  self             array              iterable       int
+//
+// So unlike swift — whose field_type is the FIRST pre-order type_identifier and
+// yields `Dictionary` for `Dictionary<String, Order>` — PHP's needs no stash from
+// the AST. Arm C's technique is declined because it is unnecessary here, not
+// because it is wrong. Pinned by TestPhpFieldTypeRefs_FieldTypeIsVerbatim.
+//
+// PROMOTED CONSTRUCTOR PARAMETERS ARE COVERED FOR FREE and are asserted rather
+// than assumed: emitPhpFieldMembers emits them through the SAME `add` closure
+// with the same Properties, so `public function __construct(public readonly
+// Customer $owner)` is one more SCOPE.Schema/field with field_type="Customer".
+// Graded by the promoted rows of TestPhpFieldTypeRefs_ShapeSpace.
+//
+// ============================================================================
+// 2. THE RESOLVER TIER THAT RESOLVES THIS ADDRESS — DRIVEN, NOT INFERRED
+// ============================================================================
+//
+// The ToID is extractor.BuildComponentStructuralRef, i.e.
+// `scope:component:class:php:<file>:<Name>`. resolveStructuralRef
+// (internal/resolve/refs.go:2982) tries, in order:
+//
+//  1. lookupLocationKind(file, name, structuralKindFamilies("component"))
+//     — i.e. componentKindFamily {Component, Class, View, Model, SCOPE.Component,
+//     SCOPE.View, SCOPE.Model} (refs.go:2341), plus each entity's SCOPE-trimmed
+//     alias (refs.go:1290-1296), which is what makes a bare `Class`-kinded
+//     entity a family member too.
+//  2. ambigLocation[file][name] (refs.go:3004) — set when TWO DISTINCT ENTITY
+//     IDS share (file, name), REGARDLESS OF KIND (refs.go:1302-1315).
+//  3. byLocation[file][name] — kind-agnostic.
+//
+// Every target this pass admits is a SCOPE.Component, so every edge it emits is
+// answered at TIER 1 and never reaches tiers 2/3. That is the whole basis of the
+// ambiguity rule below, and it was established by driving the real resolver
+// (BuildIndex → ReferencesEmbedded) over records produced by the real extractor,
+// not by reading refs.go. TestPhpFieldTypeRefs_ResolvesToEntityIDs is that drive.
+//
+// ============================================================================
+// 3. WHY PHP ENUMS ARE NOT TARGETS — A MEASUREMENT, NOT A PREFERENCE
+// ============================================================================
+//
+// buildEnum (php.go:384) mints `enum Status: string { case A = 'a'; }` as
+// SCOPE.Schema/enum named "Status", and emitConstValueSets → buildEnumValueSet
+// (const_valueset.go:181) ADDITIONALLY mints a SCOPE.Enum value-set with the
+// SAME Name in the SAME file. Two kinds, two graph nodes (graph.EntityID hashes
+// (repo, Kind, Name, SourceFile)), and NEITHER is in componentKindFamily.
+//
+// A component-space ref to such a name therefore misses tier 1, and hits tier 2
+// as AMBIGUOUS. Driven through the real resolver:
+//
+//	enum Status: string { case A = 'a'; }   ->  DANGLE (statusAmbiguous)
+//	enum Empty2 {}   (no cases, no value-set) ->  binds
+//
+// So admitting enums would emit a dangling stub for every enum that has at least
+// one case — i.e. for every enum anybody writes. A non-binding edge is WORSE than
+// no edge: it is kept verbatim and classified `bug-extractor`, a full hit on the
+// disposition denominator. Enums are refused, and the refusal is graded in both
+// directions by TestPhpFieldTypeRefs_EnumIsNotATarget (the enum field gets no
+// edge) with a same-fixture positive control (a class field in the same class
+// does get one), so the test cannot pass by the pass being broken.
+//
+// THIS IS A RECALL LOSS AND IT IS NAMED AS ONE. `public Status $status` is
+// ordinary PHP and stays orphan. Closing it needs a SECOND ADDRESS DIALECT — a
+// schema-space ref, which would hit lookupLocationKind with schemaKindFamily
+// {Schema, Field, Property, SCOPE.Schema}, where the SCOPE.Enum value-set is NOT
+// a member and the SCOPE.Schema/enum resolves uniquely. That is a real option
+// with a measured basis, and it is deliberately NOT taken here: shipping two
+// address dialects behind one ref_kind is #6451's defect shape, and it should be
+// decided across arms rather than invented by this one.
+//
+// ============================================================================
+// 4. THE AMBIGUITY RULE — DERIVED FROM THE TIER, NOT COPIED FROM AN ARM
+// ============================================================================
+//
+// The standing rule on #6912 is: COUNT THE KINDS THAT THE RESOLVER TIER WHICH
+// RESOLVES YOUR ADDRESS ACTUALLY WEIGHS. Per section 2 that tier is
+// lookupLocationKind filtered to componentKindFamily, so this pass counts kinds
+// WITHIN THAT FAMILY — arm F's scope, reached from php's own tier rather than
+// borrowed. The UNIT is the KIND and not the RECORD, mirroring refs.go:1308:
+// within one file two records sharing a Kind are ONE node, so counting records
+// would refuse edges that bind perfectly well. Arm C counts records and is wrong
+// under the rule (#7038); its rule is not copied and neither is its stated
+// reason.
+//
+// AND THE HONEST PART: SCOPE.Component IS THE ONLY componentKindFamily KIND ANY
+// PHP PRODUCER EMITS. Core (internal/extractors/php) and custom
+// (internal/custom/php) were both enumerated: neither emits SCOPE.Model,
+// SCOPE.View, SCOPE.Class, nor a bare Component/Class/View/Model. So
+// len(nameKinds[name]) can never exceed 1 from PHP source today and rule 2 is
+// VACUOUS AS SHIPPED. It is kept as a mirror of the resolver for the producer
+// that adds an in-family kind later — exactly the shape arm F's SCOPE.Class hole
+// was — and because it is unreachable from Extract it is graded by a direct-call
+// unit test (TestPhpFieldTypeRefs_Unit_InFamilyRivalSuppresses...) rather than
+// claimed to be covered by the fixture suite.
+//
+// The counterfactual of ARM D's rule (count ALL same-file kinds) is not vacuous
+// here, and it is the reason this arm does not inherit it: PHP has separate
+// symbol tables for classes and functions, so `class Money {}` beside
+// `function Money() {}` in one file is LEGAL PHP and puts a SCOPE.Operation
+// beside the SCOPE.Component. Arm D's rule refuses that target; tier 1 binds it
+// without hesitation, because SCOPE.Operation is not in the family it weighs.
+// Graded by TestPhpFieldTypeRefs_SameNamedFunctionDoesNotSuppressTheClass, whose
+// edge is additionally driven through the real resolver.
+//
+// ============================================================================
+// 5. THE TARGET ALLOW-LIST — THE LIVE WRONG-BINDING KILL
+// ============================================================================
+//
+// buildUseImports/useImportRecord (php.go:622-660) mints ONE SCOPE.Component per
+// `use` statement whose Name is the TOP namespace segment, and buildNamespace
+// (php.go:483) does the same for the file's own `namespace`. Both carry an EMPTY
+// Subtype. So `use Ship\Thing;` puts a Component literally named `Ship` in this
+// file — and a component-space ref to `Ship` BINDS TO IT (driven, section 2's
+// harness). Without the subtype allow-list a field typed `Ship` in that file
+// binds to an IMPORT PLACEHOLDER: a confident wrong answer rather than a dangle,
+// and a wrong binding is the direction `bug-extractor` cannot flag. Graded by
+// TestPhpFieldTypeRefs_ImportPlaceholderIsNeverATarget, whose file declares NO
+// class of that name so rule 2 cannot mask the allow-list.
+//
+// SCOPE.Component/file (extractor.FileEntity) is refused by the same list. It is
+// unreachable by name shape — its Name is the file path and a candidate token
+// can never contain `/` or `.` — and that is claimed as belt, not as the reason.
+//
+// ============================================================================
+// 6. NO PRIMITIVE BLOCKLIST
+// ============================================================================
+//
+// `int`, `string`, `array`, `callable`, `iterable`, `object`, `mixed`, `never`,
+// `void`, `false`, `null`, `true`, `float`, `bool`, `self`, `static`, `parent`
+// are collected as candidates like any other identifier and refused by the
+// DECLARATION GATE: the file does not declare a type of that name. No blocklist
+// exists, and none is needed — PHP reserves every one of those words as a class
+// name (`class int {}` is a fatal error), so unlike F#'s shadowable type
+// abbreviations there is no legal same-file declaration a blocklist would have to
+// out-rank. Graded by the primitive rows of TestPhpFieldTypeRefs_ShapeSpace.
+//
+// `self`/`static`/`parent` additionally name the OWNER, which is refused a second
+// time by the self-reference rule in attachPhpFieldTypeRefs.
+//
+// ============================================================================
+// 7. SAME-FILE TARGETS ONLY
+// ============================================================================
+//
+// A field whose type is declared in another .php file gets NOTHING. Binding a
+// bare type name across files is exactly the #6976/#6369 hazard, and PHP makes it
+// sharper than most: `use App\Models\Order;` means the bare `Order` in this file
+// denotes a class in a DIFFERENT file, and the same bare name is declared in
+// dozens of files across a Symfony/Laravel tree. Closing it needs the cross-file
+// namespace view pass 1 has none of. Separate arm, not a widening of this one.
+//
+// There are TWO independent same-file conjuncts and they fail in OPPOSITE
+// directions, so they are graded separately rather than one paying for the other:
+// the rival scan in phpInFileTypeTargets (a cross-file record wrongly SUPPRESSING
+// an edge) and the target scan (a cross-file record wrongly BECOMING a target).
+// TestPhpFieldTypeRefs_Unit_TargetsAreScopedToTheRequestedFile covers both.
+
+// phpFieldTargetRefKind is the value of the `ref_kind` edge property. It matches
+// arm A's csFieldTargetRefKind, arm B's protoFieldTargetRefKind, arm C's
+// rustFieldTargetRefKind, arm D's goFieldTargetRefKind, arm F's
+// javaFieldTargetRefKind and arm E's fsharpFieldTargetRefKind verbatim — the
+// discriminator is what makes the edge queryable as a field→declared-type edge
+// across languages, so it must be one string. Arm D established that the six
+// independent literals are deliberate: six graders enforcing agreement
+// transitively beat one shared constant.
+const phpFieldTargetRefKind = "field_target_type"
+
+// phpFieldTypeCandidates returns every UNQUALIFIED identifier written in a PHP
+// type expression, in source order and without deduplication.
+//
+// It is a scanner, not a parser. It models neither `?` nor `|` nor `&` nor
+// `(A&B)|null` DNF grouping, and that is the point: every named type in a PHP
+// type expression appears as a bare identifier whatever composes them, so there
+// is no type-syntax table to keep in sync. A UNION names several types and EACH
+// gets its own edge (`Customer|Money` → two), because each alternative genuinely
+// is a declared type the field may hold; an INTERSECTION likewise (`A&B` — the
+// value is both). Nullability contributes nothing: `?Customer` names exactly the
+// one type `Customer`.
+//
+// ONE token shape is consumed WHOLE and discarded, and consuming it WHOLE is what
+// makes it safe — a scanner that merely SKIPPED the backslash would re-enter
+// mid-token and produce exactly the bare name the skip exists to prevent:
+//
+//   - A NAMESPACE-QUALIFIED name, in either spelling: relative (`Other\Order`) or
+//     fully-qualified with a leading separator (`\Other\Order`, `\Money`). `\` is
+//     scanned as an identifier continuation character, AND a token may START with
+//     it, so the whole qualified name arrives as one token and is rejected as one.
+//
+// Reducing `Other\Order` to `Order` is precisely the failure arm D found in Go's
+// resolveTypeReferences, where `other.Order` bound to a same-file `Order` — a
+// wrong binding, which never reaches `bug-extractor` because it binds. A LEADING
+// separator is refused for a second and independent reason: in a file that
+// declares `namespace App;`, the bare `Money` means `App\Money` while `\Money`
+// means the GLOBAL `Money`, so they are different types and binding one to the
+// other would be wrong in the namespaced case. It is conservative in the
+// namespace-less case (where the two coincide) and that is the direction to be
+// conservative in. Both spellings are graded by the qualified rows of
+// TestPhpFieldTypeRefs_ShapeSpace and by
+// TestPhpFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName.
+//
+// A field type is at most a few dozen characters, so the scan is linear in the
+// property length with no allocation beyond the result slice.
+func phpFieldTypeCandidates(typ string) []string {
+	var out []string
+	r := []rune(typ)
+	i := 0
+	for i < len(r) {
+		switch {
+		case r[i] == '\\':
+			// Fully-qualified name — consume the separator AND every segment
+			// after it, so no segment can re-enter the scanner on its own.
+			i++
+			for i < len(r) && (isPhpIdentRune(r[i]) || r[i] == '\\') {
+				i++
+			}
+		case isPhpIdentStartRune(r[i]):
+			j := i
+			for j < len(r) && (isPhpIdentRune(r[j]) || r[j] == '\\') {
+				j++
+			}
+			if tok := string(r[i:j]); !strings.ContainsRune(tok, '\\') {
+				out = append(out, tok)
+			}
+			i = j
+		default:
+			i++
+		}
+	}
+	return out
+}
+
+// isPhpIdentStartRune / isPhpIdentRune implement PHP's identifier grammar,
+// `[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*`. The high-byte range is why
+// non-ASCII letters are admitted rather than treated as separators: `class Ünité`
+// is a legal PHP class and a field typed `Ünité` must produce the same edge as an
+// ASCII one.
+func isPhpIdentStartRune(r rune) bool {
+	return r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r >= 0x80
+}
+
+func isPhpIdentRune(r rune) bool {
+	return isPhpIdentStartRune(r) || (r >= '0' && r <= '9')
+}
+
+// phpFieldTypeTarget is one in-file type declaration a field-type edge may
+// address: the structural ToID that binds to it, and the DECLARED spelling of the
+// name for the `target_type` property and the self-reference check.
+type phpFieldTypeTarget struct {
+	toID string
+	name string
+}
+
+// phpTypeDeclSubtypes is the target ALLOW-LIST over SCOPE.Component subtypes.
+//
+// It is an allow-list rather than a denylist because PHP emits several BARE-NAMED
+// SCOPE.Components that are not type declarations (section 5), and a future
+// producer adding another one must be refused BY DEFAULT. Enumerated from this
+// package's own emit sites rather than inherited from an arm:
+//
+//	ADMITTED — every subtype buildComponent (php.go:304) is ever called with:
+//	  class      php.go:127
+//	  interface  php.go:181
+//	  trait      php.go:214
+//
+//	REFUSED:
+//	  ""     — buildNamespace (php.go:483) and useImportRecord (php.go:650).
+//	           THE LIVE KILL; see section 5.
+//	  "file" — extractor.FileEntity, the #577 file carrier.
+//
+// A PHP `trait` is admitted deliberately. It cannot be used as a type in a
+// declaration (`public SomeTrait $x` is not meaningful PHP), so the row buys no
+// edge on its own — but a trait IS a nameable SCOPE.Component this package emits
+// for a real declaration, and leaving it out would make the allow-list a list of
+// "things that happen to appear in type position" rather than a list of type
+// declarations. It is named here so its emptiness is a recorded decision rather
+// than an oversight.
+var phpTypeDeclSubtypes = map[string]bool{
+	"class":     true,
+	"interface": true,
+	"trait":     true,
+}
+
+// phpComponentAddressFamily is the set of entity Kinds that can make a
+// `scope:component:…` structural ref ambiguous — every Kind that
+// internal/resolve's lookupLocationKind weighs when resolving one.
+//
+// It is componentKindFamily (internal/resolve/refs.go:2341) CLOSED UNDER THE
+// INDEX'S TRIM ALIAS, and the closure is load-bearing rather than pedantic:
+// BuildIndex writes each entity under its raw Kind AND its SCOPE-trimmed alias
+// (refs.go:1290-1296), so an entity kinded `SCOPE.Class` is keyed under both
+// "SCOPE.Class" and "Class" — and "Class" IS in the family even though
+// "SCOPE.Class" itself is not. The membership test is therefore
+// `K ∈ family || TrimPrefix(K, "SCOPE.") ∈ family`, and these eight entries are
+// exactly that set. Arm F shipped this table with "SCOPE.Class" missing in a
+// first revision, its own comment claiming to carry both spellings; that hole is
+// not re-introduced here.
+//
+// It is duplicated rather than exported from internal/resolve because the
+// dependency must not run extractor → resolver, and because an independently
+// written literal is a stronger grader than a shared constant. The invariant to
+// preserve: a Kind ABSENT from this set cannot make a component-space ref
+// ambiguous, so adding a Kind to componentKindFamily upstream — or adding one
+// whose trimmed alias lands in it — without adding it here would let this pass
+// emit a stub the resolver refuses.
+var phpComponentAddressFamily = map[string]bool{
+	"Component": true, "Class": true, "View": true, "Model": true,
+	"SCOPE.Component": true, "SCOPE.Class": true,
+	"SCOPE.View": true, "SCOPE.Model": true,
+}
+
+// phpInFileTypeTargets indexes every TYPE DECLARED in this file that a field-type
+// edge may address, keyed by the LOWER-CASED bare name.
+//
+// THE KEY IS FOLDED BECAUSE PHP CLASS NAMES ARE CASE-INSENSITIVE. `public money
+// $m` and `public Money $m` denote the same `class Money`, and both are legal
+// PHP. The stored `name` keeps the DECLARED spelling, so the emitted ToID always
+// carries the spelling the entity was minted under and binds — folding the lookup
+// without folding the address would emit `…:money` and dangle. Graded by
+// TestPhpFieldTypeRefs_TypeNameMatchIsCaseInsensitive, which asserts the BOUND
+// endpoint and not merely the edge count.
+//
+// Two DIFFERENT declared spellings that fold together (`class Money` +
+// `interface MONEY`) would be a fatal redeclaration error in PHP, so the shape is
+// not reachable from a file PHP will load — but this pass is handed records, not
+// a running interpreter, so the collision is refused explicitly rather than
+// assumed away.
+//
+// Two rules, both argued in the header block:
+//
+//  1. The record must be a SCOPE.Component this package emits for a real type
+//     declaration (phpTypeDeclSubtypes). This is a check on the EMITTED RECORD,
+//     not on the AST, so a declaration the extractor chose not to emit can never
+//     be addressed.
+//
+//  2. A name carried by MORE THAN ONE DISTINCT KIND IN THE COMPONENT ADDRESS
+//     FAMILY is dropped. Restricted to that family — not to every same-file kind
+//     — because a non-family kind never enters the tier that resolves this
+//     address (section 4). VACUOUS AS SHIPPED, kept as a resolver mirror, graded
+//     by direct call.
+func phpInFileTypeTargets(records []types.EntityRecord, filePath string) map[string]phpFieldTypeTarget {
+	// Pass 1 — how many DISTINCT COMPONENT-FAMILY KINDS each same-file name
+	// carries, target-eligible or not.
+	nameKinds := make(map[string]map[string]bool)
+	for i := range records {
+		r := &records[i]
+		if r.SourceFile != filePath || r.Name == "" || !phpComponentAddressFamily[r.Kind] {
+			continue
+		}
+		if nameKinds[r.Name] == nil {
+			nameKinds[r.Name] = make(map[string]bool)
+		}
+		nameKinds[r.Name][r.Kind] = true
+	}
+
+	// Pass 2 — admit the type declarations whose name is unambiguous.
+	targets := make(map[string]phpFieldTypeTarget)
+	folded := make(map[string]string) // fold key -> declared spelling
+	for i := range records {
+		r := &records[i]
+		if r.SourceFile != filePath || r.Name == "" || r.Kind != "SCOPE.Component" {
+			continue
+		}
+		if !phpTypeDeclSubtypes[r.Subtype] {
+			continue
+		}
+		if len(nameKinds[r.Name]) > 1 {
+			continue
+		}
+		key := strings.ToLower(r.Name)
+		if prev, ok := folded[key]; ok && prev != r.Name {
+			// Two different spellings folding together — refuse both rather
+			// than pick one.
+			delete(targets, key)
+			continue
+		}
+		folded[key] = r.Name
+		targets[key] = phpFieldTypeTarget{
+			toID: extractor.BuildComponentStructuralRef("php", filePath, r.Name),
+			name: r.Name,
+		}
+	}
+	return targets
+}
+
+// attachPhpFieldTypeRefs appends one REFERENCES edge per (field, in-file declared
+// type) pair, reading the declared type from the field record's own `field_type`
+// property.
+//
+// It covers class properties AND promoted constructor parameters because
+// emitPhpFieldMembers emits both as the same SCOPE.Schema/field shape.
+//
+// FromID is left empty so graph assembly anchors the edge on the field record
+// that carries it — the Django precedent at
+// internal/extractors/python/django_relational.go:246-252, and arms B–F.
+//
+// Relationships is APPENDED to, never assigned: the field record carries none
+// today, but a later producer's edge must not be clobbered. (The owner→member
+// CONTAINS lives on the OWNER's record, not here.)
+//
+// CALL PLACEMENT. It runs at the end of Extract, on the fully assembled record
+// slice. Placement is NOT load-bearing today and is not claimed to be: every pass
+// that runs after walk() emits either an out-of-family kind (SCOPE.Enum,
+// SCOPE.Operation, SCOPE.Config, SCOPE.Template, SCOPE.TranslationKey) or a
+// PREFIXED / different-file name (`exception:X` on the synthetic `<exception>`
+// path), so none can become a target or change a family kind count. What the
+// placement DOES buy is that the pass sees the complete record set, which is the
+// invariant to preserve if a future pass starts minting bare-named Components.
+func attachPhpFieldTypeRefs(records []types.EntityRecord, filePath string) []types.EntityRecord {
+	targets := phpInFileTypeTargets(records, filePath)
+	if len(targets) == 0 {
+		return records
+	}
+	for i := range records {
+		r := &records[i]
+		if r.Kind != "SCOPE.Schema" || r.Subtype != "field" || r.SourceFile != filePath {
+			continue
+		}
+		declared := r.Properties["field_type"]
+		if declared == "" {
+			continue
+		}
+		owner := r.Properties["parent_class"]
+		fieldName := r.Properties["field_name"]
+		emitted := make(map[string]bool)
+		for _, cand := range phpFieldTypeCandidates(declared) {
+			t, ok := targets[strings.ToLower(cand)]
+			if !ok || emitted[t.toID] {
+				continue
+			}
+			// A field never targets its own declaring class: `class Node {
+			// public ?Node $next; }` is a self-reference the CONTAINS edge
+			// already relates, and the recursive-type edge asserts nothing new.
+			// Also what makes `self`/`static` a no-op even in a file whose owner
+			// somehow carried one of those names.
+			if owner != "" && strings.EqualFold(t.name, owner) {
+				continue
+			}
+			emitted[t.toID] = true
+			r.Relationships = append(r.Relationships, types.RelationshipRecord{
+				ToID: t.toID,
+				Kind: string(types.RelationshipKindReferences),
+				Properties: types.Props{
+					{K: "field_name", V: fieldName},
+					{K: "ref_kind", V: phpFieldTargetRefKind},
+					{K: "target_type", V: t.name},
+				},
+			})
+		}
+	}
+	return records
+}

--- a/internal/extractors/php/field_type_refs.go
+++ b/internal/extractors/php/field_type_refs.go
@@ -116,15 +116,29 @@ import (
 // under the rule (#7038); its rule is not copied and neither is its stated
 // reason.
 //
-// AND THE HONEST PART: SCOPE.Component IS THE ONLY componentKindFamily KIND ANY
-// PHP PRODUCER EMITS. Core (internal/extractors/php) and custom
-// (internal/custom/php) were both enumerated: neither emits SCOPE.Model,
-// SCOPE.View, SCOPE.Class, nor a bare Component/Class/View/Model. So
-// len(nameKinds[name]) can never exceed 1 from PHP source today and rule 2 is
-// VACUOUS AS SHIPPED. It is kept as a mirror of the resolver for the producer
-// that adds an in-family kind later — exactly the shape arm F's SCOPE.Class hole
-// was — and because it is unreachable from Extract it is graded by a direct-call
-// unit test (TestPhpFieldTypeRefs_Unit_InFamilyRivalSuppresses...) rather than
+// AND THE HONEST PART: RULE 2 IS VACUOUS AS SHIPPED, for a STRONGER reason than
+// an earlier draft of this comment gave.
+//
+// The draft's reason was that core (internal/extractors/php) and custom
+// (internal/custom/php) were both enumerated and neither emits SCOPE.Model,
+// SCOPE.View, SCOPE.Class, nor a bare Component/Class/View/Model — true, and
+// confirmed independently over 390 corpus files, where the only kinds the
+// extractor ever emits are {SCOPE.Component, SCOPE.Config, SCOPE.Enum,
+// SCOPE.ExceptionType, SCOPE.Operation, SCOPE.Schema, SCOPE.Template}. But the
+// custom half of that enumeration is not what makes the claim hold: THIS PASS
+// RUNS INSIDE CORE Extract, BEFORE MergeWithCustom, so no internal/custom/php
+// record ever reaches it at all. The core half alone settles it, a fortiori.
+//
+// Enumerating the custom lane was still the right check — it is where the
+// FUTURE producer would live, and an Eloquent-model detector re-kinding a PHP
+// class to SCOPE.Model is the concrete shape rule 2 is kept for. But the next
+// arm should not inherit a weaker argument than it is entitled to.
+//
+// So len(nameKinds[name]) can never exceed 1 from PHP source today. Rule 2 is
+// kept as a mirror of the resolver for that future producer — exactly the shape
+// arm F's SCOPE.Class hole was — and because it is unreachable from Extract it
+// is graded by a direct-call unit test
+// (TestPhpFieldTypeRefs_Unit_InFamilyRivalSuppressesTheTarget) rather than
 // claimed to be covered by the fixture suite.
 //
 // The counterfactual of ARM D's rule (count ALL same-file kinds) is not vacuous
@@ -364,6 +378,20 @@ var phpComponentAddressFamily = map[string]bool{
 //     declaration (phpTypeDeclSubtypes). This is a check on the EMITTED RECORD,
 //     not on the AST, so a declaration the extractor chose not to emit can never
 //     be addressed.
+//
+//     IT IS TWO GUARDS, AND THEY ARE MUTUALLY MASKED. No core PHP producer mints
+//     a record with Subtype ∈ {class, interface, trait} under any Kind but
+//     SCOPE.Component, so through Extract the Kind test and the subtype
+//     allow-list only ever fire together and the allow-list alone carries every
+//     refusal the fixture suite observes — including the enum one. An
+//     independent review found both a deletion of the Kind test and a widening
+//     of it to admit SCOPE.Schema ALIVE for exactly that reason. Two guards that
+//     only fire together grade neither, so they are now scored part by part:
+//     TestPhpFieldTypeRefs_Unit_OnlyComponentsAreTargets drives seven
+//     non-Component Kinds carrying an ADMITTED subtype (so the allow-list cannot
+//     be what refuses them), and the distinguishing input is
+//     {Kind: "SCOPE.Model", Subtype: "class"} — the SAME future producer rule 2
+//     below is kept for.
 //
 //  2. A name carried by MORE THAN ONE DISTINCT KIND IN THE COMPONENT ADDRESS
 //     FAMILY is dropped. Restricted to that family — not to every same-file kind

--- a/internal/extractors/php/field_type_refs_6912_test.go
+++ b/internal/extractors/php/field_type_refs_6912_test.go
@@ -1,0 +1,780 @@
+package php_test
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6912 arm H — PHP field→declared-type REFERENCES edges.
+//
+// The fixture below is the arm's shape-space enumeration and every row in it is
+// legal PHP 8.1 (checked shape by shape against the grammar, not eyeballed).
+//
+// AXES VARIED, one per property, holding the others constant:
+//   - type composition: bare, nullable `?T`, union `A|B`, intersection `A&B`,
+//     union-with-primitive, DNF `(A&B)|null`
+//   - name qualification: bare, relative `Ns\T`, fully-qualified `\Ns\T`,
+//     leading-separator-only `\T`
+//   - target existence: declared in THIS file / declared in ANOTHER file /
+//     declared nowhere
+//   - target kind: class, interface, trait, enum, import placeholder, namespace
+//   - PHP builtin: int, string, array, iterable, callable, mixed, self, static
+//   - declaration site: class property, promoted constructor parameter,
+//     multi-declarator property, untyped property
+//   - identifier case: declared spelling vs. lower-cased use
+//
+// AXES HELD CONSTANT: one file per fixture (same-file binding is the arm's
+// promise and its cross-file direction is graded by the unit test, not here);
+// one declaring class per fixture where a second would confuse the owner
+// self-reference rule; property visibility (public) except where promotion
+// requires otherwise; no framework/ORM annotations (the custom lane is gated off
+// by default and is not this pass's input).
+const phpFTPath = "models.php"
+
+const phpFTSrc = `<?php
+namespace App;
+
+use Ship\Thing;
+use Other\Order;
+
+interface Shipper {}
+trait Loggable {}
+class Money {}
+class Customer {}
+class Ship {}
+
+class Order2 {
+    public Customer $buyer;
+    public ?Customer $maybeBuyer = null;
+    public Customer|Money $either;
+    public Customer&Shipper $both;
+    public (Customer&Shipper)|null $dnf;
+    public Money|int $mixedUnion;
+    public customer $folded;
+    public Order $imported;
+    public Other\Order $relative;
+    public \Other\Order $qualified;
+    public \Money $globalMoney;
+    public Nowhere $missing;
+    public Loggable $trait;
+    public int $qty;
+    public string $label;
+    public array $rows;
+    public iterable $it;
+    public callable $cb;
+    public mixed $any;
+    public self $me;
+    public static $untyped;
+    public Money $m1, $m2;
+    public function __construct(
+        public readonly Customer $owner,
+        private ?Money $amount,
+        protected int $count = 0,
+    ) {}
+}
+`
+
+// phpFTOne extracts one PHP file through the registered extractor.
+func phpFTOne(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("php")
+	if !ok {
+		t.Fatal("php extractor not registered")
+	}
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: path, Content: []byte(src), Language: "php", TSTree: tree,
+	})
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	return got
+}
+
+// phpFTTargetsOf returns the sorted target_type values of the field-type edges
+// carried by the named field entity.
+func phpFTTargetsOf(recs []types.EntityRecord, fieldName string) []string {
+	var out []string
+	for i := range recs {
+		if recs[i].Name != fieldName {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "REFERENCES" && r.Properties.Get("ref_kind") == "field_target_type" {
+				out = append(out, r.Properties.Get("target_type"))
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func phpFTEqual(t *testing.T, got, want []string, what string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s = %v (%d), want %v (%d)", what, got, len(got), want, len(want))
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("%s = %v, want %v", what, got, want)
+			return
+		}
+	}
+}
+
+// TestPhpFieldTypeRefs_FieldTypeIsVerbatim pins the premise the whole arm rests
+// on: phpDeclaredType returns the VERBATIM source span, so the property can be
+// tokenised instead of stashed from the AST the way arm C had to. If this ever
+// becomes a lossy projection (swift's `field_type` is the first pre-order
+// type_identifier and yields `Dictionary` for `Dictionary<String, Order>`), the
+// scanner below is reading a lie and this test is the one that says so.
+func TestPhpFieldTypeRefs_FieldTypeIsVerbatim(t *testing.T) {
+	recs := phpFTOne(t, phpFTPath, phpFTSrc)
+	got := map[string]string{}
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" {
+			got[recs[i].Name] = recs[i].Properties["field_type"]
+		}
+	}
+	want := map[string]string{
+		"Order2.buyer":       "Customer",
+		"Order2.maybeBuyer":  "?Customer",
+		"Order2.either":      "Customer|Money",
+		"Order2.both":        "Customer&Shipper",
+		"Order2.mixedUnion":  "Money|int",
+		"Order2.relative":    "Other\\Order",
+		"Order2.qualified":   "\\Other\\Order",
+		"Order2.globalMoney": "\\Money",
+		"Order2.qty":         "int",
+		"Order2.rows":        "array",
+		"Order2.me":          "self",
+		"Order2.untyped":     "",
+		"Order2.m1":          "Money",
+		"Order2.m2":          "Money",
+		"Order2.owner":       "Customer",
+		"Order2.amount":      "?Money",
+		"Order2.count":       "int",
+	}
+	for name, w := range want {
+		g, ok := got[name]
+		if !ok {
+			t.Errorf("no field entity %q — the fixture premise is gone", name)
+			continue
+		}
+		if g != w {
+			t.Errorf("%s field_type = %q, want the verbatim source text %q", name, g, w)
+		}
+	}
+}
+
+// TestPhpFieldTypeRefs_ShapeSpace ENUMERATES the type-expression shape space
+// rather than sampling it: every property of the fixture class appears here with
+// the exact target set it must produce. Hand-picked attacks miss holes; a table
+// that must list every row makes an unlisted shape a compile-time-visible gap.
+func TestPhpFieldTypeRefs_ShapeSpace(t *testing.T) {
+	recs := phpFTOne(t, phpFTPath, phpFTSrc)
+
+	// Every field entity in the fixture must appear in the table below, so a
+	// property added to the fixture without a row here fails rather than
+	// silently going ungraded.
+	want := map[string][]string{
+		// --- bound: the type is declared in THIS file ---
+		"Order2.buyer":      {"Customer"},
+		"Order2.maybeBuyer": {"Customer"},                // nullable names one type
+		"Order2.either":     {"Customer", "Money"},       // a union names BOTH
+		"Order2.both":       {"Customer", "Shipper"},     // an intersection names BOTH
+		// `(Customer&Shipper)|null` — a PHP 8.2 DNF type. NO edge, and NOT
+		// because this pass refuses it: phpDeclaredType captures nothing at all
+		// for the shape, so field_type is "" (and the Signature loses the type
+		// too). A CAPTURE gap that predates this arm, made visible by
+		// enumerating the shape space rather than sampling it, and pinned as a
+		// known ceiling by TestPhpFieldTypeRefs_DNFTypeIsAKnownCaptureCeiling.
+		"Order2.dnf": nil,
+		"Order2.mixedUnion": {"Money"},                   // `int` is not declared here
+		"Order2.folded":     {"Customer"},                // PHP class names fold case
+		"Order2.trait":      {"Loggable"},                // a trait IS an admitted target
+		"Order2.m1":         {"Money"},                   // multi-declarator, first
+		"Order2.m2":         {"Money"},                   // multi-declarator, second
+		"Order2.owner":      {"Customer"},                // promoted ctor parameter
+		"Order2.amount":     {"Money"},                   // promoted + nullable
+
+		// --- refused: qualified names are never reduced to a segment ---
+		"Order2.imported":    nil, // `use Other\Order` — Order is NOT declared here
+		"Order2.relative":    nil, // Other\Order
+		"Order2.qualified":   nil, // \Other\Order
+		"Order2.globalMoney": nil, // \Money is the GLOBAL Money, not App\Money
+
+		// --- refused: nothing declares the name ---
+		"Order2.missing": nil,
+
+		// --- refused: PHP builtins, by the declaration gate and no blocklist ---
+		"Order2.qty":     nil,
+		"Order2.label":   nil,
+		"Order2.rows":    nil,
+		"Order2.it":      nil,
+		"Order2.cb":      nil,
+		"Order2.any":     nil,
+		"Order2.count":   nil,
+		"Order2.me":      nil, // `self` names the owner; refused twice over
+		"Order2.untyped": nil, // no declared type at all
+	}
+
+	seen := map[string]bool{}
+	for i := range recs {
+		r := &recs[i]
+		if r.Kind != "SCOPE.Schema" || r.Subtype != "field" {
+			continue
+		}
+		seen[r.Name] = true
+		w, ok := want[r.Name]
+		if !ok {
+			t.Errorf("field %q is in the fixture but has no row in the shape "+
+				"table — add one rather than leaving the shape ungraded", r.Name)
+			continue
+		}
+		phpFTEqual(t, phpFTTargetsOf(recs, r.Name), w, r.Name)
+	}
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("the shape table names %q but the fixture emits no such "+
+				"field entity — the row is vacuous", name)
+		}
+	}
+}
+
+// TestPhpFieldTypeRefs_DNFTypeIsAKnownCaptureCeiling pins a gap this arm found
+// and deliberately did NOT close.
+//
+// PHP 8.2's disjunctive-normal-form type `(A&B)|null` is not one of the node
+// types phpDeclaredType (field_members.go:135) switches on, so it captures
+// NOTHING: field_type is "" and the Signature drops the type as well. That is a
+// capture defect in the property producer, not an edge defect — it degrades the
+// Signature for every DNF-typed property whether or not this arm exists — so it
+// belongs to its own change with its own grading rather than riding along here.
+//
+// The test asserts the CURRENT behaviour so the ceiling is visible and so that
+// fixing the capture makes this test fail loudly, at which point the shape-space
+// row above becomes a real binding row.
+func TestPhpFieldTypeRefs_DNFTypeIsAKnownCaptureCeiling(t *testing.T) {
+	src := `<?php
+interface Shipper {}
+class Customer {}
+class Order {
+    public (Customer&Shipper)|null $dnf;
+    public Customer $control;
+}
+`
+	recs := phpFTOne(t, "dnf.php", src)
+	var got string
+	found := false
+	for i := range recs {
+		if recs[i].Name == "Order.dnf" {
+			found = true
+			got = recs[i].Properties["field_type"]
+		}
+	}
+	if !found {
+		t.Fatal("no field entity for the DNF property — the fixture premise is gone")
+	}
+	if got != "" {
+		t.Errorf("phpDeclaredType now captures the DNF type as %q. The capture "+
+			"ceiling is closed: delete this test and give Order2.dnf a real "+
+			"target row in the shape table.", got)
+	}
+	phpFTEqual(t, phpFTTargetsOf(recs, "Order.dnf"), nil, "a DNF-typed field")
+	phpFTEqual(t, phpFTTargetsOf(recs, "Order.control"), []string{"Customer"},
+		"the control field in the same class")
+}
+
+// TestPhpFieldTypeRefs_ImportPlaceholderIsNeverATarget is the wrong-binding kill.
+//
+// useImportRecord (php.go:650) mints a SCOPE.Component whose Name is the TOP
+// namespace segment of the `use`, so `use Ship\Thing;` puts a Component literally
+// named `Ship` in this file — and a component-space ref to `Ship` BINDS to it
+// (proved by TestPhpFieldTypeRefs_ResolvesToEntityIDs' harness). Without the
+// subtype allow-list a field typed `Ship` binds to an import placeholder: a
+// confident wrong answer, which nothing downstream reports because it binds.
+//
+// THE FILE MUST NOT DECLARE A CLASS OF THAT NAME, or the ambiguity rule would
+// mask the allow-list and this test would pass for the wrong reason.
+func TestPhpFieldTypeRefs_ImportPlaceholderIsNeverATarget(t *testing.T) {
+	src := `<?php
+namespace App;
+
+use Ship\Thing;
+
+class Money {}
+
+class Order {
+    public Ship $carrier;
+    public Money $price;
+}
+`
+	recs := phpFTOne(t, "imports.php", src)
+
+	// Premise: the import placeholder really is in this file's record set under
+	// the bare name, so the refusal below is doing work.
+	placeholder := false
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Name == "Ship" &&
+			recs[i].SourceFile == "imports.php" {
+			placeholder = true
+			if recs[i].Subtype != "" {
+				t.Fatalf("the import placeholder now carries Subtype %q — the "+
+					"allow-list's discriminator has moved", recs[i].Subtype)
+			}
+		}
+	}
+	if !placeholder {
+		t.Fatal("no bare-named import placeholder in this file — the refusal " +
+			"under test is unreachable and this test is vacuous")
+	}
+	// Nothing declares `class Ship` here, so rule 2 cannot be the reason.
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Name == "Ship" && recs[i].Subtype == "class" {
+			t.Fatal("the fixture declares class Ship, which lets the ambiguity " +
+				"rule mask the allow-list")
+		}
+	}
+
+	phpFTEqual(t, phpFTTargetsOf(recs, "Order.carrier"), nil,
+		"a field typed after an import placeholder")
+	// Positive control in the SAME file: the pass works here.
+	phpFTEqual(t, phpFTTargetsOf(recs, "Order.price"), []string{"Money"},
+		"the control field in the same class")
+}
+
+// TestPhpFieldTypeRefs_UnqualifiedUseImportIsNeverATarget is the SHARPER half of
+// the wrong-binding kill, and it is REPRODUCED FROM THE CORPUS rather than
+// invented.
+//
+// `use Ship\Thing;` mints a placeholder named after the namespace ROOT, which
+// only collides with a field type by coincidence. `use Closure;` — an
+// unqualified use of a global class, which is how every PHP file that touches a
+// closure is written — has NO backslash, so useImportRecord's `top` IS the whole
+// class name: the placeholder is named EXACTLY what the field types are.
+//
+// The live instance:
+//
+//	laravel-routing/src/Illuminate/Routing/Controllers/Middleware.php
+//	  use Closure;
+//	  public function __construct(public Closure|string|array $middleware, ...)
+//
+// A promoted constructor parameter, a union type, and an import placeholder
+// named `Closure` in the same file. Without phpTypeDeclSubtypes this pass emits
+// `Middleware.middleware -> Closure` and it BINDS — the one edge the whole
+// 390-file corpus produces without the allow-list, and it is wrong. Measured, not
+// hypothesised.
+func TestPhpFieldTypeRefs_UnqualifiedUseImportIsNeverATarget(t *testing.T) {
+	src := `<?php
+namespace Illuminate\Routing\Controllers;
+
+use Closure;
+
+class Money {}
+
+class Middleware
+{
+    public function __construct(
+        public Closure|string|array $middleware,
+        public Money $price,
+    ) {}
+}
+`
+	recs := phpFTOne(t, "middleware.php", src)
+	saw := false
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Name == "Closure" &&
+			recs[i].SourceFile == "middleware.php" && recs[i].Subtype == "" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Fatal("no bare `Closure` import placeholder — useImportRecord's " +
+			"single-segment `use` behaviour has changed and this test is vacuous")
+	}
+	phpFTEqual(t, phpFTTargetsOf(recs, "Middleware.middleware"), nil,
+		"a promoted parameter typed after an unqualified `use` import")
+	phpFTEqual(t, phpFTTargetsOf(recs, "Middleware.price"), []string{"Money"},
+		"the promoted-parameter control in the same constructor")
+}
+
+// TestPhpFieldTypeRefs_EnumIsNotATarget records a MEASUREMENT, not a preference.
+//
+// A PHP enum with at least one case is minted TWICE in the same file — as
+// SCOPE.Schema/enum by buildEnum and as a SCOPE.Enum value-set by
+// buildEnumValueSet — and neither Kind is in componentKindFamily. A
+// component-space ref therefore misses lookupLocationKind and lands on
+// ambigLocation as AMBIGUOUS: emitting it would ship a guaranteed dangling stub.
+// The endpoint half of that claim is driven through the real resolver in
+// TestPhpFieldTypeRefs_EnumTargetWouldDangle.
+func TestPhpFieldTypeRefs_EnumIsNotATarget(t *testing.T) {
+	src := `<?php
+namespace App;
+
+enum Status: string { case Open = 'open'; case Shut = 'shut'; }
+class Money {}
+
+class Order {
+    public Status $status;
+    public Money $price;
+}
+`
+	recs := phpFTOne(t, "enums.php", src)
+	kinds := map[string]bool{}
+	for i := range recs {
+		if recs[i].Name == "Status" {
+			kinds[recs[i].Kind] = true
+		}
+	}
+	if !kinds["SCOPE.Schema"] || !kinds["SCOPE.Enum"] {
+		t.Fatalf("the two-record premise is gone: `Status` is minted as %v, "+
+			"want both SCOPE.Schema and SCOPE.Enum", kinds)
+	}
+	phpFTEqual(t, phpFTTargetsOf(recs, "Order.status"), nil, "an enum-typed field")
+	phpFTEqual(t, phpFTTargetsOf(recs, "Order.price"), []string{"Money"},
+		"the control field in the same class")
+}
+
+// TestPhpFieldTypeRefs_EnumTargetWouldDangle proves the REASON the test above
+// asserts, by hand-emitting the refused edge and driving it through the real
+// resolver. Without this, "an enum target would dangle" is a claim about
+// internal/resolve read from source; with it, it is an observation.
+//
+// The same harness binds a class target, so a failure here cannot be the harness
+// being broken.
+func TestPhpFieldTypeRefs_EnumTargetWouldDangle(t *testing.T) {
+	src := `<?php
+enum Status: string { case Open = 'open'; }
+class Money {}
+`
+	recs := phpFTOne(t, "enums.php", src)
+	for i := range recs {
+		if recs[i].ID == "" {
+			recs[i].ID = graph.EntityID("issue6912", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+		}
+	}
+	known := map[string]bool{}
+	for i := range recs {
+		known[recs[i].ID] = true
+	}
+	probe := types.EntityRecord{
+		Name: "Probe.f", Kind: "SCOPE.Schema", Subtype: "field",
+		SourceFile: "enums.php", Language: "php",
+		Relationships: []types.RelationshipRecord{
+			{ToID: extractor.BuildComponentStructuralRef("php", "enums.php", "Status"),
+				Kind: "REFERENCES", Properties: types.Props{{K: "target_type", V: "Status"}}},
+			{ToID: extractor.BuildComponentStructuralRef("php", "enums.php", "Money"),
+				Kind: "REFERENCES", Properties: types.Props{{K: "target_type", V: "Money"}}},
+		},
+	}
+	probe.ID = graph.EntityID("issue6912", probe.Kind, probe.Name, probe.SourceFile)
+	all := append(append([]types.EntityRecord{}, recs...), probe)
+	idx := resolve.BuildIndex(all)
+	resolve.ReferencesEmbedded(all, idx)
+
+	for i := range all {
+		if all[i].Name != "Probe.f" {
+			continue
+		}
+		for _, r := range all[i].Relationships {
+			switch r.Properties.Get("target_type") {
+			case "Status":
+				if known[r.ToID] {
+					t.Errorf("a component-space ref to a PHP enum now BINDS (%s). "+
+						"The refusal in phpTypeDeclSubtypes is a recall loss with "+
+						"no remaining justification — admit enums and re-measure.",
+						r.ToID)
+				}
+			case "Money":
+				if !known[r.ToID] {
+					t.Fatalf("the class control did not bind either (%s) — this "+
+						"harness proves nothing about enums", r.ToID)
+				}
+			}
+		}
+	}
+}
+
+// TestPhpFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName is the mirror of
+// arm D's Go finding: reducing `Other\Order` to `Order` binds a field to a
+// same-file class it does not name. Here the file declares its OWN `Order`, so a
+// scanner that took the last segment would produce a WRONG binding rather than a
+// dangle.
+func TestPhpFieldTypeRefs_QualifiedTypeIsNotStrippedToASameFileName(t *testing.T) {
+	src := `<?php
+namespace App;
+
+class Order {}
+class Money {}
+
+class Invoice {
+    public Other\Order $a;
+    public \Other\Order $b;
+    public \Order $c;
+    public Order $d;
+    public Money $control;
+}
+`
+	recs := phpFTOne(t, "qualified.php", src)
+	for _, f := range []string{"Invoice.a", "Invoice.b", "Invoice.c"} {
+		phpFTEqual(t, phpFTTargetsOf(recs, f), nil, f+" (a qualified name)")
+	}
+	// The unqualified spelling in the same class DOES bind — so the three rows
+	// above are refusals of the QUALIFICATION, not of the name.
+	phpFTEqual(t, phpFTTargetsOf(recs, "Invoice.d"), []string{"Order"},
+		"the unqualified control")
+	phpFTEqual(t, phpFTTargetsOf(recs, "Invoice.control"), []string{"Money"},
+		"the second control")
+}
+
+// TestPhpFieldTypeRefs_SameNamedFunctionDoesNotSuppressTheClass is arm D's rule
+// applied to PHP, and the measured reason this arm does not inherit it.
+//
+// PHP keeps classes and functions in SEPARATE symbol tables, so `class Money {}`
+// beside `function Money() {}` in one file is legal. Arm D's count-every-kind
+// rule sees SCOPE.Component + SCOPE.Operation and refuses the target; the tier
+// that actually resolves this address weighs only componentKindFamily, so it
+// binds without hesitation — asserted here through the real resolver rather than
+// argued.
+func TestPhpFieldTypeRefs_SameNamedFunctionDoesNotSuppressTheClass(t *testing.T) {
+	src := `<?php
+class Money {}
+
+function Money() { return 1; }
+
+class Order {
+    public Money $price;
+}
+`
+	recs := phpFTOne(t, "twotables.php", src)
+
+	// Premise: both records really exist at the same (file, name).
+	var comp, op bool
+	for i := range recs {
+		if recs[i].Name != "Money" || recs[i].SourceFile != "twotables.php" {
+			continue
+		}
+		switch recs[i].Kind {
+		case "SCOPE.Component":
+			comp = true
+		case "SCOPE.Operation":
+			op = true
+		}
+	}
+	if !comp || !op {
+		t.Fatalf("the two-record premise is gone (component=%v operation=%v) — "+
+			"arm D's counterfactual is not exercised by this fixture", comp, op)
+	}
+	phpFTEqual(t, phpFTTargetsOf(recs, "Order.price"), []string{"Money"},
+		"a class target sharing its name with a same-file function")
+
+	// And it binds, which is what makes keeping the edge correct rather than
+	// merely more numerous.
+	phpFTAssertAllBind(t, recs)
+}
+
+// TestPhpFieldTypeRefs_TypeNameMatchIsCaseInsensitive — PHP class names fold
+// case, so `public customer $c` denotes `class Customer`. The assertion is on the
+// BOUND ENDPOINT and not merely on the edge count, because the failure mode of a
+// folded lookup is emitting the FOLDED spelling in the address, which dangles.
+func TestPhpFieldTypeRefs_TypeNameMatchIsCaseInsensitive(t *testing.T) {
+	src := `<?php
+class Customer {}
+
+class Order {
+    public customer $c;
+}
+`
+	recs := phpFTOne(t, "case.php", src)
+	phpFTEqual(t, phpFTTargetsOf(recs, "Order.c"), []string{"Customer"},
+		"target_type must carry the DECLARED spelling")
+	for i := range recs {
+		if recs[i].Name != "Order.c" {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if want := "scope:component:class:php:case.php:Customer"; r.ToID != want {
+				t.Errorf("ToID = %q, want %q — the address must use the declared "+
+					"spelling or it cannot bind", r.ToID, want)
+			}
+		}
+	}
+	phpFTAssertAllBind(t, recs)
+}
+
+// TestPhpFieldTypeRefs_SelfReferenceGetsNoEdge — a recursive field already has
+// the owner→member CONTAINS edge; a field→owner REFERENCES asserts nothing new.
+// The control in the same class means this cannot pass by the pass being off.
+func TestPhpFieldTypeRefs_SelfReferenceGetsNoEdge(t *testing.T) {
+	src := `<?php
+class Money {}
+
+class Node {
+    public ?Node $next;
+    public self $me;
+    public Money $cost;
+}
+`
+	recs := phpFTOne(t, "self.php", src)
+	phpFTEqual(t, phpFTTargetsOf(recs, "Node.next"), nil, "a self-typed field")
+	phpFTEqual(t, phpFTTargetsOf(recs, "Node.me"), nil, "a `self`-typed field")
+	phpFTEqual(t, phpFTTargetsOf(recs, "Node.cost"), []string{"Money"}, "the control")
+}
+
+// phpFTAssertAllBind drives every field-type edge in recs through the real
+// resolver and fails on any that does not land on a real entity id.
+func phpFTAssertAllBind(t *testing.T, recs []types.EntityRecord) {
+	t.Helper()
+	cp := append([]types.EntityRecord{}, recs...)
+	for i := range cp {
+		if cp[i].ID == "" {
+			cp[i].ID = graph.EntityID("issue6912", cp[i].Kind, cp[i].Name, cp[i].SourceFile)
+		}
+	}
+	known := map[string]string{}
+	for i := range cp {
+		known[cp[i].ID] = cp[i].SourceFile + ":" + cp[i].Kind + "/" + cp[i].Subtype + ":" + cp[i].Name
+	}
+	n := 0
+	for i := range cp {
+		for _, r := range cp[i].Relationships {
+			if r.Kind == "REFERENCES" && r.Properties.Get("ref_kind") == "field_target_type" {
+				n++
+			}
+		}
+	}
+	if n == 0 {
+		t.Fatal("no field-type edges to drive through the resolver — the " +
+			"binding assertion would be vacuous")
+	}
+	idx := resolve.BuildIndex(cp)
+	resolve.ReferencesEmbedded(cp, idx)
+	for i := range cp {
+		for _, r := range cp[i].Relationships {
+			if r.Kind != "REFERENCES" || r.Properties.Get("ref_kind") != "field_target_type" {
+				continue
+			}
+			if _, ok := known[r.ToID]; !ok {
+				t.Errorf("%s:%s -[REFERENCES]-> %q did NOT bind (dangling stub → "+
+					"bug-extractor)", cp[i].SourceFile, cp[i].Name, r.ToID)
+			}
+		}
+	}
+}
+
+// TestPhpFieldTypeRefs_ResolvesToEntityIDs drives the fixture's edges through the
+// real resolver and asserts EVERY ONE binds, NAMING the entity it binds to. This
+// is what makes "a non-binding edge is worse than no edge" a graded property
+// rather than an intention, and what makes the ADDRESS DIALECT graded: the rival
+// file declares the same bare names, so a bare-name ToID would be ambiguous.
+func TestPhpFieldTypeRefs_ResolvesToEntityIDs(t *testing.T) {
+	recs := phpFTOne(t, phpFTPath, phpFTSrc)
+	rival := phpFTOne(t, "other.php", `<?php
+class Customer {}
+class Money {}
+class Shipper {}
+`)
+	all := append(append([]types.EntityRecord{}, recs...), rival...)
+	for i := range all {
+		if all[i].ID == "" {
+			all[i].ID = graph.EntityID("issue6912", all[i].Kind, all[i].Name, all[i].SourceFile)
+		}
+	}
+	idToName := map[string]string{}
+	for i := range all {
+		idToName[all[i].ID] = all[i].SourceFile + ":" + all[i].Kind + ":" + all[i].Name
+	}
+	idx := resolve.BuildIndex(all)
+
+	// Positive control on the address dialect: the BARE name must be ambiguous
+	// across the graph, or the structural address is ungraded here.
+	if _, st := idx.LookupStatusHint("Customer", "REFERENCES"); st == 1 {
+		t.Fatalf("the bare name %q binds in this fixture, so the ambiguity this "+
+			"test controls for is absent and the structural address is ungraded",
+			"Customer")
+	}
+
+	resolve.ReferencesEmbedded(all, idx)
+	var bound []string
+	for i := range all {
+		for _, r := range all[i].Relationships {
+			if r.Kind != "REFERENCES" || r.Properties.Get("ref_kind") != "field_target_type" {
+				continue
+			}
+			name, ok := idToName[r.ToID]
+			if !ok {
+				t.Errorf("%s:%s -[REFERENCES]-> %q did NOT bind to an entity id",
+					all[i].SourceFile, all[i].Name, r.ToID)
+				continue
+			}
+			bound = append(bound, all[i].Name+" => "+name)
+		}
+	}
+	sort.Strings(bound)
+	const m = "models.php:SCOPE.Component:"
+	want := []string{
+		"Order2.amount => " + m + "Money",
+		"Order2.both => " + m + "Customer",
+		"Order2.both => " + m + "Shipper",
+		"Order2.buyer => " + m + "Customer",
+		"Order2.either => " + m + "Customer",
+		"Order2.either => " + m + "Money",
+		"Order2.folded => " + m + "Customer",
+		"Order2.m1 => " + m + "Money",
+		"Order2.m2 => " + m + "Money",
+		"Order2.maybeBuyer => " + m + "Customer",
+		"Order2.mixedUnion => " + m + "Money",
+		"Order2.owner => " + m + "Customer",
+		"Order2.trait => " + m + "Loggable",
+	}
+	phpFTEqual(t, bound, want, "resolved field-type endpoints")
+}
+
+// TestPhpFieldTypeRefs_PropertiesAgreeWithTheEndpoints — `field_name` must be the
+// field entity's own leaf name so the property agrees with the entity Name and
+// with the CONTAINS structural ref, rather than introducing a third spelling.
+func TestPhpFieldTypeRefs_PropertiesAgreeWithTheEndpoints(t *testing.T) {
+	recs := phpFTOne(t, phpFTPath, phpFTSrc)
+	n := 0
+	for i := range recs {
+		r := &recs[i]
+		if r.Kind != "SCOPE.Schema" || r.Subtype != "field" {
+			continue
+		}
+		owner := r.Properties["parent_class"]
+		for _, rel := range r.Relationships {
+			if rel.Kind != "REFERENCES" || rel.Properties.Get("ref_kind") != "field_target_type" {
+				continue
+			}
+			n++
+			fn := rel.Properties.Get("field_name")
+			if owner+"."+fn != r.Name {
+				t.Errorf("%s carries field_name=%q with parent_class=%q; the two "+
+					"must rebuild the entity Name exactly", r.Name, fn, owner)
+			}
+			if rel.Properties.Get("target_type") == "" {
+				t.Errorf("%s -> %s has an empty target_type", r.Name, rel.ToID)
+			}
+			if rel.FromID != "" {
+				t.Errorf("%s -> %s sets FromID=%q; it must stay empty so graph "+
+					"assembly anchors the edge on the field record", r.Name, rel.ToID, rel.FromID)
+			}
+			if !strings.HasPrefix(rel.ToID, "scope:component:class:php:"+phpFTPath+":") {
+				t.Errorf("%s -> %q is not a same-file php component structural ref",
+					r.Name, rel.ToID)
+			}
+		}
+	}
+	if n == 0 {
+		t.Fatal("no field-type edges in the fixture — every assertion above is vacuous")
+	}
+}

--- a/internal/extractors/php/field_type_refs_6912_test.go
+++ b/internal/extractors/php/field_type_refs_6912_test.go
@@ -188,23 +188,23 @@ func TestPhpFieldTypeRefs_ShapeSpace(t *testing.T) {
 	want := map[string][]string{
 		// --- bound: the type is declared in THIS file ---
 		"Order2.buyer":      {"Customer"},
-		"Order2.maybeBuyer": {"Customer"},                // nullable names one type
-		"Order2.either":     {"Customer", "Money"},       // a union names BOTH
-		"Order2.both":       {"Customer", "Shipper"},     // an intersection names BOTH
+		"Order2.maybeBuyer": {"Customer"},            // nullable names one type
+		"Order2.either":     {"Customer", "Money"},   // a union names BOTH
+		"Order2.both":       {"Customer", "Shipper"}, // an intersection names BOTH
 		// `(Customer&Shipper)|null` — a PHP 8.2 DNF type. NO edge, and NOT
 		// because this pass refuses it: phpDeclaredType captures nothing at all
 		// for the shape, so field_type is "" (and the Signature loses the type
 		// too). A CAPTURE gap that predates this arm, made visible by
 		// enumerating the shape space rather than sampling it, and pinned as a
 		// known ceiling by TestPhpFieldTypeRefs_DNFTypeIsAKnownCaptureCeiling.
-		"Order2.dnf": nil,
-		"Order2.mixedUnion": {"Money"},                   // `int` is not declared here
-		"Order2.folded":     {"Customer"},                // PHP class names fold case
-		"Order2.trait":      {"Loggable"},                // a trait IS an admitted target
-		"Order2.m1":         {"Money"},                   // multi-declarator, first
-		"Order2.m2":         {"Money"},                   // multi-declarator, second
-		"Order2.owner":      {"Customer"},                // promoted ctor parameter
-		"Order2.amount":     {"Money"},                   // promoted + nullable
+		"Order2.dnf":        nil,
+		"Order2.mixedUnion": {"Money"},    // `int` is not declared here
+		"Order2.folded":     {"Customer"}, // PHP class names fold case
+		"Order2.trait":      {"Loggable"}, // a trait IS an admitted target
+		"Order2.m1":         {"Money"},    // multi-declarator, first
+		"Order2.m2":         {"Money"},    // multi-declarator, second
+		"Order2.owner":      {"Customer"}, // promoted ctor parameter
+		"Order2.amount":     {"Money"},    // promoted + nullable
 
 		// --- refused: qualified names are never reduced to a segment ---
 		"Order2.imported":    nil, // `use Other\Order` — Order is NOT declared here

--- a/internal/extractors/php/field_type_refs_6912_test.go
+++ b/internal/extractors/php/field_type_refs_6912_test.go
@@ -14,18 +14,40 @@ import (
 
 // #6912 arm H — PHP field→declared-type REFERENCES edges.
 //
-// The fixture below is the arm's shape-space enumeration and every row in it is
-// legal PHP 8.1 (checked shape by shape against the grammar, not eyeballed).
+// The fixture below is the arm's shape-space enumeration. Every row is a
+// property declaration PHP will actually compile — which is a WEAKER and more
+// honest claim than the one this comment carried in the first revision.
+//
+// That revision said every row was "legal PHP 8.1, checked shape by shape
+// against the grammar". It was neither: `public callable $cb;` was in it, and
+// **`callable` is not permitted as a property type in any PHP version** (typed
+// properties exclude `void` and `callable`, the latter because it is
+// context-dependent), so that row was a fatal error rather than a program. It
+// has been replaced by `public object $obj;`, which exercises the same axis —
+// a builtin refused by the declaration gate — and is legal. The version label
+// was wrong too: `(Customer&Shipper)|null` is a PHP **8.2** DNF type, not 8.1.
+// Recorded rather than quietly corrected, because a fixture row that the
+// language does not permit is the third instance of this defect on this board
+// (an F# arm shipped `Mut: mutable Customer`), and the pattern is that the
+// CLAIM of having checked is what goes unchecked.
 //
 // AXES VARIED, one per property, holding the others constant:
 //   - type composition: bare, nullable `?T`, union `A|B`, intersection `A&B`,
-//     union-with-primitive, DNF `(A&B)|null`
+//     union-with-primitive, DNF `(A&B)|null` (PHP 8.2)
 //   - name qualification: bare, relative `Ns\T`, fully-qualified `\Ns\T`,
 //     leading-separator-only `\T`
 //   - target existence: declared in THIS file / declared in ANOTHER file /
 //     declared nowhere
-//   - target kind: class, interface, trait, enum, import placeholder, namespace
-//   - PHP builtin: int, string, array, iterable, callable, mixed, self, static
+//   - target kind: class, interface, trait, enum, import placeholder, file
+//     carrier, AND — the case that is both refused and admitted at once — a
+//     name carried by an admitted class AND a refused import placeholder in the
+//     same file (`Order2.carrier`, see
+//     TestPhpFieldTypeRefs_ImportPlaceholderSharingAClassNameIsOneNode).
+//     The `namespace` row lives in the imports.php fixture instead, because
+//     `namespace App;` puts its record in whichever file declares it and
+//     TestPhpFieldTypeRefs_ImportPlaceholderIsNeverATarget is where the
+//     empty-Subtype refusal is graded.
+//   - PHP builtin: int, string, array, iterable, object, mixed, self
 //   - declaration site: class property, promoted constructor parameter,
 //     multi-declarator property, untyped property
 //   - identifier case: declared spelling vs. lower-cased use
@@ -68,8 +90,9 @@ class Order2 {
     public string $label;
     public array $rows;
     public iterable $it;
-    public callable $cb;
+    public object $obj;
     public mixed $any;
+    public Ship $carrier;
     public self $me;
     public static $untyped;
     public Money $m1, $m2;
@@ -205,6 +228,12 @@ func TestPhpFieldTypeRefs_ShapeSpace(t *testing.T) {
 		"Order2.m2":         {"Money"},    // multi-declarator, second
 		"Order2.owner":      {"Customer"}, // promoted ctor parameter
 		"Order2.amount":     {"Money"},    // promoted + nullable
+		// The one case where the allow-list must ADMIT rather than refuse: this
+		// file declares BOTH `class Ship {}` and `use Ship\Thing;`, so the name
+		// is carried by an admitted target AND a refused placeholder at once.
+		// Safe only because graph.EntityID omits Subtype — pinned by
+		// TestPhpFieldTypeRefs_ImportPlaceholderSharingAClassNameIsOneNode.
+		"Order2.carrier": {"Ship"},
 
 		// --- refused: qualified names are never reduced to a segment ---
 		"Order2.imported":    nil, // `use Other\Order` — Order is NOT declared here
@@ -220,7 +249,7 @@ func TestPhpFieldTypeRefs_ShapeSpace(t *testing.T) {
 		"Order2.label":   nil,
 		"Order2.rows":    nil,
 		"Order2.it":      nil,
-		"Order2.cb":      nil,
+		"Order2.obj":     nil,
 		"Order2.any":     nil,
 		"Order2.count":   nil,
 		"Order2.me":      nil, // `self` names the owner; refused twice over
@@ -251,14 +280,15 @@ func TestPhpFieldTypeRefs_ShapeSpace(t *testing.T) {
 }
 
 // TestPhpFieldTypeRefs_DNFTypeIsAKnownCaptureCeiling pins a gap this arm found
-// and deliberately did NOT close.
+// and deliberately did NOT close. It is filed as **#7044** — see that issue for
+// the description; this test exists only to make the ceiling fail loudly when it
+// is closed.
 //
-// PHP 8.2's disjunctive-normal-form type `(A&B)|null` is not one of the node
-// types phpDeclaredType (field_members.go:135) switches on, so it captures
-// NOTHING: field_type is "" and the Signature drops the type as well. That is a
-// capture defect in the property producer, not an edge defect — it degrades the
-// Signature for every DNF-typed property whether or not this arm exists — so it
-// belongs to its own change with its own grading rather than riding along here.
+// In one line: PHP 8.2's disjunctive-normal-form type `(A&B)|null` is not one of
+// the node types phpDeclaredType (field_members.go:135) switches on, so it
+// captures NOTHING — field_type is "" and the Signature drops the type too. A
+// capture defect in the property producer, not an edge defect, which is why it
+// is a separate issue rather than a rider on this arm.
 //
 // The test asserts the CURRENT behaviour so the ceiling is visible and so that
 // fixing the capture makes this test fail loudly, at which point the shape-space
@@ -315,6 +345,7 @@ class Money {}
 
 class Order {
     public Ship $carrier;
+    public App $ns;
     public Money $price;
 }
 `
@@ -345,8 +376,27 @@ class Order {
 		}
 	}
 
+	// The NAMESPACE row of the target-kind axis. buildNamespace (php.go:483)
+	// mints its own bare SCOPE.Component named after the namespace ROOT with an
+	// empty Subtype — the same shape as an import placeholder but a different
+	// producer — and the axis previously claimed this row while no test drove a
+	// field at it. Premise asserted first, again so the refusal is doing work.
+	ns := false
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Name == "App" &&
+			recs[i].SourceFile == "imports.php" && recs[i].Subtype == "" {
+			ns = true
+		}
+	}
+	if !ns {
+		t.Fatal("no bare-named namespace record in this file — buildNamespace's " +
+			"shape has changed and the namespace row of the axis is vacuous")
+	}
+
 	phpFTEqual(t, phpFTTargetsOf(recs, "Order.carrier"), nil,
 		"a field typed after an import placeholder")
+	phpFTEqual(t, phpFTTargetsOf(recs, "Order.ns"), nil,
+		"a field typed after the file's own namespace root")
 	// Positive control in the SAME file: the pass works here.
 	phpFTEqual(t, phpFTTargetsOf(recs, "Order.price"), []string{"Money"},
 		"the control field in the same class")
@@ -405,6 +455,56 @@ class Middleware
 		"a promoted parameter typed after an unqualified `use` import")
 	phpFTEqual(t, phpFTTargetsOf(recs, "Middleware.price"), []string{"Money"},
 		"the promoted-parameter control in the same constructor")
+}
+
+// TestPhpFieldTypeRefs_ImportPlaceholderSharingAClassNameIsOneNode pins the
+// premise that makes the two tests above SAFE, and which nothing pinned before.
+//
+// `models.php` declares BOTH `class Ship {}` and `use Ship\Thing;`, so the name
+// `Ship` is carried by an admitted target AND a refused placeholder in ONE file.
+// This is the case where the allow-list must ADMIT — and the edge only binds
+// because `graph.EntityID` hashes `(repo, Kind, Name, SourceFile)` with
+// **Subtype excluded**, so the two records collapse to ONE node rather than
+// tripping tier 2's kind-agnostic `ambigLocation` (`refs.go:1302-1315`), which
+// is what a two-node collision at one (file, name) would do.
+//
+// The premise is asserted FIRST — two distinct records, one computed ID — so the
+// binding assertion cannot pass because the second record silently stopped being
+// emitted. If `EntityID` ever starts hashing Subtype, this test fails here
+// rather than the arm quietly beginning to dangle.
+func TestPhpFieldTypeRefs_ImportPlaceholderSharingAClassNameIsOneNode(t *testing.T) {
+	recs := phpFTOne(t, phpFTPath, phpFTSrc)
+
+	var placeholder, class *types.EntityRecord
+	for i := range recs {
+		r := &recs[i]
+		if r.Kind != "SCOPE.Component" || r.Name != "Ship" || r.SourceFile != phpFTPath {
+			continue
+		}
+		switch r.Subtype {
+		case "":
+			placeholder = r
+		case "class":
+			class = r
+		}
+	}
+	if placeholder == nil || class == nil {
+		t.Fatalf("the two-record premise is gone (placeholder=%v class=%v) — "+
+			"models.php must declare BOTH `use Ship\\Thing;` and `class Ship {}` "+
+			"or this test grades nothing", placeholder != nil, class != nil)
+	}
+	pid := graph.EntityID("issue6912", placeholder.Kind, placeholder.Name, placeholder.SourceFile)
+	cid := graph.EntityID("issue6912", class.Kind, class.Name, class.SourceFile)
+	if pid != cid {
+		t.Fatalf("the import placeholder and the class no longer collapse to one "+
+			"node (%s vs %s). graph.EntityID must exclude Subtype for the "+
+			"admitted-and-refused-at-once case to bind rather than dangle.", pid, cid)
+	}
+
+	// One edge, to the class, and it binds.
+	phpFTEqual(t, phpFTTargetsOf(recs, "Order2.carrier"), []string{"Ship"},
+		"a field typed at a name carried by both an admitted class and a placeholder")
+	phpFTAssertAllBind(t, recs)
 }
 
 // TestPhpFieldTypeRefs_EnumIsNotATarget records a MEASUREMENT, not a preference.
@@ -726,6 +826,7 @@ class Shipper {}
 		"Order2.both => " + m + "Customer",
 		"Order2.both => " + m + "Shipper",
 		"Order2.buyer => " + m + "Customer",
+		"Order2.carrier => " + m + "Ship",
 		"Order2.either => " + m + "Customer",
 		"Order2.either => " + m + "Money",
 		"Order2.folded => " + m + "Customer",

--- a/internal/extractors/php/field_type_refs_units_6912_test.go
+++ b/internal/extractors/php/field_type_refs_units_6912_test.go
@@ -1,0 +1,295 @@
+package php
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6912 arm H — INTERNAL tests for the conjuncts Extract cannot reach.
+//
+// Extract is called once per file and every record it builds carries that file's
+// path, so the `r.SourceFile != filePath` conjuncts never fire from outside and a
+// mutant deleting one survives the whole external suite. Likewise the
+// component-address-family ambiguity rule: PHP emits exactly ONE
+// componentKindFamily kind (SCOPE.Component), so no PHP source can put two family
+// kinds at one (file, name). "Unreachable from outside" is a reason to call the
+// function directly, not a reason to leave a conjunct ungraded.
+
+func phpFTKeys(m map[string]phpFieldTypeTarget) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestPhpFieldTypeRefs_Unit_TargetsAreScopedToTheRequestedFile grades BOTH
+// same-file conjuncts, in OPPOSITE failure directions. Grading one is exactly
+// what makes the other look covered.
+//
+//   - the RIVAL scan (pass 1): a cross-file record wrongly SUPPRESSING an edge.
+//   - the TARGET scan (pass 2): a cross-file record wrongly BECOMING a target.
+func TestPhpFieldTypeRefs_Unit_TargetsAreScopedToTheRequestedFile(t *testing.T) {
+	records := []types.EntityRecord{
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "a.php"},
+		{Name: "Money", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "a.php"},
+		// Same shape, other file. Neither may appear in a.php's target set —
+		// this is the TARGET-scan direction.
+		{Name: "Shipper", Kind: "SCOPE.Component", Subtype: "interface", SourceFile: "b.php"},
+		// An IN-FAMILY record in b.php sharing a name with an a.php type. This
+		// row grades the RIVAL-scan direction, which the rows above cannot:
+		// they share no name with a.php, so a cross-file leak there changes
+		// nothing. With that conjunct removed, nameKinds["Customer"] gains
+		// SCOPE.Model from b.php and the ambiguity rule wrongly suppresses
+		// a.php's perfectly unambiguous Customer.
+		{Name: "Customer", Kind: "SCOPE.Model", Subtype: "model", SourceFile: "b.php"},
+	}
+
+	got := phpInFileTypeTargets(records, "a.php")
+	if want := []string{"customer", "money"}; len(got) != 2 ||
+		got["customer"].name != "Customer" || got["money"].name != "Money" {
+		t.Fatalf("a.php targets = %v, want %v", phpFTKeys(got), want)
+	}
+	if got["customer"].toID != "scope:component:class:php:a.php:Customer" {
+		t.Errorf("toID = %q", got["customer"].toID)
+	}
+	if _, ok := got["shipper"]; ok {
+		t.Error("Shipper is declared in b.php and must NOT be a target for " +
+			"a.php — same-file targets are this arm's central promise")
+	}
+
+	// The mirror, so the assertion above is not merely "b.php was ignored":
+	// asking for b.php returns b.php's own declarations.
+	gotB := phpInFileTypeTargets(records, "b.php")
+	if _, ok := gotB["shipper"]; !ok {
+		t.Fatalf("b.php's own target set %v is missing Shipper — the assertions "+
+			"above would pass even if the function always returned nothing",
+			phpFTKeys(gotB))
+	}
+
+	// The THIRD site: the field loop's own SourceFile conjunct. A field in
+	// b.php must not pick up a.php's targets.
+	withField := append([]types.EntityRecord{}, records...)
+	withField = append(withField, types.EntityRecord{
+		Name: "Foreign.buyer", Kind: "SCOPE.Schema", Subtype: "field", SourceFile: "b.php",
+		Properties: map[string]string{
+			"field_name": "buyer", "field_type": "Money", "parent_class": "Foreign",
+		},
+	})
+	out := attachPhpFieldTypeRefs(withField, "a.php")
+	for i := range out {
+		if out[i].Name == "Foreign.buyer" && len(out[i].Relationships) != 0 {
+			t.Errorf("a b.php field received %d edge(s) from a.php's target set — "+
+				"the field loop's SourceFile conjunct is not holding",
+				len(out[i].Relationships))
+		}
+	}
+}
+
+// TestPhpFieldTypeRefs_Unit_InFamilyRivalSuppressesTheTarget grades rule 2 in the
+// direction it exists for, and its MIRROR in the same test so that "suppressed"
+// is not confused with "never worked".
+//
+// The rule is VACUOUS from PHP source today — SCOPE.Component is the only
+// componentKindFamily kind any PHP producer emits — so it is graded here by
+// direct call. It is kept because a producer that starts minting a SCOPE.Model or
+// SCOPE.View for a PHP class (an Eloquent-model detector is the obvious
+// candidate) would otherwise make this pass emit a stub the resolver refuses:
+// lookupLocationKind weighs both kinds, finds no unique answer, and ambigLocation
+// blanks the ref.
+func TestPhpFieldTypeRefs_Unit_InFamilyRivalSuppressesTheTarget(t *testing.T) {
+	base := []types.EntityRecord{
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "a.php"},
+		{Name: "Money", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "a.php"},
+	}
+
+	// Control: with no rival, both are targets.
+	if got := phpInFileTypeTargets(base, "a.php"); len(got) != 2 {
+		t.Fatalf("control: targets = %v, want both", phpFTKeys(got))
+	}
+
+	// IN-family rival — a SECOND family kind at the same (file, name).
+	inFamily := append(append([]types.EntityRecord{}, base...),
+		types.EntityRecord{Name: "Customer", Kind: "SCOPE.Model", Subtype: "model", SourceFile: "a.php"})
+	got := phpInFileTypeTargets(inFamily, "a.php")
+	if _, ok := got["customer"]; ok {
+		t.Error("an in-family rival at the same (file, name) must suppress the " +
+			"target: the resolver's own tier cannot pick between them")
+	}
+	if _, ok := got["money"]; !ok {
+		t.Error("the untouched name must still be a target — rule 2 must drop " +
+			"one name, not the file")
+	}
+
+	// OUT-of-family rival — arm D's rule would drop this one; PHP's tier does
+	// not weigh it, so it must survive. This is the counterfactual that stops
+	// arm D's rule being inherited.
+	outFamily := append(append([]types.EntityRecord{}, base...),
+		types.EntityRecord{Name: "Customer", Kind: "SCOPE.Operation", Subtype: "function", SourceFile: "a.php"},
+		types.EntityRecord{Name: "Money", Kind: "SCOPE.Enum", Subtype: "enum", SourceFile: "a.php"})
+	got = phpInFileTypeTargets(outFamily, "a.php")
+	if _, ok := got["customer"]; !ok {
+		t.Error("a same-file SCOPE.Operation is NOT weighed by the tier that " +
+			"resolves a component-space ref, so it must not suppress the class")
+	}
+	if _, ok := got["money"]; !ok {
+		t.Error("a same-file SCOPE.Enum is likewise out of family and must not " +
+			"suppress the class")
+	}
+}
+
+// TestPhpFieldTypeRefs_Unit_ScopeClassParticipatesViaTheTrimAlias grades the one
+// entry of phpComponentAddressFamily that is NOT a literal member of
+// componentKindFamily.
+//
+// BuildIndex writes every entity under its raw Kind AND its SCOPE-trimmed alias,
+// so a `SCOPE.Class` entity is keyed under "Class", which IS in the family. Drop
+// that entry and the pass emits a stub the resolver blanks. Arm F shipped this
+// hole in a first revision with a comment claiming otherwise.
+func TestPhpFieldTypeRefs_Unit_ScopeClassParticipatesViaTheTrimAlias(t *testing.T) {
+	records := []types.EntityRecord{
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "a.php"},
+		{Name: "Customer", Kind: "SCOPE.Class", Subtype: "class", SourceFile: "a.php"},
+	}
+	if got := phpInFileTypeTargets(records, "a.php"); len(got) != 0 {
+		t.Errorf("targets = %v; a SCOPE.Class rival is visible to "+
+			"lookupLocationKind through the index's trim alias and must "+
+			"suppress the target", phpFTKeys(got))
+	}
+	// Every member of the table must be able to suppress, or it is decoration.
+	for kind := range phpComponentAddressFamily {
+		if kind == "SCOPE.Component" {
+			continue
+		}
+		recs := []types.EntityRecord{
+			{Name: "Customer", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "a.php"},
+			{Name: "Customer", Kind: kind, Subtype: "x", SourceFile: "a.php"},
+		}
+		if got := phpInFileTypeTargets(recs, "a.php"); len(got) != 0 {
+			t.Errorf("a rival kinded %q did not suppress the target — the table "+
+				"entry is inert", kind)
+		}
+	}
+}
+
+// TestPhpFieldTypeRefs_Unit_OnlySchemaFieldsAreAnchors grades the field loop's
+// Kind and Subtype conjuncts, which fire together for anything Extract can
+// produce (emitPhpFieldMembers is the only site minting Subtype "field" and it
+// always sets Kind SCOPE.Schema) and so are ungradeable from outside.
+func TestPhpFieldTypeRefs_Unit_OnlySchemaFieldsAreAnchors(t *testing.T) {
+	props := map[string]string{
+		"field_name": "buyer", "field_type": "Customer", "parent_class": "Order",
+	}
+	records := []types.EntityRecord{
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "a.php"},
+		// Right subtype, WRONG kind.
+		{Name: "Order.a", Kind: "SCOPE.Component", Subtype: "field", SourceFile: "a.php", Properties: props},
+		// Right kind, WRONG subtype.
+		{Name: "Order.b", Kind: "SCOPE.Schema", Subtype: "enum", SourceFile: "a.php", Properties: props},
+		// Both right — the positive control, so a broken pass cannot pass this.
+		{Name: "Order.c", Kind: "SCOPE.Schema", Subtype: "field", SourceFile: "a.php", Properties: props},
+	}
+	out := attachPhpFieldTypeRefs(records, "a.php")
+	for i := range out {
+		switch out[i].Name {
+		case "Order.a", "Order.b":
+			if len(out[i].Relationships) != 0 {
+				t.Errorf("%s (%s/%s) is not a field entity and must not anchor a "+
+					"field-type edge", out[i].Name, out[i].Kind, out[i].Subtype)
+			}
+		case "Order.c":
+			if len(out[i].Relationships) != 1 {
+				t.Fatalf("the control got %d edges, want 1 — the two assertions "+
+					"above are vacuous", len(out[i].Relationships))
+			}
+		}
+	}
+}
+
+// TestPhpFieldTypeRefs_Unit_FoldedSpellingCollisionRefusesBoth grades the
+// case-folding collision branch. `class Money` beside `interface MONEY` is a
+// fatal redeclaration in PHP, so it is unreachable from a file PHP will load —
+// but this pass is handed RECORDS, not a running interpreter, and picking one of
+// the two arbitrarily would make the emitted address depend on record order.
+func TestPhpFieldTypeRefs_Unit_FoldedSpellingCollisionRefusesBoth(t *testing.T) {
+	records := []types.EntityRecord{
+		{Name: "Money", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "a.php"},
+		{Name: "MONEY", Kind: "SCOPE.Component", Subtype: "interface", SourceFile: "a.php"},
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "a.php"},
+	}
+	got := phpInFileTypeTargets(records, "a.php")
+	if _, ok := got["money"]; ok {
+		t.Errorf("two spellings folding to the same key must refuse both; got %v",
+			phpFTKeys(got))
+	}
+	if _, ok := got["customer"]; !ok {
+		t.Error("the untouched name must survive — the collision drops one key, " +
+			"not the file")
+	}
+	// Order-independent: the same input reversed must give the same answer.
+	rev := []types.EntityRecord{records[2], records[1], records[0]}
+	if got2 := phpInFileTypeTargets(rev, "a.php"); len(got2) != len(got) {
+		t.Errorf("the answer depends on record order: %v vs %v",
+			phpFTKeys(got), phpFTKeys(got2))
+	}
+}
+
+// TestPhpFieldTypeRefs_Unit_CandidateScannerEnumeratesTheShapeSpace grades the
+// scanner as a PROPERTY over PHP's type syntax rather than as a handful of lucky
+// fixtures. Every row is a legal PHP type expression.
+func TestPhpFieldTypeRefs_Unit_CandidateScannerEnumeratesTheShapeSpace(t *testing.T) {
+	cases := []struct {
+		typ  string
+		want []string
+	}{
+		{"Order", []string{"Order"}},
+		{"?Order", []string{"Order"}},
+		{"Order|Money", []string{"Order", "Money"}},
+		{"Order|null", []string{"Order", "null"}},
+		{"null|Order", []string{"null", "Order"}},
+		{"Order&Shipper", []string{"Order", "Shipper"}},
+		{"Order & Shipper", []string{"Order", "Shipper"}},
+		{"(Order&Shipper)|null", []string{"Order", "Shipper", "null"}},
+		{"int", []string{"int"}},
+		{"string|int", []string{"string", "int"}},
+		{"array", []string{"array"}},
+		{"self", []string{"self"}},
+		{"static", []string{"static"}},
+		{"parent", []string{"parent"}},
+		{"iterable", []string{"iterable"}},
+		{"never", []string{"never"}},
+		{"false", []string{"false"}},
+		{"Order_2", []string{"Order_2"}},
+		{"_Order", []string{"_Order"}},
+		{"Ünité", []string{"Ünité"}},
+		// Qualified in every spelling — each must vanish WHOLE, leaving no
+		// segment behind. These are the rows a "skip the separator" scanner
+		// fails: it would yield [Ns Order].
+		{"Ns\\Order", nil},
+		{"\\Ns\\Order", nil},
+		{"\\Order", nil},
+		{"A\\B\\C\\Order", nil},
+		{"?\\Ns\\Order", nil},
+		{"\\Ns\\Order|Money", []string{"Money"}},
+		{"Money|\\Ns\\Order", []string{"Money"}},
+		{"\\A\\B&\\C\\D", nil},
+		{"", nil},
+		{"?", nil},
+	}
+	for _, c := range cases {
+		got := phpFieldTypeCandidates(c.typ)
+		if len(got) != len(c.want) {
+			t.Errorf("candidates(%q) = %v, want %v", c.typ, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("candidates(%q) = %v, want %v", c.typ, got, c.want)
+				break
+			}
+		}
+	}
+}

--- a/internal/extractors/php/field_type_refs_units_6912_test.go
+++ b/internal/extractors/php/field_type_refs_units_6912_test.go
@@ -141,6 +141,77 @@ func TestPhpFieldTypeRefs_Unit_InFamilyRivalSuppressesTheTarget(t *testing.T) {
 	}
 }
 
+// TestPhpFieldTypeRefs_Unit_OnlyComponentsAreTargets grades pass 2's
+// `r.Kind != "SCOPE.Component"` conjunct, which an independent review found
+// ALIVE under two mutants (delete it; widen it to admit SCOPE.Schema).
+//
+// It is MUTUALLY MASKED by the subtype allow-list: no core PHP producer mints a
+// record with Subtype ∈ {class, interface, trait} under any Kind but
+// SCOPE.Component, so through Extract the two guards only ever fire together and
+// the allow-list alone carries every refusal — including the enum one, which
+// TestPhpFieldTypeRefs_EnumIsNotATarget therefore grades through the allow-list
+// rather than through this conjunct. Two guards that only fire together grade
+// neither, so they are scored part by part here.
+//
+// The distinguishing input is `{Kind: "SCOPE.Model", Subtype: "class"}` — which
+// is EXACTLY the future producer this arm cites to justify keeping rule 2 (an
+// Eloquent-model detector re-kinding a PHP class). Rule 2 is graded against that
+// producer by direct call; leaving the conjunct the same producer would exercise
+// ungraded was an inconsistency, not a considered scope.
+//
+// The kinds are ENUMERATED rather than hand-picked: every Kind this package or
+// its custom lane can plausibly grow, both in and out of the address family,
+// each paired with an ADMITTED subtype so the allow-list cannot be what refuses
+// it. A positive control in the same input keeps the assertions from passing
+// because the function returned nothing.
+func TestPhpFieldTypeRefs_Unit_OnlyComponentsAreTargets(t *testing.T) {
+	// Each row: a record with an ADMITTED subtype under a NON-Component Kind.
+	// None may become a target.
+	kinds := []string{
+		"SCOPE.Model",   // in-family — the Eloquent-detector shape
+		"SCOPE.View",    // in-family
+		"SCOPE.Class",   // in-family via the index's trim alias
+		"SCOPE.Schema",  // out-of-family — the reviewer's N8 widening
+		"SCOPE.Enum",    // out-of-family — the parallel value-set population
+		"SCOPE.Pattern", // out-of-family — emitted by internal/custom/php
+		"SCOPE.Service", // out-of-family — emitted by internal/custom/php
+	}
+	for _, kind := range kinds {
+		records := []types.EntityRecord{
+			// The positive control: a real Component target, distinct name.
+			{Name: "Money", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "a.php"},
+			// The row under test. A DISTINCT name, so rule 2 cannot be what
+			// refuses it — this test grades the Kind conjunct alone.
+			{Name: "Ghost", Kind: kind, Subtype: "class", SourceFile: "a.php"},
+		}
+		got := phpInFileTypeTargets(records, "a.php")
+		if _, ok := got["money"]; !ok {
+			t.Fatalf("kind %q: the control target is missing (%v) — every "+
+				"assertion in this row would be vacuous", kind, phpFTKeys(got))
+		}
+		if _, ok := got["ghost"]; ok {
+			t.Errorf("a record kinded %q with Subtype \"class\" became a target. "+
+				"Only SCOPE.Component records are type declarations this package "+
+				"emits; the allow-list is a subtype filter and cannot refuse this "+
+				"on its own.", kind)
+		}
+	}
+
+	// The mirror, so "refused" is not "the subtype was wrong": the SAME
+	// non-Component kinds with a REFUSED subtype are also absent — i.e. the two
+	// guards are independent rather than one standing in for the other.
+	for _, kind := range kinds {
+		records := []types.EntityRecord{
+			{Name: "Money", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "a.php"},
+			{Name: "Ghost", Kind: kind, Subtype: "", SourceFile: "a.php"},
+		}
+		if got := phpInFileTypeTargets(records, "a.php"); len(got) != 1 {
+			t.Errorf("kind %q with an empty subtype: targets = %v, want only the "+
+				"control", kind, phpFTKeys(got))
+		}
+	}
+}
+
 // TestPhpFieldTypeRefs_Unit_ScopeClassParticipatesViaTheTrimAlias grades the one
 // entry of phpComponentAddressFamily that is NOT a literal member of
 // componentKindFamily.

--- a/internal/extractors/php/field_type_refs_units_6912_test.go
+++ b/internal/extractors/php/field_type_refs_units_6912_test.go
@@ -237,6 +237,37 @@ func TestPhpFieldTypeRefs_Unit_FoldedSpellingCollisionRefusesBoth(t *testing.T) 
 	}
 }
 
+// TestPhpFieldTypeRefs_Unit_OneEdgePerTargetNotPerCandidate grades the `emitted`
+// dedup, which no external fixture can reach.
+//
+// Two candidates fold to ONE target only when the type expression names the same
+// class twice in different case — `Money|money` — and PHP rejects that source as
+// a duplicate union member, so no .php file can produce it. The guard is
+// therefore defensive rather than reachable, and it is graded HERE, by handing
+// the function the record such a file would produce, rather than left alive on
+// the strength of "PHP would not compile it": this function takes RECORDS, and
+// the property that matters — one edge per target, never per candidate — should
+// not depend on an upstream parser's error handling.
+func TestPhpFieldTypeRefs_Unit_OneEdgePerTargetNotPerCandidate(t *testing.T) {
+	records := []types.EntityRecord{
+		{Name: "Money", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "a.php"},
+		{Name: "Order.price", Kind: "SCOPE.Schema", Subtype: "field", SourceFile: "a.php",
+			Properties: map[string]string{
+				"field_name": "price", "field_type": "Money|money", "parent_class": "Order",
+			}},
+	}
+	out := attachPhpFieldTypeRefs(records, "a.php")
+	for i := range out {
+		if out[i].Name != "Order.price" {
+			continue
+		}
+		if n := len(out[i].Relationships); n != 1 {
+			t.Errorf("got %d edges for a type naming one target twice, want 1 — "+
+				"the edge count must follow the TARGET set, not the candidate list", n)
+		}
+	}
+}
+
 // TestPhpFieldTypeRefs_Unit_CandidateScannerEnumeratesTheShapeSpace grades the
 // scanner as a PROPERTY over PHP's type syntax rather than as a handful of lucky
 // fixtures. Every row is a legal PHP type expression.

--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -100,6 +100,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	emitPHPTestScopeOwner(root, file, &entities)
 	// Issue #4854 — in-file base-class EXTENDS for field-membership recursion.
 	entities = attachPhpExtends(entities)
+	// Issue #6912 arm H — field → declared-type REFERENCES edges. Runs on the
+	// fully assembled slice so it sees every record this file produced; see the
+	// CALL PLACEMENT note on attachPhpFieldTypeRefs for why that is an invariant
+	// to preserve rather than a load-bearing claim about today's passes.
+	entities = attachPhpFieldTypeRefs(entities, file.Path)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "php")
 	extractor.TagEntitiesLanguage(entities, "php")


### PR DESCRIPTION
## Arm H (php) of #6912 — and the headline is a ZERO

PHP fields now emit the field→declared-type `REFERENCES` edge (`ref_kind=field_target_type`), same-file targets only, matching arms A (C#), B (proto), C (rust), D (go), F (java) and E (F#).

**Measured yield on the available corpus: 0 edges from 331 field entities across 390 `.php` files.** Not an implementation failure — a structural fact about PHP, quantified below. **Read the "Is this arm worth merging?" section before merging; the decision is yours, not mine.**

The mechanism itself is exercised and correct: **23 edges across the 9 fixture files, 23 bound / 0 dangling**, driven through the real resolver (`BuildIndex` → `ReferencesEmbedded`) rather than asserted at the emit site.

**Revised after independent review** — F1–F4 fixed in `f84fc8e92`; see §13.

---

## 1. The resolver tier that resolves a PHP field's address — driven, not inferred

The ToID is `extractor.BuildComponentStructuralRef` → `scope:component:class:php:<file>:<Name>`. `resolveStructuralRef` (`internal/resolve/refs.go:2982`) tries, in order:

| tier | site | what it weighs |
|---|---|---|
| 1 | `lookupLocationKind(file, name, structuralKindFamilies("component"))` — `refs.go:2982` | `componentKindFamily` only (`refs.go:2341`), plus each entity's SCOPE-trimmed alias (`refs.go:1290-1296`) |
| 2 | `ambigLocation[file][name]` — `refs.go:3004` | **every kind** — set whenever two distinct entity IDs share (file, name) (`refs.go:1302-1315`) |
| 3 | `byLocation[file][name]` — `refs.go:3007` | kind-agnostic |

**Every target this arm admits is a `SCOPE.Component`, so every edge it emits is answered at tier 1 and never reaches tiers 2/3.** Established by driving `BuildIndex` → `ReferencesEmbedded` over records the real extractor produced, not by reading `refs.go`.

### Which kinds that tier weighs, and why

`componentKindFamily` = `{Component, Class, View, Model, SCOPE.Component, SCOPE.View, SCOPE.Model}`, closed under the index's trim alias — so the membership test is `K ∈ family ∨ TrimPrefix(K,"SCOPE.") ∈ family`, and `SCOPE.Class` is in because `Class` is. Eight entries, in `phpComponentAddressFamily`. (Arm F shipped this table with `SCOPE.Class` missing in a first revision while its comment claimed both spellings; the hole is not re-introduced, and `TestPhpFieldTypeRefs_Unit_ScopeClassParticipatesViaTheTrimAlias` asserts every entry can actually suppress, so no entry is decoration.)

**And the honest part: rule 2 is VACUOUS as shipped — for a stronger reason than the first revision gave.** `SCOPE.Component` is the only `componentKindFamily` kind *any* PHP producer emits — core `internal/extractors/php` and custom `internal/custom/php` were both enumerated, neither emits `SCOPE.Model`, `SCOPE.View`, `SCOPE.Class`, nor a bare `Component`/`Class`/`View`/`Model`. **The reviewer pointed out that the custom half of that enumeration is irrelevant**: this pass runs inside core `Extract`, *before* `MergeWithCustom`, so no `internal/custom/php` record ever reaches it. The core half alone settles it, *a fortiori* — the reason has been tightened rather than the claim weakened. (Enumerating the custom lane was still the right check: it is where the future producer would live.) So `len(nameKinds[name]) > 1` cannot fire from PHP source today. It is kept as a resolver mirror for the producer that adds an in-family kind later (an Eloquent-model detector is the obvious candidate) and, being unreachable from `Extract`, it is graded by direct call rather than claimed as fixture-covered.

## 2. Measured counterfactuals

Harness: the real extractor over 390 corpus `.php` files, computing the shipped edge set and each rival rule's edge set per file, diffing named rows.

| rule | edges (corpus, 390 files) | edges (9 fixture files) | rows changed vs shipped |
|---|---|---|---|
| **shipped** (family-scoped kind count) | **0** | **23** | — |
| **arm D** (count ALL same-file kinds) | 0 | **22** | **drops `Order.price -> Money`** (`twotables.php`), −4.3% |
| **arm F** (family-scoped kind count) | 0 | 23 | **0 — this IS the shipped rule**, reached from php's own tier, not borrowed |
| **arm C** (count RECORDS in the admitted set) | 0 | 23 | 0 on both — unreachable in PHP: two admitted same-name declarations in one file is a fatal redeclaration |
| **no allow-list** (any same-file `SCOPE.Component`) | **1** | **26** | **adds 3 WRONG BINDINGS** — `Order.carrier -> Ship` (import placeholder), `Order.ns -> App` (**namespace record**, added for F3), `Middleware.middleware -> Closure` (the corpus one); see §3 |
| **enums admitted as targets** | 0 | **24** | adds `Order.status -> Status`, which **dangles**; see §4 |

The corpus deltas are all 0 because the corpus total is 0 — a delta over an empty set separates nothing. The counterfactuals are therefore **also** measured over every fixture file this arm ships, where they are non-vacuous, using the same harness against the real extractor. That is the honest form: arm D's rule is not refused because it cost 19% here, it is refused because PHP keeps **classes and functions in separate symbol tables**, so

```php
class Money {}
function Money() { return 1; }   // legal PHP — different symbol table
class Order { public Money $price; }
```

puts a `SCOPE.Operation` beside the `SCOPE.Component`. Arm D's rule refuses that target. Tier 1 binds it without hesitation, because `SCOPE.Operation` is not in the family it weighs — asserted through the real resolver in that test, not argued. **Arm C's rule is not copied and neither is its stated reason** (#7038).

## 3. The wrong-binding kill, reproduced from the corpus rather than invented

`useImportRecord` (`php.go:650`) mints one `SCOPE.Component` per `use`, named the **top namespace segment**, with an **empty Subtype**. For an *unqualified* use there is no segment to strip, so the placeholder is named exactly what a field types:

```
laravel-routing/src/Illuminate/Routing/Controllers/Middleware.php
  use Closure;
  public function __construct(public Closure|string|array $middleware, ...)
```

Without `phpTypeDeclSubtypes` this pass emits `Middleware.middleware -> Closure` **and it binds** — to an import placeholder. It is the *one and only* edge the whole 390-file corpus produces without the allow-list, and it is wrong. A wrong binding never reaches `bug-extractor` because it binds. `TestPhpFieldTypeRefs_UnqualifiedUseImportIsNeverATarget` is that file's shape, and it asserts the placeholder record exists first so it cannot pass vacuously; `TestPhpFieldTypeRefs_ImportPlaceholderIsNeverATarget` covers the namespace-root spelling in a file that declares **no** class of that name, so rule 2 cannot mask the allow-list.

`buildNamespace` (`php.go:483`) mints the same shape for the file's own `namespace`, and is refused by the same list.

## 4. PHP enums are refused, and it is a measurement

`enum Status: string { case Open = 'open'; }` is minted **twice in one file** — `SCOPE.Schema/enum` by `buildEnum` (`php.go:384`) and a `SCOPE.Enum` value-set of the **same Name** by `buildEnumValueSet` (`const_valueset.go:181`). Two kinds, two nodes, and **neither is in `componentKindFamily`**. Driven through the real resolver:

```
enum Status: string { case Open = 'open'; }  ->  DANGLE (statusAmbiguous, tier 2)
enum Empty2 {}   (no cases, so no value-set) ->  binds
```

So admitting enums would emit a guaranteed dangling stub for every enum anybody actually writes. `TestPhpFieldTypeRefs_EnumTargetWouldDangle` hand-emits the refused edge and asserts the dangle, with a class target in the same harness that binds — so a failure cannot be the harness.

**This is a named recall loss.** `public Status $status` is ordinary PHP and stays orphan. Closing it needs a **second address dialect**: a schema-space ref would hit `lookupLocationKind` with `schemaKindFamily` `{Schema, Field, Property, SCOPE.Schema}`, where the `SCOPE.Enum` value-set is *not* a member and the `SCOPE.Schema/enum` resolves uniquely. Deliberately not taken here — two dialects behind one `ref_kind` is #6451's shape and should be decided across arms, not invented by this one.

## 5. Fixture axes

**VARIED** (one per property of one class, so a failure names the axis): type composition (bare / `?T` / `A|B` / `A&B` / `(A&B)|null` / union-with-primitive); name qualification (bare / `Ns\T` / `\Ns\T` / `\T`); target existence (this file / another file / nowhere); target kind (class, interface, trait, enum, import placeholder, namespace, file carrier); PHP builtin (`int`, `string`, `array`, `iterable`, `callable`, `mixed`, `self`); declaration site (property, **promoted constructor parameter**, multi-declarator `public Money $m1, $m2;`, untyped); identifier case (declared spelling vs lower-cased use).

**HELD CONSTANT**: one file per fixture (the cross-file direction is graded by the unit test, deliberately); one declaring class where a second would confuse the self-reference rule; visibility `public` except where promotion requires otherwise; no framework/ORM annotations (the custom lane is gated off by default and is not this pass's input).

Every field entity the fixture emits **must** have a row in the shape table and every row must match a real entity — a property added without a row fails, and a row naming no field fails as vacuous. The scanner gets its own enumeration (30 rows) over the same syntax space, which is what makes union/intersection/qualification graded as properties rather than as three lucky fixtures.

**Promoted constructor parameters are covered** — `emitPhpFieldMembers` emits them through the same `add` closure, so they are one more `SCOPE.Schema/field` with a `field_type`. Asserted (`Order2.owner`, `Order2.amount`, `Order2.count`), and the corpus wrong-binding above is itself a promoted parameter.

## 6. Two same-file conjuncts, graded in opposite directions

There are **three** `SourceFile != filePath` sites (rival scan, target scan, field loop) and none is reachable through `Extract`, since it is called once per file. Graded by direct call, in **opposite failure directions** so grading one does not make the other look covered:

- a cross-file `SCOPE.Model` named `Customer` wrongly **suppressing** `a.php`'s own unambiguous `Customer` (rival scan)
- a cross-file `interface Shipper` wrongly **becoming** a target for `a.php` (target scan)
- a `b.php` field wrongly picking up `a.php`'s target set (field loop)

Plus the mirror — asking for `b.php` returns `b.php`'s own declarations — so "absent" is never "the function returned nothing".

## 7. No primitive blocklist

`int`, `string`, `array`, `callable`, `iterable`, `object`, `mixed`, `never`, `void`, `false`, `null`, `true`, `float`, `bool`, `self`, `static`, `parent` are collected as candidates like any other identifier and refused by the **declaration gate**. No blocklist, and none is needed: PHP **reserves** every one of those as a class name (`class int {}` is a fatal error), so unlike F#'s shadowable type abbreviations there is no legal same-file declaration a blocklist would have to out-rank. `self`/`static` are refused a second time by the self-reference rule.

## 8. Qualified names vanish whole

`\` is scanned as an identifier continuation character **and** may start a token, so `Ns\Order`, `\Ns\Order` and `\Order` each arrive as one token and are rejected as one. Reducing to the last segment is the failure arm D found in Go's `resolveTypeReferences`. A **leading** separator is refused for a second, independent reason: in a file with `namespace App;`, bare `Money` means `App\Money` while `\Money` means the *global* `Money` — different types, so binding one to the other would be wrong. Conservative in the namespace-less case, which is the direction to be conservative in.

## 9. Grading — 25 mutants, 23 DEAD, 2 equivalent with the reason stated

Every mutant `go vet`-compiled, applied through a script that **asserts an exact occurrence count before and after** (three mutants aborted as "pattern occurs 0 times, edit NOT applied" rather than being scored as ALIVE), reverted by `cp` from a shasum-verified byte backup, with `git status --porcelain` checked clean after each. Final tree shasums are byte-identical to the baseline.

| # | mutant (call site, not an extracted helper) | verdict |
|---|---|---|
| M1 | allow-list disabled | DEAD (2) — both import-placeholder tests |
| M2 | ambiguity rule disabled | DEAD (2) |
| M3 | ambiguity count widened to ALL kinds (**arm D's rule**) | DEAD (2) |
| M4 | `SCOPE.Class` dropped from the family table | DEAD (1) |
| M5 | leading `\` skipped instead of consumed whole | DEAD (4) |
| M6 | `\` no longer an identifier continuation | DEAD (1) |
| M7 | return the FIRST candidate only (**swift's exact defect**) | DEAD (3) |
| M8 | store folded, look up unfolded | DEAD (15) — *plumbing half, not evidence about folding* |
| M8b | store folded, look up folded → unfolded | DEAD (10) — *ditto* |
| M8c | **fold neither side** — the coherent case-sensitive alternative | DEAD (6), incl. both behavioural tests |
| M9 | self-reference rule disabled | DEAD (1) |
| M10 | `ref_kind` near-miss (`field_target_types`) | DEAD (11) |
| M11 | `trait` row removed | DEAD (2) |
| M12 | `interface` row removed | DEAD (4) |
| M13 | `SourceFile` conjunct, rival scan | DEAD (1) |
| M14 | `SourceFile` conjunct, target scan | DEAD (1) |
| M15 | `SourceFile` conjunct, field loop | DEAD (1) |
| M16 | field-loop `Kind` conjunct | DEAD (1) |
| M17 | field-loop `Subtype` conjunct | DEAD (1) |
| M18 | folded-spelling collision branch | DEAD (1) |
| M19 | **the call site in `Extract` removed** | DEAD (11) |
| M20 | per-target dedup removed | **ALIVE → graded → DEAD** |
| M21 | **call moved to immediately after `walk()`** | ALIVE — *equivalent*, see below |
| M22 | `Relationships` assigned instead of appended | DEAD (2) |
| M23 | empty-`field_type` guard disabled | ALIVE — *equivalent*: `phpFieldTypeCandidates("")` returns nil, so the loop body never runs |
| M25 | `class` row removed | DEAD (15) |

**M8/M8b are not offered as evidence about case folding.** They are inconsistent halves of one mechanism and are lethal for that reason alone; M8c is the coherent alternative implementation and is the row that grades the behaviour.

**M20 was ALIVE and was closed rather than recorded.** Two candidates fold to one target only for `Money|money`, which PHP rejects as a duplicate union member — so no `.php` file reaches it. But `attachPhpFieldTypeRefs` takes **records**, and "one edge per target, never per candidate" should not rest on an upstream parser's error handling. Graded by unit call; M20 is now DEAD.

**M21's ALIVE is an equivalence, and the enumeration behind it is complete** (an equivalence resting on a partial enumeration is worthless). The seven passes between `walk()` and the call site, and what each emits: `emitConfigConsumerEdges` → `SCOPE.Config`; `emitTemplateRenderEdges` → `SCOPE.Template`; `emitTranslationKeyEdges` → `SCOPE.TranslationKey`; `emitExceptionFlowEdges` → `SCOPE.ExceptionType` (observed: `SourceFile "<exception>"`, `Name "exception:X"`); `emitConstValueSets` → `SCOPE.Enum`; `emitPHPTestScopeOwner` → `SCOPE.Operation` (`tests.go:83`); `attachPhpExtends` → **relationships only, no records**. **None** is in `phpComponentAddressFamily` and none is a `SCOPE.Component`, so neither placement can differ. The comment therefore claims placement is *not* load-bearing rather than inventing a reason for it — and names what would make it load-bearing (a future pass minting a bare-named Component).

Two things I deliberately did **not** copy: arm C's record-counting rule (#7038), and the "*emitting would guarantee a dangling stub*" justification carried by arms C, D and E — it is false in general, a conservative approximation load-bearing only for in-family rivals. This arm's refusals each state their own measured reason.

## 10. Gates

- `go test -count=1 ./internal/extractors/php/ ./internal/custom/php/ ./internal/resolve/ ./internal/extractor/ ./internal/quality/` — green. `gofmt -l` clean.
- **`go test -count=1 ./cmd/grafel/`** — green in 169s with a fresh `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`, no skips.
- **The digest did not move, and the reason is that its fixture has no PHP file at all** — all 18 files enumerated (`cs/*` ×7, `java/OrdersController.java`, `ts/routes.ts`, `web/server.js`, `myproj/*` ×2, `myapp/*` ×4, `svc/handler.go`, `rs/routes.rs`). A new `REFERENCES` edge **would** move it (`R <from> -[Kind]-> <to>` is hashed; only properties are not), so this is a real negative result, not a blind instrument.
- **`scripts/quality/run.sh --ratchet`** — "38 gated fixtures held", and `git status --porcelain` empty afterwards, which is the actual check. **But it is vacuous for this change and I am not offering it as evidence:** the golden set's only `.php` file, `php-slim-mini/src/restapi/v1/index.php`, declares **zero** classes and **zero** typed properties. There was nowhere for a php edge to appear.

## 11. Recall ceiling and corpus caveat, stated where the numbers are

23/23 bound is a **bind rate, not completeness**. Observed ceilings, each by probe:

- **Same-file only.** The dominant one for PHP — see below.
- **PHP enums** — refused, §4.
- **PHP 8.2 DNF types** (`(A&B)|null`) — `phpDeclaredType` captures **nothing**: `field_type` is `""` and the **Signature loses the type too**. A capture defect that predates this arm and degrades the Signature whether or not this arm exists, so it is pinned as a known ceiling (`TestPhpFieldTypeRefs_DNFTypeIsAKnownCaptureCeiling`, which fails loudly if the capture is fixed) rather than fixed in passing. **Filed as #7044**; the test references the issue instead of re-describing it.
- **Untyped properties** (`public static $untyped`) — no datum, nothing to bind.

**Corpus**: 390 `.php` files in **5 repos, effectively 4** — symfony-routing 224, laravel-routing 60, laravel-quickstart 53, symfony-demo 52, awesome-compose 1. Vendor directories excluded. A narrow corpus, and a clean result on it.

## 12. Is this arm worth merging? The zero, explained

| repo | .php files | field entities | files declaring >1 type | …of those, with fields | edges |
|---|---|---|---|---|---|
| symfony-routing | 224 | 130 | 7 | 3 | 0 |
| laravel-routing | 60 | 119 | 0 | 0 | 0 |
| laravel-quickstart | 53 | 16 | 0 | 0 | 0 |
| symfony-demo | 52 | 66 | 1 | 0 | 0 |
| awesome-compose | 1 | 0 | 0 | 0 | 0 |
| **total** | **390** | **331** | **8** | **3** | **0** |

**PSR-4 mandates one class per file.** 8 of 390 files declare more than one addressable type, 3 of those have any field, and none of those 3 names a same-file type. So the same-file constraint — which cost arms D/F/E a slice of recall — costs PHP **essentially all of it**. This is not a corpus accident; it is the language's dominant convention.

Where the PHP prize actually is, measured with the same harness: **43 field candidates resolve to a class declared in a *different* file of the same repo** (symfony-routing 29, symfony-demo 14, and 0 in both Laravel repos, whose fields are typed with framework classes outside the tree). That is an **upper bound for a naive cross-file rule** — it ignores namespaces and `use` aliasing, so some of the 43 would be wrong bindings — and it is the number that should size a cross-file arm.

**Why I still think it should merge** (the call is the coordinator's):

1. The refusals are the durable part and they are now graded from PHP source: the `Closure` import-placeholder wrong binding is **live in the corpus today** and would be the first thing a cross-file arm walked into.
2. The enum dangle is measured and recorded, so nobody re-derives it.
3. Vocabulary parity across seven languages, with a zero-edge corpus meaning zero regression risk.
4. It becomes non-zero on the multi-declaration files that do exist, and immediately meaningful when the cross-file arm lands.

**Why it might not**: it clears **no orphan** on the corpus that motivated #6726, and a producer that adds no measured edges is code with no measured benefit. If the board's standard is measured orphan reduction, the honest answer is that **PHP needs the cross-file arm, and this is its groundwork rather than its fix.** I am not going to dress a zero up as a win.

## 13. Independent review — what it broke, and what it could not

The review re-derived the headline from its own probe and its own scanner re-implementation: `FILES=390 FIELDS=331 EDGES=0 MULTITYPE=8 MULTITYPE_WITH_FIELDS=3 CROSSFILE_CANDS=43`, every cell of §12 and the per-repo split matching, the `Closure` wrong binding reproduced as **exactly one** corpus edge, the rule-2 vacuity enumeration confirmed complete, M21's seven passes confirmed (six take `&entities` and mutate in place — the shape most able to invalidate that equivalence — and none appends a `SCOPE.Component`), and the digest fixture's 18 keys confirmed. It notes the **43 is one well-corroborated measurement, not two**: their method shares an input shape with mine.

It broke four things, all sub-behavioural, none able to change a corpus edge. All four are fixed in `f84fc8e92`:

**F1 — a fixture row the language does not permit.** `public callable $cb;` is **not legal PHP**: typed properties exclude `callable` (context-dependent) and `void`. It sat under a comment claiming every row was *"legal PHP 8.1, checked shape by shape against the grammar"* — so the comment was false as well as the row, and the version label was wrong too (`(A&B)|null` is **8.2** DNF). Replaced with `public object $obj;`, same axis. The comment now records the correction rather than quietly applying it: this is the **third** instance of this shape on the board, and the pattern is that the *claim of having checked* is what goes unchecked.

**F2 — a distinguishable, ungraded conjunct (the real find).** Pass 2's `r.Kind != "SCOPE.Component"` is **mutually masked** by the subtype allow-list: no core PHP producer mints Subtype ∈ {class, interface, trait} under any other Kind, so the two guards only ever fire together and the allow-list alone carried every refusal the suite observed — *including the enum one*, which `TestPhpFieldTypeRefs_EnumIsNotATarget` therefore grades through the allow-list, not through this conjunct. Two guards that only fire together grade neither.

The distinguishing input is `{Kind: "SCOPE.Model", Subtype: "class"}` — **exactly the future Eloquent-model producer this PR cites to justify keeping rule 2**, which is graded against that producer by direct call. Grading one and not the other was an inconsistency, not a considered scope. `TestPhpFieldTypeRefs_Unit_OnlyComponentsAreTargets` closes it, **enumerating** seven non-Component Kinds (`SCOPE.Model`, `SCOPE.View`, `SCOPE.Class`, `SCOPE.Schema`, `SCOPE.Enum`, `SCOPE.Pattern`, `SCOPE.Service`) each carrying an **admitted** subtype so the allow-list cannot be what refuses them, each with a positive control in the same input, plus the mirror direction (the same Kinds with a refused subtype) so the two guards are shown independent rather than one standing in for the other.

| # | mutant | before | after |
|---|---|---|---|
| **N1** | pass-2 `r.Kind != "SCOPE.Component"` **deleted** | ALIVE | **DEAD** — `Unit_OnlyComponentsAreTargets` |
| **N8** | same conjunct **widened to admit `SCOPE.Schema`** | ALIVE | **DEAD** — `Unit_OnlyComponentsAreTargets` |

**F3 — an axis row claiming more than its content.** The target-kind axis listed `namespace`, and §3 asserted `buildNamespace` is refused by the same allow-list, but **no test drove a field typed at a namespace root**. `imports.php` now declares `public App $ns;` under `namespace App;`, with the bare `SCOPE.Component`/`""` record asserted to exist first so the refusal is doing work. It is a *different producer* from `useImportRecord` with the same shape, which is why the import tests did not already cover it — and the no-allow-list counterfactual now shows it as a third wrong binding.

**F4 — an untested interaction already sitting in the fixture.** `models.php` declared **both** `use Ship\Thing;` and `class Ship {}` and never typed a field `Ship` — the one case where the allow-list must **admit** rather than refuse, and it binds only because `graph.EntityID` hashes `(repo, Kind, Name, SourceFile)` with **Subtype excluded**, so the two records collapse to one node instead of tripping tier 2's kind-agnostic `ambigLocation`. Nothing pinned that. `Order2.carrier` is now typed `Ship`, and `TestPhpFieldTypeRefs_ImportPlaceholderSharingAClassNameIsOneNode` asserts the two-record / one-ID premise **before** the binding assertion, so it fails at the premise if `EntityID` ever starts hashing Subtype rather than the arm quietly beginning to dangle.

Also from the review, and accepted: **N2** (`strings.EqualFold(t.name, owner)` → `==`) is genuinely **equivalent** — both derive from the same class-declaration identifier text, and the fold-collision guard already refuses the only shape that could separate them. Left as `EqualFold` because it is the correct predicate for a case-insensitive language, not because a mutant demanded it.

**Not re-verified by the review, so stated as mine alone**: the fixture aggregate (now 23 edges / 23 bound), which the reviewer explicitly did not recount.

Gates re-run after the fixes: `./internal/extractors/php/ ./internal/custom/php/ ./internal/resolve/` green; `./cmd/grafel/` green in 154s in a fresh isolated `GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT` with 0 skips; ratchet "38 gated fixtures held" with `git status --porcelain` empty afterwards (still vacuous for PHP, as stated in §10).

Refs #6912, #6726, #7038, #7044, #6451, #6976, #6369.
