### PR TITLE
feat(#6912): swift's field_type property threw the type away before an edge could use it — emit the field→type REFERENCES edge from the AST, same-file targets only

### DIFF
--- a/internal/extractors/swift/field_members.go
+++ b/internal/extractors/swift/field_members.go
@@ -38,6 +38,10 @@ func emitSwiftFieldMembers(
 
 	var fields []types.EntityRecord
 	seen := make(map[string]bool)
+	// #6912 arm G — the owner's generic parameters shadow any same-named type
+	// declared in the file. Collected here because `node` (the owning
+	// declaration) is only in hand at this site.
+	typeParams := swiftTypeParameterNames(node, src)
 
 	if body != nil {
 		for i := 0; i < int(body.ChildCount()); i++ {
@@ -56,8 +60,17 @@ func emitSwiftFieldMembers(
 			}
 			seen[name] = true
 			typ := ""
+			// #6912 arm G — `cands` is the field→declared-type edge's input, and
+			// it is deliberately NOT derived from `typ`. firstDescendantText
+			// returns the FIRST pre-order type_identifier, so `typ` is
+			// "Dictionary" for `Dictionary<String, Order>` and "Foundation" for
+			// `Foundation.Data`: the information the edge needs is already gone
+			// by the time the property is written. See field_type_refs.go's
+			// header for the probe and for what the property is left as.
+			var cands []string
 			if ta := firstChildOfType(ch, "type_annotation"); ta != nil {
 				typ = firstDescendantText(ta, src, "type_identifier")
+				cands = swiftFieldTypeCandidates(ta, src, typeParams)
 			}
 			dotted := ownerName + "." + name
 			sig := name
@@ -80,7 +93,10 @@ func emitSwiftFieldMembers(
 					"field_type":   typ,
 					"parent_class": ownerName,
 				},
-				Metadata:           map[string]interface{}{"subtype": "field", "owner": ownerName},
+				Metadata: map[string]interface{}{
+					"subtype": "field", "owner": ownerName,
+					swiftFieldTypeRefsMetaKey: cands,
+				},
 				EnrichmentRequired: false,
 			})
 		}

--- a/internal/extractors/swift/field_type_refs.go
+++ b/internal/extractors/swift/field_type_refs.go
@@ -1,0 +1,501 @@
+package swift
+
+import (
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// field_type_refs.go — the field→declared-type edge for Swift (issue #6912,
+// arm G). Arm A is internal/extractors/csharp/field_type_refs.go (#6984),
+// arm B internal/extractors/proto (#6991), arm C internal/extractors/rust
+// (#7000), arm D internal/extractors/golang (#7036), arm F
+// internal/extractors/java (#7039), arm E internal/extractors/fsharp (#7040).
+//
+// THE GAP. emitSwiftFieldMembers (#4854) mints one SCOPE.Schema/field record
+// per stored property and records the declared type ONLY as the unhashed
+// `field_type` property. Nothing links the field to the ENTITY of that type,
+// so every Swift field is a leaf on its outbound side — the population
+// contributor #6726 measures at 99.3% orphan for SCOPE.Schema. Swift fields are
+// minted as SCOPE.Schema (field_members.go), so they are IN that population,
+// not adjacent to it.
+//
+// THE TRAP THIS ARM EXISTS TO CLOSE, AND WHY THE PROPERTY IS NOT THE INPUT.
+// `field_type` is firstDescendantText(type_annotation, "type_identifier") —
+// the FIRST PRE-ORDER type_identifier under the annotation. Probed against the
+// real grammar rather than read:
+//
+//	var d: Dictionary<String, Order>   user_type[ type_identifier "Dictionary",
+//	                                              type_arguments[…"Order"…] ]
+//	                                   → field_type == "Dictionary"
+//	var j: Set<Order>                  → field_type == "Set"
+//	var k: Result<Order, MyErr>        → field_type == "Result"
+//	var c: [Order]                     array_type[ user_type "Order" ]
+//	                                   → field_type == "Order"  (by luck of order)
+//	var b: Order?                      → field_type == "Order"  (by luck of order)
+//	var h: Foundation.Data             user_type[ tid "Foundation", ".", tid "Data" ]
+//	                                   → field_type == "Foundation"
+//
+// So for every generic wrapper the argument is ALREADY GONE by the time the
+// property is written, and for a module-qualified type the property holds the
+// MODULE. Reading `field_type` and emitting an edge would ship exactly the
+// `List<Customer>` → `List` binding arm A went out of its way to forbid, and a
+// `Foundation.Data` field would bind to a same-file `struct Foundation`.
+//
+// This arm therefore takes arm C's technique — stash the candidates FROM THE
+// AST at the emit site — and not arm E's (tokenise the type string), because
+// F#'s `member_type` is the declared type verbatim and Swift's `field_type` is
+// not. `field_type` is left exactly as it is: fixing it would change entity
+// Properties and Signature for every Swift field in the graph, which is a
+// separate change with its own blast radius. Its lossiness is pinned by
+// TestSwiftFieldTypeRefs_FieldTypePropertyIsLossyForGenerics so the next reader
+// meets the trap as a failing expectation rather than as prose.
+//
+// ==========================================================================
+// THE AMBIGUITY RULE — SWIFT NEEDS BOTH SHIPPED RULES, SPLIT BY TARGET KIND
+// ==========================================================================
+//
+// The standing instruction on #6912 is: COUNT THE KINDS THAT THE RESOLVER TIER
+// WHICH RESOLVES YOUR ADDRESS ACTUALLY WEIGHS. Arm D (go) counts all kinds,
+// arm F (java) counts within the component address family, arm C (rust) counts
+// records and is wrong (#7038). Swift is the first arm where the answer is not
+// one of those three, because SWIFT EMITS TARGETS IN TWO DIFFERENT KIND SPACES
+// and the same address resolves them through two DIFFERENT tiers.
+//
+// The address is BuildComponentStructuralRef → `scope:component:class:swift:
+// <file>:<Name>`, so lookupStructural (internal/resolve/refs.go:2982) calls
+// lookupLocationKind(file, name, structuralKindFamilies("component")) =
+// componentKindFamily. Driven through the real resolver, not inferred:
+//
+//   - TARGET IS SCOPE.Component (class / struct / enum / actor / protocol).
+//     byLocationKind indexes an entity under BOTH its Kind and its SCOPE-
+//     trimmed Kind (refs.go:1207-1210), so a SCOPE.Component lands under
+//     "SCOPE.Component" AND "Component", and "Component" is in
+//     componentKindFamily. lookupLocationKind's tier-2 pass therefore MATCHES
+//     and returns before ambigLocation is ever consulted. Only a second kind
+//     THAT IS ALSO IN THAT FAMILY can make uniqueMatchInFamily see two distinct
+//     ids and fail. This is arm F's rule, and Swift needs it for the same
+//     reason java did: an `enum Status` emits a SCOPE.Component AND a
+//     SCOPE.Enum value-set of the SAME NAME IN THE SAME FILE (swift.go:116-120,
+//     types.go buildEnumValueSet). SCOPE.Enum trims to "Enum", which is in NO
+//     family, so the value-set cannot shadow the Component — and arm D's
+//     all-kinds rule would refuse EVERY Swift enum target.
+//
+//   - TARGET IS SCOPE.Schema/type_alias (`typealias Money = Double`,
+//     types.go:154-165). "SCOPE.Schema" trims to "Schema", which is NOT in
+//     componentKindFamily, so lookupLocationKind MISSES ENTIRELY and the ref
+//     falls through to the kind-agnostic pair at refs.go:3004-3012:
+//     ambigLocation first, then byLocation. ambigLocation is set whenever a
+//     (file, name) meets a SECOND DISTINCT ENTITY ID (refs.go:1301-1316) —
+//     ANY kind at all. So for an alias target the count must span every kind.
+//     This is arm D's rule, and arm F's rule applied here would emit an edge
+//     that DANGLES: `typealias Tier` beside a top-level `func Tier()` is
+//     Schema + Operation, invisible to a component-family count, and
+//     statusAmbiguous at the resolver. Graded by
+//     TestSwiftFieldTypeRefs_AliasShadowedByAnOperationWouldDangleUnderArmFsRule,
+//     which drives the real resolver rather than asserting the emit decision.
+//
+// The unit is the KIND rather than the RECORD in both halves, mirroring the
+// resolver: graph.EntityID hashes (repo, Kind, Name, SourceFile) with Subtype
+// EXCLUDED, and buildSymbolIndex marks a collision only on `existing != e.ID`
+// (refs.go:1308). Two same-file records sharing a Kind are ONE node and must
+// not be counted twice. Arm C counts records and is wrong for exactly this
+// reason (#7038) — its rule is not copied here.
+//
+// WHY NOT SIMPLY DROP type_alias TARGETS AND USE ARM F'S RULE UNCHANGED. That
+// is the arm-F counterfactual and it is a pure recall loss: arm D measured 19%
+// of Go's edges on exactly this shape after nearly inheriting arm C's
+// Component-only guard. The measured Swift figure is in the PR body. A Swift
+// typealias is a first-class nameable type and a field declared with one is
+// not a different proposition from a field declared with a struct.
+//
+// ==========================================================================
+// WHAT THIS PASS IS NOT
+// ==========================================================================
+//
+//   - SAME FILE ONLY. A field whose type is declared in another file gets
+//     nothing. Binding a bare type name across files is the #6976/#6369
+//     hazard and every arm on this issue rests on refusing it. For Swift this
+//     is the dominant miss: a Swift module is a directory of files and
+//     one-type-per-file IS the convention, so the recall ceiling here is lower
+//     than C#'s or Java's. Both directions of the same-file conjuncts are
+//     graded — a foreign-file record must not SUPPRESS an edge (pass 1) and
+//     must not BECOME one (pass 2) — because grading one is precisely what
+//     makes the other look covered.
+//
+//   - A DOTTED TYPE GETS NO EDGE AT ALL, head or tail. tree-sitter-swift gives
+//     `Foundation.Data` and `Order.Inner` and the metatype `Order.Type` one
+//     `user_type` node carrying TWO type_identifier children around an
+//     anonymous ".". Taking the tail would bind `Order.Inner` to a same-file
+//     `Inner`; taking the head would bind `Order.Type` to `Order` but also
+//     `Foundation.Data` to a same-file `Foundation`. Both are wrong bindings,
+//     and a wrong binding never reaches bug-extractor precisely because it
+//     binds. So the head-and-tail of a dotted user_type are both refused —
+//     which costs the metatype and the module-qualified same-module type, the
+//     honest price of not guessing. Type ARGUMENTS are still descended into,
+//     so `Swift.Array<Order>` yields `Order`. Pinned by
+//     TestSwiftFieldTypeRefs_DottedTypeBindsNeitherHeadNorTail.
+//
+//   - AN INFERRED TYPE GETS NOTHING. `var p = Order()` has no type_annotation;
+//     the initializer expression is not read. A computed property is not a
+//     stored member and has no field entity at all (#4854).
+//
+//   - PROPERTY-WRAPPER AND ATTRIBUTE TYPES ARE NOT CANDIDATES. `@Published var
+//     s: Order` shapes `Published` as a `user_type` under a `modifiers >
+//     attribute` sibling of the type_annotation. Candidates are collected from
+//     the type_annotation subtree ONLY, so the wrapper is out of reach by
+//     construction rather than by a name filter. Graded by
+//     TestSwiftFieldTypeRefs_PropertyWrapperTypeIsNotACandidate, which declares
+//     a same-file `struct Published` so the assertion can fail.
+//
+//   - RECORDS THIS PASS CANNOT SEE. The collision scan spans the records this
+//     extractor has built, which is every record `Extract` returns. It does NOT
+//     span the custom lane: internal/custom/swift/swiftui.go:288 mints a
+//     BARE-NAMED SCOPE.Component from an @ObservedObject/@StateObject property
+//     NAME in the same file. That kind IS in the component address family, so a
+//     property named after a same-file type would make the target ambiguous at
+//     the resolver and dangle an edge this pass believed safe. Measured
+//     incidence on the corpus is in the PR body; the invariant to preserve is
+//     that the custom lane does not mint a bare Component sharing a declared
+//     type's name, not that today's corpus happens not to.
+//
+// A NON-BINDING EDGE IS WORSE THAN NO EDGE (#6912's hard requirement): an
+// unresolved stub is kept verbatim, dangles, and is classified bug-extractor,
+// so every miss is a full hit on the disposition denominator. That is why the
+// rules above refuse rather than guess, and why
+// TestSwiftFieldTypeRefs_ResolvesToEntityIDs drives every emitted edge through
+// resolve.BuildIndex → resolve.ReferencesEmbedded and names the entity each one
+// lands on.
+
+// swiftFieldTypeRefsMetaKey is the per-field stash written by
+// emitSwiftFieldMembers and consumed — and deleted — by
+// attachSwiftFieldTypeRefs.
+//
+// The candidates cannot become edges during the walk: `struct Order { var b:
+// Customer }` may be declared BEFORE `struct Customer` in the same file, so the
+// in-file declaration set is complete only once the walk has finished, and the
+// enum value-sets the collision scan must see are appended as the walk goes.
+const swiftFieldTypeRefsMetaKey = "field_type_refs"
+
+// swiftFieldTargetRefKind is the value of the `ref_kind` edge property. It
+// matches arm A's csFieldTargetRefKind, arm B's protoFieldTargetRefKind, arm
+// C's rustFieldTargetRefKind, arm D's goFieldTargetRefKind, arm F's
+// javaFieldTargetRefKind and the custom lane's referencesClassEdge verbatim —
+// the discriminator is what makes the edge queryable as a field→declared-type
+// edge across languages, so it must be one string.
+const swiftFieldTargetRefKind = "field_target_type"
+
+// swiftComponentFamilyKeys mirrors internal/resolve's componentKindFamily
+// (refs.go:2341-2348) exactly — including the deliberate ABSENCE of
+// SCOPE.Service (#6459/#6492) and of any Schema/Enum spelling.
+var swiftComponentFamilyKeys = map[string]bool{
+	"Component": true,
+	"Class":     true,
+	"View":      true,
+	"Model":     true,
+	// The SCOPE.* spellings the family lists literally.
+	"SCOPE.Component": true,
+	"SCOPE.View":      true,
+	"SCOPE.Model":     true,
+}
+
+// swiftInComponentAddressFamily reports whether an entity of this Kind is
+// WEIGHED by lookupLocationKind under componentKindFamily.
+//
+// The trim step is not defensive padding: buildSymbolIndex indexes every entity
+// under BOTH its Kind and its SCOPE-trimmed Kind (refs.go:1207-1210), so a
+// hypothetical "SCOPE.Class" entity lands under the key "Class", which the
+// family lists. Deriving membership instead of hand-listing the spellings is
+// what keeps this in step with the resolver rather than with a snapshot of it.
+func swiftInComponentAddressFamily(kind string) bool {
+	if swiftComponentFamilyKeys[kind] {
+		return true
+	}
+	if t := strings.TrimPrefix(kind, "SCOPE."); t != kind && swiftComponentFamilyKeys[t] {
+		return true
+	}
+	return false
+}
+
+// swiftTypeParameterNames returns the names bound by a declaration's
+// `type_parameters` child — `struct Box<T>` → {"T"}.
+//
+// Arms A and D both ship a KNOWN-WRONG over-fire here: a type parameter named
+// after a same-file type binds the field to that type. Swift can refuse it for
+// free because emitSwiftFieldMembers already holds the owning declaration node,
+// so the shadowing scope is in hand at the collection site rather than needing
+// a scope tracker. Doing it is a deliberate departure from those arms and it is
+// in the direction this board keeps getting caught by — too broad, and binding,
+// so invisible. Graded by
+// TestSwiftFieldTypeRefs_TypeParameterShadowedByASameFileTypeGetsNoEdge.
+func swiftTypeParameterNames(node ts.Node, src []byte) map[string]bool {
+	if node == nil {
+		return nil
+	}
+	var out map[string]bool
+	for i := 0; i < int(node.ChildCount()); i++ {
+		tp := node.Child(i)
+		if tp == nil || tp.Type() != "type_parameters" {
+			continue
+		}
+		for j := 0; j < int(tp.ChildCount()); j++ {
+			p := tp.Child(j)
+			if p == nil || p.Type() != "type_parameter" {
+				continue
+			}
+			if n := firstDescendantText(p, src, "type_identifier"); n != "" {
+				if out == nil {
+					out = make(map[string]bool)
+				}
+				out[n] = true
+			}
+		}
+	}
+	return out
+}
+
+// swiftFieldTypeCandidates returns every bare type name written in a field's
+// type_annotation, in source order and without deduplication, minus the owner's
+// type parameters.
+//
+// Node handling, each shape confirmed against the real grammar by CST probe:
+//
+//   - `user_type` — the nominal type. When it is DOTTED (an anonymous "." child
+//     stands between two type_identifier children) neither segment is taken;
+//     see the header block. Otherwise its single direct type_identifier child is
+//     the candidate. Either way any `type_arguments` child IS descended into, so
+//     `Dictionary<String, Order>` yields String and Order and NOT Dictionary,
+//     and `Swift.Array<Order>` yields Order.
+//   - everything else recurses. That covers `optional_type` (`Order?`),
+//     `array_type` (`[Order]`), `dictionary_type` (`[String: Order]`),
+//     `tuple_type` (`(Int, Order)`), `function_type` (`(Order) -> Void`),
+//     `existential_type` (`any Shape`) and `opaque_type` (`some Shape`) with no
+//     wrapper list to keep in sync.
+//
+// A SWIFT PRIMITIVE NEEDS NO BLOCKLIST, and — as in arm D and unlike arm B — a
+// blocklist would be actively wrong. `Int`, `String` and `Bool` are ordinary
+// stdlib nominal types, not grammar keywords: the parser gives them the same
+// `user_type > type_identifier` shape as a user type. They are refused by the
+// in-file declaration check instead, which is the correct order of operations,
+// because a file that declares `struct Int` genuinely does mean THAT type in
+// field position. Both directions graded:
+// TestSwiftFieldTypeRefs_PrimitiveFieldsProduceNoEdge and
+// TestSwiftFieldTypeRefs_ShadowedStdlibNameIsATarget.
+func swiftFieldTypeCandidates(ta ts.Node, src []byte, typeParams map[string]bool) []string {
+	var out []string
+	var walkType func(n ts.Node)
+	walkType = func(n ts.Node) {
+		if n == nil {
+			return
+		}
+		if n.Type() == "user_type" {
+			dotted := false
+			for i := 0; i < int(n.ChildCount()); i++ {
+				if c := n.Child(i); c != nil && c.Type() == "." {
+					dotted = true
+					break
+				}
+			}
+			for i := 0; i < int(n.ChildCount()); i++ {
+				c := n.Child(i)
+				if c == nil {
+					continue
+				}
+				switch c.Type() {
+				case "type_identifier":
+					if dotted {
+						continue
+					}
+					name := nodeTextSwift(c, src)
+					if name != "" && !typeParams[name] {
+						out = append(out, name)
+					}
+				case "type_arguments":
+					walkType(c)
+				}
+			}
+			return
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walkType(n.Child(i))
+		}
+	}
+	walkType(ta)
+	return out
+}
+
+// nodeTextSwift returns a node's source text.
+func nodeTextSwift(n ts.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	return string(src[n.StartByte():n.EndByte()])
+}
+
+// swiftFieldTypeTarget is one in-file type declaration a field can point at:
+// the structural ToID that binds to it and the bare name for `target_type`.
+type swiftFieldTypeTarget struct {
+	toID string
+	name string
+}
+
+// swiftInFileTypeTargets indexes every type DECLARED IN THIS FILE that a
+// field-type edge may address, keyed by bare name, applying the split
+// ambiguity rule derived in the header block.
+//
+// Pass 1 builds two independent collision counts because the two admitted
+// target kinds resolve through two different resolver tiers:
+//
+//	famKinds[name]  — distinct Kinds in the COMPONENT ADDRESS FAMILY. Governs a
+//	                  SCOPE.Component target, which lookupLocationKind resolves
+//	                  before ambigLocation is consulted (arm F's rule).
+//	allKinds[name]  — distinct Kinds, full stop. Governs a SCOPE.Schema/
+//	                  type_alias target, which lookupLocationKind cannot see at
+//	                  all, so it falls through to ambigLocation (arm D's rule).
+//
+// Pass 2's allow-list is written on Swift's own emit sites rather than
+// inherited:
+//
+//	SCOPE.Component + class|struct|enum|actor|protocol → admitted
+//	SCOPE.Schema    + type_alias                       → admitted
+//
+// Everything else is refused. What that actually excludes, and how reachable
+// each is, stated as measured rather than as reassurance:
+//
+//   - SCOPE.Enum (the value-set beside every `enum`) — REACHABLE AND LOAD-
+//     BEARING. Admitting it would address the value-set with a component-space
+//     ref that the component family cannot resolve to it, so the edge would
+//     have to fall through to byLocation, where the same-named Component makes
+//     it ambiguous. It is refused as a TARGET while still being invisible to
+//     the component-family COUNT — the two halves of arm F's rule.
+//   - SCOPE.Schema/field — refused so a field never targets a field. This one
+//     is ALSO unreachable by name shape: a field record's Name is dotted
+//     (`Order.buyer`) and a candidate is a single type_identifier, which cannot
+//     contain a dot. Refused anyway, claimed as nothing more.
+//   - SCOPE.Component/module (the import carrier) — refused by subtype, and
+//     ALSO unreachable by name shape, because buildImport namespaces the
+//     carrier as `<file>::import::<module>` precisely so it cannot match a bare
+//     Swift type identifier (#492). Go had no such protection and its import
+//     placeholder was the one record its allow-list genuinely had to stop; the
+//     Swift equivalent is already stopped upstream. Pinned by
+//     TestSwiftFieldTypeRefs_ImportCarrierNameCannotCollide so a rename of the
+//     carrier surfaces here.
+//   - SCOPE.Component/file (#577) — refused by subtype; its Name is the file
+//     path.
+//   - SCOPE.Operation — refused by kind. Not reachable as a wrong TARGET (its
+//     kind is not admitted) but very much reachable as a COLLIDER: a top-level
+//     `func Tier()` is what makes a same-named typealias dangle, which is the
+//     whole reason the alias arm counts all kinds.
+func swiftInFileTypeTargets(records []types.EntityRecord, filePath string) map[string]swiftFieldTypeTarget {
+	famKinds := make(map[string]map[string]bool)
+	allKinds := make(map[string]map[string]bool)
+	for i := range records {
+		r := &records[i]
+		if r.SourceFile != filePath || r.Name == "" {
+			continue
+		}
+		if allKinds[r.Name] == nil {
+			allKinds[r.Name] = make(map[string]bool)
+		}
+		allKinds[r.Name][r.Kind] = true
+		if swiftInComponentAddressFamily(r.Kind) {
+			if famKinds[r.Name] == nil {
+				famKinds[r.Name] = make(map[string]bool)
+			}
+			famKinds[r.Name][r.Kind] = true
+		}
+	}
+
+	targets := make(map[string]swiftFieldTypeTarget)
+	for i := range records {
+		r := &records[i]
+		if r.SourceFile != filePath || r.Name == "" {
+			continue
+		}
+		switch {
+		case r.Kind == "SCOPE.Component":
+			switch r.Subtype {
+			case "class", "struct", "enum", "actor", "protocol":
+			default:
+				continue
+			}
+			// Component tier: only a rival IN THE SAME ADDRESS FAMILY can
+			// break uniqueMatchInFamily. A SCOPE.Enum value-set cannot.
+			if len(famKinds[r.Name]) > 1 {
+				continue
+			}
+		case r.Kind == "SCOPE.Schema" && r.Subtype == "type_alias":
+			// Alias tier: the component family cannot see this entity at all,
+			// so the ref falls through to ambigLocation, which counts EVERY
+			// kind. A same-named Component is included in that count, which is
+			// also what keeps a Component target from being clobbered here.
+			if len(allKinds[r.Name]) > 1 {
+				continue
+			}
+		default:
+			continue
+		}
+		targets[r.Name] = swiftFieldTypeTarget{
+			toID: extractor.BuildComponentStructuralRef("swift", filePath, r.Name),
+			name: r.Name,
+		}
+	}
+	return targets
+}
+
+// attachSwiftFieldTypeRefs appends one REFERENCES edge per (field, in-file
+// declared type) pair and clears the stash it consumed.
+//
+// FromID is left empty so graph assembly anchors the edge on the field record
+// that carries it — the Django precedent at
+// internal/extractors/python/django_relational.go:246-252, and arms B, C, D
+// and F. (Hibernate sets an explicit structural FromID because it hangs its
+// edge off its own parallel SCOPE.Component node; that is a different shape and
+// #6912's body was corrected on the point.)
+//
+// A SELF-REFERENCE IS EMITTED. `class Node { var next: Node? }` yields
+// `Node.next → Node`. Arm D suppresses the equivalent, but its reason does not
+// transfer: Go already ships a struct-anchored DEPENDS_ON that declines the
+// self case, and arm D matched it. Swift has no adjacent declared-type edge to
+// stay consistent with, and arms A and C — which likewise have none — do not
+// suppress it. The CONTAINS edge relates owner→field, not field→owner, so the
+// self edge is not a restatement of one that exists. Graded by
+// TestSwiftFieldTypeRefs_SelfReferentialFieldGetsAnEdge.
+//
+// Relationships is APPENDED to, never assigned: a Swift field record carries no
+// outbound edge today, but assigning would silently clobber one added later.
+func attachSwiftFieldTypeRefs(records []types.EntityRecord, filePath string) []types.EntityRecord {
+	targets := swiftInFileTypeTargets(records, filePath)
+	for i := range records {
+		r := &records[i]
+		if r.Metadata == nil {
+			continue
+		}
+		cands, _ := r.Metadata[swiftFieldTypeRefsMetaKey].([]string)
+		delete(r.Metadata, swiftFieldTypeRefsMetaKey)
+		if len(cands) == 0 || r.Kind != "SCOPE.Schema" || r.Subtype != "field" {
+			continue
+		}
+		fieldName := r.Properties["field_name"]
+		emitted := make(map[string]bool)
+		for _, cand := range cands {
+			t, ok := targets[cand]
+			if !ok || emitted[t.toID] {
+				continue
+			}
+			emitted[t.toID] = true
+			r.Relationships = append(r.Relationships, types.RelationshipRecord{
+				ToID: t.toID,
+				Kind: string(types.RelationshipKindReferences),
+				Properties: types.Props{
+					{K: "field_name", V: fieldName},
+					{K: "ref_kind", V: swiftFieldTargetRefKind},
+					{K: "target_type", V: t.name},
+				},
+			})
+		}
+	}
+	return records
+}

--- a/internal/extractors/swift/field_type_refs_6912_test.go
+++ b/internal/extractors/swift/field_type_refs_6912_test.go
@@ -1,0 +1,744 @@
+// Package swift_test — issue #6912 arm G: the Swift field→declared-type edge.
+//
+// AXES THESE FIXTURES VARY, and the axes they HOLD CONSTANT. Stated because the
+// dominant defect on this board is that enumerating one axis thoroughly is what
+// makes its sibling look covered.
+//
+// VARIED
+//   - TYPE-EXPRESSION SHAPE: bare, optional, implicitly-unwrapped, array,
+//     dictionary-literal, generic with one and with two arguments, nested
+//     generic, tuple, function type, existential (`any`), dotted. Each shape is
+//     asserted against ONE target name so the shape is the only moving part.
+//   - TARGET KIND: struct, class, protocol, enum (Component beside its
+//     SCOPE.Enum value-set), typealias (SCOPE.Schema). These resolve through
+//     two different resolver tiers and carry two different ambiguity rules.
+//   - COLLIDER KIND: SCOPE.Enum (must NOT suppress a Component) and
+//     SCOPE.Operation (MUST suppress an alias), each with a positive control of
+//     the same declaration form and no collider, so a passing assertion cannot
+//     mean "that target kind never works". The third collider — a second
+//     COMPONENT-FAMILY kind, which must suppress a Component — has no
+//     source-level fixture, because no Swift emit site produces one today; it is
+//     graded in field_type_refs_scope_6912_test.go instead.
+//   - OWNER DECLARATION FORM: `struct` and `class` (Node), plus a generic
+//     `struct Box<T>`.
+//
+// HELD CONSTANT
+//   - FILE OF THE RIVAL: every fixture here is single-file except
+//     ForeignFileTypeIsNeverATarget. That is a recall statement, not a grading
+//     of the same-file conjuncts — Extract sees one file at a time, so those
+//     conjuncts are unreachable from this package and are graded internally in
+//     field_type_refs_scope_6912_test.go, in both directions.
+//   - REPO: one repo id throughout. Cross-repo name collision is not modelled
+//     by this pass and is not graded here.
+//   - LANGUAGE SEGMENT of the address: always "swift".
+//   - FIELD MUTABILITY / ACCESS / PROPERTY WRAPPERS: `var` with no access
+//     modifier, except the one `@Published` case whose subject IS the wrapper.
+//     `let`, `weak`, `lazy` and access modifiers are NOT varied here: none of
+//     them reaches a decision this pass makes, since candidates come from the
+//     type_annotation subtree only — but that is an argument, and the fixtures
+//     do not demonstrate it.
+//   - NESTING: no nested type declarations. walkBody emits no entity for a type
+//     declared inside a class body, so a nested type is not a candidate target
+//     in any of these fixtures — that is a property of #4854's walk, not of
+//     this pass, and it is not graded here.
+package swift_test
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+
+	extreg "github.com/cajasmota/grafel/internal/extractor"
+)
+
+const swFTPath = "Sources/App/Models.swift"
+const swFTRivalPath = "Sources/App/Other.swift"
+
+// swFTSrc is the main fixture. Every field below is referenced by name in at
+// least one assertion.
+const swFTSrc = `import Foundation
+
+typealias Tier = Int
+
+enum Status {
+    case open
+    case closed
+}
+
+protocol Shipper {
+    func ship()
+}
+
+struct Customer {
+    var name: String
+}
+
+class Node {
+    var next: Node?
+}
+
+struct Order {
+    var buyer: Customer
+    var maybe: Customer?
+    var forced: Customer!
+    var list: [Customer]
+    var dict: Dictionary<String, Customer>
+    var short: [String: Customer]
+    var pair: (Int, Customer)
+    var fn: (Customer) -> Void
+    var res: Result<Customer, Shipper>
+    var deep: [Dictionary<String, Customer>]
+    var both: (Customer, Customer)
+    var boxed: any Shipper
+    var ship: Shipper
+    var status: Status
+    var tier: Tier
+    var count: Int
+    var label: String
+    var inferred = Customer()
+    var computed: Customer { return Customer() }
+}
+`
+
+// swFTRivalSrc declares a SECOND Customer in a different file, so the BARE name
+// `Customer` is ambiguous across the graph. Without it the structural address
+// would be ungraded in TestSwiftFieldTypeRefs_ResolvesToEntityIDs — a bare-name
+// ToID would bind just as well.
+const swFTRivalSrc = `struct Customer {
+    var id: Int
+}
+`
+
+func swFTExtract(t *testing.T, files map[string]string) []types.EntityRecord {
+	t.Helper()
+	var out []types.EntityRecord
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		out = append(out, swExtract(t, files[p], p)...)
+	}
+	return out
+}
+
+func swFTOne(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	return swExtract(t, src, swFTPath)
+}
+
+// swFTTargetsOf returns the sorted target_type values of the field-type edges
+// carried by the field entity named `<owner>.<field>`.
+func swFTTargetsOf(recs []types.EntityRecord, dotted string) []string {
+	var out []string
+	for i := range recs {
+		r := &recs[i]
+		if r.Kind != "SCOPE.Schema" || r.Subtype != "field" || r.Name != dotted {
+			continue
+		}
+		for _, rel := range r.Relationships {
+			if rel.Kind == "REFERENCES" && rel.Properties.Get("ref_kind") == "field_target_type" {
+				out = append(out, rel.Properties.Get("target_type"))
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func swFTFieldExists(t *testing.T, recs []types.EntityRecord, dotted string) {
+	t.Helper()
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" && recs[i].Name == dotted {
+			return
+		}
+	}
+	t.Fatalf("fixture premise broken: no field entity named %q — any assertion "+
+		"about its edges would pass vacuously", dotted)
+}
+
+func swFTWant(t *testing.T, recs []types.EntityRecord, dotted string, want ...string) {
+	t.Helper()
+	swFTFieldExists(t, recs, dotted)
+	got := swFTTargetsOf(recs, dotted)
+	if want == nil {
+		want = []string{}
+	}
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("%s targets = %v, want %v", dotted, got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The trap this arm exists to close.
+// ---------------------------------------------------------------------------
+
+// TestSwiftFieldTypeRefs_FieldTypePropertyIsLossyForGenerics pins the reason
+// this arm reads the AST rather than the `field_type` property, as a live
+// expectation instead of a comment. If someone later fixes firstDescendantText
+// so the property carries the whole type, this test fails and points at the
+// header block that says why the property was not the input.
+func TestSwiftFieldTypeRefs_FieldTypePropertyIsLossyForGenerics(t *testing.T) {
+	recs := swFTOne(t, swFTSrc)
+	prop := func(dotted string) string {
+		for i := range recs {
+			if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" && recs[i].Name == dotted {
+				return recs[i].Properties["field_type"]
+			}
+		}
+		t.Fatalf("no field entity %q", dotted)
+		return ""
+	}
+	for _, c := range []struct{ field, want string }{
+		{"Order.dict", "Dictionary"},
+		{"Order.res", "Result"},
+		{"Order.buyer", "Customer"},
+	} {
+		if got := prop(c.field); got != c.want {
+			t.Errorf("field_type[%s] = %q, want %q — the premise of this arm's "+
+				"design changed; re-read field_type_refs.go's header before "+
+				"editing this test", c.field, got, c.want)
+		}
+	}
+	// And the consequence: the edge is NOT to the wrapper.
+	swFTWant(t, recs, "Order.dict", "Customer")
+	swFTWant(t, recs, "Order.res", "Customer", "Shipper")
+}
+
+// ---------------------------------------------------------------------------
+// Type-expression shapes.
+// ---------------------------------------------------------------------------
+
+func TestSwiftFieldTypeRefs_TypeExpressionShapes(t *testing.T) {
+	recs := swFTOne(t, swFTSrc)
+	for _, c := range []struct {
+		field string
+		want  []string
+	}{
+		{"Order.buyer", []string{"Customer"}},
+		{"Order.maybe", []string{"Customer"}},
+		{"Order.forced", []string{"Customer"}},
+		{"Order.list", []string{"Customer"}},
+		{"Order.dict", []string{"Customer"}},
+		{"Order.short", []string{"Customer"}},
+		{"Order.pair", []string{"Customer"}},
+		{"Order.fn", []string{"Customer"}},
+		{"Order.deep", []string{"Customer"}},
+		// One target, not two: the same name twice in one type expression is
+		// one relation. Without the per-field dedupe this row is [Customer
+		// Customer] and the graph carries a duplicate edge.
+		{"Order.both", []string{"Customer"}},
+		{"Order.boxed", []string{"Shipper"}},
+		{"Order.ship", []string{"Shipper"}},
+	} {
+		swFTWant(t, recs, c.field, c.want...)
+	}
+}
+
+// TestSwiftFieldTypeRefs_InferredAndComputedProducesNothing — `var inferred =
+// Customer()` has no type_annotation and the initializer is not read; a
+// computed property is not a stored member and has no field entity at all.
+func TestSwiftFieldTypeRefs_InferredAndComputedProducesNothing(t *testing.T) {
+	recs := swFTOne(t, swFTSrc)
+	swFTWant(t, recs, "Order.inferred")
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" && recs[i].Name == "Order.computed" {
+			t.Fatal("Order.computed has a field entity — the #4854 computed-property " +
+				"exclusion changed and this test's premise with it")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Dotted types — both directions of the wrong binding.
+// ---------------------------------------------------------------------------
+
+// TestSwiftFieldTypeRefs_DottedTypeBindsNeitherHeadNorTail constructs the two
+// wrong bindings a dotted user_type invites and asserts NEITHER is made, with a
+// positive control in the same file so the assertion cannot mean "no edge is
+// ever emitted here".
+func TestSwiftFieldTypeRefs_DottedTypeBindsNeitherHeadNorTail(t *testing.T) {
+	src := `struct Foundation {
+    var v: Int
+}
+
+struct Data {
+    var v: Int
+}
+
+struct Inner {
+    var v: Int
+}
+
+struct Customer {
+    var v: Int
+}
+
+struct Order {
+    var qualified: Foundation.Data
+    var nested: Customer.Inner
+    var meta: Customer.Type
+    var generic: Foundation.Array<Customer>
+    var control: Customer
+}
+`
+	recs := swFTOne(t, src)
+	swFTWant(t, recs, "Order.qualified") // not Foundation (head), not Data (tail)
+	swFTWant(t, recs, "Order.nested")    // not Customer (head), not Inner (tail)
+	swFTWant(t, recs, "Order.meta")      // metatype: the documented price
+	// Type ARGUMENTS are still descended into even under a dotted head.
+	swFTWant(t, recs, "Order.generic", "Customer")
+	// Positive control: the same file, the same target name, undotted.
+	swFTWant(t, recs, "Order.control", "Customer")
+}
+
+// ---------------------------------------------------------------------------
+// Primitives / stdlib names, both directions.
+// ---------------------------------------------------------------------------
+
+func TestSwiftFieldTypeRefs_PrimitiveFieldsProduceNoEdge(t *testing.T) {
+	recs := swFTOne(t, swFTSrc)
+	swFTWant(t, recs, "Order.count")
+	swFTWant(t, recs, "Order.label")
+}
+
+// TestSwiftFieldTypeRefs_ShadowedStdlibNameIsATarget is the other direction: a
+// file that DECLARES `struct Int` means that type in field position, and a
+// primitive blocklist would refuse the one edge that should exist. This is the
+// case that makes the absence of a blocklist a decision rather than an
+// omission.
+func TestSwiftFieldTypeRefs_ShadowedStdlibNameIsATarget(t *testing.T) {
+	src := `struct Int {
+    var v: Bool
+}
+
+struct Order {
+    var n: Int
+}
+`
+	recs := swFTOne(t, src)
+	swFTWant(t, recs, "Order.n", "Int")
+}
+
+// ---------------------------------------------------------------------------
+// The two ambiguity tiers — each with a positive control.
+// ---------------------------------------------------------------------------
+
+// TestSwiftFieldTypeRefs_EnumValueSetDoesNotSuppressItsComponent is arm F's
+// rule for Swift. `enum Status` emits a SCOPE.Component AND a same-named
+// SCOPE.Enum value-set in the SAME FILE. SCOPE.Enum trims to "Enum", which is
+// in no kind family, so lookupLocationKind resolves the Component before
+// ambigLocation is consulted — and arm D's all-kinds rule would refuse EVERY
+// Swift enum target.
+//
+// The two-record premise is asserted FIRST so the test cannot pass because the
+// value-set stopped being emitted.
+func TestSwiftFieldTypeRefs_EnumValueSetDoesNotSuppressItsComponent(t *testing.T) {
+	recs := swFTOne(t, swFTSrc)
+	var comp, vset int
+	for i := range recs {
+		if recs[i].Name != "Status" || recs[i].SourceFile != swFTPath {
+			continue
+		}
+		switch recs[i].Kind {
+		case "SCOPE.Component":
+			comp++
+		case "SCOPE.Enum":
+			vset++
+		}
+	}
+	if comp != 1 || vset != 1 {
+		t.Fatalf("premise broken: Status has %d SCOPE.Component and %d SCOPE.Enum "+
+			"records in %s; this test only grades the rule when BOTH exist",
+			comp, vset, swFTPath)
+	}
+	swFTWant(t, recs, "Order.status", "Status")
+}
+
+// The suppression half of the component tier — a rival that IS in the component
+// address family must suppress — has no source-level fixture: no Swift emit site
+// produces a second component-family kind for one name in one file today, and
+// writing Swift that "would" is fabricating an example. It is graded at the
+// function level instead, in
+// TestSwiftFieldTypeRefs_TheTwoCollisionScansAreIndependent
+// (field_type_refs_scope_6912_test.go), which also pins that the two scans
+// suppress DIFFERENT things.
+
+// TestSwiftFieldTypeRefs_AliasShadowedByAnOperationWouldDangleUnderArmFsRule is
+// the alias tier, and it grades the DEVIATION rather than the agreement: a
+// top-level `func Tier()` beside `typealias Tier` is Schema + Operation. Neither
+// is in the component address family, so arm F's component-scoped count sees
+// ONE kind and would admit the target — and the edge would then dangle, because
+// an alias target is resolved by the kind-agnostic ambigLocation/byLocation
+// pair, which counts every kind.
+//
+// The dangle is not asserted from the emit decision; the real resolver is
+// driven and asked whether such an address binds.
+func TestSwiftFieldTypeRefs_AliasShadowedByAnOperationWouldDangleUnderArmFsRule(t *testing.T) {
+	src := `typealias Tier = Int
+
+func Tier() {
+}
+
+typealias Grade = Int
+
+struct Order {
+    var t: Tier
+    var g: Grade
+}
+`
+	recs := swFTOne(t, src)
+
+	// Premise: both kinds really are emitted for Tier, and only one for Grade.
+	kinds := map[string]map[string]bool{}
+	for i := range recs {
+		if recs[i].SourceFile != swFTPath || recs[i].Name == "" {
+			continue
+		}
+		if kinds[recs[i].Name] == nil {
+			kinds[recs[i].Name] = map[string]bool{}
+		}
+		kinds[recs[i].Name][recs[i].Kind] = true
+	}
+	if len(kinds["Tier"]) != 2 {
+		t.Fatalf("premise broken: Tier carries kinds %v, want exactly two "+
+			"(SCOPE.Schema + SCOPE.Operation)", kinds["Tier"])
+	}
+	if len(kinds["Grade"]) != 1 {
+		t.Fatalf("premise broken: Grade carries kinds %v, want exactly one", kinds["Grade"])
+	}
+	// Neither collider kind is in the component address family — which is
+	// exactly why arm F's rule would not see this collision.
+	for k := range kinds["Tier"] {
+		if k == "SCOPE.Component" {
+			t.Fatalf("premise broken: %q is a component-family kind, so this "+
+				"collision IS visible to arm F's rule and the test grades nothing", k)
+		}
+	}
+
+	swFTWant(t, recs, "Order.t")          // refused
+	swFTWant(t, recs, "Order.g", "Grade") // positive control: same form, no collider
+
+	// And the reason: the address arm F's rule would have emitted does not bind.
+	for i := range recs {
+		if recs[i].ID == "" {
+			recs[i].ID = graph.EntityID("issue6912", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+		}
+	}
+	idx := resolve.BuildIndex(recs)
+	probe := []types.EntityRecord{{
+		ID: "probe", Kind: "SCOPE.Schema", Subtype: "field", Name: "Probe.t",
+		SourceFile: swFTPath,
+		Relationships: []types.RelationshipRecord{
+			{FromID: "probe", ToID: extreg.BuildComponentStructuralRef("swift", swFTPath, "Tier"), Kind: "REFERENCES"},
+			{FromID: "probe", ToID: extreg.BuildComponentStructuralRef("swift", swFTPath, "Grade"), Kind: "REFERENCES"},
+		},
+	}}
+	resolve.ReferencesEmbedded(probe, idx)
+	ids := map[string]bool{}
+	for i := range recs {
+		ids[recs[i].ID] = true
+	}
+	if ids[probe[0].Relationships[0].ToID] {
+		t.Errorf("the shadowed alias address BOUND to %q — arm F's rule would not "+
+			"have dangled here and this arm's alias tier is unmotivated; re-derive "+
+			"before deleting it", probe[0].Relationships[0].ToID)
+	}
+	if !ids[probe[0].Relationships[1].ToID] {
+		t.Errorf("the UNSHADOWED alias address did not bind (%q) — the negative "+
+			"result above is then about aliases in general, not about the collision",
+			probe[0].Relationships[1].ToID)
+	}
+}
+
+// TestSwiftFieldTypeRefs_UnshadowedAliasIsATarget — the recall half of the
+// alias tier, on the main fixture. Arm F's Component-only allow-list would drop
+// this edge entirely; arm D measured that shape at 19% of Go's edges.
+func TestSwiftFieldTypeRefs_UnshadowedAliasIsATarget(t *testing.T) {
+	recs := swFTOne(t, swFTSrc)
+	swFTWant(t, recs, "Order.tier", "Tier")
+}
+
+// ---------------------------------------------------------------------------
+// The two same-file conjuncts, in OPPOSITE failure directions.
+// ---------------------------------------------------------------------------
+
+// The two SourceFile conjuncts themselves are graded in
+// field_type_refs_scope_6912_test.go, an INTERNAL test: Extract is called once
+// per file, so from out here neither conjunct can ever fire and a mutant that
+// deletes either survives this whole file. What IS graded here is the
+// end-to-end recall statement that follows.
+//
+// TestSwiftFieldTypeRefs_ForeignFileTypeIsNeverATarget — a type declared only in
+// another file yields nothing, with a same-file control in the same fixture.
+// This is the honest floor of a same-file rule, asserted rather than described.
+func TestSwiftFieldTypeRefs_ForeignFileTypeIsNeverATarget(t *testing.T) {
+	src := `struct Order {
+    var buyer: Customer
+    var ship: Shipper
+}
+
+protocol Shipper {
+    func ship()
+}
+`
+	recs := swFTExtract(t, map[string]string{
+		swFTPath:      src,
+		swFTRivalPath: swFTRivalSrc, // declares Customer, other file
+	})
+	swFTWant(t, recs, "Order.buyer")           // cross-file: nothing
+	swFTWant(t, recs, "Order.ship", "Shipper") // same-file control
+}
+
+// ---------------------------------------------------------------------------
+// Scoping, shadowing and the records that must never be targets.
+// ---------------------------------------------------------------------------
+
+// TestSwiftFieldTypeRefs_TypeParameterShadowedByASameFileTypeGetsNoEdge — arms
+// A and D both ship this as a KNOWN-WRONG over-fire. Swift refuses it, because
+// the owning declaration node is already in hand at the collection site.
+func TestSwiftFieldTypeRefs_TypeParameterShadowedByASameFileTypeGetsNoEdge(t *testing.T) {
+	src := `struct T {
+    var v: Int
+}
+
+struct Customer {
+    var v: Int
+}
+
+struct Box<T> {
+    var item: T
+    var owner: Customer
+}
+`
+	recs := swFTOne(t, src)
+	swFTWant(t, recs, "Box.item")              // T is the parameter, not the struct
+	swFTWant(t, recs, "Box.owner", "Customer") // control: same owner, real type
+}
+
+// TestSwiftFieldTypeRefs_PropertyWrapperTypeIsNotACandidate — `@Published var s:
+// Customer` shapes `Published` as a user_type under a modifiers>attribute
+// sibling of the type_annotation. A same-file `struct Published` is declared so
+// the assertion can actually fail if candidates were collected from the whole
+// property_declaration.
+func TestSwiftFieldTypeRefs_PropertyWrapperTypeIsNotACandidate(t *testing.T) {
+	src := `struct Published {
+    var v: Int
+}
+
+struct Customer {
+    var v: Int
+}
+
+class Model {
+    @Published var s: Customer
+}
+`
+	recs := swFTOne(t, src)
+	swFTWant(t, recs, "Model.s", "Customer")
+}
+
+// TestSwiftFieldTypeRefs_ImportCarrierNameCannotCollide pins the upstream
+// protection this pass RELIES on rather than re-implements: buildImport
+// namespaces the carrier as `<file>::import::<module>` (#492), so it cannot
+// equal a bare type_identifier. Go's import placeholder carried a bare name and
+// was the one record its allow-list genuinely had to stop; if this namespacing
+// is ever removed, this test is where it surfaces.
+func TestSwiftFieldTypeRefs_ImportCarrierNameCannotCollide(t *testing.T) {
+	src := `import Customer
+
+struct Order {
+    var c: Customer
+}
+`
+	recs := swFTOne(t, src)
+	saw := false
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Subtype == "module" {
+			saw = true
+			if !strings.Contains(recs[i].Name, "::import::") {
+				t.Errorf("import carrier Name = %q — it no longer carries the #492 "+
+					"namespacing, so a bare `import Foo` can now collide with a "+
+					"same-file `struct Foo` and this pass needs an explicit guard",
+					recs[i].Name)
+			}
+		}
+	}
+	if !saw {
+		t.Fatal("premise broken: no import carrier entity emitted")
+	}
+	// `Customer` is imported and NOT declared here, so no edge.
+	swFTWant(t, recs, "Order.c")
+}
+
+// TestSwiftFieldTypeRefs_SelfReferentialFieldGetsAnEdge — the deliberate
+// departure from arm D, which suppresses the self case only because Go ships an
+// adjacent struct-anchored DEPENDS_ON that declines it. Swift has no such edge;
+// arms A and C, which likewise have none, emit it.
+func TestSwiftFieldTypeRefs_SelfReferentialFieldGetsAnEdge(t *testing.T) {
+	recs := swFTOne(t, swFTSrc)
+	swFTWant(t, recs, "Node.next", "Node")
+}
+
+// TestSwiftFieldTypeRefs_ExtensionBesideItsTypeIsStillOneNode is the SOURCE-LEVEL
+// form of #7038's direction, and it is not a contrived shape: `extension Foo`
+// beside `struct Foo` is ordinary Swift, and it is what the corpus measurement
+// found. The walk emits a SECOND SCOPE.Component for the extension (subtype
+// defaults to "class"), so the name carries TWO RECORDS and ONE graph node —
+// EntityID hashes (repo, Kind, Name, SourceFile) with Subtype excluded.
+//
+// Arm C's record-counting rule would refuse the target here. Measured on the
+// corpus that is 5 of 38 edges (13.2%), every one of them an extension in the
+// declaring file. The two-record premise is asserted FIRST so the test cannot
+// pass because the extension stopped producing a record.
+func TestSwiftFieldTypeRefs_ExtensionBesideItsTypeIsStillOneNode(t *testing.T) {
+	src := `struct Customer {
+    var name: String
+}
+
+extension Customer {
+    static let empty = Customer(name: "")
+}
+
+struct Order {
+    var buyer: Customer
+}
+`
+	recs := swFTOne(t, src)
+	records, kinds := 0, map[string]bool{}
+	for i := range recs {
+		if recs[i].Name == "Customer" && recs[i].SourceFile == swFTPath {
+			records++
+			kinds[recs[i].Kind] = true
+		}
+	}
+	if records < 2 || len(kinds) != 1 {
+		t.Fatalf("premise broken: Customer has %d records across kinds %v; this "+
+			"test only grades the record-vs-kind distinction when there are two "+
+			"records under ONE kind", records, kinds)
+	}
+	swFTWant(t, recs, "Order.buyer", "Customer")
+}
+
+// TestSwiftFieldTypeRefs_StashIsClearedFromMetadata — the candidate stash is an
+// internal handoff between the walk and the attach pass. Leaving it on the
+// record would ship extractor scratch state into the graph as entity metadata.
+func TestSwiftFieldTypeRefs_StashIsClearedFromMetadata(t *testing.T) {
+	recs := swFTOne(t, swFTSrc)
+	saw := false
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Schema" && recs[i].Subtype == "field" {
+			saw = true
+		}
+		if recs[i].Metadata == nil {
+			continue
+		}
+		if v, ok := recs[i].Metadata["field_type_refs"]; ok {
+			t.Errorf("%s still carries the field_type_refs stash: %v", recs[i].Name, v)
+		}
+	}
+	if !saw {
+		t.Fatal("no field records in fixture — the absence of a stash is vacuous")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The whole thing, through the real resolver.
+// ---------------------------------------------------------------------------
+
+// TestSwiftFieldTypeRefs_ResolvesToEntityIDs drives every emitted edge through
+// resolve.BuildIndex → resolve.ReferencesEmbedded and asserts EACH ONE BINDS,
+// naming the entity it lands on. #6912's hard requirement is that a non-binding
+// edge is worse than no edge: a dangling stub is kept verbatim and classified
+// bug-extractor, so a mis-addressed edge is a full hit on the disposition
+// denominator.
+//
+// The rival file is indexed too, so the BARE name `Customer` is ambiguous
+// across the graph — asserted explicitly, because if it were not, a bare-name
+// ToID would pass here and the structural address would be ungraded.
+func TestSwiftFieldTypeRefs_ResolvesToEntityIDs(t *testing.T) {
+	recs := swFTExtract(t, map[string]string{
+		swFTPath:      swFTSrc,
+		swFTRivalPath: swFTRivalSrc,
+	})
+	for i := range recs {
+		if recs[i].ID == "" {
+			recs[i].ID = graph.EntityID("issue6912", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+		}
+	}
+	idx := resolve.BuildIndex(recs)
+
+	before := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "REFERENCES" && r.Properties.Get("ref_kind") == "field_target_type" {
+				before++
+			}
+		}
+	}
+	if before == 0 {
+		t.Fatal("no field-type edges to drive through the resolver")
+	}
+
+	if _, st := idx.LookupStatusHint("Customer", "REFERENCES"); st == 1 {
+		t.Fatalf("the bare name %q binds in this fixture, so the ambiguity this "+
+			"test controls for is absent and the structural address is ungraded",
+			"Customer")
+	}
+
+	idToName := map[string]string{}
+	for i := range recs {
+		idToName[recs[i].ID] = recs[i].SourceFile + ":" + recs[i].Kind + "/" +
+			recs[i].Subtype + ":" + recs[i].Name
+	}
+
+	resolve.ReferencesEmbedded(recs, idx)
+
+	var bound []string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "REFERENCES" || r.Properties.Get("ref_kind") != "field_target_type" {
+				continue
+			}
+			name, ok := idToName[r.ToID]
+			if !ok {
+				t.Errorf("%s:%s -[REFERENCES]-> %q did NOT bind to an entity id "+
+					"(dangling stub → bug-extractor)", recs[i].SourceFile, recs[i].Name, r.ToID)
+				continue
+			}
+			bound = append(bound, recs[i].Name+" => "+name)
+		}
+	}
+	sort.Strings(bound)
+
+	const m = swFTPath + ":"
+	want := []string{
+		"Node.next => " + m + "SCOPE.Component/class:Node",
+		"Order.both => " + m + "SCOPE.Component/struct:Customer",
+		"Order.boxed => " + m + "SCOPE.Component/protocol:Shipper",
+		"Order.buyer => " + m + "SCOPE.Component/struct:Customer",
+		"Order.deep => " + m + "SCOPE.Component/struct:Customer",
+		"Order.dict => " + m + "SCOPE.Component/struct:Customer",
+		"Order.fn => " + m + "SCOPE.Component/struct:Customer",
+		"Order.forced => " + m + "SCOPE.Component/struct:Customer",
+		"Order.list => " + m + "SCOPE.Component/struct:Customer",
+		"Order.maybe => " + m + "SCOPE.Component/struct:Customer",
+		"Order.pair => " + m + "SCOPE.Component/struct:Customer",
+		"Order.res => " + m + "SCOPE.Component/protocol:Shipper",
+		"Order.res => " + m + "SCOPE.Component/struct:Customer",
+		"Order.ship => " + m + "SCOPE.Component/protocol:Shipper",
+		"Order.short => " + m + "SCOPE.Component/struct:Customer",
+		"Order.status => " + m + "SCOPE.Component/enum:Status",
+		"Order.tier => " + m + "SCOPE.Schema/type_alias:Tier",
+	}
+	sort.Strings(want)
+	if strings.Join(bound, "\n") != strings.Join(want, "\n") {
+		t.Errorf("bound edges:\n%s\nwant:\n%s", strings.Join(bound, "\n"), strings.Join(want, "\n"))
+	}
+}

--- a/internal/extractors/swift/field_type_refs_scope_6912_test.go
+++ b/internal/extractors/swift/field_type_refs_scope_6912_test.go
@@ -1,0 +1,283 @@
+package swift
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6912 arm G — an INTERNAL test, and it exists for one reason: the
+// `r.SourceFile != filePath` conjuncts in swiftInFileTypeTargets cannot be
+// reached through Extract.
+//
+// Extract is called once per file and every record it builds carries that
+// file's path, so from the outside neither conjunct ever fires and a mutant
+// that deletes either survives the entire external suite. That is the "alive
+// but unreachable" verdict — and the cheap answer to it is to call the function
+// directly with the input the guard exists for, rather than to leave a conjunct
+// ungraded and call it too expensive. The whole cost is this file.
+//
+// The two conjuncts fail in OPPOSITE directions and each needs its own row:
+//
+//	PASS 1 (the collision scans) — a foreign-file record sharing a same-file
+//	  type's name must not SUPPRESS an edge that is perfectly unambiguous here.
+//	PASS 2 (the target scan) — a foreign-file type declaration must not BECOME
+//	  a target for this file.
+//
+// Grading one is exactly what makes the other look covered: the pass-2 rows
+// below share no name with Models.swift, so a leak in pass 1 changes nothing
+// about them; the pass-1 rows share a name but are not themselves admissible
+// targets, so a leak in pass 2 changes nothing about them.
+//
+// The hazard is not hypothetical: attachSwiftExtends next door already takes a
+// records slice and — unlike this pass — does NOT filter by file, so a future
+// caller that batches files would silently start binding a field in one file to
+// a same-named type in another. That is the cross-file hazard #6976/#6369 are
+// about, and the same-file rule is this arm's central promise.
+func TestSwiftFieldTypeRefs_TargetsAreScopedToTheRequestedFile(t *testing.T) {
+	const a = "Sources/App/Models.swift"
+	const b = "Sources/App/Other.swift"
+
+	records := []types.EntityRecord{
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "struct", SourceFile: a},
+		{Name: "Order", Kind: "SCOPE.Component", Subtype: "struct", SourceFile: a},
+		{Name: "Tier", Kind: "SCOPE.Schema", Subtype: "type_alias", SourceFile: a},
+
+		// --- pass 2 rows: same shape, other file. Neither may become a target
+		// for `a` merely because some other file declares it.
+		{Name: "Shipper", Kind: "SCOPE.Component", Subtype: "protocol", SourceFile: b},
+		{Name: "Meters", Kind: "SCOPE.Schema", Subtype: "type_alias", SourceFile: b},
+
+		// --- pass 1 rows: DIFFERENT-KINDED records in `b` sharing a name with
+		// an `a` declaration. These grade the collision scans, which the rows
+		// above cannot. With the conjunct removed:
+		//   famKinds["Customer"] gains SCOPE.View — a component-family kind —
+		//   and wrongly suppresses `a`'s unambiguous Customer;
+		//   allKinds["Tier"] gains SCOPE.Operation and wrongly suppresses `a`'s
+		//   unambiguous alias.
+		// The two scans are separate maps with separate conjuncts, so both are
+		// graded rather than one being paid for and its twin left open.
+		{Name: "Customer", Kind: "SCOPE.View", Subtype: "class", SourceFile: b},
+		{Name: "Tier", Kind: "SCOPE.Operation", Subtype: "function", SourceFile: b},
+	}
+
+	got := swiftInFileTypeTargets(records, a)
+
+	want := map[string]string{
+		"Customer": "scope:component:class:swift:" + a + ":Customer",
+		"Order":    "scope:component:class:swift:" + a + ":Order",
+		"Tier":     "scope:component:class:swift:" + a + ":Tier",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("target set has %d entries %v, want %d %v",
+			len(got), swKeysOf(got), len(want), want)
+	}
+	for name, toID := range want {
+		tgt, ok := got[name]
+		if !ok {
+			t.Fatalf("%q missing from %s's target set %v", name, a, swKeysOf(got))
+		}
+		if tgt.toID != toID {
+			t.Errorf("%q toID = %q, want %q", name, tgt.toID, toID)
+		}
+	}
+	for _, foreign := range []string{"Shipper", "Meters"} {
+		if _, ok := got[foreign]; ok {
+			t.Errorf("%q is declared in %s and must NOT be a target for %s — "+
+				"the same-file rule is this arm's central promise", foreign, b, a)
+		}
+	}
+
+	// The mirror direction, so the assertions above are not simply "b's records
+	// were ignored entirely": asking for b returns b's declarations and none of
+	// a's.
+	gotB := swiftInFileTypeTargets(records, b)
+	if _, ok := gotB["Shipper"]; !ok {
+		t.Fatalf("%s's own target set %v is missing Shipper — the assertions "+
+			"above would pass even if the function returned nothing", b, swKeysOf(gotB))
+	}
+	if _, ok := gotB["Customer"]; ok {
+		t.Errorf("Customer must not be a target for %s: a's is cross-file and "+
+			"b's own is a SCOPE.View, which is not an admitted type declaration", b)
+	}
+}
+
+// TestSwiftFieldTypeRefs_TheTwoCollisionScansAreIndependent — the positive
+// controls for the suppression direction. Each collider is placed in the SAME
+// file so the conjunct is out of the way, and each is asserted to suppress ONLY
+// the tier it belongs to. Without this pair, TestSwiftFieldTypeRefs_...Scoped
+// above is also satisfied by collision scans that never suppress anything.
+func TestSwiftFieldTypeRefs_TheTwoCollisionScansAreIndependent(t *testing.T) {
+	const a = "Sources/App/Models.swift"
+
+	// A component-family collider suppresses the Component and leaves the alias.
+	comp := []types.EntityRecord{
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "struct", SourceFile: a},
+		{Name: "Customer", Kind: "SCOPE.View", Subtype: "class", SourceFile: a},
+		{Name: "Tier", Kind: "SCOPE.Schema", Subtype: "type_alias", SourceFile: a},
+	}
+	got := swiftInFileTypeTargets(comp, a)
+	if _, ok := got["Customer"]; ok {
+		t.Error("a same-file SCOPE.View did not suppress the SCOPE.Component target — " +
+			"the component-family collision rule is not firing")
+	}
+	if _, ok := got["Tier"]; !ok {
+		t.Error("the alias was suppressed by a collider that does not touch it")
+	}
+
+	// A NON-family collider suppresses the alias and leaves the Component. This
+	// is the whole reason the two scans are separate: SCOPE.Enum and
+	// SCOPE.Operation are invisible to the component family, and an alias is
+	// invisible to it too, so an alias must be counted against every kind.
+	alias := []types.EntityRecord{
+		{Name: "Status", Kind: "SCOPE.Component", Subtype: "enum", SourceFile: a},
+		{Name: "Status", Kind: "SCOPE.Enum", Subtype: "enum", SourceFile: a},
+		{Name: "Tier", Kind: "SCOPE.Schema", Subtype: "type_alias", SourceFile: a},
+		{Name: "Tier", Kind: "SCOPE.Operation", Subtype: "function", SourceFile: a},
+	}
+	got = swiftInFileTypeTargets(alias, a)
+	if _, ok := got["Status"]; !ok {
+		t.Error("a SCOPE.Enum value-set suppressed its own SCOPE.Component — that is " +
+			"arm D's all-kinds rule leaking into the component tier, and it would " +
+			"refuse EVERY Swift enum target")
+	}
+	if _, ok := got["Tier"]; ok {
+		t.Error("a same-file SCOPE.Operation did not suppress the alias target — that " +
+			"is arm F's component-scoped rule leaking into the alias tier, and the " +
+			"edge it admits dangles at the resolver")
+	}
+}
+
+// TestSwiftFieldTypeRefs_TwoRecordsOneKindAreOneNodeUnit — the unit of the count is
+// the KIND, not the record, because graph.EntityID hashes
+// (repo, Kind, Name, SourceFile) with Subtype EXCLUDED and buildSymbolIndex
+// marks a collision only on `existing != e.ID` (internal/resolve/refs.go:1308).
+// Two same-file records sharing a Kind are ONE graph node and must not suppress
+// each other. Arm C counts records and is wrong for exactly this reason
+// (#7038); its rule is not copied here, and this row is what would fail if it
+// were.
+func TestSwiftFieldTypeRefs_TwoRecordsOneKindAreOneNodeUnit(t *testing.T) {
+	const a = "Sources/App/Models.swift"
+	records := []types.EntityRecord{
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "struct", SourceFile: a},
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "class", SourceFile: a},
+	}
+	if _, ok := swiftInFileTypeTargets(records, a)["Customer"]; !ok {
+		t.Error("two SCOPE.Component records with one name were counted as two nodes — " +
+			"they share an entity ID, so the resolver sees one and this refusal " +
+			"deletes a legitimate edge")
+	}
+
+	// The SAME contract on the ALIAS branch, which counts a different map. The
+	// component branch's version above is reachable from Swift source
+	// (TestSwiftFieldTypeRefs_ExtensionBesideItsTypeIsStillOneNode); this one is
+	// not — the only Swift that produces two SCOPE.Schema records under one name
+	// in one file is a duplicate `typealias`, which swiftc rejects. It is graded
+	// anyway because the two maps are two pieces of code and "the component one
+	// is right" says nothing about the alias one: a record-counting alias scan
+	// survives every other test in this package.
+	alias := []types.EntityRecord{
+		{Name: "Tier", Kind: "SCOPE.Schema", Subtype: "type_alias", SourceFile: a},
+		{Name: "Tier", Kind: "SCOPE.Schema", Subtype: "field", SourceFile: a},
+	}
+	if _, ok := swiftInFileTypeTargets(alias, a)["Tier"]; !ok {
+		t.Error("two SCOPE.Schema records with one name were counted as two nodes on " +
+			"the alias branch — EntityID excludes Subtype, so the resolver sees one")
+	}
+}
+
+// TestSwiftFieldTypeRefs_OnlyFieldRecordsCarryTheEdge — the attach pass anchors
+// on SCOPE.Schema/field records and on nothing else. That is the whole point of
+// the arm: #6726 counts the FIELD as the orphan, and an edge hung off the owner
+// (arm B found protobuf already doing exactly that) leaves the orphan rate
+// where it was.
+//
+// Not reachable from Swift source today — only emitSwiftFieldMembers writes the
+// stash, and only onto field records — so it is stated as a function-level
+// contract, which is also what makes the guard graded rather than argued.
+func TestSwiftFieldTypeRefs_OnlyFieldRecordsCarryTheEdge(t *testing.T) {
+	const a = "Sources/App/Models.swift"
+	stash := func() map[string]interface{} {
+		return map[string]interface{}{swiftFieldTypeRefsMetaKey: []string{"Customer"}}
+	}
+	records := []types.EntityRecord{
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "struct", SourceFile: a},
+		{Name: "Impostor", Kind: "SCOPE.Component", Subtype: "class", SourceFile: a, Metadata: stash()},
+		{Name: "Order.buyer", Kind: "SCOPE.Schema", Subtype: "field", SourceFile: a, Metadata: stash()},
+	}
+	out := attachSwiftFieldTypeRefs(records, a)
+	count := func(name string) int {
+		n := 0
+		for i := range out {
+			if out[i].Name != name {
+				continue
+			}
+			for _, r := range out[i].Relationships {
+				if r.Kind == "REFERENCES" && r.Properties.Get("ref_kind") == swiftFieldTargetRefKind {
+					n++
+				}
+			}
+		}
+		return n
+	}
+	if got := count("Order.buyer"); got != 1 {
+		t.Fatalf("the field record got %d field-type edges, want 1 — the positive "+
+			"control is broken and the assertion below is vacuous", got)
+	}
+	if got := count("Impostor"); got != 0 {
+		t.Errorf("a SCOPE.Component carrying the stash got %d field-type edges; this "+
+			"pass must anchor on the field record only", got)
+	}
+}
+
+// TestSwiftFieldTypeRefs_AllowListRefusesNonTypeComponents grades the SUBTYPE
+// allow-list rather than arguing it is belt-and-braces — the mistake arm D
+// recorded and then corrected.
+//
+// The honest status of each row, because they are not equal:
+//
+//   - `module` (the import carrier) — this is Go's import-placeholder case, the
+//     one record whose bare name genuinely reaches the target set there. In
+//     Swift it is ALSO blocked upstream: buildImport namespaces the carrier as
+//     `<file>::import::<module>` (#492), so today's extractor cannot hand this
+//     function a bare-named module record. The row is written with a BARE name
+//     anyway, because that is the input the allow-list exists for and because
+//     the upstream namespacing is a separate decision that could be revisited
+//     (TestSwiftFieldTypeRefs_ImportCarrierNameCannotCollide watches it).
+//   - `file` (#577) — its Name is the file path, so it is additionally
+//     unreachable by name shape. Claimed as nothing more than a refusal.
+//   - `swiftpm_target` (package.go) — emitted by the SEPARATE swift_package
+//     extractor, so it is never in this extractor's record slice. Refused here
+//     as well, so a future merge of the two record streams cannot silently make
+//     a SwiftPM target name a field-type target.
+//
+// A positive control shares the fixture so a passing run cannot mean the
+// function returns nothing.
+func TestSwiftFieldTypeRefs_AllowListRefusesNonTypeComponents(t *testing.T) {
+	const a = "Sources/App/Models.swift"
+	records := []types.EntityRecord{
+		{Name: "Customer", Kind: "SCOPE.Component", Subtype: "struct", SourceFile: a},
+		{Name: "Logging", Kind: "SCOPE.Component", Subtype: "module", SourceFile: a},
+		{Name: "AppTarget", Kind: "SCOPE.Component", Subtype: "swiftpm_target", SourceFile: a},
+		{Name: a, Kind: "SCOPE.Component", Subtype: "file", SourceFile: a},
+	}
+	got := swiftInFileTypeTargets(records, a)
+	if _, ok := got["Customer"]; !ok {
+		t.Fatalf("the positive control is missing from %v — every assertion below "+
+			"would pass on a function that returns nothing", swKeysOf(got))
+	}
+	for _, n := range []string{"Logging", "AppTarget", a} {
+		if _, ok := got[n]; ok {
+			t.Errorf("%q was admitted as a field-type target; the subtype allow-list "+
+				"is not filtering", n)
+		}
+	}
+}
+
+func swKeysOf(m map[string]swiftFieldTypeTarget) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/extractors/swift/swift.go
+++ b/internal/extractors/swift/swift.go
@@ -68,6 +68,10 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	walkNode(file.TSTree.RootNode(), file, &entities)
 	// Issue #4854 — in-file base-class EXTENDS for field-membership recursion.
 	entities = attachSwiftExtends(entities)
+	// Issue #6912 arm G — field → declared-type REFERENCES, same-file targets
+	// only. Runs after the walk because the in-file declaration set (and the
+	// enum value-sets the collision scan must see) is complete only then.
+	entities = attachSwiftFieldTypeRefs(entities, file.Path)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "swift")
 	extractor.TagEntitiesLanguage(entities, "swift")


### PR DESCRIPTION
Arm G of #6912. Six arms shipped before this one: A=C# (#6984), B=proto (#6991), C=rust (#7000), D=go (#7036), F=java (#7039), E=fsharp (#7040).

Swift fields are minted as `SCOPE.Schema` (`internal/extractors/swift/field_members.go`), so they are **in** the population contributor #6726 measures at 99.3% orphan, not adjacent to it.

**19 edges, 19 bound, 0 dangling** over 234 `.swift` files in 3 corpora.

> **Review correction — the first cut of this PR emitted 38 edges and 19 of them were WRONG BINDINGS.** An independent review found that half the corpus edges bound to an `extension` carrier rather than to a declaration. `swiftDeclSubtype` has no `extension` case and falls through to `return "class"`, so `extension String { … }` mints `SCOPE.Component/class:String` in that file and pass 2 could not tell it from a real declaration. It **binds**, so it never reaches `bug-extractor` — the exact direction this arm already refused for type parameters. Fixed here; the subtype fallthrough itself is filed as **#7047** and deliberately not fixed on this PR (§2a). Section 4 records what the structural cause was: the fixture pair varied the cross-file axis and the extension axis **separately and never their intersection**, which is where half the corpus lives.

---

## 1. The trap this arm exists to close — probed, not read

`field_type` is `firstDescendantText(type_annotation, "type_identifier")`, i.e. the **first pre-order** identifier. I dumped the real CST for 21 property shapes before writing anything:

| declaration | grammar shape | `field_type` |
|---|---|---|
| `var d: Dictionary<String, Order>` | `user_type[ tid "Dictionary", type_arguments[…"Order"…] ]` | **`"Dictionary"`** |
| `var j: Set<Order>` | same | **`"Set"`** |
| `var k: Result<Order, MyErr>` | same | **`"Result"`** |
| `var h: Foundation.Data` | `user_type[ tid "Foundation", ".", tid "Data" ]` | **`"Foundation"`** |
| `var c: [Order]` | `array_type[ user_type "Order" ]` | `"Order"` (by luck of ordering) |
| `var b: Order?` | `optional_type[ user_type "Order" ]` | `"Order"` (same) |

So for **every** generic wrapper the argument is already gone, and for a module-qualified type the property holds the **module**. #6912's remaining-work list described php/cpp/swift as *"read the property, emit the edge"*; doing that in Swift ships the `List<Customer>` → `List` binding arm A went out of its way to forbid, and binds `Foundation.Data` to a same-file `struct Foundation`.

This arm therefore takes **arm C's technique** (stash AST candidates at the emit site) and **not arm E's** (tokenise the string) — F#'s `member_type` is the declared type verbatim, Swift's is not.

`field_type` is **left exactly as it is**: fixing it changes entity Properties and `Signature` for every Swift field, which is a separate change with its own blast radius. Its lossiness is now a live expectation — `TestSwiftFieldTypeRefs_FieldTypePropertyIsLossyForGenerics` asserts `Dictionary`/`Result` *and* the edge that does **not** go to the wrapper, so the next reader meets the trap as a failing test rather than as prose.

Two more things the probe settled, each turned into a test rather than an argument:

- `@Published var s: Order` shapes `Published` as a `user_type` under a `modifiers > attribute` **sibling** of the `type_annotation`. Candidates are collected from the `type_annotation` subtree only, so the wrapper is out of reach by construction. `TestSwiftFieldTypeRefs_PropertyWrapperTypeIsNotACandidate` declares a same-file `struct Published` so the assertion can actually fail.
- `Order.Type` (metatype), `Foundation.Data` (module-qualified) and `Order.Inner` (nested) are **one `user_type` node with two `type_identifier` children** around an anonymous `.`. Head and tail are both refused; type **arguments** are still descended into, so `Swift.Array<Order>` yields `Order`.

---

## 2. The three required answers

### (1) Which resolver tier resolves a Swift field's address?

The address is `extractor.BuildComponentStructuralRef` → `scope:component:class:swift:<file>:<Name>`, so `lookupStructural` (`internal/resolve/refs.go:2982`) calls

```go
idx.lookupLocationKind(filePath, tail, structuralKindFamilies("component"))   // = componentKindFamily
```

and, on a miss, falls through to `ambigLocation` / `byLocation` (`refs.go:3004-3012`).

**Swift is the first arm where the answer is not a single tier.** It emits admissible targets in two kind spaces, and the *same* address resolves them through *different* tiers:

| target | tier that resolves it | why | ambiguity count |
|---|---|---|---|
| `SCOPE.Component` (class / struct / enum / actor / protocol) | `lookupLocationKind`, **before** `ambigLocation` | `buildSymbolIndex` indexes each entity under its Kind **and** its SCOPE-trimmed Kind (`refs.go:1207-1210`), so `SCOPE.Component` lands under `"Component"`, which `componentKindFamily` lists | **within `componentKindFamily`** (arm F's rule) |
| `SCOPE.Schema/type_alias` (`typealias Money = Double`) | `lookupLocationKind` **misses entirely**; `ambigLocation` decides | `"SCOPE.Schema"` trims to `"Schema"`, which is in no family | **every kind** (arm D's rule) |

Driven through the real resolver, not inferred: `TestSwiftFieldTypeRefs_ResolvesToEntityIDs` builds the index and runs `resolve.ReferencesEmbedded`, and `TestSwiftFieldTypeRefs_AliasShadowedByAnOperationWouldDangleUnderArmFsRule` probes the *shadowed alias address itself* and asserts it does **not** bind, with the unshadowed one asserted to bind so the negative result is about the collision and not about aliases in general.

### (2) Which kinds does each tier weigh?

- **Component tier** weighs `componentKindFamily` = `Component, Class, View, Model, SCOPE.Component, SCOPE.View, SCOPE.Model`. Membership is **derived**, not hand-listed: `swiftInComponentAddressFamily` also trims a `SCOPE.` prefix before testing, because the index does — a `SCOPE.Class` entity lands under the key `Class`. (Arm F hand-listed `"SCOPE.Class"`; deriving it keeps this in step with the resolver rather than with a snapshot of it.)
  - **`SCOPE.Enum` is invisible to it**, and that is load-bearing: `swift.go:116-120` emits a `SCOPE.Enum` value-set beside **every** `enum` Component, same name, same file. Arm D's all-kinds rule would refuse **every Swift enum target**.
- **Alias tier** weighs nothing — it is the kind-agnostic `ambigLocation`, set on any second distinct entity ID (`refs.go:1301-1316`). Arm F's rule here admits `typealias Tier` beside a top-level `func Tier()` (Schema + Operation, neither in the component family) and the edge dangles.

**The unit is the KIND, not the RECORD, in both scans.** `graph.EntityID` hashes `(repo, Kind, Name, SourceFile)` with Subtype **excluded**, and `buildSymbolIndex` marks a collision only on `existing != e.ID` (`refs.go:1308`). Arm C counts records (#7038) and is wrong; that rule is not copied and its justification comment is not reproduced.

### (3) Measured counterfactuals — same corpus, same candidates, three rules

234 `.swift` files, 3 repos (vapor, vapor-api-template, ktor-samples), 295 field entities. **Re-measured against the corrected 19-edge base** — the first cut's table was computed against the 38-edge base and its percentages were therefore wrong.

| rule | edges | delta | dropped rows |
|---|---|---|---|
| **this arm** (split by target kind) | **19** | — | — |
| **arm D** (all kinds, everywhere) | 14 | **−5, −26.3%** | `OTP.swift: HOTP.digest→OTPDigest`, `HOTP.digits→OTPDigits`, `TOTP.digest→OTPDigest`, `TOTP.digits→OTPDigits`, `URLEncodedFormData.swift: URLEncodedFormData.values→URLQueryFragment` — **all five enum targets**, each refused by its own value-set |
| **arm F** (component family, Components only) | 19 | **0** | none |
| **arm C** (record count, Components only) | 14 | **−5, −26.3%** | `HTTPMediaType.swift: HTTPMediaTypeSet.compressible→HTTPMediaTypeSet`, `…incompressible→HTTPMediaTypeSet`, `…mediaTypeLookup→HTTPMediaType`, `Middleware.swift: HTTPMiddlewareResponder.middleware→Middleware`, `Session.swift: Session._id→SessionID` |

**The dropped row sets are identical to the first cut's, row for row.** The 19 wrong bindings the extension fix removed were disjoint from the rows these three rules discriminate on, so the *deltas* survive the correction unchanged and only the percentages move. That is the result, not an assumption — each counterfactual was re-run against the fixed tree.

Three things I want stated plainly rather than folded into the win:

- **Arm F's rule costs nothing measurable here, and I am not claiming go's 19%.** The corpus emits exactly **5 `SCOPE.Schema/type_alias` records across 4 distinct names**, and **none** of them is a same-file field target. Re-derived: there are 45 `typealias` source lines, but 40 are nested inside a type body and #4854's walk emits no entity for those; of the 5 top-level ones, two share the name `VaporSendableMetatype` under `#if`/`#else` (see M6b below). The alias tier is therefore justified from the resolver and graded by fixture, and is a **corpus-relative zero** — exactly the shape arm B's `protoScalars` episode warned about, so I kept it and said why rather than deleting it on the strength of a corpus that cannot see it.
- **Arm C's −5 is a new, idiomatic corroboration of #7038.** Every one of those five is `struct Foo` beside `extension Foo` **in the declaring file**: the walk emits a second `SCOPE.Component` for the extension, so the name carries two records and **one** graph node. That is the case the extension marker must *not* break, and it is the other half of §2a: when the declaration is in the same file the two records share an `EntityID`, so refusing the carrier per-record leaves the declaration record admitted and the `ToID` identical. `TestSwiftFieldTypeRefs_ExtensionBesideItsTypeIsStillOneNode` asserts the two-record/one-kind premise first so it cannot pass vacuously.
- Arm D's −5 is the **same shape** arm F measured at 12.24% in java. Third independent confirmation that the rule is per-tier.

---

## 2a. The extension defect, and why the marker rather than the subtype

`tree-sitter-swift` routes `extension` through **`class_declaration`** — the same node type as class/struct/enum/actor — and `swiftDeclSubtype` (`swift.go:236`) switches on four declaration keywords with **no `extension` case**, falling through to `return "class"`. So an extension carrier is a real graph node with the same Kind, the same Name and the same file as the type it extends, and a **different** `EntityID` from the real declaration when that declaration lives elsewhere.

Measured, by reproducing the first cut (`swiftIsExtensionDecl` disabled at the emit site) and diffing the corpus edge set row for row:

| | edges | targets |
|---|---|---|
| first cut | **38** | — |
| this revision | **19** | — |
| **removed — every one a wrong binding** | **19** | `BaseNEncoding` ×7, `String` ×6, `RoutesBuilder` ×2, `HTTPClient`, `PasswordHasher`, `Request`, `tm` ×1 each |

`tm` is `extension tm: @retroactive Sendable` in `RFC1123.swift` — a **libc struct**, bound to a per-file Swift carrier. `Request` is `FileIO.swift`'s `extension Request`, while the real `struct Request` in `Request.swift` got **no inbound edge at all**.

**The fix marks the carrier at the emit site instead of changing the subtype**, and that is a choice, not an oversight:

1. Minting `Subtype "extension"` changes an **entity field** on every Swift extension in every indexed repo. `entityTupleKey` hashes `Subtype`, so it moves the `cmd/grafel` digest and every golden expectation naming a subtype. That is a graph-wide change riding on an edge PR — what arm D declined for `resolveTypeReferences`.
2. The deciding datum, the anonymous `extension` keyword, is **already in hand** at the emit site — the same "it is in hand, so refuse it for free" argument this arm used for type parameters.
3. **The two fixes compose.** When #7047 lands and `swiftDeclSubtype` mints `"extension"`, pass 2's allow-list (`class|struct|enum|actor|protocol`) already refuses it and the marker becomes redundant rather than wrong. Pinned by the `Subtype: "extension"` row in `ExtensionCarrierIsNeverATarget`.

**The marker is read by pass 2 ONLY.** The carrier stays in pass 1's collision scans, because it *is* a real node the resolver sees. Over-correcting — hiding it from the scans as well, which reads as the tidier change — produces a **new** wrong binding, and that is graded: `TestSwiftFieldTypeRefs_AliasExtendedInItsOwnFileGetsNoEdge` (`typealias Money = Int` beside `extension Money`) fails under exactly that over-correction (mutant M19).

### What the bind-rate instrument could NOT see

Worth stating plainly, because it is the reason this survived the first round: the corpus resolver harness reports **`total=38 bound=38 dangling=0 wrongName=0 wrongFile=0`** on the *unfixed* code. The carrier has the right name, in the right file, with an admissible kind and subtype. **No bind-rate, dangle-rate or `bug-extractor` instrument can detect this defect class.** Only the declaration-vs-extension distinction detects it, which is why the grading is a fixture intersection and a corpus row-diff rather than a count.

---

## 3. Two deliberate departures beyond the ambiguity rule

**A type parameter shadowed by a same-file type is REFUSED, not pinned as known-wrong.** Arms A and D both ship this over-fire with a comment saying a real fix is expected to break their test. Swift can refuse it for free: `emitSwiftFieldMembers` already holds the owning declaration node, so `struct Box<T>`'s `type_parameters` are in hand at the collection site. It is a fix in the **too-broad** direction, which is the direction this board keeps getting caught by, and it binds when it is wrong — so it never reaches `bug-extractor`.

**A self-reference IS emitted** (`class Node { var next: Node? }` → `Node.next → Node`). Arm D suppresses the equivalent, but its reason does not transfer: Go already ships a struct-anchored `DEPENDS_ON` that declines the self case and arm D matched it. Swift has no adjacent declared-type edge, and arms A and C — which likewise have none — do not suppress it. `CONTAINS` relates owner→field, not field→owner, so this is not a restatement of an existing edge.

---

## 4. Fixture axes

**Varied.**

- **Type-expression shape** — bare, optional, implicitly-unwrapped, array, dictionary-literal, generic ×1 and ×2 args, nested generic, tuple, function type, existential `any`, dotted, duplicate-target tuple. Each asserted against **one** target name so the shape is the only moving part.
- **Target kind** — struct / class / protocol / enum-with-value-set / typealias.
- **Collider kind** — `SCOPE.Enum` must *not* suppress; `SCOPE.Operation` *must* suppress an alias. Each with a positive control of the same declaration form and no collider.
- **Owner declaration form** — `struct`, `class`, generic `struct Box<T>` / `Bag<Element>` / `Pair<A, B>`.
- **Type-parameter name length** — 1 char (`T`) **and** multi-char (`Element`), plus parameter **position** (first and second of `Pair<A, B>`). *Added this round (reviewer's R6): held at one character, a refusal restricted to short names — the obvious wrong way to write this — survived the whole suite.*
- **`SCOPE.`-prefixed vs trimmed kind spelling** — a `SCOPE.Class` collider row. *Added this round (reviewer's R3): the trim in `swiftInComponentAddressFamily` was dead and ungraded, so the claim that deriving family membership beats arm F's hand-list was unexercised.*
- **Which half of a compound guard is wrong** — `{SCOPE.Schema, type_alias}` and `{SCOPE.Component, field}` impostors, one per half of `Kind != "SCOPE.Schema" || Subtype != "field"`. *Added this round (reviewer's R1/R2): the single original impostor differed on **both** halves, so each masked the other and neither was graded.*
- **PRESENCE OF AN `extension` IN THE FIELD'S FILE, CROSSED WITH WHERE THE TYPE IS DECLARED.** ***This is the cell the first cut left empty and where half its edges were wrong.*** All four combinations are now fixtures:

  | | no `extension` here | `extension` here |
  |---|---|---|
  | **declared here** | most tests (bind) | `ExtensionBesideItsTypeIsStillOneNode` — **must still bind** |
  | **declared elsewhere** | `ForeignFileTypeIsNeverATarget` control | `ForeignFileTypeIsNeverATarget` — **must not bind** |
  | **declared in the stdlib** | `PrimitiveFieldsProduceNoEdge` | `ExtensionOfAStdlibTypeIsNeverATarget` — **must not bind** |

- **Duplicate-record origin** — `extension Foo` beside `struct Foo` (Component branch) and a `#if`/`#else` `typealias` pair (alias branch): two records, one kind, one graph node, on each branch.

**Held constant, and named because holding one axis is what makes its sibling look covered.**

- **File of the rival.** Every external fixture is single-file except `ForeignFileTypeIsNeverATarget`, which is a **recall statement, not a grading of the same-file conjuncts** — `Extract` sees one file at a time, so from the external package neither conjunct can ever fire and a mutant deleting either survives that whole file. Both are graded internally in `field_type_refs_scope_6912_test.go`, **in opposite directions**: a foreign-file record must not *suppress* an edge (pass 1) and must not *become* one (pass 2), with rows chosen so a leak in one changes nothing about the rows for the other.
- **The third collider** — a second *component-family* kind, which must suppress a Component — has **no source-level fixture**, because no Swift emit site produces one today and writing Swift that "would" is fabricating an example. Graded at the function level instead, in `TheTwoCollisionScansAreIndependent`, which also pins that the two scans suppress *different* things.
- Repo (one id; cross-repo collision is not modelled and not graded). Language segment. `let` / `weak` / `lazy` / access modifiers are **not** varied — the argument that they cannot reach a decision is in the header, and the fixtures do **not** demonstrate it. Nesting: `walkBody` emits no entity for a type declared inside a class body, so a nested type is not a candidate target in any fixture; that is a property of #4854's walk, not of this pass.

---

## 5. Mutation table — 27 mutants, all at the call site, all compiling, all DEAD

Applied by exact-string replacement with an **asserted occurrence count before and after**; reverted by `cp` from a shasum-verified byte backup, never `git checkout`. Three first-round mutants did not compile (`declared and not used`, `imported and not used`) and were rewritten until they did — a non-compiling mutant proves nothing.

| # | mutation | verdict | killed by |
|---|---|---|---|
| M1 | dotted `user_type` refusal disabled | DEAD | `DottedTypeBindsNeitherHeadNorTail` |
| M2 | do not descend into `type_arguments` | DEAD | `TypeExpressionShapes`, `FieldTypePropertyIsLossy…`, `Dotted…`, `ResolvesToEntityIDs` |
| M3 | Component tier uses **all kinds** (arm D's rule) | DEAD | `EnumValueSetDoesNotSuppressItsComponent`, `TheTwoCollisionScansAreIndependent`, `ResolvesToEntityIDs` |
| M4 | alias tier uses **component family** (arm F's rule) | DEAD | `AliasShadowedByAnOperationWouldDangle…`, `TheTwoCollisionScansAreIndependent` |
| M5 | alias tier removed entirely | DEAD | 6 tests incl. `UnshadowedAliasIsATarget` |
| M6 | component scan counts **records** (arm C's rule) | DEAD | `ExtensionBesideItsTypeIsStillOneNode`, `TwoRecordsOneKindAreOneNodeUnit` |
| M6b | alias scan counts **records** | DEAD | `TwoRecordsOneKindAreOneNodeUnit` (alias branch) |
| M7 | pass-1 `SourceFile != filePath` deleted | DEAD | `TargetsAreScopedToTheRequestedFile` |
| M8 | pass-2 `SourceFile != filePath` deleted | DEAD | `TargetsAreScopedToTheRequestedFile` |
| M9 | type-parameter filter ignored | DEAD | `TypeParameterShadowedByASameFileTypeGetsNoEdge` |
| M10 | subtype allow-list widened to any Component | DEAD | `AllowListRefusesNonTypeComponents` |
| M11 | bare-name ToID instead of the structural address | DEAD | `ResolvesToEntityIDs`, `TargetsAreScoped…` |
| M12 | per-field target dedupe removed | DEAD | `TypeExpressionShapes`, `ResolvesToEntityIDs` |
| M13 | `Kind/Subtype == field` guard removed in attach | DEAD | `OnlyFieldRecordsCarryTheEdge` |
| M14 | stash not deleted from Metadata | DEAD | `StashIsClearedFromMetadata` |
| M15 | candidates taken from the `field_type` **property** | DEAD | 5 tests — the arm's central premise |
| M16 | candidates scoped to the whole `property_declaration` | DEAD | `PropertyWrapperTypeIsNotACandidate` |

**Round 2 — the four the reviewer scored ALIVE, plus M19 and the new fix's own mutants.** Every row re-verified with an asserted occurrence count of exactly 1 before and after, `go vet` clean (a guard is disabled with `if false && <cond>` so no variable goes unused), `-count=1`, and reverted by `cp` from a shasum-verified backup.

| # | mutation | verdict | killed by |
|---|---|---|---|
| **R1** | **Kind half alone** disabled — `false && r.Kind != "SCOPE.Schema"` | **DEAD** | `OnlyFieldRecordsCarryTheEdge` (via the new `KindImpostor` row) |
| **R2** | **Subtype half alone** disabled — `false && r.Subtype != "field"` | **DEAD** | `OnlyFieldRecordsCarryTheEdge` (via the new `AliasImpostor` row) |
| M13 | the whole compound guard disabled | DEAD | `OnlyFieldRecordsCarryTheEdge` |
| **R3** | `SCOPE.`-trim branch disabled in `swiftInComponentAddressFamily` | **DEAD** | `TheTwoCollisionScansAreIndependent` (new `SCOPE.Class` rows) |
| **R6a** | type-parameter refusal restricted to 1-char names | **DEAD** | `TypeParameterShadowedByASameFileTypeGetsNoEdge` (`Bag<Element>`) |
| **R6b** | only the **first** type parameter collected | **DEAD** | `TypeParameterShadowedByASameFileTypeGetsNoEdge` (`Pair<A, B>.second`) |
| **M19** | **over-correction** — carrier also hidden from pass 1's collision scans | **DEAD** | `AliasExtendedInItsOwnFileGetsNoEdge` |
| **EXT** | pass-2 extension refusal disabled | **DEAD** | `ExtensionCarrierIsNeverATarget`, `ForeignFileTypeIsNeverATarget`, `ExtensionOfAStdlibTypeIsNeverATarget`, `AliasExtendedInItsOwnFileGetsNoEdge` |
| **MARK** | `swiftIsExtensionDecl` never consulted at the emit site | **DEAD** | `ForeignFileTypeIsNeverATarget`, `ExtensionOfAStdlibTypeIsNeverATarget`, `AliasExtendedInItsOwnFileGetsNoEdge` |
| **MARK2** | extension marker not deleted from `Metadata` | **DEAD** | `ExtensionCarrierMarkerIsClearedFromMetadata` |

**R1 and R2 are the mutually-masking finding, scored part by part.** The first revision's single `{SCOPE.Component, class}` impostor differs from a field record on *both* halves, so deleting the whole guard died while deleting *either half alone* survived — a compound grades its second half only if its first half is not lethal alone. Two impostors, one wrong on each half, is the fix; both halves are now independently lethal.

**M19 is the over-correction mutant, and it is the reason the marker's scope is narrow.** Hiding the carrier from pass 1 as well as pass 2 is the tidier-looking change and it introduces a *new* wrong binding: `typealias Money = Int` beside `extension Money` would stop being ambiguous, the alias would be admitted, and its component-space address would resolve through `lookupLocationKind` to the **extension carrier** rather than to the alias. It binds. Graded.

**Three of these were ALIVE on the first round and were graded rather than excused** — M6b, M13 and M10 — which is exactly the "too expensive to kill / belt-and-braces" verdict arm D recorded as a mistake. Each cost a handful of lines at the function level.

**Correction: M6b's reachability claim was wrong, and the retraction is narrower than it looks.** I wrote that the only Swift producing two `SCOPE.Schema` records under one name in one file is a duplicate `typealias`, "which swiftc rejects". The corpus this arm measures falsifies the *conclusion*: `vapor/Sources/Vapor/Utilities/VaporSendableMetadataType.swift` is

```swift
#if compiler(>=6.2)
public typealias VaporSendableMetatype = SendableMetatype
#else
public typealias VaporSendableMetatype = Any
#endif
```

— two top-level `typealias` declarations of one name in one file, which the **extractor** sees as two `SCOPE.Schema/type_alias` records. So M6b's alias branch is **source-reachable**, which makes grading it *more* important than the old comment implied, not less. `TestSwiftFieldTypeRefs_ConditionalTypealiasIsStillOneNode` is the source-level form.

What is **not** retracted: swiftc really does reject a genuine duplicate `typealias` in one scope. The `#if`/`#else` form compiles precisely because only one branch is active — it is a *conditional-compilation* shape the extractor flattens, not a duplicate the compiler accepts. The false step was inferring source-unreachability from a true fact about swiftc while the extractor sees both branches. The comment in `field_type_refs_scope_6912_test.go` now says exactly that, and no more.

**All-DEAD is pinning, not truth — and this PR is the proof of that, because the first cut was also all-DEAD while half its edges were wrong.** The truth claim therefore rests on the corpus row-diff in §2a, not on the mutation table: the 38-edge and 19-edge target sets were enumerated and differenced by name and site, and every removed row was confirmed to be a name with **no declaration in that file, only an extension**.

Driving the corpus through `resolve.BuildIndex` → `resolve.ReferencesEmbedded` still reports 19/19 bound and 0 dangling, but §2a records that this instrument reported **38/38 bound, 0 dangling** on the unfixed code too, so it grades address construction and nothing else. `ResolvesToEntityIDs` asserts the **bare** name `Customer` is ambiguous in its fixture, so a bare-name ToID could not pass it and the structural address is genuinely graded.

---

## 6. Gates

- `go test -count=1 ./internal/extractors/swift/` — green (24 new tests; 4 added this round).
- **`go test -count=1 ./cmd/grafel/`** — green (305s), with a **fresh `GRAFEL_HOME` + `GRAFEL_DAEMON_ROOT`** inside the worktree scratch dir; the real `~/.grafel` was not touched. **The digest did not move, and the honest reason is that the digest fixture (`custom_extractor_spans_6118_test.go`) contains no `.swift` file at all** — re-verified this round by grep, 0 matches, not assumed. A new `REFERENCES` edge *does* move `semanticDigest6118` (relationships are hashed as `R <from> -[Kind]-> <to>`); entity **properties and metadata** are not hashed, so the `Metadata` marker this PR adds moves nothing by construction and the net edge change (−19) would have, had any fixture held Swift. A real negative result about the fixture, not a blind instrument.
- `scripts/quality/run.sh --ratchet` — prints *38 gated fixtures held (29 at 100% must-have recall)*, and **`git status --porcelain` is empty of `baseline.json` afterwards**, which is the check that actually distinguishes a hold from a ceiling drop: the script **exits 0 and prints "held" even on a ceiling DROP**, so its exit code is not evidence.
  **The golden set is VACUOUS for this pass and I am not offering the ratchet as evidence.** Re-measured this round: its 6 `.swift` files hold **17 field entities and gain 0 edges** — none declares its field's type in the same file. It even contains the relevant shape (`extension User` beside `struct User` in `swift-swiftui-mini/.../User.swift`) and still gains nothing, because no field there is typed `User`. So the ratchet could not have caught the extension defect and cannot confirm the fix.
- `gofmt -l` clean; `go vet` clean.

## 7. Recall ceiling, honestly

**6.44% of Swift fields gain an edge (19 of 295). A bind rate of 19/19 is not completeness — and §2a shows it is not even soundness.** The floor is the same-file rule, and for Swift it bites harder than for C# or Java: a Swift module is a directory of files and one-type-per-file **is** the convention. Cross-file binding of a bare type name is the #6976/#6369 hazard and this arm does not open it. Also unclaimed: inferred types (`var x = Order()` has no `type_annotation`), computed properties (not stored members, no field entity at all), and every dotted type including the metatype.

**Corpus caveat:** 234 `.swift` files in **3** repos, and 219 of them are one repo (vapor). The mechanism transfers; the 6.44% is vapor's number more than Swift's. #6726's 99.3% is their corpus and no claim is made that it moves — Swift is not one of their four languages.

## 8. Known, unclosed, and left as an invariant rather than a guarantee

`internal/custom/swift/swiftui.go:288` mints a **bare-named `SCOPE.Component`** from an `@ObservedObject`/`@StateObject`/`@EnvironmentObject` **property name**, in the same file, on a lane this pass cannot see.

**Correction: the hazard is CONFLATION, not ambiguity — the earlier version of this section had the mechanism wrong.** That site emits `SCOPE.Component`, the **same** Kind as the declaration it could collide with, and entity IDs are re-derived downstream as `graph.EntityID(repo, Kind, Name, SourceFile)` (`internal/extractors/incremental.go:2068`, which deliberately ignores the emitted `r.ID`). A same-file, same-name `SCOPE.Component` from the custom lane therefore carries the **identical id**; `buildSymbolIndex` marks a collision only on `existing != e.ID` (`refs.go:1308`). So there is **no `ambigLocation` entry, no blanked `.base` key and no dangle** — the two records **merge into one node**. The residual hazard is that a property and a type would share a node, which is a different and lesser complaint than the edge failing to bind.

**This also settles why the fixture refusal in §4 was right, and the refusal stands.** The genuinely unseen hazard is a custom-lane record carrying a **second component-family KIND** under a declared type's name — and that site does not produce one. Writing Swift that "would" produce one is fabricating an example, so there is still no source-level fixture for it and it is graded at the function level in `TheTwoCollisionScansAreIndependent` instead. Fixing the derivation does not create a fixture obligation.

**Measured incidence of the conflation shape: 0** on the corpus and 0 on the golden set (whose one `@StateObject var viewModel: UserListViewModel` shares no name with a same-file declaration). That is a corpus fact, not a language fact, and the header states the invariant to preserve rather than relying on the accident.

Refs #6912, #6726, #7038, #7047, #6976, #6369, #492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861

